### PR TITLE
Word in visual mode

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -257,9 +257,9 @@ Status | Command | Description
 Status | Command | Description
 ---|--------|------------------------------
 :white_check_mark:    | :1234:  aw	| Select "a word"
-:warning:    | :1234:  iw	| Select "inner word"
+:white_check_mark:    | :1234:  iw	| Select "inner word"
 :white_check_mark:    | :1234:  aW	| Select "a |WORD|"
-    | :1234:  iW	| Select "inner |WORD|"
+:white_check_mark:    | :1234:  iW	| Select "inner |WORD|"
     | :1234:  as	| Select "a sentence"
     | :1234:  is	| Select "inner sentence"
     | :1234:  ap	| Select "a paragraph"

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -256,9 +256,9 @@ Status | Command | Description
 
 Status | Command | Description
 ---|--------|------------------------------
-:warning:    | :1234:  aw	| Select "a word"
+:white_check_mark:    | :1234:  aw	| Select "a word"
 :warning:    | :1234:  iw	| Select "inner word"
-    | :1234:  aW	| Select "a |WORD|"
+:white_check_mark:    | :1234:  aW	| Select "a |WORD|"
     | :1234:  iW	| Select "inner |WORD|"
     | :1234:  as	| Select "a sentence"
     | :1234:  is	| Select "inner sentence"

--- a/src/actions/actions.ts
+++ b/src/actions/actions.ts
@@ -2160,7 +2160,7 @@ class MovementAWordTextObject extends BaseMovement {
               await this.execAction           (position, vimState);
 
           if (firstIteration) {
-            result.start = temporaryResult.start;           
+            result.start = temporaryResult.start;
           }
 
           // Result is always a Movement.

--- a/src/actions/actions.ts
+++ b/src/actions/actions.ts
@@ -2126,7 +2126,7 @@ class MovementAWordTextObject extends BaseMovement {
           start = position.getLastWordEnd().getRight();
         } else {
           start = position.getWordLeft(true);
-    }
+        }
     }
 
     if (vimState.currentMode === ModeName.Visual && !vimState.cursorPosition.isEqual(vimState.cursorStartPosition)) {
@@ -2192,6 +2192,35 @@ class MovementAWordTextObject extends BaseMovement {
     }
 
     return res;
+  }
+}
+
+@RegisterAction
+class MovementABigWordTextObject extends MovementAWordTextObject {
+  keys = ["a", "W"];
+
+  public async execAction(position: Position, vimState: VimState): Promise<IMovement> {
+    let start: Position;
+    let stop: Position;
+
+    const currentChar = TextEditor.getLineAt(position).text[position.character];
+
+    if (/\s/.test(currentChar)) {
+        start = position.getLastBigWordEnd().getRight();
+        stop = position.getCurrentBigWordEnd();
+    } else {
+        start = position.getBigWordLeft();
+        stop = position.getBigWordRight().getLeft();
+    }
+
+    if (vimState.currentMode === ModeName.Visual && !vimState.cursorPosition.isEqual(vimState.cursorStartPosition)) {
+        start = vimState.cursorStartPosition;
+    }
+
+    return {
+      start: start,
+      stop: stop
+    };
   }
 }
 

