### PR TITLE
Fake a Block cursor when in Normal mode

### DIFF
--- a/extension.ts
+++ b/extension.ts
@@ -6,6 +6,7 @@ import {showCmdLine} from './src/cmd_line/main';
 import * as cc from './src/cmd_line/lexer';
 import ModeHandler from "./src/mode/modeHandler";
 import {ModeName} from "./src/mode/mode";
+import Cursor from "./src/cursor/cursor";
 
 var modeHandler : ModeHandler;
 
@@ -13,6 +14,7 @@ var modeHandler : ModeHandler;
 // your extension is activated the very first time the command is executed
 export function activate(context: vscode.ExtensionContext) {
     modeHandler = new ModeHandler();
+    Cursor.blockCursor(modeHandler);
 
     console.log('Congratulations, your extension "vim" is now active!');
 
@@ -85,17 +87,17 @@ export function activate(context: vscode.ExtensionContext) {
     registerCommand(context, 'extension.vim_6', () => handleKeyEvent("6"));
     registerCommand(context, 'extension.vim_7', () => handleKeyEvent("7"));
     registerCommand(context, 'extension.vim_8', () => handleKeyEvent("8"));
-    registerCommand(context, 'extension.vim_9', () => handleKeyEvent("9"));   
+    registerCommand(context, 'extension.vim_9', () => handleKeyEvent("9"));
 
     registerCommand(context, 'extension.vim_$', () => handleKeyEvent("$"));
     registerCommand(context, 'extension.vim_^', () => handleKeyEvent("^"));
 
     registerCommand(context, 'extension.vim_ctrl_r', () => handleKeyEvent("ctrl+r"));
     registerCommand(context, 'extension.vim_ctrl_[', () => handleKeyEvent("ctrl+["));
-    
+
     registerCommand(context, 'extension.vim_<', () => handleKeyEvent("<"));
     registerCommand(context, 'extension.vim_>', () => handleKeyEvent(">"));
-    
+
     registerCommand(context, 'extension.vim_backslash', () => handleKeyEvent("\\"));
 }
 

--- a/src/mode/modeHandler.ts
+++ b/src/mode/modeHandler.ts
@@ -7,8 +7,11 @@ import InsertMode from './modeInsert';
 import VisualMode from './modeVisual';
 import Configuration from '../configuration';
 
+type ModeChangedHandler = (mode: Mode) => void;
+
 export default class ModeHandler {
     private modes : Mode[];
+    private modeChangedHandlers: ModeChangedHandler[] = [];
     private statusBarItem : vscode.StatusBarItem;
     configuration : Configuration;
 
@@ -39,6 +42,10 @@ export default class ModeHandler {
 
         var statusBarText = (this.currentMode.Name === ModeName.Normal) ? '' : ModeName[modeName];
         this.setupStatusBarItem(statusBarText.toUpperCase());
+
+        for (let handler of this.modeChangedHandlers) {
+            handler(this.currentMode);
+        }
     }
 
     handleKeyEvent(key : string) : void {
@@ -66,6 +73,10 @@ export default class ModeHandler {
         }
 
         this.currentMode.HandleKeyEvent(key);
+    }
+
+    onModeChanged(handler: (newMode: Mode) => void) : void {
+        this.modeChangedHandlers.push(handler);
     }
 
     private setupStatusBarItem(text : string) : void {

--- a/test/caret.test.ts
+++ b/test/caret.test.ts
@@ -18,7 +18,7 @@ suite("caret", () => {
 		let range = new vscode.Range(Caret.documentBegin(), Caret.documentEnd());
 		TextEditor.delete(range).then(() => done());
 	});
-	
+
 	test("right on right-most column should stay at the same location", () => {
 		Caret.move(new vscode.Position(0, 7));
 


### PR DESCRIPTION
Solution for #19 until the Code team provide a better way of styling the cursor.

Slightly hacky solution using textEditor.setDecorations, but it does give a clear visual indicator when you're in Normal mode.

At present you can't set decorations past the end of text on a line, so when the cursor is on an empty line it doesn't show the block.