### PR TITLE
Align TextEditorOptions between test code and workspace

### DIFF
--- a/test/mode/modeVisualLine.test.ts
+++ b/test/mode/modeVisualLine.test.ts
@@ -74,7 +74,7 @@ suite("Mode Visual", () => {
         assertEqualLines(["One two three"]);
 
         assertEqual(modeHandler.currentMode.name, ModeName.Normal);
-    })
+    });
 
     test("Can handle x across a selection", async () => {
         await modeHandler.handleMultipleKeyEvents("ione two three".split(""));

--- a/test/testUtils.ts
+++ b/test/testUtils.ts
@@ -45,6 +45,7 @@ export async function setupWorkspace(): Promise<any> {
     const doc    = await vscode.workspace.openTextDocument(file);
 
     await vscode.window.showTextDocument(doc);
+    setTextEditorOptions(2, true);
 
     assert.ok(vscode.window.activeTextEditor);
 }
@@ -78,4 +79,11 @@ export async function cleanUpWorkspace(): Promise<any> {
         assert.equal(vscode.window.visibleTextEditors.length, 0);
         assert(!vscode.window.activeTextEditor);
     });
+}
+
+export function setTextEditorOptions(tabSize: number | string, insertSpaces: boolean | string): void {
+    vscode.window.activeTextEditor.options = {
+        tabSize,
+        insertSpaces
+    };
 }


### PR DESCRIPTION
When we format code, change code indentation, the final output relies on TextEditorOptions like `tabSize` and `insertSpaces`. Here we allow changing the options in test cases to keep alignment.