### PR TITLE
fix cursor behavior for h,j,k,l, and ESC

### DIFF
--- a/src/mode/modeNormal.ts
+++ b/src/mode/modeNormal.ts
@@ -2,6 +2,7 @@ import * as _ from 'lodash';
 import * as vscode from 'vscode';
 import {ModeName, Mode} from './mode';
 import {showCmdLine} from './../cmd_line/main';
+import TextEditor from './../textEditor';
 
 export default class CommandMode extends Mode {
     private keyHandler : { [key : string] : () => void; } = {};
@@ -13,10 +14,10 @@ export default class CommandMode extends Mode {
             ":" : () => { showCmdLine(); },
             "u" : () => { vscode.commands.executeCommand("undo"); },
             "ctrl+r" : () => { vscode.commands.executeCommand("redo"); },
-            "h" : () => { vscode.commands.executeCommand("cursorLeft"); },
-            "j" : () => { vscode.commands.executeCommand("cursorDown"); },
-            "k" : () => { vscode.commands.executeCommand("cursorUp"); },
-            "l" : () => { vscode.commands.executeCommand("cursorRight"); },
+            "h" : () => { TextEditor.CursorLeft(); },
+            "j" : () => { TextEditor.CursorDown(); },
+            "k" : () => { TextEditor.CursorUp(); },
+            "l" : () => { TextEditor.CursorRight(); },
             ">>" : () => { vscode.commands.executeCommand("editor.action.indentLines"); },
             "<<" : () => { vscode.commands.executeCommand("editor.action.outdentLines"); },
             "dd" : () => { vscode.commands.executeCommand("editor.action.deleteLines"); },
@@ -27,7 +28,7 @@ export default class CommandMode extends Mode {
 
     ShouldBeActivated(key : string, currentMode : ModeName) : boolean {
         if (key === 'esc' || key === 'ctrl+[') {
-            vscode.commands.executeCommand("cursorLeft");
+            TextEditor.CursorLeft();
             return true;
         }
     }

--- a/src/textEditor.ts
+++ b/src/textEditor.ts
@@ -52,8 +52,8 @@ export default class TextEditor {
     }
 
     static IsLastLine(): boolean {
-        return (vscode.window.activeTextEditor.document.lineCount ==
-            (this.GetCurrentPosition().line+1));
+        return (vscode.window.activeTextEditor.document.lineCount ===
+            (this.GetCurrentPosition().line + 1));
     }
     
     static CursorLeft() {
@@ -61,7 +61,7 @@ export default class TextEditor {
         var pos : vscode.Position = editor.selection.active;
 		if (pos.character > 0) {
 			vscode.commands.executeCommand("cursorLeft");
-			this.mostRightCol = pos.character-2;                    
+			this.mostRightCol = pos.character - 2;                    
 		} else {
 			this.mostRightCol = -1;
 		}
@@ -70,7 +70,7 @@ export default class TextEditor {
 	static CursorRight() {
         let editor : vscode.TextEditor = vscode.window.activeTextEditor;
         var pos : vscode.Position = editor.selection.active;
-		if ((pos.character+1) < editor.document.lineAt(pos.line).text.length) {
+		if ((pos.character + 1) < editor.document.lineAt(pos.line).text.length) {
 			vscode.commands.executeCommand("cursorRight");
 			this.mostRightCol = pos.character;
 		}
@@ -79,33 +79,37 @@ export default class TextEditor {
 	private static NewCol(line : number) : number {
         let editor : vscode.TextEditor = vscode.window.activeTextEditor;
 		var length = editor.document.lineAt(line).text.length;
-		var newCol = this.mostRightCol+1;
-		if (newCol >= length)
+		var newCol = this.mostRightCol + 1;
+		if (newCol >= length) {
 			newCol = length - 1;
-		if (newCol < 0)
+		}
+		if (newCol < 0) {
 			newCol = 0;
+		}
 		return newCol;	
 	}
 
 	static CursorDown() {
-        if (TextEditor.IsLastLine())
+		if (TextEditor.IsLastLine()) {
             return;
+		}
         
         let editor : vscode.TextEditor = vscode.window.activeTextEditor;
         var pos : vscode.Position = editor.selection.active;
 
-		var newPos = pos.with(pos.line+1, this.NewCol(pos.line+1));
+		var newPos = pos.with(pos.line + 1, this.NewCol(pos.line + 1));
 		this.SetCurrentPosition(newPos);
 	}
 
 	static CursorUp() {
-        if (TextEditor.GetCurrentPosition().line == 0)
+		if (TextEditor.GetCurrentPosition().line === 0) {
             return;
+		}
 
         let editor : vscode.TextEditor = vscode.window.activeTextEditor;
         var pos : vscode.Position = editor.selection.active;
 
-		var newPos = pos.with(pos.line-1, this.NewCol(pos.line-1));
+		var newPos = pos.with(pos.line - 1, this.NewCol(pos.line - 1));
 		this.SetCurrentPosition(newPos);
 	}
 }

--- a/src/textEditor.ts
+++ b/src/textEditor.ts
@@ -1,6 +1,8 @@
 import * as vscode from "vscode";
 
-export default class TextEditor {      
+export default class TextEditor {
+    private static mostRightCol : number = 0;
+          
     static Insert(text: string, position: vscode.Position = null) : Thenable<boolean> {
         if (position === null) {
             position = vscode.window.activeTextEditor.selection.active;
@@ -48,4 +50,63 @@ export default class TextEditor {
         const lineLength = vscode.window.activeTextEditor.document.lineAt(position.line).text.length;
         return new vscode.Position(position.line, lineLength);
     }
+
+    static IsLastLine(): boolean {
+        return (vscode.window.activeTextEditor.document.lineCount ==
+            (this.GetCurrentPosition().line+1));
+    }
+    
+    static CursorLeft() {
+        let editor : vscode.TextEditor = vscode.window.activeTextEditor;
+        var pos : vscode.Position = editor.selection.active;
+		if (pos.character > 0) {
+			vscode.commands.executeCommand("cursorLeft");
+			this.mostRightCol = pos.character-2;                    
+		} else {
+			this.mostRightCol = -1;
+		}
+    }
+
+	static CursorRight() {
+        let editor : vscode.TextEditor = vscode.window.activeTextEditor;
+        var pos : vscode.Position = editor.selection.active;
+		if ((pos.character+1) < editor.document.lineAt(pos.line).text.length) {
+			vscode.commands.executeCommand("cursorRight");
+			this.mostRightCol = pos.character;
+		}
+	}
+
+	private static NewCol(line : number) : number {
+        let editor : vscode.TextEditor = vscode.window.activeTextEditor;
+		var length = editor.document.lineAt(line).text.length;
+		var newCol = this.mostRightCol+1;
+		if (newCol >= length)
+			newCol = length - 1;
+		if (newCol < 0)
+			newCol = 0;
+		return newCol;	
+	}
+
+	static CursorDown() {
+        if (TextEditor.IsLastLine())
+            return;
+        
+        let editor : vscode.TextEditor = vscode.window.activeTextEditor;
+        var pos : vscode.Position = editor.selection.active;
+
+		var newPos = pos.with(pos.line+1, this.NewCol(pos.line+1));
+		this.SetCurrentPosition(newPos);
+	}
+
+	static CursorUp() {
+        if (TextEditor.GetCurrentPosition().line == 0)
+            return;
+
+        let editor : vscode.TextEditor = vscode.window.activeTextEditor;
+        var pos : vscode.Position = editor.selection.active;
+
+		var newPos = pos.with(pos.line-1, this.NewCol(pos.line-1));
+		this.SetCurrentPosition(newPos);
+	}
 }
+


### PR DESCRIPTION
default cursor moving function such as vscode.commands.executeCommand("cursorLeft") is a bit different from original vim's behavior, so just added similar functions in TextEditor class and call them instead.