### PR TITLE
c commands and ge motions

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,8 +82,8 @@ Status              | Key                       | Description
 :white_check_mark:  | E                         | forward to the end of the Nth blank-separated WORD
 :white_check_mark:  | b                         | words backward
 :white_check_mark:  | B                         | N blank-separated WORDS backward
-                    | ge                        | backward to the end of the Nth word
-                    | gE                        | backward to the end of the Nth blank-separated WORD
+:white_check_mark:  | ge                        | backward to the end of the Nth word
+:white_check_mark:  | gE                        | backward to the end of the Nth blank-separated WORD
 
 ### Insert Mode Commands
 Status              | Key                       | Description
@@ -107,7 +107,16 @@ dw, dW, db, dB, de, dE | d{motion}                 | delete the text that is mov
                        | D                         | delete to end-of-line (and N-1 more lines)
                        | J                         | join N-1 lines (delete newlines)
                        | {visual}J                 | join the highlighted lines
-                    
+
+### Deleting and Inserting
+Status                 | Key                       | Description
+---------------------- | ------------------------- | -------------------------
+:white_check_mark:     | C                         | Delete from the cursor position to the end of the line and enter insert mode
+:white_check_mark:     | cw                        | Delete from the cursor position to the end of the word and enter insert mode
+:white_check_mark:     | cW                        | Delete from the cursor position to the end of the WORD and enter insert mode
+:white_check_mark:     | ciw                       | Delete word and enter insert mode
+:white_check_mark:     | caw                       | Delete word, right-side blanks and enter insert mode
+
 ### Changing Text
 Status              | Key                       | Description
 ------------------- | ------------------------- | -------------------------

