### PR TITLE
Ctrl+U and Ctrl+D

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -367,10 +367,10 @@ Status | Command | Description
 Status | Command | Description
 ---|--------|------------------------------
 :x:    | :1234:  CTRL-E	| window N lines downwards (default: 1)
-  :x:  | :1234:  CTRL-D	| window N lines Downwards (default: 1/2 window)
+:warning:   | :1234:  CTRL-D	| window N lines Downwards (default: 1/2 window)
 :x:    | :1234:  CTRL-F	| window N pages Forwards (downwards)
   :x:  | :1234:  CTRL-Y	| window N lines upwards (default: 1)
- :x:   | :1234:  CTRL-U	| window N lines Upwards (default: 1/2 window)
+:warning:   | :1234:  CTRL-U	| window N lines Upwards (default: 1/2 window)
 :x:    | :1234:  CTRL-B	| window N pages Backwards (upwards)
 :x:    |    z CR or zt	| redraw, current line at top of window
 :warning: |    z.	 or zz	| redraw, current line at center of window

--- a/extension.ts
+++ b/extension.ts
@@ -78,7 +78,7 @@ export function activate(context: vscode.ExtensionContext) {
         showCmdLine("", modeHandlerToFilename[activeFileName()]);
     });
 
-    'rfb'.split('').forEach(key => {
+    'rfbdu'.split('').forEach(key => {
         registerCommand(context, `extension.vim_ctrl+${key}`, () => handleKeyEvent(`ctrl+${key}`));
     });
 

--- a/package.json
+++ b/package.json
@@ -68,6 +68,16 @@
                 "when": "editorTextFocus"
             },
             {
+                "key": "ctrl+u",
+                "command": "extension.vim_ctrl+u",
+                "when": "editorTextFocus"
+            },
+            {
+                "key": "ctrl+d",
+                "command": "extension.vim_ctrl+d",
+                "when": "editorTextFocus"
+            },
+            {
                 "key": "ctrl+w",
                 "command": "extension.vim_switchWindow",
                 "when": "editorTextFocus"
@@ -109,7 +119,7 @@
                 "vim.insertModeKeyBindings": {
                     "type": "array",
                     "description": "Keybinding overrides to use for insert mode."
-                },
+                },   
                 "vim.useSolidBlockCursor": {
                     "type": "boolean",
                     "description": "Use a non blinking block cursor."
@@ -117,6 +127,10 @@
                 "vim.visualModeKeyBindings": {
                     "type": "object",
                     "description": "Keybinding overrides to use for visual mode."
+                },
+                "vim.scroll": {
+                    "type": "number",
+                    "description": "Number of lines to scroll with CTRL-U and CTRL-D commands."
                 }
             }
         }

--- a/src/actions/actions.ts
+++ b/src/actions/actions.ts
@@ -1014,6 +1014,26 @@ class CommandMoveFullPageUp extends BaseCommand {
 }
 
 @RegisterAction
+class MCommandMoveHalfPageDown extends BaseMovement {
+  modes = [ModeName.Normal];
+  keys = ["ctrl+d"];
+
+  public async execAction(position: Position, vimState: VimState): Promise<Position> {
+    return new Position(Math.min(TextEditor.getLineCount() - 1, position.line + vimState.settings.scroll), position.character);
+  }
+}
+
+@RegisterAction
+class MCommandMoveHalfPageUp extends BaseMovement {
+  modes = [ModeName.Normal];
+  keys = ["ctrl+u"];
+
+  public async execAction(position: Position, vimState: VimState): Promise<Position> {
+    return new Position(Math.max(0, position.line - vimState.settings.scroll), position.character);
+  }
+}
+
+@RegisterAction
 class CommandDeleteToLineEnd extends BaseCommand {
   modes = [ModeName.Normal];
   keys = ["D"];

--- a/src/mode/modeHandler.ts
+++ b/src/mode/modeHandler.ts
@@ -125,6 +125,7 @@ export class VimState {
 
 export class VimSettings {
     useSolidBlockCursor = false;
+    scroll = 20;
 }
 
 export class SearchState {
@@ -477,6 +478,7 @@ export class ModeHandler implements vscode.Disposable {
     private loadSettings(): void {
         this._vimState.settings.useSolidBlockCursor = vscode.workspace.getConfiguration("vim")
             .get("useSolidBlockCursor", false);
+        this._vimState.settings.scroll = vscode.workspace.getConfiguration("vim").get("scroll", 20) || 20;
     }
 
     /**


### PR DESCRIPTION
Yay! We love PRs! 🎊

Please include a description of your change & check your PR against this list, thanks:

- [x] Commit message has a short title & issue references
- [x] Commits are squashed 
- [x] It builds and tests pass (e.g `gulp tslint`)

Fix #214. Since currently we don't have VS Code Screen Line support, we simply use `20` as the half window size, but users can configure `vim.scroll` to override this setting the same as Vim.