### PR TITLE
minor fixes

### DIFF
--- a/extension.ts
+++ b/extension.ts
@@ -91,7 +91,12 @@ export function activate(context: vscode.ExtensionContext) {
     vscode.commands.registerCommand('extension.vim_7', () => handleKeyEvent("7"));
     vscode.commands.registerCommand('extension.vim_8', () => handleKeyEvent("8"));
     vscode.commands.registerCommand('extension.vim_9', () => handleKeyEvent("9"));
-
+    
+    vscode.commands.registerCommand('extension.vim_ctrl_[', () => handleKeyEvent("ctrl+["));
+    
+    vscode.commands.registerCommand('extension.vim_<', () => handleKeyEvent("<"));
+    vscode.commands.registerCommand('extension.vim_>', () => handleKeyEvent(">"));
+    
     context.subscriptions.push(cmdLineDisposable);
 }
 

--- a/package.json
+++ b/package.json
@@ -105,8 +105,12 @@
         { "key": "Ctrl+J", "command": "cursorDown", "when": "editorTextFocus" },
         { "key": "Ctrl+K", "command": "cursorUp", "when": "editorTextFocus" },
         { "key": "Ctrl+L", "command": "cursorRight", "when": "editorTextFocus" },
+        { "key": "Ctrl+[", "command": "extension.vim_ctrl_[", "when": "editorTextFocus" },
         
-        { "key": "Ctrl+Shift+.", "command": "extension.showCmdLine", "when": "editorTextFocus" }
+        { "key": "Ctrl+Shift+.", "command": "extension.showCmdLine", "when": "editorTextFocus" },
+        
+        { "key": "Shift+,", "command": "extension.vim_<", "when": "editorTextFocus" },
+        { "key": "Shift+.", "command": "extension.vim_>", "when": "editorTextFocus" }
     ]
   },
   "scripts": {

--- a/src/mode/mode_command.ts
+++ b/src/mode/mode_command.ts
@@ -15,13 +15,8 @@ export default class CommandMode extends Mode {
             "j" : (position) => { vscode.commands.executeCommand("cursorDown"); },        
             "k" : (position) => { vscode.commands.executeCommand("cursorUp"); },      
             "l" : (position) => { vscode.commands.executeCommand("cursorRight"); },
-            ">" : (position) => { 
-                console.log('>>');
-              //  vscode.commands.executeCommand("editor.action.indentLines"); 
-            },
-            "<" : (position) => {                 console.log('<<');
-            //vscode.commands.executeCommand("editor.action.outdentLines"); 
-            }, 
+            ">>" : (position) => { vscode.commands.executeCommand("editor.action.indentLines"); },
+            "<<" : (position) => { vscode.commands.executeCommand("editor.action.outdentLines"); }, 
         };
     }
 

