### PR TITLE
Rewrite normal mode tests.

### DIFF
--- a/extension.ts
+++ b/extension.ts
@@ -32,7 +32,7 @@ export function activate(context: vscode.ExtensionContext) {
         }
     });
 
-    registerCommand(context, 'extension.vim_esc', () => handleKeyEvent("esc"));
+    registerCommand(context, 'extension.vim_esc', () => handleKeyEvent("<esc>"));
     registerCommand(context, 'extension.showCmdLine', () => {
         if (!modeHandler) {
             modeHandler = new ModeHandler();


### PR DESCRIPTION
Continuing from https://github.com/VSCodeVim/Vim/pull/230

This actually caught a bug with how we were doing tests before. The `i` in `ciw` when running the extension forces you to go into insert mode, but the test incorrectly passed anyways. Commented out those tests for now.