### PR TITLE
Implemented command mode, $, 0, ^, gg, G, plus inline search fx and Fx

### DIFF
--- a/extension.ts
+++ b/extension.ts
@@ -92,6 +92,9 @@ export function activate(context: vscode.ExtensionContext) {
     
     registerCommand(context, 'extension.vim_<', () => handleKeyEvent("<"));
     registerCommand(context, 'extension.vim_>', () => handleKeyEvent(">"));
+    
+    registerCommand(context, 'extension.vim_$', () => handleKeyEvent("$"));
+    registerCommand(context, 'extension.vim_^', () => handleKeyEvent("^"));
 }
 
 function registerCommand(context: vscode.ExtensionContext, command: string, callback: (...args: any[]) => any) {

--- a/package.json
+++ b/package.json
@@ -9,14 +9,14 @@
     "color": "#a5c9a2",
     "theme": "light"
   },
-  "license": "MIT",
+  "license":"MIT",
   "keywords": [
     "vim",
     "vi",
     "vscodevim",
     "vsc-vim"
   ],
-  "repository": {
+ "repository": {
     "type": "git",
     "url": "https://github.com/VSCodeVim/Vim.git"
   },
@@ -42,366 +42,88 @@
       }
     ],
     "keybindings": [
-      {
-        "key": "Escape",
-        "command": "extension.vim_esc",
-        "when": "editorTextFocus"
-      },
-      {
-        "key": "Shift+;",
-        "command": "extension.vim_colon",
-        "when": "editorTextFocus"
-      },
-      {
-        "key": ":",
-        "command": "extension.vim_colon",
-        "when": "editorTextFocus"
-      },
-      {
-        "key": "space",
-        "command": "extension.vim_space",
-        "when": "editorTextFocus"
-      },
-      {
-        "key": "a",
-        "command": "extension.vim_a",
-        "when": "editorTextFocus"
-      },
-      {
-        "key": "b",
-        "command": "extension.vim_b",
-        "when": "editorTextFocus"
-      },
-      {
-        "key": "c",
-        "command": "extension.vim_c",
-        "when": "editorTextFocus"
-      },
-      {
-        "key": "d",
-        "command": "extension.vim_d",
-        "when": "editorTextFocus"
-      },
-      {
-        "key": "e",
-        "command": "extension.vim_e",
-        "when": "editorTextFocus"
-      },
-      {
-        "key": "f",
-        "command": "extension.vim_f",
-        "when": "editorTextFocus"
-      },
-      {
-        "key": "g",
-        "command": "extension.vim_g",
-        "when": "editorTextFocus"
-      },
-      {
-        "key": "h",
-        "command": "extension.vim_h",
-        "when": "editorTextFocus"
-      },
-      {
-        "key": "i",
-        "command": "extension.vim_i",
-        "when": "editorTextFocus"
-      },
-      {
-        "key": "j",
-        "command": "extension.vim_j",
-        "when": "editorTextFocus"
-      },
-      {
-        "key": "k",
-        "command": "extension.vim_k",
-        "when": "editorTextFocus"
-      },
-      {
-        "key": "l",
-        "command": "extension.vim_l",
-        "when": "editorTextFocus"
-      },
-      {
-        "key": "m",
-        "command": "extension.vim_m",
-        "when": "editorTextFocus"
-      },
-      {
-        "key": "n",
-        "command": "extension.vim_n",
-        "when": "editorTextFocus"
-      },
-      {
-        "key": "o",
-        "command": "extension.vim_o",
-        "when": "editorTextFocus"
-      },
-      {
-        "key": "p",
-        "command": "extension.vim_p",
-        "when": "editorTextFocus"
-      },
-      {
-        "key": "q",
-        "command": "extension.vim_q",
-        "when": "editorTextFocus"
-      },
-      {
-        "key": "r",
-        "command": "extension.vim_r",
-        "when": "editorTextFocus"
-      },
-      {
-        "key": "s",
-        "command": "extension.vim_s",
-        "when": "editorTextFocus"
-      },
-      {
-        "key": "t",
-        "command": "extension.vim_t",
-        "when": "editorTextFocus"
-      },
-      {
-        "key": "u",
-        "command": "extension.vim_u",
-        "when": "editorTextFocus"
-      },
-      {
-        "key": "v",
-        "command": "extension.vim_v",
-        "when": "editorTextFocus"
-      },
-      {
-        "key": "w",
-        "command": "extension.vim_w",
-        "when": "editorTextFocus"
-      },
-      {
-        "key": "x",
-        "command": "extension.vim_x",
-        "when": "editorTextFocus"
-      },
-      {
-        "key": "y",
-        "command": "extension.vim_y",
-        "when": "editorTextFocus"
-      },
-      {
-        "key": "z",
-        "command": "extension.vim_z",
-        "when": "editorTextFocus"
-      },
-      {
-        "key": "Shift+a",
-        "command": "extension.vim_A",
-        "when": "editorTextFocus"
-      },
-      {
-        "key": "Shift+b",
-        "command": "extension.vim_B",
-        "when": "editorTextFocus"
-      },
-      {
-        "key": "Shift+c",
-        "command": "extension.vim_C",
-        "when": "editorTextFocus"
-      },
-      {
-        "key": "Shift+d",
-        "command": "extension.vim_D",
-        "when": "editorTextFocus"
-      },
-      {
-        "key": "Shift+e",
-        "command": "extension.vim_E",
-        "when": "editorTextFocus"
-      },
-      {
-        "key": "Shift+f",
-        "command": "extension.vim_F",
-        "when": "editorTextFocus"
-      },
-      {
-        "key": "Shift+g",
-        "command": "extension.vim_G",
-        "when": "editorTextFocus"
-      },
-      {
-        "key": "Shift+h",
-        "command": "extension.vim_H",
-        "when": "editorTextFocus"
-      },
-      {
-        "key": "Shift+i",
-        "command": "extension.vim_I",
-        "when": "editorTextFocus"
-      },
-      {
-        "key": "Shift+j",
-        "command": "extension.vim_J",
-        "when": "editorTextFocus"
-      },
-      {
-        "key": "Shift+k",
-        "command": "extension.vim_K",
-        "when": "editorTextFocus"
-      },
-      {
-        "key": "Shift+l",
-        "command": "extension.vim_L",
-        "when": "editorTextFocus"
-      },
-      {
-        "key": "Shift+m",
-        "command": "extension.vim_M",
-        "when": "editorTextFocus"
-      },
-      {
-        "key": "Shift+n",
-        "command": "extension.vim_N",
-        "when": "editorTextFocus"
-      },
-      {
-        "key": "Shift+o",
-        "command": "extension.vim_O",
-        "when": "editorTextFocus"
-      },
-      {
-        "key": "Shift+p",
-        "command": "extension.vim_P",
-        "when": "editorTextFocus"
-      },
-      {
-        "key": "Shift+q",
-        "command": "extension.vim_Q",
-        "when": "editorTextFocus"
-      },
-      {
-        "key": "Shift+r",
-        "command": "extension.vim_R",
-        "when": "editorTextFocus"
-      },
-      {
-        "key": "Shift+s",
-        "command": "extension.vim_S",
-        "when": "editorTextFocus"
-      },
-      {
-        "key": "Shift+t",
-        "command": "extension.vim_T",
-        "when": "editorTextFocus"
-      },
-      {
-        "key": "Shift+u",
-        "command": "extension.vim_U",
-        "when": "editorTextFocus"
-      },
-      {
-        "key": "Shift+v",
-        "command": "extension.vim_V",
-        "when": "editorTextFocus"
-      },
-      {
-        "key": "Shift+w",
-        "command": "extension.vim_W",
-        "when": "editorTextFocus"
-      },
-      {
-        "key": "Shift+x",
-        "command": "extension.vim_X",
-        "when": "editorTextFocus"
-      },
-      {
-        "key": "Shift+y",
-        "command": "extension.vim_Y",
-        "when": "editorTextFocus"
-      },
-      {
-        "key": "Shift+z",
-        "command": "extension.vim_Z",
-        "when": "editorTextFocus"
-      },
-      {
-        "key": "0",
-        "command": "extension.vim_0",
-        "when": "editorTextFocus"
-      },
-      {
-        "key": "1",
-        "command": "extension.vim_1",
-        "when": "editorTextFocus"
-      },
-      {
-        "key": "2",
-        "command": "extension.vim_2",
-        "when": "editorTextFocus"
-      },
-      {
-        "key": "3",
-        "command": "extension.vim_3",
-        "when": "editorTextFocus"
-      },
-      {
-        "key": "4",
-        "command": "extension.vim_4",
-        "when": "editorTextFocus"
-      },
-      {
-        "key": "5",
-        "command": "extension.vim_5",
-        "when": "editorTextFocus"
-      },
-      {
-        "key": "6",
-        "command": "extension.vim_6",
-        "when": "editorTextFocus"
-      },
-      {
-        "key": "7",
-        "command": "extension.vim_7",
-        "when": "editorTextFocus"
-      },
-      {
-        "key": "8",
-        "command": "extension.vim_8",
-        "when": "editorTextFocus"
-      },
-      {
-        "key": "9",
-        "command": "extension.vim_9",
-        "when": "editorTextFocus"
-      },
-      {
-        "key": "Ctrl+[",
-        "command": "extension.vim_ctrl_[",
-        "when": "editorTextFocus"
-      },
-      {
-        "key": "Ctrl+r",
-        "command": "extension.vim_ctrl_r",
-        "when": "editorTextFocus"
-      },
-      {
-        "key": "Shift+,",
-        "command": "extension.vim_<",
-        "when": "editorTextFocus"
-      },
-      {
-        "key": "Shift+.",
-        "command": "extension.vim_>",
-        "when": "editorTextFocus"
-      },
-      {
-        "key": "Shift+4",
-        "command": "extension.vim_$",
-        "when": "editorTextFocus"
-      },
-      {
-        "key": "Shift+6",
-        "command": "extension.vim_^",
-        "when": "editorTextFocus"
-      }      
+        { "key": "Escape", "command": "extension.vim_esc", "when": "editorTextFocus" },
+        { "key": "Shift+;", "command": "extension.vim_colon", "when": "editorTextFocus" },
+        { "key": ":", "command": "extension.vim_colon", "when": "editorTextFocus" },
+        { "key": "space", "command": "extension.vim_space", "when": "editorTextFocus" },
+        { "key": "\\", "command": "extension.vim_backslash", "when": "editorTextFocus" },
+
+        { "key": "a", "command": "extension.vim_a", "when": "editorTextFocus" },
+        { "key": "b", "command": "extension.vim_b", "when": "editorTextFocus" },
+        { "key": "c", "command": "extension.vim_c", "when": "editorTextFocus" },
+        { "key": "d", "command": "extension.vim_d", "when": "editorTextFocus" },
+        { "key": "e", "command": "extension.vim_e", "when": "editorTextFocus" },
+        { "key": "f", "command": "extension.vim_f", "when": "editorTextFocus" },
+        { "key": "g", "command": "extension.vim_g", "when": "editorTextFocus" },
+        { "key": "h", "command": "extension.vim_h", "when": "editorTextFocus" },
+        { "key": "i", "command": "extension.vim_i", "when": "editorTextFocus" },
+        { "key": "j", "command": "extension.vim_j", "when": "editorTextFocus" },
+        { "key": "k", "command": "extension.vim_k", "when": "editorTextFocus" },
+        { "key": "l", "command": "extension.vim_l", "when": "editorTextFocus" },
+        { "key": "m", "command": "extension.vim_m", "when": "editorTextFocus" },
+        { "key": "n", "command": "extension.vim_n", "when": "editorTextFocus" },
+        { "key": "o", "command": "extension.vim_o", "when": "editorTextFocus" },
+        { "key": "p", "command": "extension.vim_p", "when": "editorTextFocus" },
+        { "key": "q", "command": "extension.vim_q", "when": "editorTextFocus" },
+        { "key": "r", "command": "extension.vim_r", "when": "editorTextFocus" },
+        { "key": "s", "command": "extension.vim_s", "when": "editorTextFocus" },
+        { "key": "t", "command": "extension.vim_t", "when": "editorTextFocus" },
+        { "key": "u", "command": "extension.vim_u", "when": "editorTextFocus" },
+        { "key": "v", "command": "extension.vim_v", "when": "editorTextFocus" },
+        { "key": "w", "command": "extension.vim_w", "when": "editorTextFocus" },
+        { "key": "x", "command": "extension.vim_x", "when": "editorTextFocus" },
+        { "key": "y", "command": "extension.vim_y", "when": "editorTextFocus" },
+        { "key": "z", "command": "extension.vim_z", "when": "editorTextFocus" },
+
+        { "key": "Shift+a", "command": "extension.vim_A", "when": "editorTextFocus" },
+        { "key": "Shift+b", "command": "extension.vim_B", "when": "editorTextFocus" },
+        { "key": "Shift+c", "command": "extension.vim_C", "when": "editorTextFocus" },
+        { "key": "Shift+d", "command": "extension.vim_D", "when": "editorTextFocus" },
+        { "key": "Shift+e", "command": "extension.vim_E", "when": "editorTextFocus" },
+        { "key": "Shift+f", "command": "extension.vim_F", "when": "editorTextFocus" },
+        { "key": "Shift+g", "command": "extension.vim_G", "when": "editorTextFocus" },
+        { "key": "Shift+h", "command": "extension.vim_H", "when": "editorTextFocus" },
+        { "key": "Shift+i", "command": "extension.vim_I", "when": "editorTextFocus" },
+        { "key": "Shift+j", "command": "extension.vim_J", "when": "editorTextFocus" },
+        { "key": "Shift+k", "command": "extension.vim_K", "when": "editorTextFocus" },
+        { "key": "Shift+l", "command": "extension.vim_L", "when": "editorTextFocus" },
+        { "key": "Shift+m", "command": "extension.vim_M", "when": "editorTextFocus" },
+        { "key": "Shift+n", "command": "extension.vim_N", "when": "editorTextFocus" },
+        { "key": "Shift+o", "command": "extension.vim_O", "when": "editorTextFocus" },
+        { "key": "Shift+p", "command": "extension.vim_P", "when": "editorTextFocus" },
+        { "key": "Shift+q", "command": "extension.vim_Q", "when": "editorTextFocus" },
+        { "key": "Shift+r", "command": "extension.vim_R", "when": "editorTextFocus" },
+        { "key": "Shift+s", "command": "extension.vim_S", "when": "editorTextFocus" },
+        { "key": "Shift+t", "command": "extension.vim_T", "when": "editorTextFocus" },
+        { "key": "Shift+u", "command": "extension.vim_U", "when": "editorTextFocus" },
+        { "key": "Shift+v", "command": "extension.vim_V", "when": "editorTextFocus" },
+        { "key": "Shift+w", "command": "extension.vim_W", "when": "editorTextFocus" },
+        { "key": "Shift+x", "command": "extension.vim_X", "when": "editorTextFocus" },
+        { "key": "Shift+y", "command": "extension.vim_Y", "when": "editorTextFocus" },
+        { "key": "Shift+z", "command": "extension.vim_Z", "when": "editorTextFocus" },
+
+        { "key": "0", "command": "extension.vim_0", "when": "editorTextFocus" },
+        { "key": "1", "command": "extension.vim_1", "when": "editorTextFocus" },
+        { "key": "2", "command": "extension.vim_2", "when": "editorTextFocus" },
+        { "key": "3", "command": "extension.vim_3", "when": "editorTextFocus" },
+        { "key": "4", "command": "extension.vim_4", "when": "editorTextFocus" },
+        { "key": "5", "command": "extension.vim_5", "when": "editorTextFocus" },
+        { "key": "6", "command": "extension.vim_6", "when": "editorTextFocus" },
+        { "key": "7", "command": "extension.vim_7", "when": "editorTextFocus" },
+        { "key": "8", "command": "extension.vim_8", "when": "editorTextFocus" },
+        { "key": "9", "command": "extension.vim_9", "when": "editorTextFocus" },
+
+        { "key": "Shift+4", "command": "extension.vim_$", "when": "editorTextFocus" },
+        { "key": "Shift+6", "command": "extension.vim_^", "when": "editorTextFocus" },
+
+        { "key": "Ctrl+[", "command": "extension.vim_ctrl_[", "when": "editorTextFocus" },
+        { "key": "Ctrl+r", "command": "extension.vim_ctrl_r", "when": "editorTextFocus" },
+        
+        { "key": "Shift+,", "command": "extension.vim_<", "when": "editorTextFocus" },
+        { "key": "Shift+.", "command": "extension.vim_>", "when": "editorTextFocus" }
+     
+        { "key": "Shift+4", "command": "extension.vim_$", "when": "editorTextFocus" },
+        { "key": "Shift+6", "command": "extension.vim_^", "when": "editorTextFocus" }      
     ]
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -121,9 +121,6 @@
         
         { "key": "Shift+,", "command": "extension.vim_<", "when": "editorTextFocus" },
         { "key": "Shift+.", "command": "extension.vim_>", "when": "editorTextFocus" }
