### PR TITLE
Add %.

### DIFF
--- a/src/actions/actions.ts
+++ b/src/actions/actions.ts
@@ -1522,26 +1522,38 @@ class MovementIWordTextObject extends BaseMovement {
   }
 }
 
-/*
-// Doing this correctly is very difficult.
-   https://github.com/Microsoft/vscode/issues/7177
-
 @RegisterAction
 class MoveToMatchingBracket extends BaseMovement {
   modes = [ModeName.Normal, ModeName.Visual, ModeName.VisualLine];
-  key = ["%"];
+  keys = ["%"];
 
-  public async execAction(position: Position, vimState: VimState): Promise<VimState> {
+  pairings = {
+    "(" : { match: ")",  direction:  1 },
+    "{" : { match: "}",  direction:  1 },
+    "[" : { match: "]",  direction:  1 },
+    ")" : { match: "(",  direction: -1 },
+    "}" : { match: "{",  direction: -1 },
+    "]" : { match: "[",  direction: -1 },
+    // "'" : { match: "'",  direction:  0 },
+    // "\"": { match: "\"", direction:  0 },
+  };
 
-    vscode.window.activeTextEditor.setDecorations
+  public async execAction(position: Position, vimState: VimState): Promise<Position> {
+    const text = TextEditor.getLineAt(position).text;
 
-     await vscode.commands.executeCommand("editor.action.jumpToBracket");
-     await vscode.commands.executeCommand("editor.action.jumpToBracket");
+    if (!this.pairings[text[position.character]]) {
+      // go right until we find a pairable character or hit the end of line.
 
+      for (let i = position.character; i < text.length; i++) {
+        if (this.pairings[text[i]]) {
+          return new Position(position.line, i);
+        }
+      }
 
-    vimState.cursorPosition = position.getLineEnd();
+      // TODO (bell);
+      return position;
+    }
 
-    return vimState;
+    return position;
   }
 }
-*/

--- a/src/actions/actions.ts
+++ b/src/actions/actions.ts
@@ -1586,6 +1586,18 @@ class MoveToMatchingBracket extends BaseMovement {
       return position;
     }
 
+    /**
+     * We do a fairly basic implementation that only tracks the state of the type of
+     * character you're over and its pair (e.g. "[" and "]"). This is similar to
+     * what Vim does.
+     *
+     * It can't handle strings very well - something like "|( ')' )" where | is the
+     * cursor will cause it to go to the ) in the quotes, even though it should skip over it.
+     *
+     * PRs welcomed! (TODO)
+     * Though ideally VSC implements https://github.com/Microsoft/vscode/issues/7177
+     */
+
     let stackHeight = 0;
     let matchedPosition: Position = undefined;
 

