### PR TITLE
Add commands support for 'gg' and 'G'

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Vim emulation for Visual Studio Code.
 
 * Commands:
 	* Command Palette: `:`
-	* Navigation: `h`, `j`, `k`, `l`
+	* Navigation: `h`, `j`, `k`, `l`, `w`, `b`, `gg`, `G`
 	* Indentation: `>>`, `<<`
 	* Deletion: `dd`, `dw`, `db`
 	* Editing: `u`, `ctrl+r`

--- a/src/cursor.ts
+++ b/src/cursor.ts
@@ -124,6 +124,17 @@ export default class Cursor {
 		return new vscode.Position(pos.line, lineLength);
 	}
 
+	static firstLineNonBlankChar() : vscode.Position {
+		let character = Cursor.posOfFirstNonBlankChar(0);
+		return new vscode.Position(0, character);
+	}
+
+	static lastLineNonBlankChar() : vscode.Position {
+		const line = vscode.window.activeTextEditor.document.lineCount - 1;
+		let character = Cursor.posOfFirstNonBlankChar(line);
+		return new vscode.Position(line, character);
+	}
+
 	static documentBegin() : vscode.Position {
 		return new vscode.Position(0, 0);
 	}
@@ -223,5 +234,9 @@ export default class Cursor {
 		}
 
 		return null;
+	}
+
+	private static posOfFirstNonBlankChar(line: number): number {
+		return TextEditor.readLine(line).match(/^\s*/)[0].length;
 	}
 }

--- a/src/mode/modeNormal.ts
+++ b/src/mode/modeNormal.ts
@@ -21,6 +21,8 @@ export default class CommandMode extends Mode {
 			"l" : () => { Cursor.move(Cursor.right()); },
 			"$" : () => { Cursor.move(Cursor.lineEnd()); },
 			"^" : () => { Cursor.move(Cursor.lineBegin()); },
+			"gg" : () => { Cursor.move(Cursor.firstLineNonBlankChar()); },
+			"G" : () => { Cursor.move(Cursor.lastLineNonBlankChar()); },
 			"w" : () => { Cursor.move(Cursor.wordRight()); },
 			"b" : () => { Cursor.move(Cursor.wordLeft()); },
 			">>" : () => { vscode.commands.executeCommand("editor.action.indentLines"); },

--- a/test/cursor.test.ts
+++ b/test/cursor.test.ts
@@ -242,4 +242,29 @@ suite("cursor", () => {
 		assert.equal(pos.line, 1);
 		assert.equal(pos.character, 1);
 	});
+
+	test("get first line begin cursor on first non-blank character", () => {
+		let cursor = Cursor.firstLineNonBlankChar();
+
+		assert.equal(cursor.line, 0);
+		assert.equal(cursor.character, 0);
+
+		TextEditor.insert("  ", new vscode.Position(0, 0)).then(() => {
+			assert.equal(cursor.line, 0);
+			assert.equal(cursor.character, 2);
+		});
+	});
+
+	test("get last line begin cursor on first non-blank character", () => {
+		let cursor = Cursor.lastLineNonBlankChar();
+
+		assert.equal(cursor.line, 2);
+		assert.equal(cursor.character, 0);
+
+		let line = Cursor.documentEnd().line;
+		TextEditor.insert("  ", new vscode.Position(line, 0)).then(() => {
+			assert.equal(cursor.line, 2);
+			assert.equal(cursor.character, 2);
+		});
+	});
 });


### PR DESCRIPTION
Add navigation commands support:
 - 'gg': go to fist line, on first non-blank character
 - 'G': go to last line, on first non-blank character