### PR TITLE
Sentence

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -79,8 +79,8 @@ Status | Command | Description
 :white_check_mark:   | :1234:  B		| N blank-separated |WORD|s backward
 :white_check_mark:   | :1234:  ge		| N words backward to the end of the Nth word
 :white_check_mark:   | :1234:  gE		| N words backward to the end of the Nth blank-separated |WORD|
-   | :1234:  )		| N sentences forward
-   | :1234:  (		| N sentences backward
+:white_check_mark:   | :1234:  )		| N sentences forward
+:white_check_mark:   | :1234:  (		| N sentences backward
 :white_check_mark:   | :1234:  }		| N paragraphs forward
 :white_check_mark:   | :1234:  {		| N paragraphs backward
    | :1234:  ]]		| N sections forward, at start of section

--- a/src/actions/actions.ts
+++ b/src/actions/actions.ts
@@ -1490,6 +1490,16 @@ class MoveBeginningFullWord extends BaseMovement {
 }
 
 @RegisterAction
+class MoveNextSentenceBegin extends BaseMovement {
+  modes = [ModeName.Normal, ModeName.Visual, ModeName.VisualLine];
+  keys = [")"];
+
+  public async execAction(position: Position, vimState: VimState): Promise<Position> {
+    return position.getNextSentenceBegin();
+  }
+}
+
+@RegisterAction
 class MoveParagraphEnd extends BaseMovement {
   modes = [ModeName.Normal, ModeName.Visual, ModeName.VisualLine];
   keys = ["}"];

--- a/src/actions/actions.ts
+++ b/src/actions/actions.ts
@@ -1490,6 +1490,16 @@ class MoveBeginningFullWord extends BaseMovement {
 }
 
 @RegisterAction
+class MovePreviousSentenceBegin extends BaseMovement {
+  modes = [ModeName.Normal, ModeName.Visual, ModeName.VisualLine];
+  keys = ["("];
+
+  public async execAction(position: Position, vimState: VimState): Promise<Position> {
+    return position.getPreviousSentenceBegin();
+  }
+}
+
+@RegisterAction
 class MoveNextSentenceBegin extends BaseMovement {
   modes = [ModeName.Normal, ModeName.Visual, ModeName.VisualLine];
   keys = [")"];

--- a/src/motion/position.ts
+++ b/src/motion/position.ts
@@ -17,7 +17,7 @@ export class Position extends vscode.Position {
 
         this._nonWordCharRegex = this.makeWordRegex(Position.NonWordCharacters);
         this._nonBigWordCharRegex = this.makeWordRegex(Position.NonBigWordCharacters);
-        this._sentenceEndRegex = /[\.!\?]{1}[ \n\t]+/g;
+        this._sentenceEndRegex = /[\.!\?]{1}([ \n\t]+|$)/g;
     }
 
     public static FromVSCodePosition(pos: vscode.Position): Position {
@@ -503,7 +503,7 @@ export class Position extends vscode.Position {
                           (index >= this.character &&  inclusive)) || currentLine !== this.line);
 
             if (newCharacter !== undefined) {
-                return new Position(currentLine, newCharacter).getRight();
+                return new Position(currentLine, newCharacter).getRightThroughLineBreaks();
             }
         }
 

--- a/src/motion/position.ts
+++ b/src/motion/position.ts
@@ -501,7 +501,7 @@ export class Position extends vscode.Position {
         for (let currentLine = this.line; currentLine >= paragraphBegin.line; currentLine--) {
             let endPositions = this.getAllEndPositions(TextEditor.getLineAt(new vscode.Position(currentLine, 0)).text, regex);
             let newCharacter = _.find(endPositions.reverse(),
-                index => ((index <  this.character && !inclusive)  ||
+                index => ((index <  this.character && !inclusive && new Position(currentLine, index).getRightThroughLineBreaks().compareTo(this)) ||
                           (index <= this.character &&  inclusive)) || currentLine !== this.line)
 
             if (newCharacter !== undefined) {
@@ -509,7 +509,7 @@ export class Position extends vscode.Position {
             }
         }
 
-        if ((paragraphBegin.line + 1 === this.line || paragraphBegin.line === this.line) && this.character === 0) {
+        if ((paragraphBegin.line + 1 === this.line || paragraphBegin.line === this.line)) {
             return paragraphBegin;
         }
         else {

--- a/src/motion/position.ts
+++ b/src/motion/position.ts
@@ -501,8 +501,10 @@ export class Position extends vscode.Position {
         for (let currentLine = this.line; currentLine >= paragraphBegin.line; currentLine--) {
             let endPositions = this.getAllEndPositions(TextEditor.getLineAt(new vscode.Position(currentLine, 0)).text, regex);
             let newCharacter = _.find(endPositions.reverse(),
-                index => ((index <  this.character && !inclusive && new Position(currentLine, index).getRightThroughLineBreaks().compareTo(this)) ||
-                          (index <= this.character &&  inclusive)) || currentLine !== this.line)
+                index => ((index <  this.character && !inclusive
+                           && new Position(currentLine, index).getRightThroughLineBreaks().compareTo(this))
+                           || (index <= this.character && inclusive)
+                         ) || currentLine !== this.line);
 
             if (newCharacter !== undefined) {
                 return new Position(currentLine, newCharacter).getRightThroughLineBreaks();
@@ -511,8 +513,7 @@ export class Position extends vscode.Position {
 
         if ((paragraphBegin.line + 1 === this.line || paragraphBegin.line === this.line)) {
             return paragraphBegin;
-        }
-        else {
+        } else {
             return new Position(paragraphBegin.line + 1, 0);
         }
     }

--- a/test/motion.test.ts
+++ b/test/motion.test.ts
@@ -420,7 +420,7 @@ suite("sentence motion", () => {
             let motion = new Position(0, 35).getPreviousSentenceBegin();
             assert.equal(motion.line, 0);
             assert.equal(motion.character, 0);
-        })
+        });
 
         test("current sentence begin with no concrete sentense inside", () => {
             let motion = new Position(3, 0).getPreviousSentenceBegin();

--- a/test/motion.test.ts
+++ b/test/motion.test.ts
@@ -360,6 +360,53 @@ suite("word motion", () => {
     });
 });
 
+suite("sentence motion", () => {
+    let text: Array<string> = [
+        "This text has many sections in it. What do you think?",
+        "",
+        "A paragraph boundary is also a sentence boundry, see",
+        "",
+        "Weird things happen when there is no appropriate sentence ending",
+        "",
+        "Next line is just whitespace",
+        "   ",
+        "Wow!"
+    ];
+
+    suiteSetup(() => {
+        return setupWorkspace().then(() => {
+            return TextEditor.insert(text.join('\n'));
+        });
+    });
+
+    suiteTeardown(cleanUpWorkspace);
+
+    suite("next sentence", () => {
+        test("next concrete sentence", () => {
+            let motion = new Position(0, 0).getNextSentenceBegin();
+            assert.equal(motion.line, 0);
+            assert.equal(motion.character, 35);
+        });
+
+        test("next sentence that ends with paragraph ending", () => {
+            let motion = new Position(2, 50).getNextLineBegin();
+            assert.equal(motion.line, 3);
+            assert.equal(motion.character, 0);
+        });
+
+        test("next sentence when cursor is at the end of previous paragraph", () => {
+            let motion = new Position(3, 0).getNextSentenceBegin();
+            assert.equal(motion.line, 4);
+            assert.equal(motion.character, 0);
+        });
+
+        test("next sentence when paragraph contains a line of whilte spaces", () => {
+            let motion = new Position(6, 2).getNextSentenceBegin();
+            assert.equal(motion.line, 8);
+            assert.equal(motion.character, 4);
+        });
+    });
+});
 
 suite("paragraph motion", () => {
     let text: Array<string> = [

--- a/test/motion.test.ts
+++ b/test/motion.test.ts
@@ -370,7 +370,8 @@ suite("sentence motion", () => {
         "",
         "Next line is just whitespace",
         "   ",
-        "Wow!"
+        "Wow!",
+        "Another sentence inside one paragraph."
     ];
 
     suiteSetup(() => {
@@ -381,7 +382,7 @@ suite("sentence motion", () => {
 
     suiteTeardown(cleanUpWorkspace);
 
-    suite("next sentence", () => {
+    suite("sentence forward", () => {
         test("next concrete sentence", () => {
             let motion = new Position(0, 0).getNextSentenceBegin();
             assert.equal(motion.line, 0);
@@ -402,8 +403,8 @@ suite("sentence motion", () => {
 
         test("next sentence when paragraph contains a line of whilte spaces", () => {
             let motion = new Position(6, 2).getNextSentenceBegin();
-            assert.equal(motion.line, 8);
-            assert.equal(motion.character, 4);
+            assert.equal(motion.line, 9);
+            assert.equal(motion.character, 0);
         });
     });
 });

--- a/test/motion.test.ts
+++ b/test/motion.test.ts
@@ -416,6 +416,12 @@ suite("sentence motion", () => {
             assert.equal(motion.character, 35);
         });
 
+        test("sentence forward when cursor is at the beginning of the second sentence", () => {
+            let motion = new Position(0, 35).getPreviousSentenceBegin();
+            assert.equal(motion.line, 0);
+            assert.equal(motion.character, 0);
+        })
+
         test("current sentence begin with no concrete sentense inside", () => {
             let motion = new Position(3, 0).getPreviousSentenceBegin();
             assert.equal(motion.line, 2);

--- a/test/motion.test.ts
+++ b/test/motion.test.ts
@@ -407,6 +407,33 @@ suite("sentence motion", () => {
             assert.equal(motion.character, 0);
         });
     });
+
+
+    suite("sentence backward", () => {
+        test("current sentence begin", () => {
+            let motion = new Position(0, 37).getPreviousSentenceBegin();
+            assert.equal(motion.line, 0);
+            assert.equal(motion.character, 35);
+        });
+
+        test("current sentence begin with no concrete sentense inside", () => {
+            let motion = new Position(3, 0).getPreviousSentenceBegin();
+            assert.equal(motion.line, 2);
+            assert.equal(motion.character, 0);
+        });
+
+        test("current sentence begin when it's not the same as current paragraph begin", () => {
+            let motion = new Position(2, 0).getPreviousSentenceBegin();
+            assert.equal(motion.line, 1);
+            assert.equal(motion.character, 0);
+        });
+
+        test("current sentence begin when previous line ends with a concrete sentence", () => {
+            let motion = new Position(9, 5).getPreviousSentenceBegin();
+            assert.equal(motion.line, 9);
+            assert.equal(motion.character, 0);
+        });
+    });
 });
 
 suite("paragraph motion", () => {


### PR DESCRIPTION
Sentence related movements.

A paragraph boundary is also a sentence boundary, so the regex can handle all sentence endings pattern. Another tricky part is when the cursor is at the end of a paragraph (seems it's also the beginning of next paragraph), next section will jump to the first non-whitespace character whether it's a valid sentence or not.