### PR TITLE
Add simpler test mechanism and convert some tests

### DIFF
--- a/test/testSimplifier.ts
+++ b/test/testSimplifier.ts
@@ -1,0 +1,149 @@
+import * as assert from 'assert';
+import { ModeName } from '../src/mode/mode'
+import { Position } from '../src/motion/position';
+import { ModeHandler } from '../src/mode/modeHandler';
+import { TextEditor } from '../src/textEditor';
+import { assertEqualLines } from './testUtils';
+
+
+interface TestObject {
+    start: string[],
+    keysPressed: string,
+    end: string[],
+    endMode?: ModeName
+}
+
+class TestObjectHelper {
+    startPosition = new Position(0, 0);
+    endPosition = new Position(0, 0);
+    private _isValid = false;
+    
+    constructor(private _testObject: TestObject) {
+        this._parse(_testObject);
+    }
+
+    public get isValid(): boolean {
+        return this._isValid;
+    }
+    
+    private _setStartCursorPosition(lines: string[]): boolean {
+        let result = this._getCursorPosition(lines);
+        this.startPosition = result.position;
+        return result.success;
+    }
+
+    private _setEndCursorPosition(lines: string[]): boolean {
+        let result = this._getCursorPosition(lines);
+        this.endPosition = result.position;
+        return result.success;
+    }
+    
+    private _getCursorPosition(lines: string[]): { success: boolean; position: Position} {
+        let ret = { success: false, position: new Position(0, 0) };
+        for (let i = 0; i < lines.length; i++) {
+            let columnIdx = lines[i].indexOf('|');
+            if (columnIdx >= 0) {
+                ret.position = ret.position.setLocation(i, columnIdx);
+                ret.success = true;
+            }
+        }
+
+        return ret;
+    }
+
+    private _parse(t: TestObject): void {
+        if (!this._setStartCursorPosition(t.start)) {
+            this._isValid = false;
+            return;
+        }
+        if (!this._setEndCursorPosition(t.end)) {
+            this._isValid = false;
+            return;
+        }
+
+        this._isValid = true;
+    }
+
+    public asVimInputText(): string[] {
+        let ret = 'i' + this._testObject.start.join('\n').replace('|', '');
+        return ret.split('');
+    }
+
+    public asVimOutputText(): string[] {
+        let ret = this._testObject.end.slice(0);
+        ret[this.endPosition.line] = ret[this.endPosition.line].replace('|', '');
+        return ret;
+    }
+
+    /** Returns a sequence of Vim movement characters 'hjkl' as a string array
+     * which will move the cursor to the start position given in the test. */
+    public getKeyPressesToMoveToStartPosition(): string[] {
+        let ret = '';
+        let h = 0, j = 0, k = 0, l = 0;
+        let linesToMove = this.startPosition.line - (this._testObject.start.length - 1);
+
+        let cursorPosAfterEsc =
+            this._testObject.start[this._testObject.start.length - 1].replace('|', '').length - 1;
+        let numCharsInCursorStartLine =
+            this._testObject.start[this.startPosition.line].replace('|', '').length - 1;
+        let columnOnStartLine = Math.min(cursorPosAfterEsc, numCharsInCursorStartLine);
+        let charactersToMove = this.startPosition.character - columnOnStartLine;
+
+        if (linesToMove > 0) {
+            ret += Array(linesToMove + 1).join('j');
+        }   
+        else if (linesToMove < 0) {
+            ret += Array(Math.abs(linesToMove) + 1).join('k');
+        }
+
+        if (charactersToMove > 0) {
+            ret += Array(charactersToMove + 1).join('l');
+        }
+        else if (charactersToMove < 0) {
+            ret += Array(Math.abs(charactersToMove) + 1).join('h');
+        }
+        //console.log("ret is " + ret);
+        return ret.split('');
+    }
+}
+
+async function testIt(modeHandler: ModeHandler, testObj: TestObject): Promise<void> {
+    let helper = new TestObjectHelper(testObj);
+
+    // start:
+    //
+    await modeHandler.handleMultipleKeyEvents(helper.asVimInputText());
+    
+    // keysPressed:
+    //
+    await modeHandler.handleKeyEvent('<esc>');
+    // move cursor to start position using 'hjkl'
+    await modeHandler.handleMultipleKeyEvents(helper.getKeyPressesToMoveToStartPosition());
+
+    // assumes key presses are single characters for now    
+    await modeHandler.handleMultipleKeyEvents(testObj.keysPressed.split(''));
+        
+    // Check valid test object input
+    assert(helper.isValid, "Missing '|' in test object.");
+    
+    // Check final cursor position
+    //
+    let actualPosition = Position.FromVSCodePosition(TextEditor.getSelection().start);
+    let expectedPosition = helper.endPosition;
+    assert.equal(actualPosition.line, expectedPosition.line, "Cursor LINE position is wrong.");
+    assert.equal(actualPosition.character, expectedPosition.character, "Cursor CHARACTER position is wrong.");
+    
+    // end: check given end output is correct
+    //
+    assertEqualLines(helper.asVimOutputText());
+
+    // endMode: check end mode is correct if given
+    if (typeof testObj.endMode !== 'undefined') {
+        let actualMode = ModeName[modeHandler.currentMode.name].toUpperCase();
+        let expectedMode = ModeName[testObj.endMode].toUpperCase();
+        assert.equal(actualMode, expectedMode, "Didn't enter correct mode.");    
+    }
+}
+
+
+export { TestObject, testIt }

--- a/test/testUtils.ts
+++ b/test/testUtils.ts
@@ -23,10 +23,10 @@ async function createRandomFile(contents: string): Promise<vscode.Uri> {
 }
 
 export function assertEqualLines(expectedLines: string[]) {
-    assert.equal(TextEditor.getLineCount(), expectedLines.length);
+    assert.equal(TextEditor.getLineCount(), expectedLines.length, "Line count does not match.");
 
     for (let i = 0; i < expectedLines.length; i++) {
-        assert.equal(TextEditor.readLineAt(i), expectedLines[i]);
+        assert.equal(TextEditor.readLineAt(i), expectedLines[i], `Line ${i} is different.`);
     }
 }
 


### PR DESCRIPTION
Hi I've had a first crack at #256.

I'm new to typescript/javascript/git/github so feel free to tell me how to improve or change this to what you have in mind.

I've added an extra optional **endMode**: parameter so we can check the final mode.
```typescript
+    newTest("Can handle 'caw' on blanks",
+        {
+            start: ['text   tex|t'],
+            keysPressed: '^lllllcaw',
+            end: ['text|'],
+            endMode: ModeName.Insert
+        }
+    );
```

Here is a code snippet which will make entering tests easier. Activate with 'newt':
```typescript
	"Add new test": {
		"prefix": "newt",
		"body": [
    	"newTest(\"$1\",",
		"	{",
		"		start: ['$2'],",
		"		keysPressed: '$3',",
		"		end: ['$4'],",
		"		//endMode: ModeName.Insert",
		"	}",
    	");",
		"$5"
		],
		"description": "Create a new test"
	}
```

I also added a few 'P' tests. Note that 3 tests are currently failing.