--- a/src/mode/mode_command.ts
+++ b/src/mode/mode_command.ts
@@ -1,14 +1,32 @@
+import * as _ from 'lodash';
 import {ModeName, Mode} from './mode';
 import {showCmdLine} from './../cmd_line/main';
 import * as vscode from 'vscode';
 
 export default class CommandMode extends Mode {
+    private keyHandler : { [key : string] : (position : vscode.Position) => void; } = {};
+    
     constructor() {
         super(ModeName.Command);
+        
+        this.keyHandler = {
+            ":" : (position) => { showCmdLine() },   
+            "h" : (position) => { vscode.commands.executeCommand("cursorLeft"); },        
+            "j" : (position) => { vscode.commands.executeCommand("cursorDown"); },        
+            "k" : (position) => { vscode.commands.executeCommand("cursorUp"); },      
+            "l" : (position) => { vscode.commands.executeCommand("cursorRight"); },
+            ">" : (position) => { 
+                console.log('>>');
+              //  vscode.commands.executeCommand("editor.action.indentLines"); 
+            },
+            "<" : (position) => {                 console.log('<<');
+            //vscode.commands.executeCommand("editor.action.outdentLines"); 
+            }, 
+        };
     }
 
     ShouldBeActivated(key : string, currentMode : ModeName) : boolean {
-        return (key === 'esc');
+        return (key === 'esc' || key == 'ctrl+[');
     }
 
     HandleActivation(key : string) : void {
@@ -17,23 +35,28 @@ export default class CommandMode extends Mode {
 
     HandleKeyEvent(key : string) : void {
         this.keyHistory.push(key);
+        
+        const editor = vscode.window.activeTextEditor;
+        const currentPosition = editor.selection.active;
+        
+        //var commands = vscode.commands.getCommands();
+        //commands.then(a => console.log(a));
 
-        switch (key) {
-            case ':':
-                showCmdLine();
-                break;
-            case 'h':
-                vscode.commands.executeCommand("cursorLeft");
-                break;
-            case 'j':
-                vscode.commands.executeCommand("cursorDown");
-                break;
-            case 'k':
-                vscode.commands.executeCommand("cursorUp");
-                break;
-            case 'l':
-                vscode.commands.executeCommand("cursorRight");
-                break;
+        var keyHandled = false;
+        for (var window = 1; window <= 2 && window <= this.keyHistory.length && keyHandled === false; window++) {
+            var keys : string  = _.takeRight(this.keyHistory, window).join('').toString();
+            
+            console.log(keys);
+            if (this.keyHandler[key] !== undefined) {
+                // Bug: 'two characters does not work'
+                console.log('handled');
+                keyHandled = true;
+                this.keyHandler[key](currentPosition);
+            }
+        }
+        
+        if (keyHandled) {
+            this.keyHistory = [];
         }
     }
 }

--- a/src/mode/mode_command.ts
+++ b/src/mode/mode_command.ts
@@ -5,51 +5,47 @@ import * as vscode from 'vscode';
 
 export default class CommandMode extends Mode {
     private keyHandler : { [key : string] : (position : vscode.Position) => void; } = {};
-    
+
     constructor() {
         super(ModeName.Command);
-        
+
         this.keyHandler = {
-            ":" : (position) => { showCmdLine() },   
-            "h" : (position) => { vscode.commands.executeCommand("cursorLeft"); },        
-            "j" : (position) => { vscode.commands.executeCommand("cursorDown"); },        
-            "k" : (position) => { vscode.commands.executeCommand("cursorUp"); },      
+            ":" : (position) => { showCmdLine(); },
+            "h" : (position) => { vscode.commands.executeCommand("cursorLeft"); },
+            "j" : (position) => { vscode.commands.executeCommand("cursorDown"); },
+            "k" : (position) => { vscode.commands.executeCommand("cursorUp"); },
             "l" : (position) => { vscode.commands.executeCommand("cursorRight"); },
-            ">>" : (position) => { vscode.commands.executeCommand("editor.action.indentLines"); },
-            "<<" : (position) => { vscode.commands.executeCommand("editor.action.outdentLines"); }, 
+            // XXX(guillermooo): renamed these commands for testing from >> and << because VSC can't handle '<'
+            "tt" : (position) => { vscode.commands.executeCommand("editor.action.indentLines"); },
+            "TT" : (position) => { vscode.commands.executeCommand("editor.action.outdentLines"); }
+            // ================================================================================================
         };
     }
 
     ShouldBeActivated(key : string, currentMode : ModeName) : boolean {
-        return (key === 'esc' || key == 'ctrl+[');
+        return (key === 'esc' || key === 'ctrl+[');
     }
 
     HandleActivation(key : string) : void {
         // do nothing
-    }    
+    }
 
     HandleKeyEvent(key : string) : void {
         this.keyHistory.push(key);
-        
+
         const editor = vscode.window.activeTextEditor;
         const currentPosition = editor.selection.active;
-        
-        //var commands = vscode.commands.getCommands();
-        //commands.then(a => console.log(a));
 
         var keyHandled = false;
-        for (var window = 1; window <= 2 && window <= this.keyHistory.length && keyHandled === false; window++) {
-            var keys : string  = _.takeRight(this.keyHistory, window).join('').toString();
-            
-            console.log(keys);
-            if (this.keyHandler[key] !== undefined) {
-                // Bug: 'two characters does not work'
-                console.log('handled');
-                keyHandled = true;
-                this.keyHandler[key](currentPosition);
+        
+        for (let window = 1; window <= 2 && window <= this.keyHistory.length && !keyHandled; window++) {
+            let keys  = _.takeRight(this.keyHistory, window).join('').toString();
+
+            if (keyHandled = this.keyHandler[keys] !== undefined) {
+                this.keyHandler[keys](currentPosition);
             }
         }
-        
+
         if (keyHandled) {
             this.keyHistory = [];
         }


### PR DESCRIPTION
@jpoon 2-char commands can be handled (see your comment). But for me VSC  fails to forward the `<` charcter through the key bindings. I've renamed the commands just to prove the code works. Also, minor clean up.