### PR TITLE
Input handling v2

### DIFF
--- a/extension.ts
+++ b/extension.ts
@@ -25,7 +25,7 @@ export function activate(context: vscode.ExtensionContext) {
         showCmdLine("", modeHandler);
     });
 
-    registerCommand(context, 'extension.vim_esc', () => handleKeyEvent("esc"));
+    registerCommand(context, 'extension.vim_esc', () => handleKeyEvent("<esc>"));
     registerCommand(context, 'extension.vim_colon', () => handleKeyEvent(":"));
     registerCommand(context, 'extension.vim_space', () => handleKeyEvent("space"));
     registerCommand(context, 'extension.vim_left_curly_bracket', () => handleKeyEvent("{"));
@@ -99,13 +99,13 @@ export function activate(context: vscode.ExtensionContext) {
     registerCommand(context, 'extension.vim_$', () => handleKeyEvent("$"));
     registerCommand(context, 'extension.vim_^', () => handleKeyEvent("^"));
 
-    registerCommand(context, 'extension.vim_ctrl_r', () => handleKeyEvent("ctrl+r"));
+    registerCommand(context, 'extension.vim_ctrl_r', () => handleKeyEvent("<c-r>"));
     registerCommand(context, 'extension.vim_ctrl_[', () => handleKeyEvent("ctrl+["));
-    registerCommand(context, 'extension.vim_ctrl_f', () => handleKeyEvent("ctrl+f"));
-    registerCommand(context, 'extension.vim_ctrl_b', () => handleKeyEvent("ctrl+b"));
+    registerCommand(context, 'extension.vim_ctrl_f', () => handleKeyEvent("<c-f>"));
+    registerCommand(context, 'extension.vim_ctrl_b', () => handleKeyEvent("<c-b>"));
 
     registerCommand(context, 'extension.vim_%', () => handleKeyEvent("%"));
-    
+
     registerCommand(context, 'extension.vim_<', () => handleKeyEvent("<"));
     registerCommand(context, 'extension.vim_>', () => handleKeyEvent(">"));
 

--- a/package.json
+++ b/package.json
@@ -146,7 +146,9 @@
     "postinstall": "node ./node_modules/vscode/bin/install && gulp init"
   },
   "dependencies": {
-    "lodash": "^4.5.1"
+    "bennu": "^17.3.0",
+    "lodash": "^4.5.1",
+    "nu-stream": "^3.3.1"
   },
   "devDependencies": {
     "gulp": "^3.9.1",

--- a/src/mode/keyParser.ts
+++ b/src/mode/keyParser.ts
@@ -1,0 +1,183 @@
+"use strict";
+
+import * as _ from 'lodash';
+import { text, parse, incremental } from 'bennu';
+import { stream } from 'nu-stream';
+
+export class KeyParser {
+    private initialParserState;
+    private currentParserState;
+
+    // motions/textObjects/commands should be a mapping of commandString to any value
+    constructor(motions : Array<string>, textObjects : Array<string>, commands : Array<string>) {
+        this.compile(motions, textObjects, commands);
+        this.reset();
+    }
+
+    // reset parser state
+    public reset() : void {
+        this.currentParserState = this.initialParserState;
+    }
+
+    // takes strings of keys, and returns:
+    //   a command object if successfully parsed
+    //   true - if not yet successfully parsed, but still potentially valid
+    //   false - input not valid
+    public digestKey(input : string) : any {
+        const newState = incremental.provideString(input, this.currentParserState);
+        let retval;
+        try {
+            retval = incremental.finish(newState);
+        } catch (e) {
+            // parser error - do we need more input or dead state already?
+            if (newState.done) {
+                this.reset();
+                return false;
+            } else {
+                this.currentParserState = newState;
+                return true;
+            }
+        }
+
+        this.reset();
+        return retval;
+    }
+
+    // converts a string of keys into an array of keys, also normalizes to <lowercase>
+    // 3i<c-w><c-w><esc>
+    public convertKeyString(input : string) : Array<string> {
+        const retval = [];
+        const characters = input.split('');
+        let currentTag = '';
+        for (const char of characters) {
+            if (currentTag) {
+                currentTag = currentTag + char;
+                if (char === '>') {
+                    retval.push(currentTag.toLocaleLowerCase());
+                    currentTag = '';
+                }
+            } else if (char === '<') {
+                currentTag = '<';
+            } else {
+                retval.push(char);
+            }
+        }
+        return retval;
+    }
+
+    private deepConcat(s) {
+        const parts = [];
+        function readStrings(s2) {
+            stream.forEach(value => {
+            if (typeof value === 'string') {
+                parts.push(value);
+            } else {
+                readStrings(value);
+            }
+            }, s2);
+        }
+        readStrings(s);
+        return parts.join('');
+    }
+
+    private compile(motions, textObjects, commands) {
+
+        const register = parse.bind(
+            parse.optional('"', parse.next(text.character('"'), text.anyChar)),
+            (r) => {
+                return parse.always({ register: r });
+            }
+        );
+
+        const count = parse.bind(
+            parse.optional(0, parse.enumeration(text.oneOf('123456789'), parse.many(text.digit)).map(this.deepConcat).map(Number)),
+            (c) => {
+                return parse.always({ count: c });
+            }
+        );
+
+        const argument = parse.bind(
+            text.anyChar,
+            (a) => {
+                return parse.always({ argument: a });
+            }
+        );
+
+        const compiledTextObjects = parse.bind(
+            parse.choicea(
+                textObjects.map(text.string)
+            ),
+            (t) => {
+                return parse.always({ textObject: t });
+            }
+        );
+
+        const range = parse.late(() => { return parse.either(compiledTextObjects, compiledMotions); });
+
+        const compiledMotions = parse.choicea(
+            motions.map((m) => {
+                const keys = this.convertKeyString(m);
+                return parse.attempt(
+                    parse.bind(
+                        parse.enumerationa(keys.map(convertKeyToParser)),
+                        (x) => {
+                            let command = { command: m };
+                            stream.forEach((value) => {
+                                if (value.argument !== undefined ||
+                                    value.count !== undefined) {
+                                    command = _.extend(command, value);
+                                }
+                            }, x);
+                            return parse.always(command);
+                        }
+                    )
+                );
+            })
+        );
+
+        const compiledCommands = parse.choicea(
+            commands.map((c) => {
+                const keys = this.convertKeyString(c);
+                return parse.attempt(
+                    parse.bind(
+                        parse.enumerationa(keys.map(convertKeyToParser)),
+                        (x) => {
+                            let command = { command: c, motion: null };
+                            stream.forEach((value) => {
+                                if (value.command !== undefined) {
+                                    // motion
+                                    command.motion = value;
+                                } else if (value.argument !== undefined ||
+                                    value.count !== undefined ||
+                                    value.register !== undefined ||
+                                    value.textObject !== undefined) {
+                                    command = _.extend(command, value);
+                                }
+                            }, x);
+                            return parse.always(command);
+                        }
+                    )
+                );
+            })
+        );
+
+        const compiledInputs = parse.either(parse.attempt(compiledMotions), compiledCommands);
+
+        function convertKeyToParser(key) {
+            const mapping = {
+                '<count>': count,
+                '<argument>': argument,
+                '<register>': register,
+                '<range>': range
+            };
+            if (mapping[key]) {
+                return mapping[key];
+            } else {
+                return text.string(key);
+            }
+        }
+
+        this.initialParserState = incremental.runInc(compiledInputs);
+    }
+
+}

--- a/src/mode/modeInsert.ts
+++ b/src/mode/modeInsert.ts
@@ -53,15 +53,16 @@ export class InsertMode extends Mode {
         await this.activationKeyHandler[key](this.motion);
     }
 
-    async handleKeyEvent(key : string) : Promise<void> {
+    async handleKeyEvent(key : string) : Promise<boolean> {
         const retval = this.keyParser.digestKey(key);
 
         if (retval && retval.command) {
-            return await this.handleCommand(retval);
+            await this.handleCommand(retval);
         } else if (retval === false) {
             await TextEditor.insert(this.resolveKeyValue(key));
             await vscode.commands.executeCommand("editor.action.triggerSuggest");
         }
+        return retval;
     }
 
     // Some keys have names that are different to their value.

--- a/src/mode/modeNormal.ts
+++ b/src/mode/modeNormal.ts
@@ -1,6 +1,5 @@
 "use strict";
 
-import * as _ from 'lodash';
 import * as vscode from 'vscode';
 
 import {ModeName, Mode} from './mode';
@@ -8,78 +7,39 @@ import {showCmdLine} from './../cmd_line/main';
 import {Motion, MotionMode} from './../motion/motion';
 import {ModeHandler} from './modeHandler';
 import {DeleteOperator} from './../operator/delete';
+import {Position} from './../motion/position';
 
 export class NormalMode extends Mode {
-    protected keyHandler : { [key : string] : (motion : Motion) => Promise<{}>; } = {
-        ":" : async () => { return showCmdLine("", this._modeHandler); },
-        "u" : async () => { return vscode.commands.executeCommand("undo"); },
-        "ctrl+r" : async () => { return vscode.commands.executeCommand("redo"); },
-        "h" : async (c) => { return c.left().move(); },
-        "j" : async (c) => { return c.down().move(); },
-        "k" : async (c) => { return c.up().move(); },
-        "l" : async (c) => { return c.right().move(); },
-        "$" : async (c) => { return c.lineEnd().move(); },
-        "0" : async (c) => { return c.lineBegin().move(); },
-        "^" : async () => { return vscode.commands.executeCommand("cursorHome"); },
-        "gg" : async (c) => { return c.firstLineNonBlankChar().move(); },
-        "G" : async (c) => { return c.lastLineNonBlankChar().move(); },
-        "w" : async (c) => { return c.wordRight().move(); },
-        "W" : async (c) => { return c.bigWordRight().move(); },
-        "e" : async (c) => { return c.goToEndOfCurrentWord().move(); },
-        "E" : async (c) => { return c.goToEndOfCurrentBigWord().move(); },
-        "b" : async (c) => { return c.wordLeft().move(); },
-        "B" : async (c) => { return c.bigWordLeft().move(); },
-        "}" : async (c) => { return c.goToEndOfCurrentParagraph().move(); },
-        "{" : async (c) => { return c.goToBeginningOfCurrentParagraph().move(); },
-        "ctrl+f": async (c) => { return vscode.commands.executeCommand("cursorPageDown"); },
-        "ctrl+b": async (c) => { return vscode.commands.executeCommand("cursorPageUp"); },
-        "%" : async () => { return vscode.commands.executeCommand("editor.action.jumpToBracket"); },
-        ">>" : async () => { return vscode.commands.executeCommand("editor.action.indentLines"); },
-        "<<" : async () => { return vscode.commands.executeCommand("editor.action.outdentLines"); },
-        "dd" : async () => { return vscode.commands.executeCommand("editor.action.deleteLines"); },
-        "dw" : async (m) => {
-            m.changeMode(MotionMode.Cursor);
-            await new DeleteOperator(this._modeHandler).run(m.position, m.position.getWordRight());
+
+    protected textObjects : { [key : string] : () => Promise<{}>; } = {
+        "iw" : async () => { return {}; }
+    };
+
+    protected commands : { [key : string] : (range : Array<Position>) => Promise<{}>; } = {
+        ":" : async (r) => { return showCmdLine("", this._modeHandler); },
+        "u" : async (r) => { return vscode.commands.executeCommand("undo"); },
+        "<c-r>" : async (r) => { return vscode.commands.executeCommand("redo"); },
+
+        // "<count>>>" : async () => { return vscode.commands.executeCommand("editor.action.indentLines"); },
+        // "<count><<" : async () => { return vscode.commands.executeCommand("editor.action.outdentLines"); },
+        "<register><count>dd" : async (r) => { return vscode.commands.executeCommand("editor.action.deleteLines"); },
+        "<register><count>d<range>" : async (r) => {
+            await new DeleteOperator(this._modeHandler).run(r[0], r[1]);
+            return {};
+        },
+        "<register><count>D" : async (r) => {
+            this.motion.changeMode(MotionMode.Cursor);
+            await new DeleteOperator(this._modeHandler).run(this.motion.position, this.motion.position.getLineEnd());
+            this.motion.changeMode(MotionMode.Caret);
             this.motion.left().move();
             return {};
         },
-        "dW" : async (m) => {
-            m.changeMode(MotionMode.Cursor);
-            await new DeleteOperator(this._modeHandler).run(m.position, m.position.getBigWordRight());
-            this.motion.left().move();
+        "x" : async (r) => {
+            await new DeleteOperator(this._modeHandler).run(this.motion.position, this.motion.position.getRight());
             return {};
         },
-        "db" : async (m) => {
-            m.changeMode(MotionMode.Cursor);
-            await new DeleteOperator(this._modeHandler).run(m.position, m.position.getWordLeft());
-            return {};
-        },
-        "dB" : async (m) => {
-            m.changeMode(MotionMode.Cursor);
-            await new DeleteOperator(this._modeHandler).run(m.position, m.position.getBigWordLeft());
-            return {};
-        },
-        "de" : async (m) => {
-            m.changeMode(MotionMode.Cursor);
-            await new DeleteOperator(this._modeHandler).run(m.position, m.position.getCurrentWordEnd());
-            this.motion.left().move();
-            return {};
-        },
-        "dE" : async (m) => {
-            m.changeMode(MotionMode.Cursor);
-            await new DeleteOperator(this._modeHandler).run(m.position, m.position.getCurrentBigWordEnd());
-            this.motion.left().move();
-            return {};
-        },
-        "D" : async (m) => {
-            m.changeMode(MotionMode.Cursor);
-            await new DeleteOperator(this._modeHandler).run(m.position, m.position.getLineEnd());
-            this.motion.left().move();
-            return {};
-        },
-        "x" : async (m) => { await new DeleteOperator(this._modeHandler).run(m.position, m.position.getRight()); return {}; },
-        "X" : async (m) => { return vscode.commands.executeCommand("deleteLeft"); },
-        "esc": async () => { return vscode.commands.executeCommand("workbench.action.closeMessages"); }
+        "X" : async (r) => { return vscode.commands.executeCommand("deleteLeft"); },
+        "<esc>": async (r) => { return vscode.commands.executeCommand("workbench.action.closeMessages"); }
     };
 
     private _modeHandler: ModeHandler;
@@ -88,33 +48,16 @@ export class NormalMode extends Mode {
         super(ModeName.Normal, motion);
 
         this._modeHandler = modeHandler;
+
+        this.initializeParser();
     }
 
     shouldBeActivated(key : string, currentMode : ModeName) : boolean {
-        return (key === 'esc' || key === 'ctrl+[' || (key === "v" && currentMode === ModeName.Visual));
+        return (key === '<esc>' || key === 'ctrl+[' || (key === "v" && currentMode === ModeName.Visual));
     }
 
     async handleActivation(key : string): Promise<void> {
         this.motion.left().move();
     }
 
-    async handleKeyEvent(key : string): Promise<void>  {
-        this.keyHistory.push(key);
-
-        let keyHandled = false;
-        let keysPressed: string;
-
-        for (let window = this.keyHistory.length; window > 0; window--) {
-            keysPressed = _.takeRight(this.keyHistory, window).join('');
-            if (this.keyHandler[keysPressed] !== undefined) {
-                keyHandled = true;
-                break;
-            }
-        }
-
-        if (keyHandled) {
-            this.keyHistory = [];
-            await this.keyHandler[keysPressed](this.motion);
-        }
-    }
 }

--- a/src/mode/modeNormal.ts
+++ b/src/mode/modeNormal.ts
@@ -7,12 +7,37 @@ import {showCmdLine} from './../cmd_line/main';
 import {Motion, MotionMode} from './../motion/motion';
 import {ModeHandler} from './modeHandler';
 import {DeleteOperator} from './../operator/delete';
+import {ChangeOperator} from './../operator/change';
 import {Position} from './../motion/position';
+import {TextEditor} from "./../textEditor";
 
 export class NormalMode extends Mode {
 
-    protected textObjects : { [key : string] : () => Promise<{}>; } = {
-        "iw" : async () => { return {}; }
+    protected textObjects : { [key : string] : (position: Position) => Promise<Array<Position>>; } = {
+        "iw" : async (p) => {
+            const range = [];
+            const currentChar = TextEditor.getLineAt(p).text[p.character];
+            if (currentChar === ' ' || currentChar === '\t') {
+                range[0] = p.getLastWordEnd();
+                range[1] = p.getWordRight();
+            } else {
+                range[0] = p.getWordLeft();
+                range[1] = p.getCurrentWordEnd();
+            }
+            return range;
+        },
+        "aw" : async (p) => {
+            const range = [];
+            const currentChar = TextEditor.getLineAt(p).text[p.character];
+            if (currentChar === ' ' || currentChar === '\t') {
+                range[0] = p.getLastWordEnd();
+                range[1] = p.getCurrentWordEnd();
+            } else {
+                range[0] = p.getWordLeft();
+                range[1] = p.getWordRight();
+            }
+            return range;
+        },
     };
 
     protected commands : { [key : string] : (range : Array<Position>) => Promise<{}>; } = {
@@ -24,17 +49,26 @@ export class NormalMode extends Mode {
         // "<count><<" : async () => { return vscode.commands.executeCommand("editor.action.outdentLines"); },
         "<register><count>dd" : async (r) => { return vscode.commands.executeCommand("editor.action.deleteLines"); },
         "<register><count>d<range>" : async (r) => {
+            this.motion.changeMode(MotionMode.Cursor);
             await new DeleteOperator(this._modeHandler).run(r[0], r[1]);
+            return {};
+        },
+        "<register><count>c<range>" : async (r) => {
+            await new ChangeOperator(this._modeHandler).run(r[0], r[1]);
             return {};
         },
         "<register><count>D" : async (r) => {
             this.motion.changeMode(MotionMode.Cursor);
             await new DeleteOperator(this._modeHandler).run(this.motion.position, this.motion.position.getLineEnd());
-            this.motion.changeMode(MotionMode.Caret);
-            this.motion.left().move();
+            return {};
+        },
+        "<register><count>C" : async (r) => {
+            this.motion.changeMode(MotionMode.Cursor);
+            await new ChangeOperator(this._modeHandler).run(this.motion.position, this.motion.position.getLineEnd());
             return {};
         },
         "x" : async (r) => {
+            this.motion.changeMode(MotionMode.Cursor);
             await new DeleteOperator(this._modeHandler).run(this.motion.position, this.motion.position.getRight());
             return {};
         },

--- a/src/mode/modeVisual.ts
+++ b/src/mode/modeVisual.ts
@@ -5,7 +5,6 @@ import * as _      from 'lodash';
 import { ModeName, Mode } from './mode';
 import { Motion} from './../motion/motion';
 import { Position } from './../motion/position';
-import { Operator } from './../operator/operator';
 import { DeleteOperator } from './../operator/delete';
 import { ModeHandler } from './modeHandler.ts';
 import { ChangeOperator } from './../operator/change';
@@ -22,21 +21,26 @@ export class VisualMode extends Mode {
     private _selectionStop : Position;
     private _modeHandler   : ModeHandler;
 
-    private _keysToOperators: { [key: string]: Operator };
-
     constructor(motion: Motion, modeHandler: ModeHandler) {
         super(ModeName.Visual, motion);
 
         this._modeHandler = modeHandler;
-        this._keysToOperators = {
-            // TODO: use DeleteOperator.key()
+        this.initializeParser();
+    }
 
-            // TODO: Don't pass in mode handler to DeleteOperators,
-            // simply allow the operators to say what mode they transition into.
-            'd': new DeleteOperator(modeHandler),
-            'x': new DeleteOperator(modeHandler),
-            'c': new ChangeOperator(modeHandler)
-        };
+    protected commands : { [key : string] : (range : Array<Position>) => Promise<{}>; } = {
+        "d" : async (r) => {
+            await new DeleteOperator(this._modeHandler).run(r[0], r[1]);
+            return {};
+        },
+        "x" : async (r) => {
+            await new DeleteOperator(this._modeHandler).run(r[0], r[1]);
+            return {};
+        },
+        "c" : async (r) => {
+            await new ChangeOperator(this._modeHandler).run(r[0], r[1]);
+            return {};
+        }
     }
 
     shouldBeActivated(key: string, currentMode: ModeName): boolean {
@@ -56,27 +60,20 @@ export class VisualMode extends Mode {
         this.motion.moveTo(this._selectionStop.line, this._selectionStop.character);
     }
 
-    /**
-     * TODO:
-     *
-     * Eventually, the following functions should be moved into a unified
-     * key handler and dispatcher thing.
-     */
-
-    private async _handleMotion(): Promise<boolean> {
-        let keyHandled = false;
-        let keysPressed: string;
-
-        for (let window = this.keyHistory.length; window > 0; window--) {
-            keysPressed = _.takeRight(this.keyHistory, window).join('');
-            if (this.keyToNewPosition[keysPressed] !== undefined) {
-                keyHandled = true;
-                break;
+    private async _handleOperator(command): Promise<void> {
+        if (command) {
+            if (this._selectionStart.compareTo(this._selectionStop) <= 0) {
+                await command([this._selectionStart, this._selectionStop.getRight()]);
+            } else {
+                await command([this._selectionStart.getRight(), this._selectionStop]);
             }
         }
+    }
 
-        if (keyHandled) {
-            this._selectionStop = await this.keyToNewPosition[keysPressed](this._selectionStop);
+    async handleCommand(command) : Promise<void> {
+        const commandString = command.command;
+        if (this.motions[commandString]) {
+            this._selectionStop = await this.motions[commandString](this.motion.position, command);
 
             this.motion.moveTo(this._selectionStart.line, this._selectionStart.character);
 
@@ -98,43 +95,8 @@ export class VisualMode extends Mode {
             } else {
                 this.motion.select(this._selectionStart.getRight(), this._selectionStop);
             }
-
-            this.keyHistory = [];
-        }
-
-        return keyHandled;
-    }
-
-    private async _handleOperator(): Promise<boolean> {
-        let keysPressed: string;
-        let operator: Operator;
-
-        for (let window = this.keyHistory.length; window > 0; window--) {
-            keysPressed = _.takeRight(this.keyHistory, window).join('');
-            if (this._keysToOperators[keysPressed] !== undefined) {
-                operator = this._keysToOperators[keysPressed];
-                break;
-            }
-        }
-
-        if (operator) {
-            if (this._selectionStart.compareTo(this._selectionStop) <= 0) {
-                await operator.run(this._selectionStart, this._selectionStop.getRight());
-            } else {
-                await operator.run(this._selectionStart.getRight(), this._selectionStop);
-            }
-        }
-
-        return !!operator;
-    }
-
-    async handleKeyEvent(key: string): Promise<void> {
-        this.keyHistory.push(key);
-
-        const wasMotion = await this._handleMotion();
-
-        if (!wasMotion) {
-            await this._handleOperator();
+        } else if (this.commands[commandString]) {
+            await this._handleOperator(this.commands[commandString]);
         }
     }
 }

--- a/src/motion/position.ts
+++ b/src/motion/position.ts
@@ -32,110 +32,136 @@ export class Position extends vscode.Position {
         return position;
     }
 
-    public getLeft() : Position {
-        if (!this.isLineBeginning()) {
-            return new Position(this.line, this.character - 1, this.positionOptions);
-        }
+    public getLeft(count? : number) : Position {
+        count = count || 1;
+        let position : Position = this;
 
-        return this;
+        while (count) {
+            if (!position.isLineBeginning()) {
+                position = new Position(position.line, position.character - 1, position.positionOptions);
+            }
+            count--;
+        }
+        return position;
     }
 
-    public getRight() : Position {
-        if (!this.isLineEnd()) {
-            return new Position(this.line, this.character + 1, this.positionOptions);
-        }
+    public getRight(count? : number) : Position {
+        count = count || 1;
+        let position : Position = this;
 
-        return this;
+        while (count) {
+            if (!position.isLineEnd()) {
+                position = new Position(position.line, position.character + 1, position.positionOptions);
+            }
+            count--;
+        }
+        return position;
     }
 
     /**
      * Get the position of the line directly below the current line.
      */
-    public getDown(desiredColumn: number) : Position {
-        if (this.getDocumentEnd().line !== this.line) {
-            let nextLine = this.line + 1;
-            let nextLineLength = Position.getLineLength(nextLine, this.positionOptions);
+    public getDown(desiredColumn: number, count? : number) : Position {
+        count = count || 1;
+        let position : Position = this;
 
-            return new Position(nextLine, Math.min(nextLineLength, desiredColumn), this.positionOptions);
+        while (count) {
+            if (position.getDocumentEnd().line !== position.line) {
+                let nextLine = position.line + 1;
+                let nextLineLength = Position.getLineLength(nextLine, position.positionOptions);
+
+                position = new Position(nextLine, Math.min(nextLineLength, desiredColumn), this.positionOptions);
+            }
+            count--;
         }
-
-        return this;
+        return position;
     }
 
     /**
      * Get the position of the line directly above the current line.
      */
-    public getUp(desiredColumn: number) : Position {
-        if (this.getDocumentBegin().line !== this.line) {
-            let prevLine = this.line - 1;
-            let prevLineLength  = Position.getLineLength(prevLine, this.positionOptions);
+    public getUp(desiredColumn: number, count? : number) : Position {
+        count = count || 1;
+        let position : Position = this;
 
-            return new Position(prevLine, Math.min(prevLineLength, desiredColumn), this.positionOptions);
+        while (count) {
+            if (position.getDocumentBegin().line !== position.line) {
+                let prevLine = position.line - 1;
+                let prevLineLength  = Position.getLineLength(prevLine, position.positionOptions);
+
+                position = new Position(prevLine, Math.min(prevLineLength, desiredColumn), position.positionOptions);
+            }
+            count--;
         }
-
-        return this;
+        return position;
     }
 
-    public getWordLeft() : Position {
-        return this.getWordLeftWithRegex(this._nonWordCharRegex);
+    public getWordLeft(count? : number) : Position {
+        return this.getWordLeftWithRegex(this._nonWordCharRegex, count || 1);
     }
 
-    public getBigWordLeft() : Position {
-        return this.getWordLeftWithRegex(this._nonBigWordCharRegex);
+    public getBigWordLeft(count? : number) : Position {
+        return this.getWordLeftWithRegex(this._nonBigWordCharRegex, count || 1);
     }
 
-    public getWordRight() : Position {
-        return this.getWordRightWithRegex(this._nonWordCharRegex);
+    public getWordRight(count? : number) : Position {
+        return this.getWordRightWithRegex(this._nonWordCharRegex, count || 1);
     }
 
-    public getBigWordRight() : Position {
-        return this.getWordRightWithRegex(this._nonBigWordCharRegex);
+    public getBigWordRight(count? : number) : Position {
+        return this.getWordRightWithRegex(this._nonBigWordCharRegex, count || 1);
     }
 
-    public getCurrentWordEnd(): Position {
-        return this.getCurrentWordEndWithRegex(this._nonWordCharRegex);
+    public getCurrentWordEnd(count? : number): Position {
+        return this.getCurrentWordEndWithRegex(this._nonWordCharRegex, count || 1);
     }
 
-    public getCurrentBigWordEnd(): Position {
-        return this.getCurrentWordEndWithRegex(this._nonBigWordCharRegex);
+    public getCurrentBigWordEnd(count? : number): Position {
+        return this.getCurrentWordEndWithRegex(this._nonBigWordCharRegex, count || 1);
     }
 
     /**
      * Get the end of the current paragraph.
      */
-    public getCurrentParagraphEnd(): Position {
-      let pos: Position = this;
+    public getCurrentParagraphEnd(count? : number): Position {
+        count = count || 1;
+        let pos: Position = this;
 
-      // If we're not in a paragraph yet, go down until we are.
-      while (TextEditor.getLineAt(pos).text === "" && !TextEditor.isLastLine(pos)) {
-        pos = pos.getDown(0);
-      }
+        while (count) {
+            // If we're not in a paragraph yet, go down until we are.
+            while (TextEditor.getLineAt(pos).text === "" && !TextEditor.isLastLine(pos)) {
+                pos = pos.getDown(0);
+            }
 
-      // Go until we're outside of the paragraph, or at the end of the document.
-      while (TextEditor.getLineAt(pos).text !== "" && pos.line < TextEditor.getLineCount() - 1) {
-         pos = pos.getDown(0);
-      }
-
-      return pos.getLineEnd();
+            // Go until we're outside of the paragraph, or at the end of the document.
+            while (TextEditor.getLineAt(pos).text !== "" && pos.line < TextEditor.getLineCount() - 1) {
+                pos = pos.getDown(0);
+            }
+            count--;
+        }
+        return pos.getLineEnd();
     }
 
     /**
      * Get the beginning of the current paragraph.
      */
-    public getCurrentParagraphBeginning(): Position {
-      let pos: Position = this;
+    public getCurrentParagraphBeginning(count? : number): Position {
+        count = count || 1;
+        let pos: Position = this;
 
-      // If we're not in a paragraph yet, go up until we are.
-      while (TextEditor.getLineAt(pos).text === "" && !TextEditor.isFirstLine(pos)) {
-          pos = pos.getUp(0);
-      }
+        while (count) {
+            // If we're not in a paragraph yet, go up until we are.
+            while (TextEditor.getLineAt(pos).text === "" && !TextEditor.isFirstLine(pos)) {
+                pos = pos.getUp(0);
+            }
 
-      // Go until we're outside of the paragraph, or at the beginning of the document.
-      while (pos.line > 0 && TextEditor.getLineAt(pos).text !== "") {
-          pos = pos.getUp(0);
-      }
-
-      return pos.getLineBegin();
+            // Go until we're outside of the paragraph, or at the beginning of the document.
+            while (pos.line > 0 && TextEditor.getLineAt(pos).text !== "") {
+                pos = pos.getUp(0);
+            }
+            count--;
+        }
+        return pos.getLineBegin();
     }
 
     public getLineBegin() : Position {
@@ -196,6 +222,44 @@ export class Position extends vscode.Position {
         return this.character === Position.getLineLength(this.line, this.positionOptions);
     }
 
+    public tilForwards(argument : string, count : number) : Position {
+        const position = this.findHelper(argument, count, +1);
+        if (!position) {
+            return this;
+        } if (this.positionOptions === PositionOptions.CharacterWiseInclusive) {
+            return new Position(this.line, position.character, this.positionOptions);
+        } else {
+            return new Position(this.line, position.character - 1, this.positionOptions);
+        }
+    }
+
+    public tilBackwards(argument : string, count : number) : Position {
+        const position = this.findHelper(argument, count, -1);
+        if (!position) {
+            return this;
+        }
+        return new Position(this.line, position.character + 1, this.positionOptions);
+    }
+
+    public findForwards(argument : string, count : number) : Position {
+        const position = this.findHelper(argument, count, +1);
+        if (!position) {
+            return this;
+        } else if (this.positionOptions === PositionOptions.CharacterWiseInclusive) {
+            return new Position(this.line, position.character + 1, this.positionOptions);
+        } else {
+            return new Position(this.line, position.character, this.positionOptions);
+        }
+    }
+
+    public findBackwards(argument : string, count : number) : Position {
+        const position = this.findHelper(argument, count, -1);
+        if (!position) {
+            return this;
+        }
+        return position;
+    }
+
     public static getFirstNonBlankCharAtLine(line: number): number {
         return TextEditor.readLineAt(line).match(/^\s*/)[0].length;
     }
@@ -212,6 +276,27 @@ export class Position extends vscode.Position {
 
             default:
                 throw new Error("Unhandled PositionOptions: " + options);
+        }
+    }
+
+    private findHelper(argument : string, count: number, direction : number) {
+        // -1 = backwards, +1 = forwards
+        count = count || 1;
+        const line = TextEditor.getLineAt(this);
+        let index = this.character;
+        while (count && index !== -1) {
+            if (direction > 0) {
+                index = line.text.indexOf(argument, index + direction);
+            } else {
+                index = line.text.lastIndexOf(argument, index + direction);
+            }
+            count--;
+        }
+
+        if (index > -1) {
+            return new Position(this.line, index, this.positionOptions);
+        } else {
+            return null;
         }
     }
 
@@ -260,33 +345,42 @@ export class Position extends vscode.Position {
         return positions;
     }
 
-    private getWordLeftWithRegex(regex: RegExp) : Position {
+    private getWordLeftWithRegex(regex: RegExp, count: number) : Position {
+        if (!count) {
+            return this;
+        }
         for (let currentLine = this.line; currentLine >= 0; currentLine--) {
             let positions    = this.getAllPositions(TextEditor.getLineAt(new vscode.Position(currentLine, 0)).text, regex);
             let newCharacter = _.find(positions.reverse(), index => index < this.character || currentLine !== this.line);
 
             if (newCharacter !== undefined) {
-                return new Position(currentLine, newCharacter, this.positionOptions);
+                return new Position(currentLine, newCharacter, this.positionOptions).getWordLeftWithRegex(regex, count - 1);
             }
         }
 
         return new Position(0, 0, this.positionOptions).getLineBegin();
     }
 
-    private getWordRightWithRegex(regex: RegExp): Position {
+    private getWordRightWithRegex(regex: RegExp, count: number): Position {
+        if (!count) {
+            return this;
+        }
         for (let currentLine = this.line; currentLine < TextEditor.getLineCount(); currentLine++) {
             let positions    = this.getAllPositions(TextEditor.getLineAt(new vscode.Position(currentLine, 0)).text, regex);
             let newCharacter = _.find(positions, index => index > this.character || currentLine !== this.line);
 
             if (newCharacter !== undefined) {
-                return new Position(currentLine, newCharacter, this.positionOptions);
+                return new Position(currentLine, newCharacter, this.positionOptions).getWordRightWithRegex(regex, count - 1);
             }
         }
 
         return new Position(TextEditor.getLineCount() - 1, 0, this.positionOptions).getLineEnd();
     }
 
-    private getCurrentWordEndWithRegex(regex: RegExp) : Position {
+    private getCurrentWordEndWithRegex(regex: RegExp, count: number) : Position {
+        if (!count) {
+            return this;
+        }
         for (let currentLine = this.line; currentLine < TextEditor.getLineCount(); currentLine++) {
             let positions    = this.getAllEndPositions(TextEditor.getLineAt(new vscode.Position(currentLine, 0)).text, regex);
             let newCharacter = _.find(positions, index => index > this.character || currentLine !== this.line);
@@ -299,6 +393,7 @@ export class Position extends vscode.Position {
             }
         }
 
-        return new Position(TextEditor.getLineCount() - 1, 0, this.positionOptions).getLineEnd();
+        return new Position(TextEditor.getLineCount() - 1, 0, this.positionOptions)
+            .getLineEnd().getCurrentWordEndWithRegex(regex, count - 1);
     }
 }

--- a/src/motion/position.ts
+++ b/src/motion/position.ts
@@ -112,12 +112,12 @@ export class Position extends vscode.Position {
         return this.getWordRightWithRegex(this._nonBigWordCharRegex, count || 1);
     }
 
-    public getLastWordEnd(): Position {
-        return this.getLastWordEndWithRegex(this._nonWordCharRegex);
+    public getLastWordEnd(count? : number): Position {
+        return this.getLastWordEndWithRegex(this._nonWordCharRegex, count || 1);
     }
 
-    public getLastBigWordEnd(): Position {
-        return this.getLastWordEndWithRegex(this._nonBigWordCharRegex);
+    public getLastBigWordEnd(count? : number): Position {
+        return this.getLastWordEndWithRegex(this._nonBigWordCharRegex, count || 1);
     }
 
     public getCurrentWordEnd(count? : number): Position {
@@ -385,7 +385,10 @@ export class Position extends vscode.Position {
         return new Position(TextEditor.getLineCount() - 1, 0, this.positionOptions).getLineEnd();
     }
 
-    private getLastWordEndWithRegex(regex: RegExp) : Position {
+    private getLastWordEndWithRegex(regex: RegExp, count: number) : Position {
+        if (!count) {
+            return this;
+        }
         for (let currentLine = this.line; currentLine < TextEditor.getLineCount(); currentLine++) {
             let positions    = this.getAllEndPositions(TextEditor.getLineAt(new vscode.Position(currentLine, 0)).text, regex);
             let index = _.findIndex(positions, index => index >= this.character || currentLine !== this.line);
@@ -400,7 +403,7 @@ export class Position extends vscode.Position {
                 if (this.positionOptions === PositionOptions.CharacterWiseInclusive) {
                     newCharacter++;
                 }
-                return new Position(currentLine, newCharacter, this.positionOptions);
+                return new Position(currentLine, newCharacter, this.positionOptions).getLastWordEndWithRegex(regex, count - 1);
             }
         }
 

--- a/src/operator/change.ts
+++ b/src/operator/change.ts
@@ -1,10 +1,12 @@
 "use strict";
 
 import { Position } from './../motion/position';
-import { DeleteOperator } from './delete';
 import { Operator } from './operator';
 import { ModeHandler } from './../mode/modeHandler.ts';
 import { ModeName } from './../mode/mode';
+import { TextEditor } from './../textEditor';
+
+import * as vscode from 'vscode';
 
 export class ChangeOperator extends Operator {
 
@@ -18,7 +20,8 @@ export class ChangeOperator extends Operator {
      * Run this operator on a range.
      */
     public async run(start: Position, end: Position): Promise<void> {
-        await new DeleteOperator(this.modeHandler).run(start, end);
+        // Similar to DeleteOperator, but we set different mode
+        await TextEditor.delete(new vscode.Range(start, end));
         this.modeHandler.setCurrentModeByName(ModeName.Insert);
     }
 }

--- a/test/mode/modeNormal.test.ts
+++ b/test/mode/modeNormal.test.ts
@@ -4,7 +4,7 @@ import * as assert from 'assert';
 import {setupWorkspace, cleanUpWorkspace, assertEqualLines} from './../testUtils';
 import {NormalMode} from '../../src/mode/modeNormal';
 import {ModeName} from '../../src/mode/mode';
-import {Motion, MotionMode} from '../../src/motion/motion';
+import {Motion} from '../../src/motion/motion';
 import {TextEditor} from '../../src/textEditor';
 import {ModeHandler} from '../../src/mode/modeHandler';
 
@@ -18,14 +18,14 @@ suite("Mode Normal", () => {
         await setupWorkspace();
 
         modeHandler = new ModeHandler();
-        motion      = new Motion(MotionMode.Cursor);
+        motion      = modeHandler.motion;
         modeNormal  = new NormalMode(motion, modeHandler);
     });
 
     teardown(cleanUpWorkspace);
 
     test("can be activated", () => {
-        let activationKeys = ['esc', 'ctrl+['];
+        let activationKeys = ['<esc>', 'ctrl+['];
 
         for (let i = 0; i < activationKeys.length; i++) {
             let key = activationKeys[i];
@@ -46,9 +46,11 @@ suite("Mode Normal", () => {
     });
 
     test("Can handle 'dw'", async () => {
-        await TextEditor.insert("text text");
+        await TextEditor.insert("text text text");
 
         motion = motion.moveTo(0, 5);
+        await modeNormal.handleKeyEvent("dw");
+        await assertEqualLines(["text text"]);
         await modeNormal.handleKeyEvent("dw");
         await assertEqualLines(["text "]);
         await modeNormal.handleKeyEvent("dw");
@@ -93,7 +95,7 @@ suite("Mode Normal", () => {
         motion = motion.moveTo(0, 6);
         await modeNormal.handleKeyEvent("g");
         await modeNormal.handleKeyEvent("e");
-        await assert.equal(motion.position.character, 4, "wrong position");
+        await assert.equal(motion.position.character, 3, "wrong position");
     });
 
     test("Can handle 'C'", async () => {

--- a/test/mode/modeNormal.test.ts
+++ b/test/mode/modeNormal.test.ts
@@ -76,7 +76,7 @@ suite("Mode Normal", () => {
         await modeNormal.handleKeyEvent("db");
         await assertEqualLines(["t"]);
     });
-    
+
     test("Can handle 'D'", async () => {
         await TextEditor.insert("text");
 

--- a/test/testUtils.ts
+++ b/test/testUtils.ts
@@ -13,7 +13,7 @@ function rndName() {
 
 async function createRandomFile(contents: string): Promise<vscode.Uri> {
     const tmpFile = join(os.tmpdir(), rndName());
-    
+
     try {
         fs.writeFileSync(tmpFile, contents);
         return vscode.Uri.file(tmpFile);

--- a/typings/bennu.d.ts
+++ b/typings/bennu.d.ts
@@ -1,0 +1,56 @@
+interface ITextParser {
+    string(match: string): IParser;
+    anyChar: IParser;
+    character(match: string): IParser;
+    oneOf(match: string): IParser;
+    digit: IParser;
+}
+
+interface IParser {
+    always(input): IParser;
+    bind(parser: IParser, callback: (result) => IParser): IParser;
+    optional(def, parser: IParser): IParser;
+    next(p: IParser, q: IParser): IParser;
+    many(p: IParser): IParser;
+    enumeration(...parsers: IParser[]): IStream;
+    enumerationa(parsers: IParser[]): IParser;
+    late(callback: () => IParser): IParser;
+    choicea(parsers: IParser[]): IParser;
+    either(p: IParser, q: IParser): IParser;
+    attempt(p: IParser): IParser;
+
+}
+
+interface IParserState {
+    done: boolean;
+}
+
+interface IIncrementalParser {
+    provideString(input: string, state: IParserState): IParserState;
+    finish(state: IParserState);
+    runInc(p: IParser);
+}
+
+declare namespace bennu {
+    const text: ITextParser;
+    const parse: IParser;
+    const incremental: IIncrementalParser;
+}
+
+declare module "bennu" {
+    export = bennu;
+}
+
+
+interface IStream {
+    forEach(callback: (value) => void, inStream: IStream);
+    map(x);
+}
+
+declare namespace nustream {
+    const stream: IStream;
+}
+
+declare module "nu-stream" {
+    export = nustream;
+}


### PR DESCRIPTION
This would be a second generation version of my previous input handling pull request (#166) rewritten from "scratch".

Primary item of interest is that it now compiles the key mappings into a bennu (https://github.com/mattbierner/bennu) based incremental parser and uses that for parsing the input stream.

Motion key mappings are defined like:
* `<count>w`
* `<count>t<argument>`
* `0`
* `gg`
* `<count>G`

Command key mappings are defined like:
* `<register><count>yy`
* `<register><count>y<range>`
* `m<argument>`
* `<register><count>dd`
* `<esc>`
* `<c-f>`

`<register>` is an optional sequence of `"<argument>`
`<count>` is an optional sequence of [1-9][0-9]* (special allowance for the 0 command)
`<argument>` is a single key
`<range>` = `<count><motion>` or `<textObject>`

I've started moving keys to be `<esc>` instead of just "esc" because I needed to differentiate between the key stroke `<esc>` versus the keys e-s-c typed in sequence.

As with my other pull request, mode switching should again probably be moved out of modeHandler.handleKeyEvent() as it intercepts i/a and prevents the user from doing "fa".