### PR TITLE
Fix TS2318 and ignore .vscode-test folder

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,6 +9,10 @@
     "experimentalDecorators": true
   },
   "exclude": [
-    "node_modules"
+    "node_modules",
+    ".vscode-test"
+  ],
+  "files": [
+    "node_modules/typescript/lib/lib.es6.d.ts"
   ]
 }


### PR DESCRIPTION
Yay! We love PRs! 🎊

Please include a description of your change & check your PR against this list, thanks:

- [x] Commit message has a short title & issue references
- [x] Commits are squashed 
- [x] It builds and tests pass (e.g `gulp tslint`)

Firstly ignore `.vscode-test` folder, otherwise it will slow down the auto-compilation. Secondly as we set `noLib` as `true` and we are using ES6 most of the time (currently we don't have any ES7 syntax yet), so I add es6 lib file to it.