### PR TITLE
Fixes Issue with Cursor Position After 'dw'

### DIFF
--- a/src/mode/modeNormal.ts
+++ b/src/mode/modeNormal.ts
@@ -91,11 +91,11 @@ export class NormalMode extends Mode {
         "dw" : async (m) => {
             m.changeMode(MotionMode.Cursor);
             await new DeleteOperator(this._modeHandler).run(m.position, m.position.getWordRight());
-            
-            if (m.lineEnd().position === m.position) {
+
+            if (m.position.character >= m.position.getLineEnd().character) {
                 m.left().move();
             }
-                        
+
             return {};
         },
         "dW" : async (m) => {
@@ -131,9 +131,9 @@ export class NormalMode extends Mode {
             return {};
         },
         "x" : async (m) => {
-            m.changeMode(MotionMode.Cursor);            
-            await new DeleteOperator(this._modeHandler).run(m.position, m.position.getRight()); 
-            return {}; 
+            m.changeMode(MotionMode.Cursor);
+            await new DeleteOperator(this._modeHandler).run(m.position, m.position.getRight());
+            return {};
         },
         "X" : async (m) => { return vscode.commands.executeCommand("deleteLeft"); },
         "esc": async () => { return vscode.commands.executeCommand("workbench.action.closeMessages"); }

--- a/src/motion/motion.ts
+++ b/src/motion/motion.ts
@@ -72,7 +72,7 @@ export class Motion implements vscode.Disposable {
         this.redraw();
         return this;
     }
-    
+
     public move(): Motion {
         return this.moveTo(null, null);
     }
@@ -102,12 +102,12 @@ export class Motion implements vscode.Disposable {
             case MotionMode.Caret:
                 // Valid Positions for Caret: [0, eol)
                 this._position.positionOptions = PositionOptions.CharacterWiseExclusive;
-                
+
                 if (this.position.character > this._position.getLineEnd().character) {
                     this._position = this._position.getLineEnd();
                     this._desiredColumn = this._position.character;
                 }
-                
+
                 this.highlightBlock(this.position);
                 break;
 
@@ -118,7 +118,7 @@ export class Motion implements vscode.Disposable {
                 break;
         }
     }
-    
+
     /**
      * Allows us to simulate a block cursor by highlighting a 1 character
      * space at the provided position in a lighter color.

--- a/test/mode/modeNormal.test.ts
+++ b/test/mode/modeNormal.test.ts
@@ -46,15 +46,15 @@ suite("Mode Normal", () => {
     });
 
     test("Can handle 'dw'", async () => {
-        await TextEditor.insert("text text");
+        await TextEditor.insert("text text text");
 
         motion = motion.moveTo(0, 5);
+        await modeNormal.handleKeyEvent("dw");
+        await assertEqualLines(["text text"]);
         await modeNormal.handleKeyEvent("dw");
         await assertEqualLines(["text "]);
         await modeNormal.handleKeyEvent("dw");
         await assertEqualLines(["text"]);
-        await modeNormal.handleKeyEvent("dw");
-        await assertEqualLines(["tex"]);
     });
 
     test("Can handle 'de'", async () => {


### PR DESCRIPTION
- This fixes `dw` so that the cursor ends in the correct position.

Closes https://github.com/VSCodeVim/Vim/issues/199