### PR TITLE
d{motion} support

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,17 +96,17 @@ Status              | Key                       | Description
 :white_check_mark:  | O                         | open a new line above the current line, append text (N times)
 
 ### Deleting Text
-Status              | Key                       | Description
-------------------- | ------------------------- | -------------------------
-:white_check_mark:  | x                         | delete characters under and after the cursor
-                    | <Del>                     | delete N characters under and after the cursor
-:white_check_mark:  | X                         | delete N characters before the cursor
-dw, db              | d{motion}                 | delete the text that is moved over with {motion}
-                    | {visual}d                 | delete the highlighted text
-:white_check_mark:  | dd                        | delete N lines
-                    | D                         | delete to end-of-line (and N-1 more lines)
-                    | J                         | join N-1 lines (delete newlines)
-                    | {visual}J                 | join the highlighted lines
+Status                 | Key                       | Description
+---------------------- | ------------------------- | -------------------------
+:white_check_mark:     | x                         | delete characters under and after the cursor
+                       | <Del>                     | delete N characters under and after the cursor
+:white_check_mark:     | X                         | delete N characters before the cursor
+dw, dW, db, dB, de, dE | d{motion}                 | delete the text that is moved over with {motion}
+                       | {visual}d                 | delete the highlighted text
+:white_check_mark:     | dd                        | delete N lines
+                       | D                         | delete to end-of-line (and N-1 more lines)
+                       | J                         | join N-1 lines (delete newlines)
+                       | {visual}J                 | join the highlighted lines
                     
 ### Changing Text
 Status              | Key                       | Description

--- a/src/mode/modeNormal.ts
+++ b/src/mode/modeNormal.ts
@@ -5,7 +5,7 @@ import * as vscode from 'vscode';
 
 import {ModeName, Mode} from './mode';
 import {showCmdLine} from './../cmd_line/main';
-import {Motion} from './../motion/motion';
+import {Motion, MotionMode} from './../motion/motion';
 import {ModeHandler} from './modeHandler';
 import {DeleteOperator} from './../operator/delete';
 
@@ -37,8 +37,46 @@ export class NormalMode extends Mode {
         ">>" : async () => { return vscode.commands.executeCommand("editor.action.indentLines"); },
         "<<" : async () => { return vscode.commands.executeCommand("editor.action.outdentLines"); },
         "dd" : async () => { return vscode.commands.executeCommand("editor.action.deleteLines"); },
-        "dw" : async () => { return vscode.commands.executeCommand("deleteWordRight"); },
-        "db" : async () => { return vscode.commands.executeCommand("deleteWordLeft"); },
+        "dw" : async (m) => {
+            m.changeMode(MotionMode.Cursor);
+            await new DeleteOperator(this._modeHandler).run(m.position, m.position.getWordRight());
+            this.motion.left().move();
+            return {};
+        },
+        "dW" : async (m) => {
+            m.changeMode(MotionMode.Cursor);
+            await new DeleteOperator(this._modeHandler).run(m.position, m.position.getBigWordRight());
+            this.motion.left().move();
+            return {};
+        },
+        "db" : async (m) => {
+            m.changeMode(MotionMode.Cursor);
+            await new DeleteOperator(this._modeHandler).run(m.position, m.position.getWordLeft());
+            return {};
+        },
+        "dB" : async (m) => {
+            m.changeMode(MotionMode.Cursor);
+            await new DeleteOperator(this._modeHandler).run(m.position, m.position.getBigWordLeft());
+            return {};
+        },
+        "de" : async (m) => {
+            m.changeMode(MotionMode.Cursor);
+            await new DeleteOperator(this._modeHandler).run(m.position, m.position.getCurrentWordEnd());
+            this.motion.left().move();
+            return {};
+        },
+        "dE" : async (m) => {
+            m.changeMode(MotionMode.Cursor);
+            await new DeleteOperator(this._modeHandler).run(m.position, m.position.getCurrentBigWordEnd());
+            this.motion.left().move();
+            return {};
+        },
+        "D" : async (m) => {
+            m.changeMode(MotionMode.Cursor);
+            await new DeleteOperator(this._modeHandler).run(m.position, m.position.getLineEnd());
+            this.motion.left().move();
+            return {};
+        },
         "x" : async (m) => { await new DeleteOperator(this._modeHandler).run(m.position, m.position.getRight()); return {}; },
         "X" : async (m) => { return vscode.commands.executeCommand("deleteLeft"); },
         "esc": async () => { return vscode.commands.executeCommand("workbench.action.closeMessages"); }

--- a/src/motion/position.ts
+++ b/src/motion/position.ts
@@ -292,6 +292,9 @@ export class Position extends vscode.Position {
             let newCharacter = _.find(positions, index => index > this.character || currentLine !== this.line);
 
             if (newCharacter !== undefined) {
+                if (this.positionOptions === PositionOptions.CharacterWiseInclusive) {
+                    newCharacter++;
+                }
                 return new Position(currentLine, newCharacter, this.positionOptions);
             }
         }

--- a/test/mode/modeNormal.test.ts
+++ b/test/mode/modeNormal.test.ts
@@ -44,4 +44,46 @@ suite("Mode Normal", () => {
         await modeNormal.handleKeyEvent("x");
         assertEqualLines(["te"]);
     });
+
+    test("Can handle 'dw'", async () => {
+        await TextEditor.insert("text text");
+
+        motion = motion.moveTo(0, 5);
+        await modeNormal.handleKeyEvent("dw");
+        await assertEqualLines(["text "]);
+        await modeNormal.handleKeyEvent("dw");
+        await assertEqualLines(["text"]);
+        await modeNormal.handleKeyEvent("dw");
+        await assertEqualLines(["tex"]);
+    });
+
+    test("Can handle 'de'", async () => {
+        await TextEditor.insert("text text");
+
+        motion = motion.moveTo(0, 0);
+        await modeNormal.handleKeyEvent("de");
+        await assertEqualLines([" text"]);
+        await modeNormal.handleKeyEvent("de");
+        await assertEqualLines([""]);
+    });
+
+    test("Can handle 'db'", async () => {
+        await TextEditor.insert("text text");
+
+        motion = motion.moveTo(0, 8);
+        await modeNormal.handleKeyEvent("db");
+        await assertEqualLines(["text t"]);
+        await modeNormal.handleKeyEvent("db");
+        await assertEqualLines(["t"]);
+    });
+    
+    test("Can handle 'D'", async () => {
+        await TextEditor.insert("text");
+
+        motion = motion.moveTo(0, 2);
+        await modeNormal.handleKeyEvent("D");
+        await assertEqualLines(["te"]);
+        await modeNormal.handleKeyEvent("D");
+        await assertEqualLines(["t"]);
+    });
 });


### PR DESCRIPTION
Implemented `dw`, `dW`, `db`, `dB`, `de`, `dE` and some tests. 

Not the best way of handling `d` motions (we need a specific case for each key combo), but it _fits_ with the current key handling API. 