### PR TITLE
Open file in new window.

### DIFF
--- a/src/cmd_line/commands/file.ts
+++ b/src/cmd_line/commands/file.ts
@@ -4,8 +4,14 @@ import * as vscode from "vscode";
 import * as path from "path";
 import * as node from "../node";
 
+export enum FilePosition {
+    CurrentWindow,
+    NewWindow
+}
+
 export interface IFileCommandArguments extends node.ICommandArgs {
     name?: string;
+    position?: FilePosition;
 }
 
 
@@ -23,13 +29,48 @@ export class FileCommand extends node.CommandBase {
         return this._arguments;
     }
 
+    getViewColumn(sideBySide: boolean) : vscode.ViewColumn {
+        const active = vscode.window.activeTextEditor;
+        if (!active) {
+            return vscode.ViewColumn.One;
+        }
+
+        if (!sideBySide) {
+            return active.viewColumn;
+        }
+
+        switch (active.viewColumn) {
+            case vscode.ViewColumn.One:
+                return vscode.ViewColumn.Two;
+            case vscode.ViewColumn.Two:
+                return vscode.ViewColumn.Three;
+        }
+
+        return active.viewColumn;
+    }
+
     execute(): void {
+        if (!this._arguments.name) {
+            // Open an empty file
+            if (this._arguments.position === FilePosition.CurrentWindow) {
+                vscode.commands.executeCommand("workbench.action.files.newUntitledFile");
+            }
+
+            vscode.commands.executeCommand("workbench.action.splitEditor").then(() => {
+                vscode.commands.executeCommand("workbench.action.files.newUntitledFile").then(() => {
+                    vscode.commands.executeCommand("workbench.action.closeOtherEditors");
+                });
+            });
+
+            return;
+        }
+
         let currentFilePath = vscode.window.activeTextEditor.document.uri.path;
         let newFilePath = path.join(path.dirname(currentFilePath), this._arguments.name);
 
         if (newFilePath !== currentFilePath) {
             let folder = vscode.Uri.file(newFilePath);
-            vscode.commands.executeCommand("vscode.open", folder);
+            vscode.commands.executeCommand("vscode.open", folder, this.getViewColumn(this._arguments.position === FilePosition.NewWindow));
         }
     }
 }

--- a/src/cmd_line/subparser.ts
+++ b/src/cmd_line/subparser.ts
@@ -42,5 +42,8 @@ export const commandParsers = {
 
     e: fileCmd.parseEditFileCommandArgs,
 
-    s: parseSubstituteCommandArgs
+    s: parseSubstituteCommandArgs,
+    vsp: fileCmd.parseEditFileInNewWindowCommandArgs,
+    vne: fileCmd.parseEditNewFileInNewWindowCommandArgs,
+    vnew: fileCmd.parseEditNewFileInNewWindowCommandArgs
 };

--- a/src/cmd_line/subparsers/file.ts
+++ b/src/cmd_line/subparsers/file.ts
@@ -12,6 +12,26 @@ export function parseEditFileCommandArgs(args: string): node.FileCommand {
     let name = scanner.nextWord();
 
     return new node.FileCommand({
-        name: name
+        name: name,
+        position: node.FilePosition.CurrentWindow
+    });
+}
+
+export function parseEditNewFileInNewWindowCommandArgs(args: string): node.FileCommand {
+    return new node.FileCommand({
+        position: node.FilePosition.NewWindow
+    });
+}
+
+export function parseEditFileInNewWindowCommandArgs(args: string): node.FileCommand {
+    let name = "";
+    if (args) {
+        var scanner = new Scanner(args);
+        name = scanner.nextWord();
+    }
+
+    return new node.FileCommand({
+        name: name,
+        position: node.FilePosition.NewWindow
     });
 }

--- a/src/cmd_line/subparsers/file.ts
+++ b/src/cmd_line/subparsers/file.ts
@@ -8,7 +8,7 @@ export function parseEditFileCommandArgs(args: string): node.FileCommand {
         return new node.FileCommand({});
     }
 
-    var scanner = new Scanner(args);
+    let scanner = new Scanner(args);
     let name = scanner.nextWord();
 
     return new node.FileCommand({
@@ -25,8 +25,9 @@ export function parseEditNewFileInNewWindowCommandArgs(args: string): node.FileC
 
 export function parseEditFileInNewWindowCommandArgs(args: string): node.FileCommand {
     let name = "";
+    
     if (args) {
-        var scanner = new Scanner(args);
+        let scanner = new Scanner(args);
         name = scanner.nextWord();
     }
 

--- a/src/cmd_line/subparsers/file.ts
+++ b/src/cmd_line/subparsers/file.ts
@@ -25,7 +25,7 @@ export function parseEditNewFileInNewWindowCommandArgs(args: string): node.FileC
 
 export function parseEditFileInNewWindowCommandArgs(args: string): node.FileCommand {
     let name = "";
-    
+
     if (args) {
         let scanner = new Scanner(args);
         name = scanner.nextWord();


### PR DESCRIPTION
Yay! We love PRs! 🎊

Please include a description of your change & check your PR against this list, thanks:

- [x] Commit message has a short title & issue references
- [x] Commits are squashed 
- [x] It builds and tests pass (e.g `gulp tslint`)

Support `:vsp`, `:vne` and `:vnew`.

This feature is limited to VS Code's group editors, which only support 3 groups at most. Besides, all horizontal splitting commands wont' work in VS Code