### PR TITLE
Add Swedish keyboard layout

### DIFF
--- a/extension.ts
+++ b/extension.ts
@@ -97,6 +97,9 @@ export function activate(context: vscode.ExtensionContext) {
     
     registerCommand(context, 'extension.vim_backslash', () => handleKeyEvent("\\"));
     
+    registerCommand(context, 'extension.vim_oem_102', () => handleKeyEvent("oem_102"));
+    registerCommand(context, 'extension.vim_shift_oem_102', () => handleKeyEvent("shift+oem_102"));
+    
     context.subscriptions.push(modeHandler); 
 }
 

--- a/package.json
+++ b/package.json
@@ -117,7 +117,9 @@
         { "key": "Ctrl+r", "command": "extension.vim_ctrl_r", "when": "editorTextFocus" },
         
         { "key": "Shift+,", "command": "extension.vim_<", "when": "editorTextFocus" },
-        { "key": "Shift+.", "command": "extension.vim_>", "when": "editorTextFocus" }
+        { "key": "Shift+.", "command": "extension.vim_>", "when": "editorTextFocus" },
+        { "key": "oem_102", "command": "extension.vim_oem_102", "when": "editorTextFocus" },
+        { "key": "Shift+oem_102", "command": "extension.vim_shift_oem_102", "when": "editorTextFocus" }
     ],
     "configuration": {
       "title": "Vim Configuration",

--- a/src/keyboard.ts
+++ b/src/keyboard.ts
@@ -27,6 +27,8 @@ export class KeyboardLayout {
                 return new KeyboardLayout(new KeyMapperDeDeQwertz());
             case 'da-DK (QWERTY)':
                 return new KeyboardLayout(new KeyMapperDaDKQwerty());
+            case 'sv-SE (QWERTY)':
+                return new KeyboardLayout(new KeyMapperSvSEQwerty());
             default:
                 return new KeyboardLayout();
         }
@@ -99,6 +101,30 @@ class KeyMapperDaDKQwerty implements KeyMapper {
 
     get name() : string {
         return 'da-DK (QWERTY)';
+    }
+
+    get(key : string) : string {
+        return this.mappings[key] || key;
+    }
+}
+
+class KeyMapperSvSEQwerty implements KeyMapper {
+
+    private mappings = {};
+
+    constructor() {
+        this.mappings = {
+            'oem_102': '<', // Only works when building from source atm, should work next vscode update
+            'shift+oem_102': '>', // Only works when building from source atm, should work next vscode update
+            '>': ':',
+            '<': ';',
+            ':': '^',
+            '^': '&'
+        };
+    }
+
+    get name() : string {
+        return 'sv-SE (QWERTY)';
     }
 
     get(key : string) : string {


### PR DESCRIPTION
Solution for #128 

This also adds support for binding and translating the ```oem_102``` key.
Note: This only works when building the vscode from source, but it should be available in their next release.