-     
-        { "key": "Shift+4", "command": "extension.vim_$", "when": "editorTextFocus" },
-        { "key": "Shift+6", "command": "extension.vim_^", "when": "editorTextFocus" }      
     ]
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -9,14 +9,14 @@
     "color": "#a5c9a2",
     "theme": "light"
   },
-  "license" : "MIT",
+  "license": "MIT",
   "keywords": [
     "vim",
     "vi",
     "vscodevim",
     "vsc-vim"
   ],
- "repository": {
+  "repository": {
     "type": "git",
     "url": "https://github.com/VSCodeVim/Vim.git"
   },
@@ -42,81 +42,366 @@
       }
     ],
     "keybindings": [
-        { "key": "Escape", "command": "extension.vim_esc", "when": "editorTextFocus" },
-        { "key": "Shift+;", "command": "extension.vim_colon", "when": "editorTextFocus" },
-        { "key": ":", "command": "extension.vim_colon", "when": "editorTextFocus" },
-        { "key": "space", "command": "extension.vim_space", "when": "editorTextFocus" },
-
-        { "key": "a", "command": "extension.vim_a", "when": "editorTextFocus" },
-        { "key": "b", "command": "extension.vim_b", "when": "editorTextFocus" },
-        { "key": "c", "command": "extension.vim_c", "when": "editorTextFocus" },
-        { "key": "d", "command": "extension.vim_d", "when": "editorTextFocus" },
-        { "key": "e", "command": "extension.vim_e", "when": "editorTextFocus" },
-        { "key": "f", "command": "extension.vim_f", "when": "editorTextFocus" },
-        { "key": "g", "command": "extension.vim_g", "when": "editorTextFocus" },
-        { "key": "h", "command": "extension.vim_h", "when": "editorTextFocus" },
-        { "key": "i", "command": "extension.vim_i", "when": "editorTextFocus" },
-        { "key": "j", "command": "extension.vim_j", "when": "editorTextFocus" },
-        { "key": "k", "command": "extension.vim_k", "when": "editorTextFocus" },
-        { "key": "l", "command": "extension.vim_l", "when": "editorTextFocus" },
-        { "key": "m", "command": "extension.vim_m", "when": "editorTextFocus" },
-        { "key": "n", "command": "extension.vim_n", "when": "editorTextFocus" },
-        { "key": "o", "command": "extension.vim_o", "when": "editorTextFocus" },
-        { "key": "p", "command": "extension.vim_p", "when": "editorTextFocus" },
-        { "key": "q", "command": "extension.vim_q", "when": "editorTextFocus" },
-        { "key": "r", "command": "extension.vim_r", "when": "editorTextFocus" },
-        { "key": "s", "command": "extension.vim_s", "when": "editorTextFocus" },
-        { "key": "t", "command": "extension.vim_t", "when": "editorTextFocus" },
-        { "key": "u", "command": "extension.vim_u", "when": "editorTextFocus" },
-        { "key": "v", "command": "extension.vim_v", "when": "editorTextFocus" },
-        { "key": "w", "command": "extension.vim_w", "when": "editorTextFocus" },
-        { "key": "x", "command": "extension.vim_x", "when": "editorTextFocus" },
-        { "key": "y", "command": "extension.vim_y", "when": "editorTextFocus" },
-        { "key": "z", "command": "extension.vim_z", "when": "editorTextFocus" },
-
-        { "key": "Shift+a", "command": "extension.vim_A", "when": "editorTextFocus" },
-        { "key": "Shift+b", "command": "extension.vim_B", "when": "editorTextFocus" },
-        { "key": "Shift+c", "command": "extension.vim_C", "when": "editorTextFocus" },
-        { "key": "Shift+d", "command": "extension.vim_D", "when": "editorTextFocus" },
-        { "key": "Shift+e", "command": "extension.vim_E", "when": "editorTextFocus" },
-        { "key": "Shift+f", "command": "extension.vim_F", "when": "editorTextFocus" },
-        { "key": "Shift+g", "command": "extension.vim_G", "when": "editorTextFocus" },
-        { "key": "Shift+h", "command": "extension.vim_H", "when": "editorTextFocus" },
-        { "key": "Shift+i", "command": "extension.vim_I", "when": "editorTextFocus" },
-        { "key": "Shift+j", "command": "extension.vim_J", "when": "editorTextFocus" },
-        { "key": "Shift+k", "command": "extension.vim_K", "when": "editorTextFocus" },
-        { "key": "Shift+l", "command": "extension.vim_L", "when": "editorTextFocus" },
-        { "key": "Shift+m", "command": "extension.vim_M", "when": "editorTextFocus" },
-        { "key": "Shift+n", "command": "extension.vim_N", "when": "editorTextFocus" },
-        { "key": "Shift+o", "command": "extension.vim_O", "when": "editorTextFocus" },
-        { "key": "Shift+p", "command": "extension.vim_P", "when": "editorTextFocus" },
-        { "key": "Shift+q", "command": "extension.vim_Q", "when": "editorTextFocus" },
-        { "key": "Shift+r", "command": "extension.vim_R", "when": "editorTextFocus" },
-        { "key": "Shift+s", "command": "extension.vim_S", "when": "editorTextFocus" },
-        { "key": "Shift+t", "command": "extension.vim_T", "when": "editorTextFocus" },
-        { "key": "Shift+u", "command": "extension.vim_U", "when": "editorTextFocus" },
-        { "key": "Shift+v", "command": "extension.vim_V", "when": "editorTextFocus" },
-        { "key": "Shift+w", "command": "extension.vim_W", "when": "editorTextFocus" },
-        { "key": "Shift+x", "command": "extension.vim_X", "when": "editorTextFocus" },
-        { "key": "Shift+y", "command": "extension.vim_Y", "when": "editorTextFocus" },
-        { "key": "Shift+z", "command": "extension.vim_Z", "when": "editorTextFocus" },
-
-        { "key": "0", "command": "extension.vim_0", "when": "editorTextFocus" },
-        { "key": "1", "command": "extension.vim_1", "when": "editorTextFocus" },
-        { "key": "2", "command": "extension.vim_2", "when": "editorTextFocus" },
-        { "key": "3", "command": "extension.vim_3", "when": "editorTextFocus" },
-        { "key": "4", "command": "extension.vim_4", "when": "editorTextFocus" },
-        { "key": "5", "command": "extension.vim_5", "when": "editorTextFocus" },
-        { "key": "6", "command": "extension.vim_6", "when": "editorTextFocus" },
-        { "key": "7", "command": "extension.vim_7", "when": "editorTextFocus" },
-        { "key": "8", "command": "extension.vim_8", "when": "editorTextFocus" },
-        { "key": "9", "command": "extension.vim_9", "when": "editorTextFocus" },
-
-        { "key": "Ctrl+[", "command": "extension.vim_ctrl_[", "when": "editorTextFocus" },
-        { "key": "Ctrl+r", "command": "extension.vim_ctrl_r", "when": "editorTextFocus" },
-        
-        { "key": "Shift+,", "command": "extension.vim_<", "when": "editorTextFocus" },
-        { "key": "Shift+.", "command": "extension.vim_>", "when": "editorTextFocus" }
+      {
+        "key": "Escape",
+        "command": "extension.vim_esc",
+        "when": "editorTextFocus"
+      },
+      {
+        "key": "Shift+;",
+        "command": "extension.vim_colon",
+        "when": "editorTextFocus"
+      },
+      {
+        "key": ":",
+        "command": "extension.vim_colon",
+        "when": "editorTextFocus"
+      },
+      {
+        "key": "space",
+        "command": "extension.vim_space",
+        "when": "editorTextFocus"
+      },
+      {
+        "key": "a",
+        "command": "extension.vim_a",
+        "when": "editorTextFocus"
+      },
+      {
+        "key": "b",
+        "command": "extension.vim_b",
+        "when": "editorTextFocus"
+      },
+      {
+        "key": "c",
+        "command": "extension.vim_c",
+        "when": "editorTextFocus"
+      },
+      {
+        "key": "d",
+        "command": "extension.vim_d",
+        "when": "editorTextFocus"
+      },
+      {
+        "key": "e",
+        "command": "extension.vim_e",
+        "when": "editorTextFocus"
+      },
+      {
+        "key": "f",
+        "command": "extension.vim_f",
+        "when": "editorTextFocus"
+      },
+      {
+        "key": "g",
+        "command": "extension.vim_g",
+        "when": "editorTextFocus"
+      },
+      {
+        "key": "h",
+        "command": "extension.vim_h",
+        "when": "editorTextFocus"
+      },
+      {
+        "key": "i",
+        "command": "extension.vim_i",
+        "when": "editorTextFocus"
+      },
+      {
+        "key": "j",
+        "command": "extension.vim_j",
+        "when": "editorTextFocus"
+      },
+      {
+        "key": "k",
+        "command": "extension.vim_k",
+        "when": "editorTextFocus"
+      },
+      {
+        "key": "l",
+        "command": "extension.vim_l",
+        "when": "editorTextFocus"
+      },
+      {
+        "key": "m",
+        "command": "extension.vim_m",
+        "when": "editorTextFocus"
+      },
+      {
+        "key": "n",
+        "command": "extension.vim_n",
+        "when": "editorTextFocus"
+      },
+      {
+        "key": "o",
+        "command": "extension.vim_o",
+        "when": "editorTextFocus"
+      },
+      {
+        "key": "p",
+        "command": "extension.vim_p",
+        "when": "editorTextFocus"
+      },
+      {
+        "key": "q",
+        "command": "extension.vim_q",
+        "when": "editorTextFocus"
+      },
+      {
+        "key": "r",
+        "command": "extension.vim_r",
+        "when": "editorTextFocus"
+      },
+      {
+        "key": "s",
+        "command": "extension.vim_s",
+        "when": "editorTextFocus"
+      },
+      {
+        "key": "t",
+        "command": "extension.vim_t",
+        "when": "editorTextFocus"
+      },
+      {
+        "key": "u",
+        "command": "extension.vim_u",
+        "when": "editorTextFocus"
+      },
+      {
+        "key": "v",
+        "command": "extension.vim_v",
+        "when": "editorTextFocus"
+      },
+      {
+        "key": "w",
+        "command": "extension.vim_w",
+        "when": "editorTextFocus"
+      },
+      {
+        "key": "x",
+        "command": "extension.vim_x",
+        "when": "editorTextFocus"
+      },
+      {
+        "key": "y",
+        "command": "extension.vim_y",
+        "when": "editorTextFocus"
+      },
+      {
+        "key": "z",
+        "command": "extension.vim_z",
+        "when": "editorTextFocus"
+      },
+      {
+        "key": "Shift+a",
+        "command": "extension.vim_A",
+        "when": "editorTextFocus"
+      },
+      {
+        "key": "Shift+b",
+        "command": "extension.vim_B",
+        "when": "editorTextFocus"
+      },
+      {
+        "key": "Shift+c",
+        "command": "extension.vim_C",
+        "when": "editorTextFocus"
+      },
+      {
+        "key": "Shift+d",
+        "command": "extension.vim_D",
+        "when": "editorTextFocus"
+      },
+      {
+        "key": "Shift+e",
+        "command": "extension.vim_E",
+        "when": "editorTextFocus"
+      },
+      {
+        "key": "Shift+f",
+        "command": "extension.vim_F",
+        "when": "editorTextFocus"
+      },
+      {
+        "key": "Shift+g",
+        "command": "extension.vim_G",
+        "when": "editorTextFocus"
+      },
+      {
+        "key": "Shift+h",
+        "command": "extension.vim_H",
+        "when": "editorTextFocus"
+      },
+      {
+        "key": "Shift+i",
+        "command": "extension.vim_I",
+        "when": "editorTextFocus"
+      },
+      {
+        "key": "Shift+j",
+        "command": "extension.vim_J",
+        "when": "editorTextFocus"
+      },
+      {
+        "key": "Shift+k",
+        "command": "extension.vim_K",
+        "when": "editorTextFocus"
+      },
+      {
+        "key": "Shift+l",
+        "command": "extension.vim_L",
+        "when": "editorTextFocus"
+      },
+      {
+        "key": "Shift+m",
+        "command": "extension.vim_M",
+        "when": "editorTextFocus"
+      },
+      {
+        "key": "Shift+n",
+        "command": "extension.vim_N",
+        "when": "editorTextFocus"
+      },
+      {
+        "key": "Shift+o",
+        "command": "extension.vim_O",
+        "when": "editorTextFocus"
+      },
+      {
+        "key": "Shift+p",
+        "command": "extension.vim_P",
+        "when": "editorTextFocus"
+      },
+      {
+        "key": "Shift+q",
+        "command": "extension.vim_Q",
+        "when": "editorTextFocus"
+      },
+      {
+        "key": "Shift+r",
+        "command": "extension.vim_R",
+        "when": "editorTextFocus"
+      },
+      {
+        "key": "Shift+s",
+        "command": "extension.vim_S",
+        "when": "editorTextFocus"
+      },
+      {
+        "key": "Shift+t",
+        "command": "extension.vim_T",
+        "when": "editorTextFocus"
+      },
+      {
+        "key": "Shift+u",
+        "command": "extension.vim_U",
+        "when": "editorTextFocus"
+      },
+      {
+        "key": "Shift+v",
+        "command": "extension.vim_V",
+        "when": "editorTextFocus"
+      },
+      {
+        "key": "Shift+w",
+        "command": "extension.vim_W",
+        "when": "editorTextFocus"
+      },
+      {
+        "key": "Shift+x",
+        "command": "extension.vim_X",
+        "when": "editorTextFocus"
+      },
+      {
+        "key": "Shift+y",
+        "command": "extension.vim_Y",
+        "when": "editorTextFocus"
+      },
+      {
+        "key": "Shift+z",
+        "command": "extension.vim_Z",
+        "when": "editorTextFocus"
+      },
+      {
+        "key": "0",
+        "command": "extension.vim_0",
+        "when": "editorTextFocus"
+      },
+      {
+        "key": "1",
+        "command": "extension.vim_1",
+        "when": "editorTextFocus"
+      },
+      {
+        "key": "2",
+        "command": "extension.vim_2",
+        "when": "editorTextFocus"
+      },
+      {
+        "key": "3",
+        "command": "extension.vim_3",
+        "when": "editorTextFocus"
+      },
+      {
+        "key": "4",
+        "command": "extension.vim_4",
+        "when": "editorTextFocus"
+      },
+      {
+        "key": "5",
+        "command": "extension.vim_5",
+        "when": "editorTextFocus"
+      },
+      {
+        "key": "6",
+        "command": "extension.vim_6",
+        "when": "editorTextFocus"
+      },
+      {
+        "key": "7",
+        "command": "extension.vim_7",
+        "when": "editorTextFocus"
+      },
+      {
+        "key": "8",
+        "command": "extension.vim_8",
+        "when": "editorTextFocus"
+      },
+      {
+        "key": "9",
+        "command": "extension.vim_9",
+        "when": "editorTextFocus"
+      },
+      {
+        "key": "Ctrl+[",
+        "command": "extension.vim_ctrl_[",
+        "when": "editorTextFocus"
+      },
+      {
+        "key": "Ctrl+r",
+        "command": "extension.vim_ctrl_r",
+        "when": "editorTextFocus"
+      },
+      {
+        "key": "Shift+,",
+        "command": "extension.vim_<",
+        "when": "editorTextFocus"
+      },
+      {
+        "key": "Shift+.",
+        "command": "extension.vim_>",
+        "when": "editorTextFocus"
+      },
+      {
+        "key": "Shift+4",
+        "command": "extension.vim_$",
+        "when": "editorTextFocus"
+      },
+      {
+        "key": "Shift+6",
+        "command": "extension.vim_^",
+        "when": "editorTextFocus"
+      }      
     ]
   },
   "scripts": {
@@ -130,6 +415,7 @@
     "gulp-tsd": "0.0.4",
     "gulp-tslint": "^3.6.0",
     "gulp-typescript": "^2.9.2",
+    "lodash": "^3.10.1",
     "tsd": "^0.6.5",
     "typescript": "^1.6.2",
     "vscode": "0.10.x"

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "color": "#a5c9a2",
     "theme": "light"
   },
