### PR TITLE
Wait for test files to get written

### DIFF
--- a/test/testUtils.ts
+++ b/test/testUtils.ts
@@ -13,14 +13,13 @@ function rndName() {
 
 async function createRandomFile(contents: string): Promise<vscode.Uri> {
     const tmpFile = join(os.tmpdir(), rndName());
-
+    
     try {
-        await fs.writeFile(tmpFile, contents);
+        fs.writeFileSync(tmpFile, contents);
+        return vscode.Uri.file(tmpFile);
     } catch (error) {
         throw error;
     }
-
-    return vscode.Uri.file(tmpFile);
 }
 
 export function assertEqualLines(expectedLines: string[]) {


### PR DESCRIPTION
Waiting asynchronously for the workspace test files to get written helps to get rid of those unexpected `cannot open file` failures on test runs. 