### PR TITLE
Rewrite Normal Mode tests to use the ModeHandler interface.

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -11,8 +11,8 @@
             // "runtimeArgs": ["--harmony-default-parameters", "--harmony-rest-parameters"],
 			"stopOnEntry": false,
 			"sourceMaps": true,
-			"outDir": "${workspaceRoot}/out/src",
-			"preLaunchTask": "npm"
+			"outDir": "${workspaceRoot}/out/src"
+			// "preLaunchTask": "npm"
 		},
 		{
 			"name": "Launch Tests",
@@ -23,8 +23,8 @@
             // "runtimeArgs": ["--js-flags=\"--harmony --harmony-default-parameters\""],
 			"stopOnEntry": false,
 			"sourceMaps": true,
-			"outDir": "${workspaceRoot}/out/test",
-			"preLaunchTask": "npm"
+			"outDir": "${workspaceRoot}/out/test"
+			// "preLaunchTask": "npm"
 		}
 	]
 }

--- a/extension.ts
+++ b/extension.ts
@@ -1,33 +1,37 @@
-"use strict"
+"use strict";
+
+/**
+ * Extension.ts is a lightweight wrapper around ModeHandler. It converts key
+ * events to their string names and passes them on to ModeHandler via
+ * handleKeyEvent().
+ */
 
 import * as vscode from 'vscode';
 import {showCmdLine} from './src/cmd_line/main';
-import * as cc from './src/cmd_line/lexer';
 import {ModeHandler} from "./src/mode/modeHandler";
-import {ModeName} from "./src/mode/mode";
 
