### PR TITLE
Add jsdiff typings and fix tslint

### DIFF
--- a/src/mode/modeHandler.ts
+++ b/src/mode/modeHandler.ts
@@ -583,7 +583,7 @@ export class ModeHandler implements vscode.Disposable {
         // have changed it as well. (TODO: do you even decomposition bro)
 
         if (vimState.currentMode !== this.currentModeName) {
-            this.setCurrentModeByName(vimState)
+            this.setCurrentModeByName(vimState);
 
             if (vimState.currentMode === ModeName.Normal) {
                 ranRepeatableAction = true;

--- a/test/mode/modeNormal.test.ts
+++ b/test/mode/modeNormal.test.ts
@@ -10,8 +10,7 @@ suite("Mode Normal", () => {
     let modeHandler: ModeHandler = new ModeHandler();
 
     let {
-        newTest,
-        newTestOnly
+        newTest
     } = getTestingFunctions(modeHandler);
 
     setup(async () => {

--- a/typings/diff.d.ts
+++ b/typings/diff.d.ts
@@ -1,0 +1,14 @@
+declare module 'diff' {
+    interface ChangeObject {
+        value: string;
+        added: boolean;
+        removed: boolean;
+    }
+
+    interface Option {
+        ignoreWhitespace: boolean;
+        newlineIsToken: boolean;
+    }
+
+    function diffChars(oldStr: string, newStr: string, options?: Option): ChangeObject[];
+}


### PR DESCRIPTION
Add typings for jsdiff to bypass `vscode:precompile` failure. The typings file is a draft and only contains what we used for now. We can add more detailed if we have more usage later and then extract them out of our repo.

Another fix is tslint :)