### PR TITLE
Add format code support. Fix #308.

### DIFF
--- a/src/actions/actions.ts
+++ b/src/actions/actions.ts
@@ -661,6 +661,18 @@ export class CommandSearchBackwards extends BaseCommand {
 }
 
 @RegisterAction
+class CommandFormatCode extends BaseCommand {
+  modes = [ModeName.Visual, ModeName.VisualLine];
+  keys = ["="];
+
+  public async exec(position: Position, vimState: VimState): Promise<VimState> {
+    await vscode.commands.executeCommand("editor.action.format");
+    vimState.currentMode = ModeName.Normal;
+    return vimState;
+  }
+}
+
+@RegisterAction
 export class DeleteOperator extends BaseOperator {
     public keys = ["d"];
     public modes = [ModeName.Normal, ModeName.Visual, ModeName.VisualLine];


### PR DESCRIPTION
Code formatting requires language mode detection. In current test infrastructure, we just create a temp file with no extension, there is no way for VS Code to guess what's the correct language. We should add some test files (like js files, cs files, etc) and launch them directly instead of creating temp files in some cases related to Language Mode. This can be done later with a separate PR.