### PR TITLE
Fix vims wonky visual eol behavior

### DIFF
--- a/src/mode/modeHandler.ts
+++ b/src/mode/modeHandler.ts
@@ -340,21 +340,15 @@ export class ModeHandler implements vscode.Disposable {
 
             // Keep the cursor within bounds
 
-            if (!(this.currentMode instanceof InsertMode)) {
-                if (stop.character >= TextEditor.getLineAt(stop).text.length) {
-                    stop = new Position(stop.line, TextEditor.getLineAt(stop).text.length);
-                }
-            }
-
-            if (this.currentMode instanceof NormalMode) {
+            if (this.currentMode.name === ModeName.Normal) {
                 if (stop.character >= Position.getLineLength(stop.line)) {
                     stop = stop.getLineEnd().getLeft();
                     this._vimState.cursorPosition = stop;
                 }
             } else if (this.currentMode.name === ModeName.Visual ||
                        this.currentMode.name === ModeName.VisualLine) {
-                if (stop.character >= Position.getLineLength(stop.line)) {
-                    stop = stop.getLineEnd().getLeft();
+                if (stop.character > Position.getLineLength(stop.line)) {
+                    stop = stop.getLineEnd();
                     this._vimState.cursorPosition = stop;
                 }
 

--- a/src/mode/modeHandler.ts
+++ b/src/mode/modeHandler.ts
@@ -347,6 +347,11 @@ export class ModeHandler implements vscode.Disposable {
                 }
             } else if (this.currentMode.name === ModeName.Visual ||
                        this.currentMode.name === ModeName.VisualLine) {
+
+                // Vim does this weird thing where it allows you to select and delete
+                // the newline character, which it places 1 past the last character
+                // in the line. This is why we use > instead of >=.
+
                 if (stop.character > Position.getLineLength(stop.line)) {
                     stop = stop.getLineEnd();
                     this._vimState.cursorPosition = stop;
@@ -393,6 +398,7 @@ export class ModeHandler implements vscode.Disposable {
             } else {
                 vscode.window.activeTextEditor.selection = new vscode.Selection(stop, stop);
             }
+
             // Updated desired column
 
             const movement = actionState.movement, command = actionState.command;

--- a/src/mode/modeHandler.ts
+++ b/src/mode/modeHandler.ts
@@ -13,7 +13,7 @@ import {
     KeypressState } from './../actions/actions';
 import { Configuration } from '../configuration/configuration';
 import { Position } from './../motion/position';
-import { TextEditor } from '../../src/textEditor';
+import { RegisterMode } from './../register/register';
 import { showCmdLine } from '../../src/cmd_line/main';
 
 export enum VimCommandActions {
@@ -65,6 +65,10 @@ export class VimState {
      * The mode Vim will be in once this action finishes.
      */
     public currentMode = ModeName.Normal;
+
+    public currentRegisterMode = RegisterMode.FigureItOutFromCurrentMode;
+
+    public registerName = '"';
 
     /**
      * This is for oddball commands that don't manipulate text in any way.
@@ -447,7 +451,7 @@ export class ModeHandler implements vscode.Disposable {
 
             if (this.currentModeName === ModeName.VisualLine) {
                 start = Position.EarlierOf(start, stop).getLineBegin();
-                stop = Position.LaterOf(start, stop).getLineEnd();
+                stop  = Position.LaterOf(start, stop).getLineEnd();
             }
 
             return await actionState.operator.run(this._vimState, start, stop);

--- a/src/motion/position.ts
+++ b/src/motion/position.ts
@@ -219,8 +219,16 @@ export class Position extends vscode.Position {
     /**
      * Returns a new position at the end of this position's line.
      */
-    public getLineEnd() : Position {
+    public getLineEnd(): Position {
         return new Position(this.line, Position.getLineLength(this.line));
+    }
+
+    /**
+     * Returns a new position at the end of this position's line, including the
+     * invisible newline character.
+     */
+    public getLineEndIncludingEOL(): Position {
+        return new Position(this.line, Position.getLineLength(this.line) + 1);
     }
 
     public getDocumentBegin() : Position {

--- a/src/register/register.ts
+++ b/src/register/register.ts
@@ -1,27 +1,60 @@
+import { ModeName } from './../mode/mode';
+import { VimState } from './../mode/modeHandler';
+
+export enum RegisterMode {
+    FigureItOutFromCurrentMode,
+    CharacterWise,
+    LineWise,
+};
+
+export interface IRegisterContent {
+    text: string;
+    registerMode: RegisterMode;
+}
+
 export class Register {
     private static validRegisters = [
         '"'
     ];
 
-    private static registers: {[key: string]: string } = {};
+    private static registers: { [key: string]: IRegisterContent } = {};
 
     /**
      * Puts content in a register. If none is specified, uses the default
      * register ".
      */
-    public static put(content: string, register: string = '"'): void {
+    public static put(content: string, vimState: VimState): void {
+        const register = vimState.registerName;
+
         if (Register.validRegisters.indexOf(register) === -1) {
             throw new Error(`Invalid register ${register}`);
         }
 
-        Register.registers[register] = content;
+        let registerMode: RegisterMode;
+
+        if (vimState.currentRegisterMode === RegisterMode.FigureItOutFromCurrentMode) {
+            if (vimState.currentMode === ModeName.VisualLine) {
+                registerMode = RegisterMode.LineWise;
+            } else {
+                registerMode = RegisterMode.CharacterWise;
+            }
+        } else {
+            registerMode = vimState.currentRegisterMode;
+        }
+
+        Register.registers[register] = {
+            text        : content,
+            registerMode: registerMode,
+        };
     }
 
     /**
      * Gets content from a register. If none is specified, uses the default
      * register ".
      */
-    public static get(register: string = '"'): string {
+    public static get(vimState: VimState): IRegisterContent {
+        const register = vimState.registerName;
+
         if (Register.validRegisters.indexOf(register) === -1) {
             throw new Error(`Invalid register ${register}`);
         }

--- a/src/register/register.ts
+++ b/src/register/register.ts
@@ -1,6 +1,13 @@
 import { ModeName } from './../mode/mode';
 import { VimState } from './../mode/modeHandler';
 
+
+/**
+ * There are two different modes of copy/paste in Vim - copy by character
+ * and copy by line. Copy by line typically happens in Visual Line mode, but
+ * also shows up in some other actions that work over lines (most noteably dd,
+ * yy, and cc).
+ */
 export enum RegisterMode {
     FigureItOutFromCurrentMode,
     CharacterWise,
@@ -8,7 +15,7 @@ export enum RegisterMode {
 };
 
 export interface IRegisterContent {
-    text: string;
+    text        : string;
     registerMode: RegisterMode;
 }
 

--- a/src/textEditor.ts
+++ b/src/textEditor.ts
@@ -1,7 +1,6 @@
 "use strict";
 
 import * as vscode from "vscode";
-import { Register } from './register/register';
 
 export class TextEditor {
     static async insert(text: string): Promise<boolean> {

--- a/src/textEditor.ts
+++ b/src/textEditor.ts
@@ -16,14 +16,7 @@ export class TextEditor {
         });
     }
 
-    static async copy(range: vscode.Range): Promise<void> {
-        const text = vscode.window.activeTextEditor.document.getText(range);
-
-        Register.put(text);
-    }
-
     static async delete(range: vscode.Range): Promise<boolean> {
-        TextEditor.copy(range);
         return vscode.window.activeTextEditor.edit(editBuilder => {
             editBuilder.delete(range);
         });

--- a/test/mode/modeNormal.test.ts
+++ b/test/mode/modeNormal.test.ts
@@ -114,7 +114,7 @@ suite("Mode Normal", () => {
             'y', 'y', 'O', '<esc>', 'p'
         ]);
 
-        assertEqualLines(["one", "one"]);
+        assertEqualLines(["", "one", "one"]);
     });
 
     test("Can handle 'de'", async () => {

--- a/test/mode/modeNormal.test.ts
+++ b/test/mode/modeNormal.test.ts
@@ -66,7 +66,7 @@ suite("Mode Normal", () => {
         await assertEqualLines(["text"]);
     });
 
-    test("Can handle dd end-of-line", async () => {
+    test("Can handle dd last line", async () => {
         await modeHandler.handleMultipleKeyEvents("ione\ntwo".split(""));
         await modeHandler.handleMultipleKeyEvents([
             '<esc>', '^',

--- a/test/mode/modeNormal.test.ts
+++ b/test/mode/modeNormal.test.ts
@@ -96,6 +96,17 @@ suite("Mode Normal", () => {
         assertEqualLines(["two"]);
     });
 
+
+    test("Can handle dd empty line", async () => {
+        await modeHandler.handleMultipleKeyEvents("ione\n\ntwo".split(""));
+        await modeHandler.handleMultipleKeyEvents([
+            '<esc>', 'g', 'g', 'j',
+            'd', 'd'
+        ]);
+
+        assertEqualLines(["one", "two"]);
+    });
+
     test("Can handle cc", async () => {
         await modeHandler.handleMultipleKeyEvents("ione\none two".split(""));
         await modeHandler.handleMultipleKeyEvents([

--- a/test/mode/modeVisual.test.ts
+++ b/test/mode/modeVisual.test.ts
@@ -141,4 +141,65 @@ suite("Mode Visual", () => {
         assertEqualLines(["wo three"]);
         assertEqual(modeHandler.currentMode.name, ModeName.Insert);
     });
+
+    suite("Vim's EOL handling is weird", () => {
+
+        test("delete through eol", async () => {
+            await modeHandler.handleMultipleKeyEvents(
+                'ione\ntwo'.split('')
+            );
+
+            await modeHandler.handleMultipleKeyEvents([
+                '<esc>',
+                '^', 'g', 'g',
+                'v', 'l', 'l', 'l',
+                'd'
+            ]);
+
+            assertEqualLines(["two"]);
+        });
+
+        test("join 2 lines by deleting through eol", async () => {
+            await modeHandler.handleMultipleKeyEvents(
+                'ione\ntwo'.split('')
+            );
+
+            await modeHandler.handleMultipleKeyEvents([
+                '<esc>',
+                'g', 'g',
+                'l', 'v', 'l', 'l',
+                'd'
+            ]);
+
+            assertEqualLines(["otwo"]);
+        });
+
+        test("d$ doesn't delete whole line", async () => {
+            await modeHandler.handleMultipleKeyEvents(
+                'ione\ntwo'.split('')
+            );
+
+            await modeHandler.handleMultipleKeyEvents([
+                '<esc>',
+                'g', 'g',
+                'd', '$'
+            ]);
+
+            assertEqualLines(["", "two"]);
+        });
+
+        test("vd$ does delete whole line", async () => {
+            await modeHandler.handleMultipleKeyEvents(
+                'ione\ntwo'.split('')
+            );
+
+            await modeHandler.handleMultipleKeyEvents([
+                '<esc>',
+                'g', 'g',
+                'v', '$', 'd'
+            ]);
+
+            assertEqualLines(["two"]);
+        });
+    });
 });

--- a/test/operator/put.test.ts
+++ b/test/operator/put.test.ts
@@ -15,7 +15,7 @@ suite("put operator", () => {
 
     suiteTeardown(cleanUpWorkspace);
 
-    test ("basic put test", async () => {
+    test("basic put test", async () => {
         await modeHandler.handleMultipleKeyEvents(
             'iblah blah'.split('')
         );
@@ -27,4 +27,44 @@ suite("put operator", () => {
 
         await assertEqualLines(["blah blahblah blah"]);
     });
+
+    test("test yy end of line", async () => {
+        await modeHandler.handleMultipleKeyEvents(
+            'iblah blah\nblah'.split('')
+        );
+
+        await modeHandler.handleMultipleKeyEvents([
+            '<esc>',
+            '^', 'y', 'y', 'p'
+        ]);
+
+        await assertEqualLines(["blah blah", "blah", "blah"]);
+    });
+
+    test("test yy first line", async () => {
+        await modeHandler.handleMultipleKeyEvents(
+            'iblah blah\nblah'.split('')
+        );
+
+        await modeHandler.handleMultipleKeyEvents([
+            '<esc>',
+            'g', 'g', 'y', 'y', 'p'
+        ]);
+
+        await assertEqualLines(["blah blah", "blah blah", "blah"]);
+    });
+
+    test("test yy middle line", async () => {
+        await modeHandler.handleMultipleKeyEvents(
+            'i1\n2\n3'.split('')
+        );
+
+        await modeHandler.handleMultipleKeyEvents([
+            '<esc>',
+            'k', 'y', 'y', 'p'
+        ]);
+
+        await assertEqualLines(["1", "2", "2", "3"]);
+    });
+
 });

--- a/test/textEditor.test.ts
+++ b/test/textEditor.test.ts
@@ -2,9 +2,8 @@
 
 import * as assert from 'assert';
 import * as vscode from 'vscode';
-import {TextEditor} from './../src/textEditor';
-import {setupWorkspace, cleanUpWorkspace} from './testUtils';
-import { Register } from './../src/register/register';
+import { TextEditor } from './../src/textEditor';
+import { setupWorkspace, cleanUpWorkspace } from './testUtils';
 
 suite("text editor", () => {
     suiteSetup(setupWorkspace);
@@ -12,7 +11,7 @@ suite("text editor", () => {
     suiteTeardown(cleanUpWorkspace);
 
     test("insert 'Hello World'", async () => {
-        let expectedText = "Hello World";
+    let expectedText = "Hello World";
 
         await TextEditor.insert(expectedText);
 

--- a/test/textEditor.test.ts
+++ b/test/textEditor.test.ts
@@ -60,15 +60,4 @@ suite("text editor", () => {
         assert.throws(() => TextEditor.readLineAt(1), RangeError);
         assert.throws(() => TextEditor.readLineAt(2), RangeError);
     });
-
-    test("delete should copy to clipboard", async () => {
-        const expectedText = "Hello World";
-        await TextEditor.insert(expectedText);
-
-        const range = vscode.window.activeTextEditor.document.lineAt(0).range;
-
-        await TextEditor.delete(range);
-        const actualText = Register.get();
-        assert.equal(actualText, expectedText);
-    });
 });


### PR DESCRIPTION
Vim does this weird thing where it allows you to select and delete the newline character, which it places 1 past the last character in the line (it looks like a space). Properly handling this character makes some visual mode idiosyncrasies work. It also makes Visual Line mode work a lot better.