--- a/src/mode/modeHandler.ts
+++ b/src/mode/modeHandler.ts
@@ -287,8 +287,10 @@ export class ModeHandler implements vscode.Disposable {
         // is not (0, 0) - e.g., if you previously edited the file and left the cursor
         // somewhere else when you closed it. This will set our cursor's position to the position
         // that VSC set it to.
-        this._vimState.cursorStartPosition = Position.FromVSCodePosition(vscode.window.activeTextEditor.selection.start);
-        this._vimState.cursorPosition = Position.FromVSCodePosition(vscode.window.activeTextEditor.selection.start);
+        if (vscode.window.activeTextEditor) {
+            this._vimState.cursorStartPosition = Position.FromVSCodePosition(vscode.window.activeTextEditor.selection.start);
+            this._vimState.cursorPosition = Position.FromVSCodePosition(vscode.window.activeTextEditor.selection.start);
+        }
 
         // Handle scenarios where mouse used to change current position.
         vscode.window.onDidChangeTextEditorSelection(async (e) => {

--- a/src/motion/position.ts
+++ b/src/motion/position.ts
@@ -33,6 +33,42 @@ export class Position extends vscode.Position {
     }
 
     /**
+     * Iterates over every position in the document starting at start, returning
+     * at every position the current line text, character text, and a position object.
+     */
+    public static *IterateDocument(start: Position, forward = true): Iterable<{ line: string, char: string, pos: Position }> {
+      let lineIndex: number, charIndex: number;
+
+      if (forward) {
+        for (lineIndex = start.line; lineIndex < TextEditor.getLineCount(); lineIndex++) {
+            charIndex = lineIndex === start.line ? start.character : 0;
+            const line = TextEditor.getLineAt(new Position(lineIndex, 0)).text;
+
+            for (; charIndex < line.length; charIndex++) {
+                yield {
+                    line: line,
+                    char: line[charIndex],
+                    pos: new Position(lineIndex, charIndex)
+                };
+            }
+        }
+      } else {
+        for (lineIndex = start.line; lineIndex >= 0; lineIndex--) {
+            const line = TextEditor.getLineAt(new Position(lineIndex, 0)).text;
+            charIndex = lineIndex === start.line ? start.character : line.length - 1;
+
+            for (; charIndex >= 0; charIndex--) {
+                yield {
+                    line: line,
+                    char: line[charIndex],
+                    pos: new Position(lineIndex, charIndex)
+                };
+            }
+        }
+      }
+    }
+
+    /**
      * Returns which of the 2 provided Positions comes later in the document.
      */
     public static LaterOf(p1: Position, p2: Position): Position {

--- a/test/mode/modeNormal.test.ts
+++ b/test/mode/modeNormal.test.ts
@@ -38,7 +38,49 @@ suite("Mode Normal", () => {
       title: "Can handle x",
       start: ['te|xt'],
       keysPressed: 'x',
-      end: ["tet"],
+      end: ["te|t"],
+    });
+
+    newTest({
+      title: "Can handle %",
+      start: ['|((( )))'],
+      keysPressed: '%',
+      end: ["((( ))|)"],
+    });
+
+    newTest({
+      title: "Can handle %",
+      start: ['((( ))|)'],
+      keysPressed: '%',
+      end: ["|((( )))"],
+    });
+
+    newTest({
+      title: "Can handle %",
+      start: ['|[(( ))]'],
+      keysPressed: '%',
+      end: ["[(( ))|]"],
+    });
+
+    newTest({
+      title: "Can handle %",
+      start: ['|[(( }}} ))]'],
+      keysPressed: '%',
+      end: ["[(( }}} ))|]"],
+    });
+
+    newTest({
+      title: "Can handle %",
+      start: ['|[(( }}} ))]'],
+      keysPressed: '%',
+      end: ["[(( }}} ))|]"],
+    });
+
+    newTest({
+      title: "Can handle %",
+      start: ['[(( }}} ))|]'],
+      keysPressed: '%',
+      end: ["|[(( }}} ))]"],
     });
 
     newTest({
@@ -203,14 +245,14 @@ suite("Mode Normal", () => {
       start: ['text text', 'text', 'text tex|t'],
       keysPressed: 'kk',
       end: ['text tex|t', 'text', 'text text'],
-});
+    });
 
     newTest({
       title: "$ always keeps cursor on EOL",
       start: ['text text', 'text', 'text tex|t'],
       keysPressed: 'gg$jj',
       end: ['text text', 'text', 'text tex|t'],
-});
+    });
 
     newTest({
       title: "Can handle 'ciw'",


### PR DESCRIPTION
We do a fairly basic implementation that only tracks the state of the type character you're over and its pair (e.g. "[" and "]"). This is similar to what Vim does.

It can't handle strings very well - something like "|( ')' )" where | is the cursor will cause it to go to the ) in the quotes, even though it should skip over it.

PRs welcomed! I have this case at low priority because I believe it's a lot of effort for very little gain. 

Ideally though, VSC implements https://github.com/Microsoft/vscode/issues/7177.