### PR TITLE
Fix#369. `dw` eats EOF.

### DIFF
--- a/src/actions/actions.ts
+++ b/src/actions/actions.ts
@@ -1512,8 +1512,8 @@ export class MoveWordBegin extends BaseMovement {
     next line.
     */
 
-    if (result.isLineBeginning()) {
-        return result.getLeftThroughLineBreaks();
+    if (result.line > position.line + 1 || (result.line === position.line + 1 && result.isFirstWordOfLine())) {
+      return position.getLineEnd();
     }
 
     if (result.isLineEnd()) {

--- a/src/motion/position.ts
+++ b/src/motion/position.ts
@@ -369,6 +369,10 @@ export class Position extends vscode.Position {
         return this.character >= Position.getLineLength(this.line);
     }
 
+    public isFirstWordOfLine(): boolean {
+        return Position.getFirstNonBlankCharAtLine(this.line) === this.character;
+    }
+
     public isAtDocumentEnd(): boolean {
         return this.line === TextEditor.getLineCount() - 1 && this.isLineEnd();
     }

--- a/test/mode/modeNormal.test.ts
+++ b/test/mode/modeNormal.test.ts
@@ -64,6 +64,20 @@ suite("Mode Normal", () => {
     });
 
     newTest({
+      title: "Can handle dw across lines",
+      start: ['one |two', '  three'],
+      keysPressed: 'dw',
+      end: ["one| ", "  three"]
+    });
+
+    newTest({
+      title: "Can handle dw across lines",
+      start: ['one |two', '', 'three'],
+      keysPressed: 'dw',
+      end: ["one| ", "", "three"]
+    });
+
+    newTest({
       title: "Can handle dd last line",
       start: ['one', '|two'],
       keysPressed: 'dd',


### PR DESCRIPTION
Yay! We love PRs! 🎊

Please include a description of your change & check your PR against this list, thanks:

- [x] Commit message has a short title & issue references
- [x] Commits are squashed 
- [x] It builds and tests pass (e.g `gulp tslint`)

Since #369 is out there for a while so I'd like to give it a quick fix.