### PR TITLE
Bring Ctrl keys back

### DIFF
--- a/extension.ts
+++ b/extension.ts
@@ -47,6 +47,10 @@ export function activate(context: vscode.ExtensionContext) {
         showCmdLine("", modeHandler);
     });
 
+    'rfb'.split('').forEach(key=> {
+        registerCommand(context, `extension.vim_ctrl+${key}`, () => handleKeyEvent(`ctrl+${key}`));
+    });
+
     context.subscriptions.push(modeHandler);
 }
 

--- a/package.json
+++ b/package.json
@@ -51,6 +51,21 @@
                 "key": "Backspace",
                 "command": "extension.vim_backspace",
                 "when": "editorTextFocus"
+            },
+            {
+                "key": "ctrl+r",
+                "command": "extension.vim_ctrl+r",
+                "when": "editorTextFocus"
+            },
+            {
+                "key": "ctrl+f",
+                "command": "extension.vim_ctrl+f",
+                "when": "editorTextFocus"
+            },
+            {
+                "key": "ctrl+b",
+                "command": "extension.vim_ctrl+b",
+                "when": "editorTextFocus"
             }
         ],
         "configuration": {


### PR DESCRIPTION
Since VS Code treats ctrl keys as modifiers, all modifiers related keys need be registered in contribution. Here I just register them then we have all related functionalities back

1. `ctrl-b`
2. `ctrl-f`
3. `ctrl-r`