### PR TITLE
Include vscode typings

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -2,16 +2,16 @@ var gulp = require('gulp'),
     tslint = require('gulp-tslint'),
     typings = require('gulp-typings'),
     shell = require('gulp-shell'),
-    mocha = require('gulp-mocha'),
     soften = require('gulp-soften'),
     git = require('gulp-git'),
     bump = require('gulp-bump'),
     filter = require('gulp-filter'),
     tag_version = require('gulp-tag-version'),
+    inject = require('gulp-inject-string'),
     trimlines = require('gulp-trimlines');
 
 var paths = {
-    scripts_ts: "src/**/*.ts",
+    src_ts: "src/**/*.ts",
     tests_ts: "test/**/*.ts"
 };
 
@@ -33,11 +33,23 @@ gulp.task('typings', function () {
         .pipe(typings());
 });
 
+gulp.task('typings-vscode-definitions', ['typings'], function() {
+    // add vscode definitions
+    var vscodeTypings = '/// <reference path="../node_modules/vscode/typings/index.d.ts" />\n';
+    var vscodeNodeTypings = '/// <reference path="../node_modules/vscode/typings/node.d.ts" />\n';
+    return gulp.src('./typings/index.d.ts')
+        .pipe(inject.replace(vscodeTypings, ''))
+        .pipe(inject.replace(vscodeNodeTypings, ''))
+        .pipe(inject.prepend(vscodeTypings))
+        .pipe(inject.prepend(vscodeNodeTypings))
+        .pipe(gulp.dest('./typings'));
+})
+
 gulp.task('fix-whitespace', function() {
     // 1. change tabs to spaces
     // 2. trim trailing whitespace
-    return gulp.src([paths.scripts_ts, paths.tests_ts], { base: "./" })
-        .pipe(soften(4))
+    return gulp.src([paths.src_ts, paths.tests_ts], { base: "./" })
+        .pipe(soften(2))
         .pipe(trimlines({
             leading: false
         }))
@@ -45,10 +57,11 @@ gulp.task('fix-whitespace', function() {
 });
 
 gulp.task('tslint', ['fix-whitespace'], function() {
-    return gulp.src([paths.scripts_ts, paths.tests_ts])
+    return gulp.src([paths.src_ts, paths.tests_ts])
         .pipe(tslint())
         .pipe(tslint.report('prose', {
-          summarizeFailureOutput: true
+          summarizeFailureOutput: true,
+          emitError: false
         }));
 });
 
@@ -56,6 +69,6 @@ gulp.task('compile', shell.task([
   'node ./node_modules/vscode/bin/compile -p ./',
 ]));
 
-gulp.task('init', ['typings']);
+gulp.task('init', ['typings', 'typings-vscode-definitions']);
 gulp.task('default', ['tslint', 'compile']);
 gulp.task('release', ['default', 'patch']);

--- a/package.json
+++ b/package.json
@@ -136,7 +136,7 @@
         "gulp-bump": "^2.1.0",
         "gulp-filter": "^4.0.0",
         "gulp-git": "^1.7.1",
-        "gulp-mocha": "^2.2.0",
+        "gulp-inject-string": "^1.1.0",
         "gulp-shell": "^0.5.2",
         "gulp-soften": "^0.0.1",
         "gulp-tag-version": "^1.3.0",

--- a/src/actions/actions.ts
+++ b/src/actions/actions.ts
@@ -1002,7 +1002,6 @@ class CommandMoveFullPageDown extends BaseCommand {
   }
 }
 
-
 @RegisterAction
 class CommandMoveFullPageUp extends BaseCommand {
   modes = [ModeName.Normal];


### PR DESCRIPTION
Here's how it works:
1) `npm postinstall` script (which auto-runs after npm install) will run `gulp init`
2) `gulp init` will run `typings install` and once that is finished we manually modify the `index.d.ts` to include the vscode definitions.

Somewhat of a hack but it works.