### PR TITLE
Fix layout mistake in Contributing and gulp typo

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -32,8 +32,9 @@ When submitting a PR, ensure:
 2. Fork and clone the repository
 3. `cd Vim`
 4. Install the dependencies:
+
 	```bash
-	$ npm install -g gulp typescript
+	$ npm install -g gulp-cli typescript
 	$ npm install
 	```
 5. Open the folder in VS Code


### PR DESCRIPTION
I changed `npm i -g gulp` to `npm i -g gulp-cli` as I thought this was a mistake

Also I made a minor layout fix.

----


Yay! We love PRs! 🎊

Please include a description of your change & check your PR against this list, thanks:

- [ ] Commit message has a short title & issue references
- [ ] Commits are squashed 
- [ ] It builds and tests pass (e.g `gulp tslint`)

More info can be found by clicking the "guidelines for contributing" link above.
