### PR TITLE
another POC to handling normal mode/keys

### DIFF
--- a/src/cursor.ts
+++ b/src/cursor.ts
@@ -176,7 +176,7 @@ export default class Cursor {
 
 	private static _nonWordCharacters = "/\\()\"':,.;<>~!@#$%^&*|+=[]{}`?-";
 
-	private static getNextWordPosition(): vscode.Position {
+	public static getNextWordPosition(): vscode.Position {
 		let segments = ["(^[\t ]*$)"];
 		segments.push(`([^\\s${_.escapeRegExp(this._nonWordCharacters) }]+)`);
 		segments.push(`[\\s${_.escapeRegExp(this._nonWordCharacters) }]+`);
@@ -205,7 +205,7 @@ export default class Cursor {
 		return null;
 	}
 
-	private static getPreviousWordPosition(): vscode.Position {
+	public static getPreviousWordPosition(): vscode.Position {
 		let segments = ["(^[\t ]*$)"];
 		segments.push(`([^\\s${_.escapeRegExp(this._nonWordCharacters) }]+)`);
 		segments.push(`[\\s${_.escapeRegExp(this._nonWordCharacters) }]+`);

--- a/src/motions/commonMotions.ts
+++ b/src/motions/commonMotions.ts
@@ -1,0 +1,67 @@
+import Cursor from './../cursor';
+import * as vscode from 'vscode';
+
+export abstract class Motion {
+	execute(): void {
+		this.moveCursor();
+	}
+	
+	abstract moveCursor(): void;
+	
+	select(): vscode.Range {
+		var pos = Cursor.currentPosition();
+		this.moveCursor();
+		var end = Cursor.currentPosition();
+		return new vscode.Range(pos, end);
+	};
+}
+
+export class Left extends Motion {
+	moveCursor() {
+		Cursor.move(Cursor.left());
+	}
+}
+
+export class Right extends Motion {
+	moveCursor() {
+		Cursor.move(Cursor.right());
+	}
+} 
+
+export class Down extends Motion {
+	moveCursor() {
+		Cursor.move(Cursor.down());
+	}
+}
+
+export class Up extends Motion {
+	moveCursor() {
+		Cursor.move(Cursor.up());
+	}
+}
+
+export class WordRight extends Motion {
+	moveCursor() {
+		Cursor.move(Cursor.wordRight());
+	}
+}
+
+export class WordLeft extends Motion {
+	moveCursor() {
+		Cursor.move(Cursor.wordLeft());
+	}
+}
+
+export class MoveToRelativeLine extends Motion {
+	moveCursor() {
+		var pos = Cursor.currentPosition();
+		Cursor.move(Cursor.down());
+		Cursor.move(Cursor.lineBegin());
+	}
+	
+	select(): vscode.Range {
+		let start = Cursor.lineBegin();
+		let end = start.translate(1, 0);
+		return new vscode.Range(start, end);
+	}
+}

--- a/src/operations/commonOperations.ts
+++ b/src/operations/commonOperations.ts
@@ -1,0 +1,26 @@
+import {Motion} from './../motions/commonMotions';
+import TextEditor from './../textEditor';
+
+export abstract class Operator {
+	protected motion: Motion;
+	public isComposed: boolean = false;
+	
+	canComposeWith(motion: Motion): boolean {
+		return typeof motion.select === "function";
+	}
+
+	compose(motion: Motion): void {
+		this.motion = motion;
+		this.isComposed = true;
+	};
+	
+	
+	abstract execute(): void;
+}
+
+
+export class Delete extends Operator {
+	execute() {
+		TextEditor.delete(this.motion.select());
+	}
+}


### PR DESCRIPTION
:warning: Proof of Concept

This is kind of the idea I had from the start with some help from atom/vim-mode.

Basically as keys are pressed we push a motion or operator onto a stack, and then when ready the stack is processed.

Operators use the motion behaviour of selecting and performing its operation on that selection. This is quite nice because with an operator like d, any motion after words just works. For this POC, dl, dh, dj, dk, dw, db is implemented without duplicating calculations of selections, and any new operator will be able to work with all motions already in place.

This also allows for composing an operator and motion together for one key, like the x, X commands in the POC.

dd is also implemented here, its not obvious but the d operator with a "special Motion.select" will delete the current line.

By adding a Repeater operation on the stack we could implement the count for each command as well.
