### PR TITLE
Refactor dot

### DIFF
--- a/src/actions/actions.ts
+++ b/src/actions/actions.ts
@@ -380,7 +380,7 @@ class CommandInsertInInsertMode extends BaseCommand {
   keys = ["<character>"];
 
   public async exec(position: Position, vimState: VimState): Promise<VimState> {
-    const char = vimState.actionState.actionKeys[0];
+    const char = vimState.actionState.actionKeys[vimState.actionState.actionKeys.length - 1];
 
     if (char === "<enter>") {
       await TextEditor.insert("\n");

--- a/src/actions/actions.ts
+++ b/src/actions/actions.ts
@@ -79,8 +79,8 @@ export class BaseAction {
     // TODO - this is not exactly correct and will eventually make me rage
     // It's for cases like daw where a would otherwise by treated as append and insert.
     if (this instanceof BaseCommand &&
-      !vimState.actionState.isInInitialState &&
-      !(this instanceof CommandInsertInSearchMode)) { return false; }
+        vimState.actionState.operator &&
+        !(this instanceof CommandInsertInSearchMode)) { return false; }
     if (this instanceof BaseOperator && vimState.actionState.operator) { return false; }
 
     return true;
@@ -93,8 +93,8 @@ export class BaseAction {
     if (this.modes.indexOf(vimState.currentMode) === -1) { return false; }
     if (!compareKeypressSequence(this.keys.slice(0, keysPressed.length), keysPressed)) { return false; }
     if (this instanceof BaseCommand &&
-      !vimState.actionState.isInInitialState &&
-      !(this instanceof CommandInsertInSearchMode)) { return false; }
+        vimState.actionState.operator &&
+        !(this instanceof CommandInsertInSearchMode)) { return false; }
     if (this instanceof BaseOperator && vimState.actionState.operator) { return false; }
 
     return true;
@@ -208,6 +208,22 @@ export function RegisterAction(action) {
 
 
 
+@RegisterAction
+class CommandEsc extends BaseCommand {
+  modes = [ModeName.Insert, ModeName.Visual, ModeName.VisualLine];
+  keys = ["<esc>"];
+
+  public async exec(position: Position, vimState: VimState): Promise<VimState> {
+    if (vimState.currentMode !== ModeName.Visual &&
+        vimState.currentMode !== ModeName.VisualLine) {
+      vimState.cursorPosition = position.getLeft();
+    }
+
+    vimState.currentMode = ModeName.Normal;
+
+    return vimState;
+  }
+}
 
 @RegisterAction
 class CommandInsertAtCursor extends BaseCommand {
@@ -759,23 +775,6 @@ class CommandMoveFullPageUp extends BaseCommand {
 
   public async exec(position: Position, vimState: VimState): Promise<VimState> {
     vimState.commandAction = VimCommandActions.MoveFullPageUp;
-
-    return vimState;
-  }
-}
-
-@RegisterAction
-class CommandEsc extends BaseCommand {
-  modes = [ModeName.Insert, ModeName.Visual, ModeName.VisualLine];
-  keys = ["<esc>"];
-
-  public async exec(position: Position, vimState: VimState): Promise<VimState> {
-    if (vimState.currentMode !== ModeName.Visual &&
-        vimState.currentMode !== ModeName.VisualLine) {
-      vimState.cursorPosition = position.getLeft();
-    }
-
-    vimState.currentMode = ModeName.Normal;
 
     return vimState;
   }

--- a/src/actions/actions.ts
+++ b/src/actions/actions.ts
@@ -430,7 +430,7 @@ class CommandInsertInInsertMode extends BaseCommand {
 }
 
 @RegisterAction
-class CommandSearchForwards extends BaseCommand {
+export class CommandSearchForwards extends BaseCommand {
   modes = [ModeName.Normal];
   keys = ["/"];
 
@@ -448,7 +448,7 @@ class CommandSearchForwards extends BaseCommand {
 
 
 @RegisterAction
-class CommandSearchBackward extends BaseCommand {
+export class CommandSearchBackwards extends BaseCommand {
   modes = [ModeName.Normal];
   keys = ["?"];
 

--- a/src/actions/actions.ts
+++ b/src/actions/actions.ts
@@ -1,4 +1,4 @@
-import { VimCommandActions, VimState, RecordedState } from './../mode/modeHandler';
+import { VimCommandActions, VimState } from './../mode/modeHandler';
 import { ModeName } from './../mode/mode';
 import { TextEditor } from './../textEditor';
 import { Register, RegisterMode } from './../register/register';

--- a/src/mode/modeHandler.ts
+++ b/src/mode/modeHandler.ts
@@ -11,7 +11,7 @@ import { SearchInProgressMode } from './modeSearchInProgress';
 import { VisualLineMode } from './modeVisualLine';
 import {
     BaseMovement, BaseCommand, Actions, BaseAction,
-    BaseOperator, PutCommand, isIMovement,
+    BaseOperator, isIMovement,
     CommandSearchForwards, CommandSearchBackwards,
     KeypressState } from './../actions/actions';
 import { Configuration } from '../configuration/configuration';

--- a/src/mode/modeHandler.ts
+++ b/src/mode/modeHandler.ts
@@ -150,15 +150,15 @@ export class RecordedState {
 
         if (list.length > 1) { throw "Too many operators!"; }
 
-        return list[0];
+        return list[0] as any;
     }
 
     public get command(): BaseCommand {
         const list = _.filter(this.actionsRun, a => a instanceof BaseCommand);
 
-        // TODO - just disregard <esc>
+        // TODO - disregard <esc>, then assert this is of length 1.
 
-        return list[0];
+        return list[0] as any;
     }
 
     public get hasRunAMovement(): boolean {

--- a/src/mode/modeHandler.ts
+++ b/src/mode/modeHandler.ts
@@ -162,6 +162,28 @@ export class ActionState {
                this.motionsRun.length === 0   &&
                this.count       === 1;
     }
+
+    public toString(): string {
+        let result = "";
+
+        if (this.command) {
+            result += this.command.keys.join("") + " ";
+        }
+
+        for (let i = 0; i < this.motionsRun.length; i++) {
+            result += this.motionsRun[i].keys.join("");
+        }
+
+        if (this.motionsRun.length > 0) {
+            result += " ";
+        }
+
+        if (this.operator) {
+            result += this.operator.keys.join("");
+        }
+
+        return result;
+    }
 }
 
 interface IViewState {
@@ -347,6 +369,8 @@ export class ModeHandler implements vscode.Disposable {
             selectionStop : vimState.cursorPosition,
             currentMode   : vimState.currentMode,
         });
+
+        console.log(actionState.toString());
 
         return vimState;
     }


### PR DESCRIPTION
This makes . work with actions such as `cawasdf<esc>` and even the extra-tricky `d/blah<esc>`. 

. is actually pretty solid now. Now I just need to do repeated actions and then my work here is done. 😉 