-var modeHandler : ModeHandler;
-var extensionContext : vscode.ExtensionContext;
+var extensionContext: vscode.ExtensionContext;
+var modeHandler: ModeHandler;
 
 export function activate(context: vscode.ExtensionContext) {
     extensionContext = context;
 
     registerCommand(context, 'type', async (args) => {
-		if (!vscode.window.activeTextEditor) {
-			return;
-		}
-        
+        if (!vscode.window.activeTextEditor) {
+            return;
+        }
+
         console.log(args.text);
-        
+
         var isHandled = await handleKeyEvent(args.text);
 
-        if (!isHandled) {        
+        if (!isHandled) {
             vscode.commands.executeCommand('default:type', {
                 text: args.text
             });
         }
     });
-    
+
     registerCommand(context, 'extension.vim_esc', () => handleKeyEvent("esc"));
     registerCommand(context, 'extension.showCmdLine', () => {
         if (!modeHandler) {

--- a/src/mode/modeHandler.ts
+++ b/src/mode/modeHandler.ts
@@ -29,10 +29,13 @@ export class ModeHandler implements vscode.Disposable {
         this.setCurrentModeByName(ModeName.Normal);
     }
 
+    /**
+     * The active mode.
+     */
     get currentMode() : Mode {
         return this._modes.find(mode => mode.isActive);
     }
-    
+
     setNormal() {
         this.setCurrentModeByName(ModeName.Normal);
     }
@@ -56,7 +59,7 @@ export class ModeHandler implements vscode.Disposable {
         this.setupStatusBarItem(statusBarText ? `-- ${statusBarText.toUpperCase()} --` : '');
     }
 
-    handleKeyEvent(key : string) : Promise<Boolean> {
+    async handleKeyEvent(key : string) : Promise<Boolean> {
         // Due to a limitation in Electron, en-US QWERTY char codes are used in international keyboards.
         // We'll try to mitigate this problem until it's fixed upstream.
         // https://github.com/Microsoft/vscode/issues/713
@@ -79,9 +82,18 @@ export class ModeHandler implements vscode.Disposable {
         if (nextMode) {
             this.currentMode.handleDeactivation();
             this.setCurrentModeByName(nextMode.name);
-            return nextMode.handleActivation(key).then(() => { return true; });
+
+            await nextMode.handleActivation(key);
+
+            return true;
         } else {
             return this.currentMode.handleKeyEvent(key);
+        }
+    }
+
+    async handleMultipleKeyEvents(keys: string[]): Promise<void> {
+        for (const key of keys) {
+            await this.handleKeyEvent(key);
         }
     }
 

--- a/src/mode/modeNormal.ts
+++ b/src/mode/modeNormal.ts
@@ -211,13 +211,10 @@ export class NormalMode extends Mode {
     }
 
     shouldBeActivated(key : string, currentMode : ModeName) : boolean {
-        // TODO: Have these keybinds configurable
-        return (key === 'esc' || key === 'ctrl+[' || (key === "v" && currentMode === ModeName.Visual));
+        return (key === '<esc>' || key === '<c-[>' || key === '<c-c>' || (key === "v" && currentMode === ModeName.Visual));
     }
 
-    async handleActivation(key : string): Promise<void> {
-        this.motion.left().move();
-    }
+    async handleActivation(key : string): Promise<void> { ; }
 
     async handleKeyEvent(key : string): Promise<Boolean>  {
         this._keyHistory.push(key);

--- a/src/operator/put.ts
+++ b/src/operator/put.ts
@@ -18,7 +18,7 @@ export class PutOperator extends Operator {
      * Run this operator on a range.
      */
     public async run(start: Position, end: Position): Promise<void> {
-        return new Promise<void>((resolve, reject) => {
+        return new Promise<void>(async (resolve, reject) => {
             paste(async (err, data) => {
                 if (err) {
                     reject();

--- a/src/textEditor.ts
+++ b/src/textEditor.ts
@@ -33,7 +33,7 @@ export class TextEditor {
     }
 
     /**
-     * Delete the entire document.
+     * Removes all text in the entire document.
      */
     static async deleteDocument(): Promise<boolean> {
         const start    = new vscode.Position(0, 0);

--- a/test/mode/modeNormal.test.ts
+++ b/test/mode/modeNormal.test.ts
@@ -26,7 +26,7 @@ suite("Mode Normal", () => {
     teardown(cleanUpWorkspace);
 
     test("can be activated", () => {
-        let activationKeys = ['esc', 'ctrl+['];
+        let activationKeys = ['<esc>', '<c-[>'];
 
         for (let i = 0; i < activationKeys.length; i++) {
             let key = activationKeys[i];

--- a/test/operator/put.test.ts
+++ b/test/operator/put.test.ts
@@ -19,7 +19,10 @@ suite("put operator", () => {
         const position = new Position(0, 0, PositionOptions.CharacterWiseExclusive);
         const mode = new ModeHandler();
         const put = new PutOperator(mode);
-        copy(expectedText);
+
+        await new Promise(resolve => {
+            copy(expectedText, () => resolve());
+        });
 
         await put.run(position, position);
 
@@ -39,7 +42,10 @@ suite("put operator", () => {
         const position = new Position(0, 3, PositionOptions.CharacterWiseExclusive);
         const mode = new ModeHandler();
         const put = new PutOperator(mode);
-        copy(phrase);
+
+        await new Promise(resolve => {
+            copy(phrase, () => resolve());
+        });
 
         // using ^ to show the cusor position
         // before : the dog

--- a/test/testUtils.ts
+++ b/test/testUtils.ts
@@ -30,6 +30,16 @@ export function assertEqualLines(expectedLines: string[]) {
     }
 }
 
+/**
+ * Assert that the first two arguments are equal, and fail a test otherwise.
+ *
+ * The only difference between this and assert.equal is that here we
+ * check to ensure the types of the variables are correct.
+ */
+export function assertEqual<T>(one: T, two: T, message: string = ""): void {
+    assert.equal(one, two, message);
+}
+
 export async function setupWorkspace(): Promise<any> {
     const file   = await createRandomFile("");
     const doc    = await vscode.workspace.openTextDocument(file);


### PR DESCRIPTION
This is much nicer because now it's an end-to-end test of the Vim interface. Also, it's much easier to test that commands allow us to enter/leave different modes. 