### PR TITLE
Fix infinite loop when workspace is empty

### DIFF
--- a/src/motion/position.ts
+++ b/src/motion/position.ts
@@ -254,12 +254,14 @@ export class Position extends vscode.Position {
         let positions = [];
 
         regex.lastIndex = 0;
-        while (true) {
-            let result = regex.exec(currentLine.text);
-            if (result === null) {
-                break;
+        if (currentLine.text) {
+            while (true) {
+                let result = regex.exec(currentLine.text);
+                if (result === null) {
+                    break;
+                }
+                positions.push(result.index);
             }
-            positions.push(result.index);
         }
 
         for (var index = 0; index < positions.length; index++) {

--- a/src/motion/position.ts
+++ b/src/motion/position.ts
@@ -290,12 +290,14 @@ export class Position extends vscode.Position {
         let positions = [];
 
         regex.lastIndex = 0;
-        while (true) {
-            let result = regex.exec(currentLine.text);
-            if (result === null) {
-                break;
+        if (currentLine.text) {
+            while (true) {
+                let result = regex.exec(currentLine.text);
+                if (result === null) {
+                    break;
+                }
+                positions.push(result.index);
             }
-            positions.push(result.index);
         }
 
         for (var index = 0; index < positions.length; index++) {


### PR DESCRIPTION
Repro steps:

1. Open an empty document
2. Use `b`
3. Notice the plugin won't respond to events anymore
