### PR TITLE
Search '/' in Command Mode

### DIFF
--- a/extension.ts
+++ b/extension.ts
@@ -30,6 +30,7 @@ export function activate(context: vscode.ExtensionContext) {
     registerCommand(context, 'extension.vim_space', () => handleKeyEvent("space"));
     registerCommand(context, 'extension.vim_left_curly_bracket', () => handleKeyEvent("{"));
     registerCommand(context, 'extension.vim_right_curly_bracket', () => handleKeyEvent("}"));
+    registerCommand(context, 'extension.vim_forwardslash', () => handleKeyEvent("/"));
 
     registerCommand(context, 'extension.vim_a', () => handleKeyEvent("a"));
     registerCommand(context, 'extension.vim_b', () => handleKeyEvent("b"));

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
         { "key": "\\", "command": "extension.vim_backslash", "when": "editorTextFocus" },
         { "key": "Shift+[", "command": "extension.vim_left_curly_bracket", "when": "editorTextFocus" },
         { "key": "Shift+]", "command": "extension.vim_right_curly_bracket", "when": "editorTextFocus" },
+        { "key": "/", "command": "extension.vim_forwardslash", "when": "editorTextFocus" },
 
         { "key": "a", "command": "extension.vim_a", "when": "editorTextFocus" },
         { "key": "b", "command": "extension.vim_b", "when": "editorTextFocus" },

--- a/src/mode/modeNormal.ts
+++ b/src/mode/modeNormal.ts
@@ -14,6 +14,7 @@ import {TextEditor} from './../textEditor';
 export class NormalMode extends Mode {
     protected keyHandler : { [key : string] : (motion : Motion) => Promise<{}>; } = {
         ":" : async () => { return showCmdLine("", this._modeHandler); },
+        "/" : async () => { return vscode.commands.executeCommand("workbench.view.search"); },
         "u" : async () => { return vscode.commands.executeCommand("undo"); },
         "ctrl+r" : async () => { return vscode.commands.executeCommand("redo"); },
         "h" : async (c) => { return c.left().move(); },


### PR DESCRIPTION
* fixes #159 
* opens vscode's search panel when '/' pressed in command mode