### PR TITLE
move cursor position after getting normal mode

### DIFF
--- a/src/mode/modeNormal.ts
+++ b/src/mode/modeNormal.ts
@@ -26,7 +26,10 @@ export default class CommandMode extends Mode {
     }
 
     ShouldBeActivated(key : string, currentMode : ModeName) : boolean {
-        return (key === 'esc' || key === 'ctrl+[');
+        if (key === 'esc' || key === 'ctrl+[') {
+            vscode.commands.executeCommand("cursorLeft");
+            return true;
+        }
     }
 
     HandleActivation(key : string) : void {


### PR DESCRIPTION
After getting normal mode (e.g. from insert mode to normal mode), the cursor position should be moved to 1 left.