### PR TITLE
[WIP]: Switch Window

### DIFF
--- a/extension.ts
+++ b/extension.ts
@@ -37,6 +37,7 @@ export function activate(context: vscode.ExtensionContext) {
 
     registerCommand(context, 'extension.vim_esc', () => handleKeyEvent("<esc>"));
     registerCommand(context, 'extension.vim_backspace', () => handleKeyEvent("<backspace>"));
+    registerCommand(context, 'extension.vim_switchWindow', () => handleKeyEvent("ctrl+w"));
 
     registerCommand(context, 'extension.showCmdLine', () => {
         if (!modeHandler) {

--- a/package.json
+++ b/package.json
@@ -51,6 +51,11 @@
                 "key": "Backspace",
                 "command": "extension.vim_backspace",
                 "when": "editorTextFocus"
+            },
+            {
+                "key": "ctrl+w",
+                "command": "extension.vim_switchWindow",
+                "when": "editorTextFocus"
             }
         ],
         "configuration": {

--- a/src/actions/actions.ts
+++ b/src/actions/actions.ts
@@ -1166,6 +1166,28 @@ class MoveRightWithSpace extends BaseMovement {
 }
 
 @RegisterAction
+class MoveToRightPane  extends BaseCommand {
+  modes = [ModeName.Normal, ModeName.Visual, ModeName.VisualLine];
+  keys = ["ctrl+w", "l"];
+
+  public async exec(position: Position, vimState: VimState): Promise<VimState> {
+    await vscode.commands.executeCommand("workbench.action.focusNextGroup");
+    return vimState;
+  }
+}
+
+@RegisterAction
+class MoveToLeftPane  extends BaseCommand {
+  modes = [ModeName.Normal, ModeName.Visual, ModeName.VisualLine];
+  keys = ["ctrl+w", "h"];
+
+  public async exec(position: Position, vimState: VimState): Promise<VimState> {
+    await vscode.commands.executeCommand("workbench.action.focusPreviousGroup");
+    return vimState;
+  }
+}
+
+@RegisterAction
 class MoveDownNonBlank extends BaseMovement {
   modes = [ModeName.Normal, ModeName.Visual, ModeName.VisualLine];
   keys = ["+"];


### PR DESCRIPTION
Leverage VS Code TabGroup to implement Windows management. Mark it as Work in progress as we still have no key mapping and it will still people's Ctrl+w on Windows. Besides, VS Code treats Ctrl as modifiers but not keys, so you must press `ctrl+w` first then `hjkl` so the experience is somewhat not smooth. 