### PR TITLE
Fixes Incorrect Cursor Position after Transition into Normal Mode

### DIFF
--- a/src/motion/motion.ts
+++ b/src/motion/motion.ts
@@ -60,7 +60,13 @@ export class Motion implements vscode.Disposable {
                 let line = selection.active.line;
                 let char = selection.active.character;
 
-                this.position = new Position(line, char, null);
+                var newPosition = new Position(line, char, this._position.positionOptions);
+
+                if (char > newPosition.getLineEnd().character) {
+                   newPosition = new Position(newPosition.line, newPosition.getLineEnd().character, null);
+                }
+
+                this.position = newPosition;
                 this._desiredColumn = this.position.character;
                 this.changeMode(this._motionMode);
             }
@@ -102,11 +108,6 @@ export class Motion implements vscode.Disposable {
             case MotionMode.Caret:
                 // Valid Positions for Caret: [0, eol)
                 this._position.positionOptions = PositionOptions.CharacterWiseExclusive;
-
-                if (this.position.character > this._position.getLineEnd().character) {
-                    this._position = this._position.getLineEnd();
-                    this._desiredColumn = this._position.character;
-                }
 
                 this.highlightBlock(this.position);
                 break;


### PR DESCRIPTION
- By having `redraw` enforce cursor position, we were double
  moving because both `redraw` (via `Motion.changedMode`) and
  `handleActivationKey` were moving the cursor left. This makes
  it so `redraw` is not responsible for enforcing the cursor
  position. Instead, position enforcement is handled only when
  the cursor may have been moved externally (ie via the mouse).

Closes https://github.com/VSCodeVim/Vim/issues/201