### PR TITLE
`workbench.files.action.closeAllFiles` is deprecated.

### DIFF
--- a/test/testUtils.ts
+++ b/test/testUtils.ts
@@ -70,7 +70,6 @@ export async function cleanUpWorkspace(): Promise<any> {
         }, 10);
 
         vscode.commands.executeCommand('workbench.action.closeAllEditors')
-            .then(() => vscode.commands.executeCommand('workbench.files.action.closeAllFiles'))
             .then(null, err => {
                 clearInterval(interval);
                 e(err);


### PR DESCRIPTION
Yay! We love PRs! 🎊

Please include a description of your change & check your PR against this list, thanks:

- [x] Commit message has a short title & issue references
- [x] Commits are squashed 
- [x] It builds and tests pass (e.g `gulp tslint`)

`workbench.files.action.closeAllFiles` is deprecated and we should use `workbench.action.closeAllEditors ` instead, which is already invoked before.

This is just test code so it won't block any user as we are using the latest version of VS Code to develop. But if it's an API we are using in production code, I don't know how we can avoid breaking users using old version of VS Code.