### PR TITLE
Fix ctrl+b, ctrl+f

### DIFF
--- a/src/actions/actions.ts
+++ b/src/actions/actions.ts
@@ -997,8 +997,7 @@ class CommandMoveFullPageDown extends BaseCommand {
   keys = ["ctrl+f"];
 
   public async exec(position: Position, vimState: VimState): Promise<VimState> {
-    await vscode.commands.executeCommand("cursorPageUp");
-
+    await vscode.commands.executeCommand("cursorPageDown");
     return vimState;
   }
 }
@@ -1010,8 +1009,7 @@ class CommandMoveFullPageUp extends BaseCommand {
   keys = ["ctrl+b"];
 
   public async exec(position: Position, vimState: VimState): Promise<VimState> {
-    await vscode.commands.executeCommand("cursorPageDown");
-
+    await vscode.commands.executeCommand("cursorPageUp");
     return vimState;
   }
 }

--- a/src/mode/modeHandler.ts
+++ b/src/mode/modeHandler.ts
@@ -930,5 +930,6 @@ export class ModeHandler implements vscode.Disposable {
     }
 
     dispose() {
+        // do nothing
     }
 }


### PR DESCRIPTION
As noted in https://github.com/VSCodeVim/Vim/issues/416, ctrl+b should be upward, ctrl+f should be downward.