-  "license":"MIT",
+  "license" : "MIT",
   "keywords": [
     "vim",
     "vi",

--- a/package.json
+++ b/package.json
@@ -134,7 +134,6 @@
     "gulp-tsd": "0.0.4",
     "gulp-tslint": "^3.6.0",
     "gulp-typescript": "^2.9.2",
-    "lodash": "^3.10.1",
     "tsd": "^0.6.5",
     "typescript": "^1.6.2",
     "vscode": "0.10.x"

--- a/src/cursor.ts
+++ b/src/cursor.ts
@@ -77,6 +77,39 @@ export default class Cursor {
 		return new vscode.Position(line, column);
 	}
 	
+	static nonBlankLineBegin() : vscode.Position {
+		let pos = this.currentPosition();
+		const linetext = TextEditor.ReadLine(pos.line);
+		if (linetext.length !==0) {
+			var fc = linetext.length - linetext.replace(/^\s+/,"").length;				
+			return new vscode.Position(pos.line, fc);
+		}
+		return new vscode.Position(pos.line, 0);	
+	}
+	
+	static searchLineForward(s : string) : vscode.Position {
+		let pos = this.currentPosition();
+		const linetext = TextEditor.ReadLine(pos.line);
+		let column = pos.character;
+		let searchpos = linetext.indexOf(s, column);		
+		if (searchpos !== -1) {
+			return new vscode.Position(pos.line, searchpos);
+		} 
+		return new vscode.Position(pos.line, 0);
+	}
+	
+	static searchLineBackward(s : string) : vscode.Position {
+		let pos = this.currentPosition();
+		let linetext = TextEditor.ReadLine(pos.line);		
+		let column = pos.character;
+		linetext = linetext.substr(0,column);
+		let searchpos = linetext.lastIndexOf(s, column);		
+		if (searchpos !== -1) {
+			return new vscode.Position(pos.line, searchpos);
+		} 
+		return new vscode.Position(pos.line, 0);		
+	}
+			
 	static lineBegin() : vscode.Position {
 		let pos = this.currentPosition();		
 		return new vscode.Position(pos.line, 0);

--- a/src/mode/modeNormal.ts
+++ b/src/mode/modeNormal.ts
@@ -6,6 +6,7 @@ import Cursor from './../cursor';
 
 export default class CommandMode extends Mode {
 	private keyHandler : { [key : string] : () => void; } = {};
+	private duoKeyHandler : { [key : string] : (string) => void; } = {};
 
 	constructor() {
 		super(ModeName.Normal);
@@ -13,20 +14,30 @@ export default class CommandMode extends Mode {
 		this.keyHandler = {
 			":" : () => { showCmdLine(); },
 			"u" : () => { vscode.commands.executeCommand("undo"); },
-			"ctrl+r" : () => { vscode.commands.executeCommand("redo"); },
+			"ctrl\+r" : () => { vscode.commands.executeCommand("redo"); },
 			"h" : () => { Cursor.move(Cursor.left()); },
 			"j" : () => { Cursor.move(Cursor.down()); },
 			"k" : () => { Cursor.move(Cursor.up()); },
 			"l" : () => { Cursor.move(Cursor.right()); },
+			"$" : () => { Cursor.move(Cursor.lineEnd()); },
+			"0" : () => { Cursor.move(Cursor.lineBegin()); },
+			"^" : () => { Cursor.move(Cursor.nonBlankLineBegin()); },						
 			"w" : () => { vscode.commands.executeCommand("cursorWordRight"); },
-			"b" : () => { vscode.commands.executeCommand("cursorWordLeft"); },
+			"b" : () => { vscode.commands.executeCommand("cursorWordLeft"); },			
 			">>" : () => { vscode.commands.executeCommand("editor.action.indentLines"); },
 			"<<" : () => { vscode.commands.executeCommand("editor.action.outdentLines"); },
 			"dd" : () => { vscode.commands.executeCommand("editor.action.deleteLines"); },
 			"dw" : () => { vscode.commands.executeCommand("deleteWordRight"); },
 			"db" : () => { vscode.commands.executeCommand("deleteWordLeft"); },
+			"gg" : () => { vscode.commands.executeCommand("cursorTop"); },
+			"G" : () => { vscode.commands.executeCommand("cursorBottom"); },			
 			"esc": () => { vscode.commands.executeCommand("workbench.action.closeMessages"); }
-		};
+		};	
+				
+		this.duoKeyHandler = {
+			"f" : (schar) => { Cursor.move(Cursor.searchLineForward(schar)); },
+			"F" : (schar) => { Cursor.move(Cursor.searchLineBackward(schar)); }
+		}				
 	}
 
 	ShouldBeActivated(key : string, currentMode : ModeName) : boolean {
@@ -43,14 +54,20 @@ export default class CommandMode extends Mode {
 	HandleKeyEvent(key : string) : void {
 		this.keyHistory.push(key);
 
-		let keyHandled = false;
+		let keyHandled = false;		
 		
 		for (let window = this.keyHistory.length; window > 0; window--) {
 			let keysPressed = _.takeRight(this.keyHistory, window).join('');
-			if (this.keyHandler[keysPressed] !== undefined) {
+			if (this.duoKeyHandler[keysPressed[0]] !== undefined && keysPressed.length == 2) {
 				keyHandled = true;
-				this.keyHandler[keysPressed]();
+				this.duoKeyHandler[keysPressed[0]](keysPressed[1]);
 				break;
+			} else {							
+				if (this.keyHandler[keysPressed] !== undefined) {
+					keyHandled = true;
+					this.keyHandler[keysPressed]();
+					break;
+				}
 			}
 		}
 		

--- a/src/mode/modeNormal.ts
+++ b/src/mode/modeNormal.ts
@@ -30,7 +30,7 @@ export default class CommandMode extends Mode {
 			"dw" : () => { vscode.commands.executeCommand("deleteWordRight"); },
 			"db" : () => { vscode.commands.executeCommand("deleteWordLeft"); },
 			"gg" : () => { vscode.commands.executeCommand("cursorTop"); },
-			"G" : () => { vscode.commands.executeCommand("cursorBottom"); },			
+			"G" : () => { vscode.commands.executeCommand("cursorBottom"); },
 			"esc": () => { vscode.commands.executeCommand("workbench.action.closeMessages"); }
 		};	
 				

--- a/src/mode/modeNormal.ts
+++ b/src/mode/modeNormal.ts
@@ -23,7 +23,7 @@ export default class CommandMode extends Mode {
 			"0" : () => { Cursor.move(Cursor.lineBegin()); },
 			"^" : () => { Cursor.move(Cursor.nonBlankLineBegin()); },						
 			"w" : () => { vscode.commands.executeCommand("cursorWordRight"); },
-			"b" : () => { vscode.commands.executeCommand("cursorWordLeft"); },			
+			"b" : () => { vscode.commands.executeCommand("cursorWordLeft"); },
 			">>" : () => { vscode.commands.executeCommand("editor.action.indentLines"); },
 			"<<" : () => { vscode.commands.executeCommand("editor.action.outdentLines"); },
 			"dd" : () => { vscode.commands.executeCommand("editor.action.deleteLines"); },
@@ -54,7 +54,7 @@ export default class CommandMode extends Mode {
 	HandleKeyEvent(key : string) : void {
 		this.keyHistory.push(key);
 
-		let keyHandled = false;		
+		let keyHandled = false;
 		
 		for (let window = this.keyHistory.length; window > 0; window--) {
 			let keysPressed = _.takeRight(this.keyHistory, window).join('');

--- a/src/mode/modeNormal.ts
+++ b/src/mode/modeNormal.ts
@@ -14,7 +14,7 @@ export default class CommandMode extends Mode {
 		this.keyHandler = {
 			":" : () => { showCmdLine(); },
 			"u" : () => { vscode.commands.executeCommand("undo"); },
-			"ctrl\+r" : () => { vscode.commands.executeCommand("redo"); },
+			"ctrl+r" : () => { vscode.commands.executeCommand("redo"); },
 			"h" : () => { Cursor.move(Cursor.left()); },
 			"j" : () => { Cursor.move(Cursor.down()); },
 			"k" : () => { Cursor.move(Cursor.up()); },


### PR DESCRIPTION
Looking over the changes I realize I might have to watch the formatting in things like the package.json.  I don't understand how mine was formatted so differently.  But I am also very new to git so I am not really sure how to selectively do stuff.  But it was suggested to me to make this pull request so that the logic for 0 vs ^ could be in there.  To keep this to a single commit, the fx and Fx are in here as well.  I am hoping to chat with the major directors here though on the approach for thing like f and t commands, as you will see in my commit, I created sort of a duo key handler since it is different that two key commands.  But there are a lot of ways to approach this.  I have ideas, but right now this extension is so early, it might need a lot of refactoring, as we puzzle through this.