### PR TITLE
Add Ncc support and revise cc behavior

### DIFF
--- a/src/actions/actions.ts
+++ b/src/actions/actions.ts
@@ -1675,10 +1675,11 @@ class MoveCC extends BaseMovement {
   modes = [ModeName.Normal];
   keys = ["c"];
 
-  public async execAction(position: Position, vimState: VimState): Promise<IMovement> {
+  public async execActionWithCount(position: Position, vimState: VimState, count: number): Promise<IMovement> {
     return {
       start       : position.getLineBegin(),
-      stop        : position.getLineEnd(),
+      stop        : position.getDownByCount(Math.max(0, count - 1)).getLineEnd(),
+      registerMode: RegisterMode.CharacterWise
     };
   }
 }

--- a/src/register/register.ts
+++ b/src/register/register.ts
@@ -4,7 +4,7 @@ import { VimState } from './../mode/modeHandler';
  * There are two different modes of copy/paste in Vim - copy by character
  * and copy by line. Copy by line typically happens in Visual Line mode, but
  * also shows up in some other actions that work over lines (most noteably dd,
- * yy, and cc).
+ * yy).
  */
 export enum RegisterMode {
     FigureItOutFromCurrentMode,

--- a/test/mode/normalModeTests/commands.test.ts
+++ b/test/mode/normalModeTests/commands.test.ts
@@ -27,9 +27,16 @@ suite("Mode Normal", () => {
 
     newTest({
       title: "Can handle 'cc'",
-      start: ['one', '|one two'],
+      start: ['one', '|one two', 'three'],
       keysPressed: 'cca<esc>',
-      end: ["one", "|a"],
+      end: ["one", "|a", "three"],
+    });
+
+    newTest({
+      title: "Can handle 'Ncc'",
+      start: ['one', '|one two', 'three four', 'five'],
+      keysPressed: '2cca<esc>',
+      end: ["one","|a", "five"]
     });
 
     newTest({

--- a/test/mode/normalModeTests/commands.test.ts
+++ b/test/mode/normalModeTests/commands.test.ts
@@ -36,7 +36,7 @@ suite("Mode Normal", () => {
       title: "Can handle 'Ncc'",
       start: ['one', '|one two', 'three four', 'five'],
       keysPressed: '2cca<esc>',
-      end: ["one","|a", "five"]
+      end: ["one", "|a", "five"]
     });
 
     newTest({


### PR DESCRIPTION
Original `cc` behaviour is not the same as Vim. When you trigger `cc` in Vim with below content,

```
one
|two
three
```

You will get
```
one
|
three
```

However, what we get in VSCodeVim is

```
one
|three
```

I suppose it's not a correct way of `cc` and it's caused by treating `cc` as `LineWise`. Now I add numeric support and set it as `CharacterWise` to fix this problem. 
