### PR TITLE
Add support for 'U' uppercase

### DIFF
--- a/src/actions/actions.ts
+++ b/src/actions/actions.ts
@@ -229,6 +229,17 @@ export class BaseOperator extends BaseAction {
      * Run this operator on a range, returning the new location of the cursor.
      */
     run(vimState: VimState, start: Position, stop: Position): Promise<VimState> { return; }
+
+    public transformRange(start: Position, end: Position): [Position, Position] {
+      if (start.compareTo(end) <= 0) {
+        end = new Position(end.line, end.character + 1);
+      } else {
+        [start, end] = [end, start];
+        end = new Position(end.line, end.character + 1);
+      }
+
+      return [start, end];
+    }
 }
 
 export enum KeypressState {
@@ -656,16 +667,7 @@ export class DeleteOperator extends BaseOperator {
      * Deletes from the position of start to 1 past the position of end.
      */
     public async run(vimState: VimState, start: Position, end: Position): Promise<VimState> {
-        if (start.compareTo(end) <= 0) {
-          end = new Position(end.line, end.character + 1);
-        } else {
-          const tmp = start;
-          start = end;
-          end = tmp;
-
-          end = new Position(end.line, end.character + 1);
-        }
-
+        [start, end] = this.transformRange(start, end);
         const isOnLastLine = end.line === TextEditor.getLineCount() - 1;
 
         // Vim does this weird thing where it allows you to select and delete
@@ -767,6 +769,20 @@ export class DeleteOperatorXVisual extends BaseOperator {
 
     public async run(vimState: VimState, start: Position, end: Position): Promise<VimState> {
       return await new DeleteOperator().run(vimState, start, end);
+    }
+}
+
+@RegisterAction
+export class UpperCaseOperator extends BaseOperator {
+    public keys = ["U"];
+    public modes = [ModeName.Visual, ModeName.VisualLine];
+    
+    public async run(vimState: VimState, start: Position, end: Position): Promise<VimState> {
+      [start, end] = this.transformRange(start, end);
+      let text = vscode.window.activeTextEditor.document.getText(new vscode.Range(start, end));
+      await TextEditor.replace(new vscode.Range(start, end), text.toUpperCase());        
+      vimState.currentMode = ModeName.Normal;
+      return vimState;
     }
 }
 

--- a/test/mode/modeVisualLine.test.ts
+++ b/test/mode/modeVisualLine.test.ts
@@ -64,6 +64,18 @@ suite("Mode Visual", () => {
         assertEqual(modeHandler.currentMode.name, ModeName.Normal);
     });
 
+    test("Can handle U", async () => {
+        await modeHandler.handleMultipleKeyEvents("ione two three".split(""));
+        await modeHandler.handleMultipleKeyEvents([
+             '<esc>', '^',
+            'v', 'U'
+        ]);
+
+        assertEqualLines(["One two three"]);
+
+        assertEqual(modeHandler.currentMode.name, ModeName.Normal);
+    })
+
     test("Can handle x across a selection", async () => {
         await modeHandler.handleMultipleKeyEvents("ione two three".split(""));
         await modeHandler.handleMultipleKeyEvents([
@@ -108,6 +120,30 @@ suite("Mode Visual", () => {
         ]);
 
         assertEqualLines(["our"]);
+    });
+
+    test("Can handle U across a selection", async () => {
+        await modeHandler.handleMultipleKeyEvents("ione two three".split(""));
+        await modeHandler.handleMultipleKeyEvents([
+            '<esc>', '^',
+            'v', 'l', 'l', 'l', 'l', 'U'
+        ]);
+
+        assertEqualLines(["ONE Two three"]);
+
+        assertEqual(modeHandler.currentMode.name, ModeName.Normal);
+    });
+
+    test("Can handle U across a selection in reverse order", async () => {
+        await modeHandler.handleMultipleKeyEvents("ione two three".split(""));
+        await modeHandler.handleMultipleKeyEvents([
+            '<esc>', '^',
+            'w', 'v', 'h', 'h', 'U'
+        ]);
+
+        assertEqualLines(["onE Two three"]);
+
+        assertEqual(modeHandler.currentMode.name, ModeName.Normal);
     });
 
     test("handles case where we go from selecting on right side to selecting on left side", async () => {


### PR DESCRIPTION
Convert selected range to Uppercase is an often-used command.

The code is well designed so it's easy enough to add new commands support. The only catch is all commands are implemented inside a single file, which makes it lack of categorization and readability, any ideas to refactor it?