### PR TITLE
Experimental key handling 2

### DIFF
--- a/extension.ts
+++ b/extension.ts
@@ -97,6 +97,7 @@ export function activate(context: vscode.ExtensionContext) {
     registerCommand(context, 'extension.vim_>', () => handleKeyEvent(">"));
     
     registerCommand(context, 'extension.vim_backslash', () => handleKeyEvent("\\"));
+    registerCommand(context, 'extension.vim_slash', () => handleKeyEvent("/"));
 }
 
 function registerCommand(context: vscode.ExtensionContext, command: string, callback: (...args: any[]) => any) {

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
         { "key": ":", "command": "extension.vim_colon", "when": "editorTextFocus" },
         { "key": "space", "command": "extension.vim_space", "when": "editorTextFocus" },
         { "key": "\\", "command": "extension.vim_backslash", "when": "editorTextFocus" },
+        { "key": "/", "command": "extension.vim_slash", "when": "editorTextFocus" },
 
         { "key": "a", "command": "extension.vim_a", "when": "editorTextFocus" },
         { "key": "b", "command": "extension.vim_b", "when": "editorTextFocus" },

--- a/src/keyState.ts
+++ b/src/keyState.ts
@@ -1,0 +1,100 @@
+import * as _ from 'lodash';
+import {Mode, ModeName} from './mode/mode';
+
+export interface TopHandler {
+	currentMode : Mode;
+	modes : Mode[];
+	setCurrentModeByName(modeName : ModeName);
+	handleModeChange(key : string);
+}
+
+export interface ConcreteModeHandler {
+	handleKeys(state : KeyState) : void;
+}
+
+export interface KeyParser {
+	(state : KeyState) : KeyParser;
+}
+
+export class KeyState {
+	private keys : Array<string>;
+	private index : number;
+	private start : number;
+	requestInput : boolean;
+	errors : Array<string>;
+	nextMode : string;
+
+	addKey(key : string) {
+		this.keys.push(key);
+	}
+
+	constructor() {
+		this.requestInput = false;
+		this.index = 0;
+		this.start = 0;
+		this.keys = [];
+		this.errors = [];
+	}
+
+	handle(topHandler : TopHandler) {
+        while (!this.isAtEof) {		
+			topHandler.currentMode.handleKeys(this);
+            if (this.nextMode) {
+				topHandler.handleModeChange(this.nextMode);
+			}
+        }
+		
+		if (this.errors.length > 0) {			
+			console.warn(this.errors[this.errors.length - 1]);
+			this.clear();
+			return;
+		}
+
+        if (this.requestInput || !this.isAtEof) {
+            this.reset();
+        } else {
+			this.clear();
+		}
+	}
+
+	clear() : void  {
+		this.keys = [];
+		this.errors = [];
+		this.reset();
+	}
+
+	backup() : void {
+		if (--this.index < this.start) {
+			this.ignore();
+		}
+	}
+
+	next() : string {
+		if (this.isAtEof) {
+			return "";
+		}
+		return this.keys[this.index++];
+		// let val = _.slice(this.keys, this.start, this.index).join("");
+		// return val;
+	}
+
+	cumulative() : string {
+		let val = _.slice(this.keys, this.start, this.index).join("");
+		return val;
+	}	
+
+	ignore() : void {
+		this.start = this.index;
+	}
+
+	get isAtEof() {
+		return this.index >= this.keys.length;
+	}
+
+	reset() {
+		this.index = 0;
+		this.start = 0;
+		this.nextMode = '';
+		this.requestInput = false;
+	}
+}

--- a/src/mode/mode.ts
+++ b/src/mode/mode.ts
@@ -1,10 +1,12 @@
+import {ConcreteModeHandler, KeyState} from '../keyState';
+
 export enum ModeName {
     Normal,
     Insert,
     Visual,
 }
 
-export abstract class Mode {
+export abstract class Mode implements ConcreteModeHandler {
     private isActive : boolean;
     private name : ModeName;
     protected keyHistory : string[];
@@ -18,6 +20,8 @@ export abstract class Mode {
     get Name(): ModeName {
         return this.name;
     }
+
+    abstract handleKeys(state: KeyState) : void;
 
     get IsActive() : boolean {
         return this.isActive;

--- a/src/mode/modeInsert.ts
+++ b/src/mode/modeInsert.ts
@@ -2,6 +2,7 @@ import * as vscode from 'vscode';
 import {ModeName, Mode} from './mode';
 import TextEditor from './../textEditor';
 import {Cursor} from './../motion/motion';
+import {KeyState} from '../keyState';
 
 export default class InsertMode extends Mode {
     private cursor : Cursor;
@@ -36,6 +37,22 @@ export default class InsertMode extends Mode {
         super(ModeName.Insert);
         this.cursor = new Cursor();
     }
+
+    handleKeys(state : KeyState) {
+        while (!state.isAtEof) {
+            const c = state.next();
+            if (this.shouldRequestModeChange(c)) {
+                state.nextMode = c;
+                return null;
+            }
+            this.HandleKeyEvent(c);
+            // console.warn("insert: " + c);
+        }
+    }
+    
+	private shouldRequestModeChange(key : string) : boolean {
+		return (key === 'esc');
+	}	    
 
     ShouldBeActivated(key : string, currentMode : ModeName) : boolean {
         return key in this.activationKeyHandler;

--- a/src/mode/modeNormal.ts
+++ b/src/mode/modeNormal.ts
@@ -2,82 +2,67 @@ import * as _ from 'lodash';
 import * as vscode from 'vscode';
 import {ModeName, Mode} from './mode';
 import {showCmdLine} from './../cmd_line/main';
-import {Caret} from './../motion/motion';
+import {Caret, Operator, VimOperation, Cursor, RequestInput, Root, StopRequestingInput, ChangeMode} from './../motion/motion';
+import {KeyState, KeyParser} from '../keyState';
+import {WordLeft, WordRight, FindCharacter, Delete, SingleCharArgument, Pick, Motion, VimOp} from '../motion';
 
-export default class NormalMode extends Mode {
-	private caret : Caret;
-	private keyHandler : { [key : string] : (caret : Caret) => Thenable<{}>; } = {
-		":" : () => { return showCmdLine(); },
-		"u" : () => { return vscode.commands.executeCommand("undo"); },
-		"ctrl+r" : () => { return vscode.commands.executeCommand("redo"); },
-		"h" : c => { return Promise.resolve(c.left().move()); },
-		"j" : c => { return Promise.resolve(c.down().move()); },
-		"k" : c => { return Promise.resolve(c.up().move()); },
-		"l" : c => { return Promise.resolve(c.right().move()); },
-		"$" : c => { return Promise.resolve(c.lineEnd().move()); },
-		"^" : c => { return Promise.resolve(c.lineBegin().move()); },
-		"gg" : c => {return Promise.resolve(c.firstLineNonBlankChar().move()); },
-		"G" : c => { return Promise.resolve(c.lastLineNonBlankChar().move()); },
-		"w" : c => { return Promise.resolve(c.wordRight().move()); },
-		"b" : c => { return Promise.resolve(c.wordLeft().move()); },
-		">>" : () => { return vscode.commands.executeCommand("editor.action.indentLines"); },
-		"<<" : () => { return vscode.commands.executeCommand("editor.action.outdentLines"); },
-		"dd" : () => { return vscode.commands.executeCommand("editor.action.deleteLines"); },
-		"dw" : () => { return vscode.commands.executeCommand("deleteWordRight"); },
-		"db" : () => { return vscode.commands.executeCommand("deleteWordLeft"); },
-		// "x" : () => { this.CommandDelete(1); }
-		"esc": () => { return vscode.commands.executeCommand("workbench.action.closeMessages"); }
-	};
+export default class CommandMode extends Mode {
+    private caret : Caret = new Caret();
+	private cursor : Cursor = new Cursor();
+	private operator : Operator = new Operator();
+	private normal : { [key: string] : VimOp } = {};
+	private operatorPending : { [key: string] : Motion } = {};
+	private ops : VimOp;
 
 	constructor() {
 		super(ModeName.Normal);
-		this.caret = new Caret();
+		
+		this.operatorPending = {
+			'w': new WordLeft(),
+			'b': new WordRight(),
+			'f': new FindCharacter().and(new SingleCharArgument())			
+		}		
+				
+		this.normal = {
+			'w': new WordLeft(),
+			'b': new WordRight(),
+			'f': new FindCharacter().and(new SingleCharArgument()),
+			'd': new Delete().and(new Pick(this.operatorPending)),
+		}		
+	}	
+
+	// receives keys
+	handleKeys(state :KeyState) : void {
+		const operation = this.normal[state.next()];
+		if (this.ops) {
+			this.ops.and(operation);
+		} else {
+			this.ops = operation;
+		}
+		this.eval(state);
+	}
+	
+	// run a command if available
+	private eval(state : KeyState) {
+		if (this.ops) {
+			this.ops.execute(state);
+		}
+		this.ops = null;
 	}
 
 	ShouldBeActivated(key : string, currentMode : ModeName) : boolean {
 		return (key === 'esc' || key === 'ctrl+[');
 	}
+	
+	private shouldRequestModeChange(key : string) : boolean {
+		return (key === 'i' || key === 'I' || key === 'a' || key === 'A' || key === 'o' || key === 'O');
+	}	
 
 	HandleActivation(key : string) : Thenable<{}> {
 		return Promise.resolve(this.caret.reset().left().move());
 	}
 
-	HandleKeyEvent(key : string) : Thenable<{}>  {
-		this.keyHistory.push(key);
-
-		return new Promise(resolve => {
-			let keyHandled = false;
-			let keysPressed : string;
-
-			for (let window = this.keyHistory.length; window > 0; window--) {
-				keysPressed = _.takeRight(this.keyHistory, window).join('');
-				if (this.keyHandler[keysPressed] !== undefined) {
-					keyHandled = true;
-					break;
-				}
-			}
-
-			if (keyHandled) {
-				this.keyHistory = [];
-				return this.keyHandler[keysPressed](this.caret);
-			}
-
-			resolve();
-		});
+	HandleKeyEvent(key : string) : Thenable<{}> {
+		return null;
 	}
-
-/*
-    private CommandDelete(n: number) : void {
-        let pos = Caret.currentPosition();
-        let end = pos.translate(0, n);
-        let range : vscode.Range = new vscode.Range(pos, end);
-        TextEditor.delete(range).then(function() {
-			let lineEnd = Caret.lineEnd();
-
-			if (pos.character === lineEnd.character + 1) {
-				Caret.move(Caret.left());
-			}
-		});
-    }
-*/
 }

--- a/src/mode/modeVisual.ts
+++ b/src/mode/modeVisual.ts
@@ -1,4 +1,5 @@
 import {ModeName, Mode} from './mode';
+import {KeyState} from '../keyState';
 
 export default class VisualMode extends Mode {
     constructor() {
@@ -12,6 +13,9 @@ export default class VisualMode extends Mode {
 
     HandleActivation(key : string) : Thenable<{}> {
         return Promise.resolve({});
+    }
+
+    handleKeys(state : KeyState) : void {
     }
 
     HandleKeyEvent(key : string) : Thenable<{}> {

--- a/src/motion.ts
+++ b/src/motion.ts
@@ -1,0 +1,164 @@
+import {KeyState} from './keyState';
+
+export interface VimOp {
+	execute(state : KeyState) : void;
+	and(op : any) : VimOp;
+}
+
+interface ArgumentProvider<T> extends VimOp {
+	value : T;
+}
+
+abstract class Operation implements VimOp {
+	protected argumentProvider : ArgumentProvider<string>;
+	protected motion : Motion;
+	protected operation : (m : string, arg: string) => void;
+		
+	constructor(operation : (m, arg) => void) {
+		this.operation = operation;
+	}
+	
+	execute(state : KeyState) : void {
+		if (this.argumentProvider) {
+			this.argumentProvider.execute(state);
+			if (state.requestInput) {
+				return;
+			}
+			const m = this.motion.select(state);
+			if (state.requestInput) {
+				return;
+			}
+			this.operation(m, this.argumentProvider.value);
+		} else {
+			const m = this.motion.select(state);
+			if (state.requestInput) {
+				return;
+			}			
+			this.operation(m, null);
+		}
+	}
+	
+	and(motion : Motion) : Operation  {
+		this.motion = motion;
+		return this;
+	}	
+}
+
+export abstract class Motion implements VimOp {
+	protected argumentProvider : ArgumentProvider<string>;
+	protected operation : (x : string) => string;
+	
+	constructor(operation : (arg) => string) {
+		this.operation = operation;
+	}
+	
+	execute(state : KeyState) : void {
+		if (this.argumentProvider) {
+			this.argumentProvider.execute(state);
+			if (state.requestInput) {
+				return;
+			}
+			console.warn(this.operation(this.argumentProvider.value));
+		} else {
+			console.warn(this.operation(null));
+		}
+	}
+	
+	select(state : KeyState) : string {
+		if (this.argumentProvider) {
+			this.argumentProvider.execute(state);
+			if (state.requestInput) {
+				return;
+			}
+			return this.operation(this.argumentProvider.value);
+		} else {
+			return this.operation(null);
+		}
+	}
+	
+	and(provider : ArgumentProvider<string>) : Motion  {
+		this.argumentProvider = provider;
+		return this;
+	}
+}
+
+export class WordLeft extends Motion {
+	constructor() {
+		super((_) => "word left");
+	}
+}
+
+export class WordRight extends Motion {
+	constructor() {
+		super((_) => "word right");
+	}
+}
+
+export class FindCharacter extends Motion {
+	constructor() {
+		super((arg) => "find char " + arg);
+	}
+}
+
+export class Delete extends Operation {
+	constructor() {
+		super((m, arg) => console.warn("delete(" + m + ")"));
+	}
+}
+
+export class SingleCharArgument implements ArgumentProvider<string> {
+	value : string;
+	
+	execute(state : KeyState) : void {
+		if (state.isAtEof) {
+			state.requestInput = true;
+			return;
+		}
+		this.value = state.next();
+	}
+	
+	and(other : VimOp) : VimOp {
+		throw new Error("invalid operation");
+		return this;
+	}
+}
+
+
+export class Pick extends Motion {
+	private options : { [key : string] : Motion }
+	
+	constructor(options : { [key : string]: Motion }) {
+		super(() => "");
+		this.options = options;
+	}
+	
+	execute(state : KeyState) : void {
+		if (state.isAtEof) {
+			state.requestInput = true;
+			return;
+		}
+		const c = state.next();
+		const m = this.options[c];
+		if (!m) {
+			throw new Error("invalid motion");
+		}
+		m.execute(state);
+	}
+
+	select(state : KeyState) : string {
+		if (state.isAtEof) {
+			state.requestInput = true;
+			return;
+		}
+		const c = state.next();
+		const m = this.options[c];
+		if (!m) {
+			throw new Error("invalid motion");
+		}
+		return m.select(state);
+	}	
+	
+	and(op : ArgumentProvider<string>) : Motion {
+		throw new Error("invalid operation");
+	}
+}


### PR DESCRIPTION
Revised experimental branch for handling keys. This POC prints command names to the debug panel; it does not run any commands. It only works in normal and insert modes. You can switch between the two using `i` or `esc` only.

The code is able to process all types of commands, like `w`, `dw`, `daw`, `dd`, `D`, `dfa`, `d/foo`.

![screenshot 2015-12-05 00 55 20](https://cloud.githubusercontent.com/assets/684948/11604351/c50f80b0-9aeb-11e5-8956-b0c89baccaac.png)
