### PR TITLE
map keys from US keyboard to other layouts

### DIFF
--- a/extension.ts
+++ b/extension.ts
@@ -95,6 +95,8 @@ export function activate(context: vscode.ExtensionContext) {
     
     registerCommand(context, 'extension.vim_<', () => handleKeyEvent("<"));
     registerCommand(context, 'extension.vim_>', () => handleKeyEvent(">"));
+    
+    registerCommand(context, 'extension.vim_backslash', () => handleKeyEvent("\\"));
 }
 
 function registerCommand(context: vscode.ExtensionContext, command: string, callback: (...args: any[]) => any) {

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
         { "key": "Shift+;", "command": "extension.vim_colon", "when": "editorTextFocus" },
         { "key": ":", "command": "extension.vim_colon", "when": "editorTextFocus" },
         { "key": "space", "command": "extension.vim_space", "when": "editorTextFocus" },
+        { "key": "\\", "command": "extension.vim_backslash", "when": "editorTextFocus" },
 
         { "key": "a", "command": "extension.vim_a", "when": "editorTextFocus" },
         { "key": "b", "command": "extension.vim_b", "when": "editorTextFocus" },
@@ -120,8 +121,18 @@
         
         { "key": "Shift+,", "command": "extension.vim_<", "when": "editorTextFocus" },
         { "key": "Shift+.", "command": "extension.vim_>", "when": "editorTextFocus" }
-        
-    ]
+    ],
+    "configuration": {
+      "title": "Vim Configuration",
+      "type": "object",
+      "properties": {
+        "vim.keyboardLayout": {
+          "default": "en-US (QWERTY)",
+          "type": "string",
+          "description": "Keyboard layout to use to translated key presses."
+        }
+      }
+    }
   },
   "scripts": {
     "vscode:prepublish": "node ./node_modules/vscode/bin/compile",

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -1,0 +1,15 @@
+import {KeyboardLayout} from "./keyboard";
+
+export default class Configuration {
+
+	keyboardLayout : KeyboardLayout;
+
+	constructor(keyboard : KeyboardLayout) {
+		this.keyboardLayout = keyboard;
+	}
+
+	static fromUserFile() {
+		// TODO: read .vimrc or a similar file.
+		return new Configuration(KeyboardLayout.fromUserConfiguration());
+	}
+}

--- a/src/keyboard.ts
+++ b/src/keyboard.ts
@@ -1,0 +1,58 @@
+import * as vscode from "vscode";
+
+export class KeyboardLayout {
+	private mapper : KeyMapper;
+
+	constructor(mapper? : KeyMapper) {
+		this.mapper = mapper;
+	}
+
+	get name() : string {
+		return this.mapper ? this.mapper.name : 'en-US (QWERTY)';
+	}
+
+	translate (key : string) : string {
+		return this.mapper ? this.mapper.get(key) : key;
+	}
+
+	static fromUserConfiguration() : KeyboardLayout {
+		const layout = vscode.workspace.getConfiguration('vim').get("keyboardLayout");
+
+		console.log("Using Vim keyboard layout: " + layout);
+
+		switch (layout) {
+			case 'es-ES (QWERTY)':
+				return new KeyboardLayout(new KeyMapperEsEsQwerty());
+
+			default:
+				return new KeyboardLayout();
+		}
+	}
+}
+
+export interface KeyMapper {
+	name : string;
+	get(key : string) : string;
+}
+
+class KeyMapperEsEsQwerty implements KeyMapper {
+
+	private mappings = {};
+
+	constructor() {
+		this.mappings = {
+			'>': ':',
+			// '\\': '<', // doesn't really work; in my keyboard there are two keys for \ in US
+			';': 'ñ',
+			"'": "´"
+		};
+	}
+
+	get name() : string {
+		return 'es-ES (QWERTY)';
+	}
+
+	get(key : string) : string {
+		return this.mappings[key] || key;
+	}
+}

--- a/src/mode/modeHandler.ts
+++ b/src/mode/modeHandler.ts
@@ -5,12 +5,16 @@ import {Mode, ModeName} from './mode';
 import NormalMode from './modeNormal';
 import InsertMode from './modeInsert';
 import VisualMode from './modeVisual';
+import Configuration from '../configuration';
 
 export default class ModeHandler {
     private modes : Mode[];
     private statusBarItem : vscode.StatusBarItem;
+    configuration : Configuration;
 
     constructor() {
+        this.configuration = Configuration.fromUserFile();
+
         this.modes = [
             new NormalMode(),
             new InsertMode(),
@@ -38,8 +42,12 @@ export default class ModeHandler {
     }
 
     handleKeyEvent(key : string) : void {
-        var currentModeName = this.currentMode.Name;
+        // Due to a limitation in Electron, en-US QWERTY char codes are used in international keyboards.
+        // We'll try to mitigate this problem until it's fixed upstream.
+        // https://github.com/Microsoft/vscode/issues/713
+        key = this.configuration.keyboardLayout.translate(key);
 
+        var currentModeName = this.currentMode.Name;
         var nextMode : Mode;
         var inactiveModes = _.filter(this.modes, (m) => !m.IsActive);
 

--- a/test/keyboard.test.ts
+++ b/test/keyboard.test.ts
@@ -1,0 +1,40 @@
+// The module 'assert' provides assertion methods from node
+import * as assert from 'assert';
+import {KeyboardLayout, KeyMapper} from '../src/keyboard';
+
+suite("KeyboardLayout", () => {
+
+	test("ctor", () => {
+		const layout = new KeyboardLayout();
+		assert.equal(layout.name, "en-US (QWERTY)");
+	});
+
+	test("lets keys through if using default layout", () => {
+		const layout = new KeyboardLayout();
+		assert.equal(layout.translate('>'), '>');
+		assert.equal(layout.translate(':'), ':');
+		assert.equal(layout.translate('.'), '.');
+	});
+
+	test("can use custom mapper", () => {
+		class FakeMapper implements KeyMapper {
+			get name() : string {
+				return "fake mapper";
+			}
+
+			get(key : string) : string {
+				return "fake key";
+			}
+		}
+
+		const layout = new KeyboardLayout(new FakeMapper());
+		assert.equal(layout.name, "fake mapper");
+		assert.equal(layout.translate('>'), 'fake key');
+		assert.equal(layout.translate(':'), 'fake key');
+		assert.equal(layout.translate('.'), 'fake key');
+	});
+});
+
+suite("KeyMapperEsEsQwerty", () => {
+	// TODO: cannot set settings from api?
+});


### PR DESCRIPTION
Uses a `vim.keyboardLayout` setting to determine which keyboart layout to use; defaults to letting the key trhough as is.