### PR TITLE
esc dismisses ui messages too

### DIFF
--- a/src/mode/mode_command.ts
+++ b/src/mode/mode_command.ts
@@ -3,8 +3,11 @@ import {showCmdLine} from './../cmd_line/main';
 import * as vscode from 'vscode';
 
 export default class CommandMode extends Mode {
+    private timesEscHandled : number;
+
     constructor() {
         super(ModeName.Command);
+        this.timesEscHandled = 0;
     }
 
     ShouldBeActivated(key : string, currentMode : ModeName) : boolean {
@@ -13,12 +16,23 @@ export default class CommandMode extends Mode {
 
     HandleActivation(key : string) : void {
         // do nothing
-    }    
+    }
+
+    handleDeactivation() : void {
+        this.timesEscHandled = 0;
+    }
 
     HandleKeyEvent(key : string) : void {
         this.keyHistory.push(key);
 
         switch (key) {
+            case 'esc':
+                // If the user presses Esc while in normal mode, close any open messages.
+                // XXX: Can/should we use a custom key binding context for this?
+                if (++this.timesEscHandled > 1) {
+                    vscode.commands.executeCommand("workbench.action.closeMessages");
+                }
+                break;
             case ':':
                 showCmdLine();
                 break;


### PR DESCRIPTION
It's very annoying that we cannot dismiss messages from the editor. Even if this is a stop-gap solution in the end, I think it's worth having. :)