### PR TITLE
Fix #397.

### DIFF
--- a/src/mode/modeHandler.ts
+++ b/src/mode/modeHandler.ts
@@ -736,6 +736,10 @@ export class ModeHandler implements vscode.Disposable {
         let recordedState = vimState.recordedState;
 
         if (recordedState.operator) {
+            if (start.compareTo(stop) > 0) {
+                [start, stop] = [stop, start];
+            }
+
             if (vimState.currentMode !== ModeName.Visual &&
                 vimState.currentMode !== ModeName.VisualLine &&
                 vimState.currentRegisterMode !== RegisterMode.LineWise) {
@@ -744,10 +748,6 @@ export class ModeHandler implements vscode.Disposable {
                 } else {
                     stop = stop.getRight();
                 }
-            }
-
-            if (start.compareTo(stop) > 0) {
-                [start, stop] = [stop, start];
             }
 
             if (this.currentModeName === ModeName.VisualLine) {

--- a/test/mode/modeNormal.test.ts
+++ b/test/mode/modeNormal.test.ts
@@ -121,16 +121,16 @@ suite("Mode Normal", () => {
 
     newTest({
       title: "Can handle 'db'",
-      start: ['text tex|t'],
+      start: ['One tw|o'],
       keysPressed: '$db',
-      end: ['text |t'],
+      end: ['One |o'],
     });
 
     newTest({
       title: "Can handle 'db then 'db' again",
-      start: ['text tex|t'],
+      start: ['One tw|o'],
       keysPressed: '$dbdb',
-      end: ['|t'],
+      end: ['|o'],
     });
 
     newTest({


### PR DESCRIPTION
Yay! We love PRs! 🎊

Please include a description of your change & check your PR against this list, thanks:

- [x] Commit message has a short title & issue references
- [x] Commits are squashed 
- [x] It builds and tests pass (e.g `gulp tslint`)

While we run `b` movement, cursor start position is after stop position and we did some stop position adjustment, that's why we are not doing the `db` right.

Besides, the test cases covering `db` happen to be false positive. Run `db` inside `test test` always pass because both the first word and second word start and stop with `t`. It's a really interesting trap.