### PR TITLE
Added basic fold commands zc, zo, zC, zO.

### DIFF
--- a/src/mode/commands.ts
+++ b/src/mode/commands.ts
@@ -45,6 +45,12 @@ export enum Command {
     // Find
     Find,
 
+    // Folding
+    Fold,
+    Unfold,
+    FoldAll,
+    UnfoldAll,
+
     // Text Modification
     Undo,
     Redo,
@@ -131,6 +137,12 @@ export function newDefaultNormalKeymap() : {[key: string]: Command} {
         "X": Command.DeleteLastChar,
 
         "/": Command.Find,
+
+        "zc": Command.Fold,
+        "zo": Command.Unfold,
+        "zC": Command.FoldAll,
+        "zO": Command.UnfoldAll,
+
         ":": Command.EnterCommand,
         "v": Command.EnterVisualMode,
         "esc": Command.ExitMessages

--- a/src/mode/modeNormal.ts
+++ b/src/mode/modeNormal.ts
@@ -20,6 +20,14 @@ export class NormalMode extends Mode {
                 return async () => { return showCmdLine("", this._modeHandler); };
             case Command.Find:
                 return async () => { return vscode.commands.executeCommand("actions.find"); };
+            case Command.Fold:
+                return async () => { return vscode.commands.executeCommand("editor.fold"); };
+            case Command.Unfold:
+                return async () => { return vscode.commands.executeCommand("editor.unfold"); };
+            case Command.FoldAll:
+                return async () => { return vscode.commands.executeCommand("editor.foldAll"); };
+            case Command.UnfoldAll:
+                return async () => { return vscode.commands.executeCommand("editor.unfoldAll"); };
             case Command.Undo:
                 return async () => { return vscode.commands.executeCommand("undo"); };
             case Command.Redo :


### PR DESCRIPTION
Executes in normal mode:
`zc` - editor.fold
`zo` - editor.unfold
`zC` - editor.foldAll
`zO` - editor.unfoldAll