--- a/src/actions/actions.ts
+++ b/src/actions/actions.ts
@@ -198,6 +198,13 @@ export abstract class BaseMovement extends BaseAction {
             result = temporaryResult;
             position = temporaryResult;
           } else if (isIMovement(temporaryResult)) {
+            if (result instanceof Position) {
+              result = {
+                start : new Position(0, 0),
+                stop : new Position(0, 0)
+              };
+            }
+
             if (firstIteration) {
               (result as IMovement).start = temporaryResult.start;
             }

--- a/src/actions/actions.ts
+++ b/src/actions/actions.ts
@@ -2173,23 +2173,12 @@ class MovementAWordTextObject extends BaseMovement {
 
       return result;
   }
-
   public async execActionForOperator(position: Position, vimState: VimState): Promise<IMovement> {
-    const line = TextEditor.getLineAt(position).text;
-    const currentChar = line[position.character];
     const res = await this.execAction(position, vimState);
-    const wordEnd = await new MoveWordBegin().execActionForOperator(position, vimState);
-
-    // TODO(whitespace)
-    if (currentChar !== ' ' && currentChar !== '\t') {
-      res.stop = wordEnd.getRight();
-    } else {
-      res.stop = wordEnd;
-    }
-
-    if (res.stop.character === line.length + 1) {
-      res.start = (await new MoveLastWordEnd().execAction(res.start, vimState)).getRight();
-    }
+    // Since we need to handle leading spaces, we cannot use MoveWordBegin.execActionForOperator
+    // In normal mode, the character on the stop position will be the first character after the operator executed
+    // and we do left-shifting in operator-pre-execution phase, here we need to right-shift the stop position accordingly.
+    res.stop = new Position(res.stop.line, res.stop.character + 1);
 
     return res;
   }

--- a/src/actions/actions.ts
+++ b/src/actions/actions.ts
@@ -2110,31 +2110,27 @@ class MovementAWordTextObject extends BaseMovement {
   keys = ["a", "w"];
 
   public async execAction(position: Position, vimState: VimState): Promise<IMovement> {
-    if (vimState.currentMode === ModeName.Visual && !vimState.cursorPosition.isEqual(vimState.cursorStartPosition)) {
-      // TODO: This is kind of a bad way to do this, but text objects only work in
-      // visual mode if you JUST entered visual mode
-      // TODO TODO: I just looked at this again and omg this is awful what was I smoking plz get rid of this asap
-      return {
-        start: vimState.cursorStartPosition,
-        stop: await new MoveWordBegin().execAction(position, vimState),
-      };
-    }
+    let start: Position;
+    let stop: Position;
 
     const currentChar = TextEditor.getLineAt(position).text[position.character];
 
-    // TODO(whitespace) - this is a bad way to do this. we need some sort of global
-    // white space checking function.
-    if (currentChar === ' ' || currentChar === '\t') {
-      return {
-        start: position.getLastWordEnd().getRight(),
-        stop: position.getCurrentWordEnd()
-      };
+    if (/\s/.test(currentChar)) {
+        start = position.getLastWordEnd().getRight();
+        stop = position.getCurrentWordEnd();
     } else {
-      return {
-        start: position.getWordLeft(true),
-        stop: position.getWordRight().getLeft()
-      };
+        start = position.getWordLeft(true);
+        stop = position.getWordRight().getLeft();
     }
+
+    if (vimState.currentMode === ModeName.Visual && !vimState.cursorPosition.isEqual(vimState.cursorStartPosition)) {
+        start = vimState.cursorStartPosition;
+    }
+
+    return {
+      start: start,
+      stop: stop
+    };
   }
 
   public async execActionForOperator(position: Position, vimState: VimState): Promise<IMovement> {

--- a/src/actions/actions.ts
+++ b/src/actions/actions.ts
@@ -2119,8 +2119,13 @@ class MovementAWordTextObject extends BaseMovement {
         start = position.getLastWordEnd().getRight();
         stop = position.getCurrentWordEnd();
     } else {
-        start = position.getWordLeft(true);
         stop = position.getWordRight().getLeft();
+
+        if (stop.isEqual(position.getCurrentWordEnd())) {
+          start = position.getLastWordEnd().getRight();
+        } else {
+          start = position.getWordLeft(true);
+    }
     }
 
     if (vimState.currentMode === ModeName.Visual && !vimState.cursorPosition.isEqual(vimState.cursorStartPosition)) {

--- a/src/actions/actions.ts
+++ b/src/actions/actions.ts
@@ -2131,6 +2131,15 @@ class MovementAWordTextObject extends BaseMovement {
 
     if (vimState.currentMode === ModeName.Visual && !vimState.cursorPosition.isEqual(vimState.cursorStartPosition)) {
         start = vimState.cursorStartPosition;
+
+        if (vimState.cursorPosition.isBefore(vimState.cursorStartPosition)) {
+          // If current cursor postion is before cursor start position, we are selecting words in reverser order.
+          if (/\s/.test(currentChar)) {
+            stop = position.getWordLeft(true);
+          } else {
+            stop = position.getLastWordEnd().getRight();
+          }
+        }
     }
 
     return {
@@ -2205,6 +2214,15 @@ class MovementABigWordTextObject extends MovementAWordTextObject {
 
     if (vimState.currentMode === ModeName.Visual && !vimState.cursorPosition.isEqual(vimState.cursorStartPosition)) {
         start = vimState.cursorStartPosition;
+
+        if (vimState.cursorPosition.isBefore(vimState.cursorStartPosition)) {
+          // If current cursor postion is before cursor start position, we are selecting words in reverser order.
+          if (/\s/.test(currentChar)) {
+            stop = position.getBigWordLeft();
+          } else {
+            stop = position.getLastBigWordEnd().getRight();
+          }
+        }
     }
 
     return {
@@ -2220,28 +2238,35 @@ class MovementIWordTextObject extends MovementAWordTextObject {
   keys = ["i", "w"];
 
   public async execAction(position: Position, vimState: VimState): Promise<IMovement> {
-    if (vimState.currentMode === ModeName.Visual && !vimState.cursorPosition.isEqual(vimState.cursorStartPosition)) {
-      // TODO: This is kind of a bad way to do this, but text objects only work in
-      // visual mode if you JUST entered visual mode
-      return {
-        start: vimState.cursorStartPosition,
-        stop: await new MoveWordBegin().execAction(position, vimState),
-      };
-    }
-
+    let start: Position;
+    let stop: Position;
     const currentChar = TextEditor.getLineAt(position).text[position.character];
 
     if (/\s/.test(currentChar)) {
-      return {
-        start: position.getLastWordEnd().getRight(),
-        stop:  position.getWordRight().getLeft()
-      };
+        start = position.getLastWordEnd().getRight();
+        stop = position.getWordRight().getLeft();
     } else {
-      return {
-        start: position.getWordLeft(true),
-        stop: position.getCurrentWordEnd(true),
-      };
+        start = position.getWordLeft(true);
+        stop = position.getCurrentWordEnd(true);
     }
+
+    if (vimState.currentMode === ModeName.Visual && !vimState.cursorPosition.isEqual(vimState.cursorStartPosition)) {
+      start = vimState.cursorStartPosition;
+
+      if (vimState.cursorPosition.isBefore(vimState.cursorStartPosition)) {
+        // If current cursor postion is before cursor start position, we are selecting words in reverser order.
+        if (/\s/.test(currentChar)) {
+          stop = position.getLastWordEnd().getRight();
+        } else {
+          stop = position.getWordLeft(true);
+        }
+      }
+    }
+
+    return {
+      start: start,
+      stop: stop
+    };
   }
 }
 
@@ -2251,28 +2276,35 @@ class MovementIBigWordTextObject extends MovementAWordTextObject {
   keys = ["i", "W"];
 
   public async execAction(position: Position, vimState: VimState): Promise<IMovement> {
-    if (vimState.currentMode === ModeName.Visual && !vimState.cursorPosition.isEqual(vimState.cursorStartPosition)) {
-      // TODO: This is kind of a bad way to do this, but text objects only work in
-      // visual mode if you JUST entered visual mode
-      return {
-        start: vimState.cursorStartPosition,
-        stop: await new MoveWordBegin().execAction(position, vimState),
-      };
-    }
-
+    let start: Position;
+    let stop: Position;
     const currentChar = TextEditor.getLineAt(position).text[position.character];
 
     if (/\s/.test(currentChar)) {
-      return {
-        start: position.getLastBigWordEnd().getRight(),
-        stop:  position.getBigWordRight().getLeft()
-      };
+        start = position.getLastBigWordEnd().getRight();
+        stop = position.getBigWordRight().getLeft();
     } else {
-      return {
-        start: position.getBigWordLeft(),
-        stop: position.getCurrentBigWordEnd(true),
-      };
+        start = position.getBigWordLeft();
+        stop = position.getCurrentBigWordEnd(true);
     }
+
+    if (vimState.currentMode === ModeName.Visual && !vimState.cursorPosition.isEqual(vimState.cursorStartPosition)) {
+      start = vimState.cursorStartPosition;
+
+      if (vimState.cursorPosition.isBefore(vimState.cursorStartPosition)) {
+        // If current cursor postion is before cursor start position, we are selecting words in reverser order.
+        if (/\s/.test(currentChar)) {
+          stop = position.getLastBigWordEnd().getRight();
+        } else {
+          stop = position.getBigWordLeft();
+        }
+      }
+    }
+
+    return {
+      start: start,
+      stop: stop
+    };
   }
 }
 

--- a/test/mode/modeNormal.test.ts
+++ b/test/mode/modeNormal.test.ts
@@ -397,8 +397,88 @@ suite("Mode Normal", () => {
     newTest({
       title: "Can handle 'daW' on word with numeric prefix and across lines",
       start: ['one   two   three,   fo|ur  ', 'five.  six'],
-      keysPressed: 'd2aWd',
+      keysPressed: 'd2aW',
       end: ['one   two   three,   |six'],
+      endMode: ModeName.Normal
+    });
+
+    newTest({
+      title: "Can handle 'diw' on word with cursor inside spaces",
+      start: ['one   two |  three,   four  '],
+      keysPressed: 'diw',
+      end: ['one   two|three,   four  '],
+      endMode: ModeName.Normal
+    });
+
+    newTest({
+      title: "Can handle 'diw' on word",
+      start: ['one   tw|o   three,   four  '],
+      keysPressed: 'diw',
+      end: ['one   |   three,   four  '],
+      endMode: ModeName.Normal
+    });
+
+    newTest({
+      title: "Can handle 'diw' on word with numeric prefix",
+      start: ['on|e   two   three,   four  '],
+      keysPressed: 'd3iw',
+      end: ['|   three,   four  '],
+      endMode: ModeName.Normal
+    });
+
+    newTest({
+      title: "Can handle 'diw' on word with numeric prefix and across lines",
+      start: ['one   two   three,   fo|ur  ', 'five  six'],
+      keysPressed: 'd3iw',
+      end: ['one   two   three,   |  six'],
+      endMode: ModeName.Normal
+    });
+
+    newTest({
+      title: "Can handle 'diw' on word with numeric prefix and across lines, containing words end with `.`",
+      start: ['one   two   three,   fo|ur  ', 'five.  six'],
+      keysPressed: 'd3iw',
+      end: ['one   two   three,   |.  six'],
+      endMode: ModeName.Normal
+    });
+
+    newTest({
+      title: "Can handle 'diW' on big word with cursor inside spaces",
+      start: ['one   two |  three,   four  '],
+      keysPressed: 'diW',
+      end: ['one   two|three,   four  '],
+      endMode: ModeName.Normal
+    });
+
+    newTest({
+      title: "Can handle 'diW' on word with trailing spaces",
+      start: ['one   tw|o,   three,   four  '],
+      keysPressed: 'diW',
+      end: ['one   |   three,   four  '],
+      endMode: ModeName.Normal
+    });
+
+    newTest({
+      title: "Can handle 'diW' on word with leading spaces",
+      start: ['one   two   th|ree,   four  '],
+      keysPressed: 'diW',
+      end: ['one   two   |   four  '],
+      endMode: ModeName.Normal
+    });
+
+    newTest({
+      title: "Can handle 'diW' on word with numeric prefix",
+      start: ['on|e   two   three,   four  '],
+      keysPressed: 'd3iW',
+      end: ['|   three,   four  '],
+      endMode: ModeName.Normal
+    });
+
+    newTest({
+      title: "Can handle 'diW' on word with numeric prefix and across lines",
+      start: ['one   two   three,   fo|ur  ', 'five.  six'],
+      keysPressed: 'd3iW',
+      end: ['one   two   three,   |  six'],
       endMode: ModeName.Normal
     });
 

--- a/test/mode/modeNormal.test.ts
+++ b/test/mode/modeNormal.test.ts
@@ -9,8 +9,7 @@ suite("Mode Normal", () => {
     let modeHandler: ModeHandler = new ModeHandler();
 
     let {
-        newTest,
-        newTestOnly
+        newTest
     } = getTestingFunctions(modeHandler);
 
     setup(async () => {

--- a/test/mode/modeNormal.test.ts
+++ b/test/mode/modeNormal.test.ts
@@ -316,6 +316,94 @@ suite("Mode Normal", () => {
     });
 
     newTest({
+      title: "Can handle 'daw' on word with cursor inside spaces",
+      start: ['one   two |  three,   four  '],
+      keysPressed: 'daw',
+      end: ['one   two|,   four  '],
+      endMode: ModeName.Normal
+    });
+
+    newTest({
+      title: "Can handle 'daw' on word with trailing spaces",
+      start: ['one   tw|o   three,   four  '],
+      keysPressed: 'daw',
+      end: ['one   |three,   four  '],
+      endMode: ModeName.Normal
+    });
+
+    newTest({
+      title: "Can handle 'daw' on word with leading spaces",
+      start: ['one   two   th|ree,   four  '],
+      keysPressed: 'daw',
+      end: ['one   two|,   four  '],
+      endMode: ModeName.Normal
+    });
+
+    newTest({
+      title: "Can handle 'daw' on word with numeric prefix",
+      start: ['on|e   two   three,   four  '],
+      keysPressed: 'd3aw',
+      end: ['|,   four  '],
+      endMode: ModeName.Normal
+    });
+
+    newTest({
+      title: "Can handle 'daw' on word with numeric prefix and across lines",
+      start: ['one   two   three,   fo|ur  ', 'five  six'],
+      keysPressed: 'd2aw',
+      end: ['one   two   three,   |six'],
+      endMode: ModeName.Normal
+    });
+
+    newTest({
+      title: "Can handle 'daw' on word with numeric prefix and across lines, containing words end with `.`",
+      start: ['one   two   three,   fo|ur  ', 'five.  six'],
+      keysPressed: 'd2aw',
+      end: ['one   two   three,   |.  six'],
+      endMode: ModeName.Normal
+    });
+
+    newTest({
+      title: "Can handle 'daW' on big word with cursor inside spaces",
+      start: ['one   two |  three,   four  '],
+      keysPressed: 'daW',
+      end: ['one   two|   four  '],
+      endMode: ModeName.Normal
+    });
+
+    newTest({
+      title: "Can handle 'daW' on word with trailing spaces",
+      start: ['one   tw|o   three,   four  '],
+      keysPressed: 'daW',
+      end: ['one   |three,   four  '],
+      endMode: ModeName.Normal
+    });
+
+    newTest({
+      title: "Can handle 'daW' on word with leading spaces",
+      start: ['one   two   th|ree,   four  '],
+      keysPressed: 'daW',
+      end: ['one   two   |four  '],
+      endMode: ModeName.Normal
+    });
+
+    newTest({
+      title: "Can handle 'daW' on word with numeric prefix",
+      start: ['on|e   two   three,   four  '],
+      keysPressed: 'd3aW',
+      end: ['|four  '],
+      endMode: ModeName.Normal
+    });
+
+    newTest({
+      title: "Can handle 'daW' on word with numeric prefix and across lines",
+      start: ['one   two   three,   fo|ur  ', 'five.  six'],
+      keysPressed: 'd2aWd',
+      end: ['one   two   three,   |six'],
+      endMode: ModeName.Normal
+    });
+
+    newTest({
       title: "Can handle 'df'",
       start: ['aext tex|t'],
       keysPressed: '^dft',

--- a/test/mode/modeVisual.test.ts
+++ b/test/mode/modeVisual.test.ts
@@ -329,7 +329,7 @@ suite("Mode Visual", () => {
       endMode: ModeName.Normal
     });
   });
-  
+
   suite("handles aW in visual mode", () => {
     newTest({
       title: "Can handle 'vaWd' on big word with cursor inside spaces",

--- a/test/mode/modeVisual.test.ts
+++ b/test/mode/modeVisual.test.ts
@@ -237,4 +237,96 @@ suite("Mode Visual", () => {
       end: ['blah', 'duh', '|r', 'hur']
     });
   });
+
+  suite("handles aw in visual mode", () => {
+    newTest({
+      title: "Can handle 'vawd' on word with cursor inside spaces",
+      start: ['one   two |  three,   four  '],
+      keysPressed: 'vawd',
+      end: ['one   two|,   four  '],
+      endMode: ModeName.Normal
+    });
+
+    newTest({
+      title: "Can handle 'vawd' on word with trailing spaces",
+      start: ['one   tw|o   three,   four  '],
+      keysPressed: 'vawd',
+      end: ['one   |three,   four  '],
+      endMode: ModeName.Normal
+    });
+
+    newTest({
+      title: "Can handle 'vawd' on word with leading spaces",
+      start: ['one   two   th|ree,   four  '],
+      keysPressed: 'vawd',
+      end: ['one   two|,   four  '],
+      endMode: ModeName.Normal
+    });
+
+    newTest({
+      title: "Can handle 'vawd' on word with numeric prefix",
+      start: ['on|e   two   three,   four  '],
+      keysPressed: 'v3awd',
+      end: ['|,   four  '],
+      endMode: ModeName.Normal
+    });
+
+    newTest({
+      title: "Can handle 'vawd' on word with numeric prefix and across lines",
+      start: ['one   two   three,   fo|ur  ', 'five  six'],
+      keysPressed: 'v2awd',
+      end: ['one   two   three,   |six'],
+      endMode: ModeName.Normal
+    });
+
+    newTest({
+      title: "Can handle 'vawd' on word with numeric prefix and across lines, containing words end with `.`",
+      start: ['one   two   three,   fo|ur  ', 'five.  six'],
+      keysPressed: 'v2awd',
+      end: ['one   two   three,   |.  six'],
+      endMode: ModeName.Normal
+    });
+  });
+
+  suite("handles aW in visual mode", () => {
+    newTest({
+      title: "Can handle 'vaWd' on big word with cursor inside spaces",
+      start: ['one   two |  three,   four  '],
+      keysPressed: 'vaWd',
+      end: ['one   two|   four  '],
+      endMode: ModeName.Normal
+    });
+
+    newTest({
+      title: "Can handle 'vaWd' on word with trailing spaces",
+      start: ['one   tw|o   three,   four  '],
+      keysPressed: 'vaWd',
+      end: ['one   |three,   four  '],
+      endMode: ModeName.Normal
+    });
+
+    newTest({
+      title: "Can handle 'vaWd' on word with leading spaces",
+      start: ['one   two   th|ree,   four  '],
+      keysPressed: 'vaWd',
+      end: ['one   two   |four  '],
+      endMode: ModeName.Normal
+    });
+
+    newTest({
+      title: "Can handle 'vaWd' on word with numeric prefix",
+      start: ['on|e   two   three,   four  '],
+      keysPressed: 'v3aWd',
+      end: ['|four  '],
+      endMode: ModeName.Normal
+    });
+
+    newTest({
+      title: "Can handle 'vaWd' on word with numeric prefix and across lines",
+      start: ['one   two   three,   fo|ur  ', 'five.  six'],
+      keysPressed: 'v2aWd',
+      end: ['one   two   three,   |six'],
+      endMode: ModeName.Normal
+    });
+  })
 });

--- a/test/mode/modeVisual.test.ts
+++ b/test/mode/modeVisual.test.ts
@@ -328,5 +328,47 @@ suite("Mode Visual", () => {
       end: ['one   two   three,   |six'],
       endMode: ModeName.Normal
     });
-  })
+  });
+  
+  suite("handles aW in visual mode", () => {
+    newTest({
+      title: "Can handle 'vaWd' on big word with cursor inside spaces",
+      start: ['one   two |  three,   four  '],
+      keysPressed: 'vaWd',
+      end: ['one   two|   four  '],
+      endMode: ModeName.Normal
+    });
+
+    newTest({
+      title: "Can handle 'vaWd' on word with trailing spaces",
+      start: ['one   tw|o   three,   four  '],
+      keysPressed: 'vaWd',
+      end: ['one   |three,   four  '],
+      endMode: ModeName.Normal
+    });
+
+    newTest({
+      title: "Can handle 'vaWd' on word with leading spaces",
+      start: ['one   two   th|ree,   four  '],
+      keysPressed: 'vaWd',
+      end: ['one   two   |four  '],
+      endMode: ModeName.Normal
+    });
+
+    newTest({
+      title: "Can handle 'vaWd' on word with numeric prefix",
+      start: ['on|e   two   three,   four  '],
+      keysPressed: 'v3aWd',
+      end: ['|four  '],
+      endMode: ModeName.Normal
+    });
+
+    newTest({
+      title: "Can handle 'vaWd' on word with numeric prefix and across lines",
+      start: ['one   two   three,   fo|ur  ', 'five.  six'],
+      keysPressed: 'v2aWd',
+      end: ['one   two   three,   |six'],
+      endMode: ModeName.Normal
+    });
+  });
 });

--- a/test/mode/modeVisual.test.ts
+++ b/test/mode/modeVisual.test.ts
@@ -371,4 +371,96 @@ suite("Mode Visual", () => {
       endMode: ModeName.Normal
     });
   });
+
+  suite("handles aw in visual mode", () => {
+    newTest({
+      title: "Can handle 'vawd' on word with cursor inside spaces",
+      start: ['one   two |  three,   four  '],
+      keysPressed: 'vawd',
+      end: ['one   two|,   four  '],
+      endMode: ModeName.Normal
+    });
+
+    newTest({
+      title: "Can handle 'vawd' on word with trailing spaces",
+      start: ['one   tw|o   three,   four  '],
+      keysPressed: 'vawd',
+      end: ['one   |three,   four  '],
+      endMode: ModeName.Normal
+    });
+
+    newTest({
+      title: "Can handle 'vawd' on word with leading spaces",
+      start: ['one   two   th|ree,   four  '],
+      keysPressed: 'vawd',
+      end: ['one   two|,   four  '],
+      endMode: ModeName.Normal
+    });
+
+    newTest({
+      title: "Can handle 'vawd' on word with numeric prefix",
+      start: ['on|e   two   three,   four  '],
+      keysPressed: 'v3awd',
+      end: ['|,   four  '],
+      endMode: ModeName.Normal
+    });
+
+    newTest({
+      title: "Can handle 'vawd' on word with numeric prefix and across lines",
+      start: ['one   two   three,   fo|ur  ', 'five  six'],
+      keysPressed: 'v2awd',
+      end: ['one   two   three,   |six'],
+      endMode: ModeName.Normal
+    });
+
+    newTest({
+      title: "Can handle 'vawd' on word with numeric prefix and across lines, containing words end with `.`",
+      start: ['one   two   three,   fo|ur  ', 'five.  six'],
+      keysPressed: 'v2awd',
+      end: ['one   two   three,   |.  six'],
+      endMode: ModeName.Normal
+    });
+  });
+
+  suite("handles aW in visual mode", () => {
+    newTest({
+      title: "Can handle 'vaWd' on big word with cursor inside spaces",
+      start: ['one   two |  three,   four  '],
+      keysPressed: 'vaWd',
+      end: ['one   two|   four  '],
+      endMode: ModeName.Normal
+    });
+
+    newTest({
+      title: "Can handle 'vaWd' on word with trailing spaces",
+      start: ['one   tw|o   three,   four  '],
+      keysPressed: 'vaWd',
+      end: ['one   |three,   four  '],
+      endMode: ModeName.Normal
+    });
+
+    newTest({
+      title: "Can handle 'vaWd' on word with leading spaces",
+      start: ['one   two   th|ree,   four  '],
+      keysPressed: 'vaWd',
+      end: ['one   two   |four  '],
+      endMode: ModeName.Normal
+    });
+
+    newTest({
+      title: "Can handle 'vaWd' on word with numeric prefix",
+      start: ['on|e   two   three,   four  '],
+      keysPressed: 'v3aWd',
+      end: ['|four  '],
+      endMode: ModeName.Normal
+    });
+
+    newTest({
+      title: "Can handle 'vaWd' on word with numeric prefix and across lines",
+      start: ['one   two   three,   fo|ur  ', 'five.  six'],
+      keysPressed: 'v2aWd',
+      end: ['one   two   three,   |six'],
+      endMode: ModeName.Normal
+    });
+  });
 });


### PR DESCRIPTION
1. Enrich `aw` with `executeWithOperator` and `executeWithCount`
2. Add `aW`
3. Enrich `iw`
4. Add `iW`
5. Normal/Visual mode test cases.