### PR TITLE
Add rudimentary register implementation.

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,8 +72,7 @@
     "postinstall": "node ./node_modules/vscode/bin/install && gulp init"
   },
   "dependencies": {
-    "lodash": "^4.12.0",
-    "copy-paste": "^1.2.0"
+    "lodash": "^4.12.0"
   },
   "devDependencies": {
     "gulp": "^3.9.1",

--- a/src/operator/put.ts
+++ b/src/operator/put.ts
@@ -1,10 +1,10 @@
 "use strict";
 
-import { paste } from 'copy-paste';
 import { Position } from './../motion/position';
 import { Operator } from './operator';
 import { ModeHandler } from './../mode/modeHandler.ts';
 import { TextEditor } from './../textEditor';
+import { Register } from './../register/register';
 
 export class PutOperator extends Operator {
 
@@ -18,16 +18,9 @@ export class PutOperator extends Operator {
      * Run this operator on a range.
      */
     public async run(start: Position, end: Position): Promise<void> {
-        return new Promise<void>(async (resolve, reject) => {
-            paste(async (err, data) => {
-                if (err) {
-                    reject();
-                } else {
-                    await TextEditor.insertAt(data, start.getRight());
-                    this.modeHandler.currentMode.motion.moveTo(start.line, start.getRight().character);
-                    resolve();
-                }
-            });
-        });
+        const data = Register.get();
+
+        await TextEditor.insertAt(data, start.getRight());
+        this.modeHandler.currentMode.motion.moveTo(start.line, start.getRight().character);
     }
 }

--- a/src/register/register.ts
+++ b/src/register/register.ts
@@ -1,0 +1,31 @@
+export class Register {
+    private static validRegisters = [
+        '"'
+    ];
+
+    private static registers: {[key: string]: string } = {};
+
+    /**
+     * Puts content in a register. If none is specified, uses the default
+     * register ".
+     */
+    public static put(content: string, register: string = '"'): void {
+        if (Register.validRegisters.indexOf(register) === -1) {
+            throw new Error(`Invalid register ${register}`);
+        }
+
+        Register.registers[register] = content;
+    }
+
+    /**
+     * Gets content from a register. If none is specified, uses the default
+     * register ".
+     */
+    public static get(register: string = '"'): string {
+        if (Register.validRegisters.indexOf(register) === -1) {
+            throw new Error(`Invalid register ${register}`);
+        }
+
+        return Register.registers[register];
+    }
+}

--- a/src/textEditor.ts
+++ b/src/textEditor.ts
@@ -1,7 +1,7 @@
 "use strict";
 
 import * as vscode from "vscode";
-import {copy} from "copy-paste";
+import { Register } from './register/register';
 
 export class TextEditor {
     static async insert(text: string): Promise<boolean> {
@@ -17,12 +17,9 @@ export class TextEditor {
     }
 
     static async copy(range: vscode.Range): Promise<void> {
-        return new Promise<void>((resolve, reject) => {
-            const text = vscode.window.activeTextEditor.document.getText(range);
-            copy(text, (err) => {
-                (err) ? reject() : resolve();
-            });
-        });
+        const text = vscode.window.activeTextEditor.document.getText(range);
+
+        Register.put(text);
     }
 
     static async delete(range: vscode.Range): Promise<boolean> {

--- a/test/mode/modeNormal.test.ts
+++ b/test/mode/modeNormal.test.ts
@@ -1,11 +1,8 @@
 "use strict";
 
 import * as assert from 'assert';
-import {CommandKeyMap} from '../../src/configuration/commandKeyMap';
 import {setupWorkspace, cleanUpWorkspace, assertEqualLines, assertEqual} from './../testUtils';
-import {NormalMode} from '../../src/mode/modeNormal';
 import {ModeName} from '../../src/mode/mode';
-import {Motion, MotionMode} from '../../src/motion/motion';
 import {TextEditor} from '../../src/textEditor';
 import {ModeHandler} from '../../src/mode/modeHandler';
 
@@ -114,7 +111,7 @@ suite("Mode Normal", () => {
         ]);
 
         await assertEqualLines(["te"]);
-        await modeHandler.handleKeyEvent('D')
+        await modeHandler.handleKeyEvent('D');
         await assertEqualLines(["t"]);
     });
 

--- a/test/operator/put.test.ts
+++ b/test/operator/put.test.ts
@@ -2,12 +2,12 @@
 
 import * as assert from 'assert';
 import * as vscode from 'vscode';
-import { copy } from "copy-paste";
 import { ModeHandler } from "../../src/mode/modeHandler";
 import { PutOperator } from "../../src/operator/put";
 import { TextEditor } from '../../src/textEditor';
 import { Position, PositionOptions } from "../../src/motion/position";
 import { setupWorkspace, cleanUpWorkspace } from '../testUtils';
+import { Register } from '../../src/register/register';
 
 suite("put operator", () => {
     suiteSetup(setupWorkspace);
@@ -20,9 +20,7 @@ suite("put operator", () => {
         const mode = new ModeHandler();
         const put = new PutOperator(mode);
 
-        await new Promise(resolve => {
-            copy(expectedText, () => resolve());
-        });
+        Register.put(expectedText);
 
         await put.run(position, position);
 
@@ -43,9 +41,7 @@ suite("put operator", () => {
         const mode = new ModeHandler();
         const put = new PutOperator(mode);
 
-        await new Promise(resolve => {
-            copy(phrase, () => resolve());
-        });
+        Register.put(phrase);
 
         // using ^ to show the cusor position
         // before : the dog

--- a/test/textEditor.test.ts
+++ b/test/textEditor.test.ts
@@ -2,9 +2,9 @@
 
 import * as assert from 'assert';
 import * as vscode from 'vscode';
-import {paste} from "copy-paste";
 import {TextEditor} from './../src/textEditor';
 import {setupWorkspace, cleanUpWorkspace} from './testUtils';
+import { Register } from './../src/register/register';
 
 suite("text editor", () => {
     suiteSetup(setupWorkspace);
@@ -68,7 +68,7 @@ suite("text editor", () => {
         const range = vscode.window.activeTextEditor.document.lineAt(0).range;
 
         await TextEditor.delete(range);
-        const actualText = paste();
+        const actualText = Register.get();
         assert.equal(actualText, expectedText);
     });
 });

--- a/typings.json
+++ b/typings.json
@@ -1,10 +1,6 @@
 {
   "name": "vim",
-  "ambientDependencies": {
-    "copy-paste": "registry:dt/copy-paste#1.1.3+20160117130525"
-  },
   "globalDependencies": {
-    "copy-paste": "registry:dt/copy-paste#1.1.3+20160117130525",
     "lodash": "registry:dt/lodash#3.10.0+20160330154726"
   }
 }


### PR DESCRIPTION
Hoping to kill 2 birds with one stone here:

1. Remove that dumb copy-paste dependency that (I think) caused some intermittent test failures.
2. Begin to implement Registers with a simple enough API.

This has the downside of no longer yanking to the clipboard, but many other implementations of Vim don't yank to clipboard either, including... uh... Vim itself. Cmd-C or Ctrl-C still work, too, so I'm not concerned.