--- a/src/mode/mode.ts
+++ b/src/mode/mode.ts
@@ -13,13 +13,13 @@ export abstract class Mode {
     private _isActive : boolean;
     private _name : ModeName;
     private _motion : Motion;
-    protected keyHistory : string[];
+    protected _keyHistory : string[];
 
     constructor(name: ModeName, motion: Motion) {
         this._name = name;
         this._motion = motion;
         this._isActive = false;
-        this.keyHistory = [];
+        this._keyHistory = [];
     }
 
     get name(): ModeName {
@@ -42,8 +42,12 @@ export abstract class Mode {
         this._isActive = val;
     }
 
+    get keyHistory() : string[] {
+        return this._keyHistory;
+    }
+
     public handleDeactivation() : void {
-        this.keyHistory = [];
+        this._keyHistory = [];
     }
 
     protected keyToNewPosition: { [key: string]: (motion: Position) => Promise<Position>; } = {
@@ -72,5 +76,5 @@ export abstract class Mode {
 
     abstract handleActivation(key : string) : Promise<void>;
 
-    abstract handleKeyEvent(key : string) : Promise<void>;
+    abstract handleKeyEvent(key : string) : Promise<boolean>;
 }

--- a/src/mode/modeHandler.ts
+++ b/src/mode/modeHandler.ts
@@ -59,11 +59,12 @@ export class ModeHandler implements vscode.Disposable {
         key = this._configuration.keyboardLayout.translate(key);
 
         let currentModeName = this.currentMode.name;
+        let keysPressed = this.currentMode.keyHistory.join('') + key;
         let nextMode : Mode;
         let inactiveModes = _.filter(this._modes, (m) => !m.isActive);
 
         for (let mode of inactiveModes) {
-          if (mode.shouldBeActivated(key, currentModeName)) {
+          if (mode.shouldBeActivated(keysPressed, currentModeName)) {
             if (nextMode) {
               console.error("More that one mode matched in handleKeyEvent!");
             }

--- a/src/mode/modeInsert.ts
+++ b/src/mode/modeInsert.ts
@@ -46,11 +46,11 @@ export class InsertMode extends Mode {
         await this.activationKeyHandler[key](this.motion);
     }
 
-    async handleKeyEvent(key : string) : Promise<void> {
-        this.keyHistory.push(key);
-
+    async handleKeyEvent(key : string) : Promise<boolean> {
         await TextEditor.insert(this.resolveKeyValue(key));
         await vscode.commands.executeCommand("editor.action.triggerSuggest");
+
+        return true;
     }
 
     // Some keys have names that are different to their value.

--- a/src/mode/modeVisual.ts
+++ b/src/mode/modeVisual.ts
@@ -67,8 +67,8 @@ export class VisualMode extends Mode {
         let keyHandled = false;
         let keysPressed: string;
 
-        for (let window = this.keyHistory.length; window > 0; window--) {
-            keysPressed = _.takeRight(this.keyHistory, window).join('');
+        for (let window = this._keyHistory.length; window > 0; window--) {
+            keysPressed = _.takeRight(this._keyHistory, window).join('');
             if (this.keyToNewPosition[keysPressed] !== undefined) {
                 keyHandled = true;
                 break;
@@ -99,7 +99,7 @@ export class VisualMode extends Mode {
                 this.motion.select(this._selectionStart.getRight(), this._selectionStop);
             }
 
-            this.keyHistory = [];
+            this._keyHistory = [];
         }
 
         return keyHandled;
@@ -109,8 +109,8 @@ export class VisualMode extends Mode {
         let keysPressed: string;
         let operator: Operator;
 
-        for (let window = this.keyHistory.length; window > 0; window--) {
-            keysPressed = _.takeRight(this.keyHistory, window).join('');
+        for (let window = this._keyHistory.length; window > 0; window--) {
+            keysPressed = _.takeRight(this._keyHistory, window).join('');
             if (this._keysToOperators[keysPressed] !== undefined) {
                 operator = this._keysToOperators[keysPressed];
                 break;
@@ -128,13 +128,13 @@ export class VisualMode extends Mode {
         return !!operator;
     }
 
-    async handleKeyEvent(key: string): Promise<void> {
-        this.keyHistory.push(key);
+    async handleKeyEvent(key: string): Promise<boolean> {
+        this._keyHistory.push(key);
 
         const wasMotion = await this._handleMotion();
 
         if (!wasMotion) {
-            await this._handleOperator();
+            return await this._handleOperator();
         }
     }
 }

--- a/src/motion/motion.ts
+++ b/src/motion/motion.ts
@@ -230,6 +230,18 @@ export class Motion implements vscode.Disposable {
         return this;
     }
 
+    public goToEndOfLastWord(): Motion {
+        this._position = this.position.getLastWordEnd();
+        this._desiredColumn = this._position.character;
+        return this;
+    }
+
+    public goToEndOfLastBigWord(): Motion {
+        this._position = this.position.getLastBigWordEnd();
+        this._desiredColumn = this._position.character;
+        return this;
+    }
+
     public goToEndOfCurrentWord(): Motion {
         this._position = this.position.getCurrentWordEnd();
         this._desiredColumn = this._position.character;

--- a/src/motion/position.ts
+++ b/src/motion/position.ts
@@ -92,6 +92,14 @@ export class Position extends vscode.Position {
         return this.getWordRightWithRegex(this._nonBigWordCharRegex);
     }
 
+    public getLastWordEnd(): Position {
+        return this.getLastWordEndWithRegex(this._nonWordCharRegex);
+    }
+
+    public getLastBigWordEnd(): Position {
+        return this.getLastWordEndWithRegex(this._nonBigWordCharRegex);
+    }
+
     public getCurrentWordEnd(): Position {
         return this.getCurrentWordEndWithRegex(this._nonWordCharRegex);
     }
@@ -279,6 +287,28 @@ export class Position extends vscode.Position {
             let newCharacter = _.find(positions, index => index > this.character || currentLine !== this.line);
 
             if (newCharacter !== undefined) {
+                return new Position(currentLine, newCharacter, this.positionOptions);
+            }
+        }
+
+        return new Position(TextEditor.getLineCount() - 1, 0, this.positionOptions).getLineEnd();
+    }
+
+    private getLastWordEndWithRegex(regex: RegExp) : Position {
+        for (let currentLine = this.line; currentLine < TextEditor.getLineCount(); currentLine++) {
+            let positions    = this.getAllEndPositions(TextEditor.getLineAt(new vscode.Position(currentLine, 0)).text, regex);
+            let index = _.findIndex(positions, index => index >= this.character || currentLine !== this.line);
+            let newCharacter = 0;
+            if (index === -1) {
+                newCharacter = positions[positions.length - 1];
+            } else if (index > 0) {
+                newCharacter = positions[index - 1];
+            }
+
+            if (newCharacter !== undefined) {
+                if (this.positionOptions === PositionOptions.CharacterWiseInclusive) {
+                    newCharacter++;
+                }
                 return new Position(currentLine, newCharacter, this.positionOptions);
             }
         }

--- a/test/mode/modeNormal.test.ts
+++ b/test/mode/modeNormal.test.ts
@@ -76,7 +76,7 @@ suite("Mode Normal", () => {
         await modeNormal.handleKeyEvent("db");
         await assertEqualLines(["t"]);
     });
-    
+
     test("Can handle 'D'", async () => {
         await TextEditor.insert("text");
 
@@ -85,5 +85,79 @@ suite("Mode Normal", () => {
         await assertEqualLines(["te"]);
         await modeNormal.handleKeyEvent("D");
         await assertEqualLines(["t"]);
+    });
+
+    test("Can handle 'ge'", async () => {
+        await TextEditor.insert("text text");
+
+        motion = motion.moveTo(0, 6);
+        await modeNormal.handleKeyEvent("g");
+        await modeNormal.handleKeyEvent("e");
+        await assert.equal(motion.position.character, 4, "wrong position");
+    });
+
+    test("Can handle 'C'", async () => {
+        await TextEditor.insert("text");
+
+        motion = motion.moveTo(0, 2);
+        await modeNormal.handleKeyEvent("C");
+        await assertEqualLines(["te"]);
+        await assert.equal(modeHandler.currentMode.name === ModeName.Insert, true, "didn't enter insert mode");
+    });
+
+    test("Can handle 'cw'", async () => {
+        await TextEditor.insert("text text text");
+
+        motion = motion.moveTo(0, 7);
+        await modeNormal.handleKeyEvent("c");
+        await modeNormal.handleKeyEvent("w");
+        await assertEqualLines(["text te text"]);
+        await assert.equal(modeHandler.currentMode.name === ModeName.Insert, true, "didn't enter insert mode");
+    });
+
+    test("Can handle 'ciw'", async () => {
+        await TextEditor.insert("text text text");
+
+        motion = motion.moveTo(0, 7);
+        await modeNormal.handleKeyEvent("c");
+        await modeNormal.handleKeyEvent("i");
+        await modeNormal.handleKeyEvent("w");
+        await assertEqualLines(["text  text"]);
+        await assert.equal(modeHandler.currentMode.name, ModeName.Insert, "didn't enter insert mode");
+    });
+
+    test("Can handle 'ciw' on blanks", async () => {
+        await TextEditor.insert("text   text text");
+
+        motion = motion.moveTo(0, 5);
+        await modeNormal.handleKeyEvent("c");
+        await modeNormal.handleKeyEvent("i");
+        await modeNormal.handleKeyEvent("w");
+        await assertEqualLines(["texttext text"]);
+        await assert.equal(modeHandler.currentMode.name, ModeName.Insert, "didn't enter insert mode");
+    });
+
+    test("Can handle 'caw'", async () => {
+        await TextEditor.insert("text text text");
+
+        motion = motion.moveTo(0, 7);
+        await modeNormal.handleKeyEvent("c");
+        await modeNormal.handleKeyEvent("a");
+        await modeNormal.handleKeyEvent("w");
+        await assertEqualLines(["text text"]);
+        await assert.equal(motion.position.character, 5, "wrong position");
+        await assert.equal(modeHandler.currentMode.name, ModeName.Insert, "didn't enter insert mode");
+    });
+
+    test("Can handle 'caw' on blanks", async () => {
+        await TextEditor.insert("text   text");
+
+        motion = motion.moveTo(0, 5);
+        await modeNormal.handleKeyEvent("c");
+        await modeNormal.handleKeyEvent("a");
+        await modeNormal.handleKeyEvent("w");
+        await assertEqualLines(["text"]);
+        await assert.equal(motion.position.character, 4, "wrong position");
+        await assert.equal(modeHandler.currentMode.name, ModeName.Insert, "didn't enter insert mode");
     });
 });

--- a/test/testUtils.ts
+++ b/test/testUtils.ts
@@ -13,7 +13,7 @@ function rndName() {
 
 async function createRandomFile(contents: string): Promise<vscode.Uri> {
     const tmpFile = join(os.tmpdir(), rndName());
-    
+
     try {
         fs.writeFileSync(tmpFile, contents);
         return vscode.Uri.file(tmpFile);


### PR DESCRIPTION
Adds commands `cw`, `ciw`, `caw`, `C`, `ge` and `gE`. 
Fixes #179. 

Had to rework a bit how the mode handler activates modes, as e.g. `ciw` activated insert mode. 