### PR TITLE
Read TextEditor options from active editor

### DIFF
--- a/src/textEditor.ts
+++ b/src/textEditor.ts
@@ -134,8 +134,8 @@ export class TextEditor {
     }
 
     static setIndentationLevel(line: string, screenCharacters: number): string {
-        let tabSize = vscode.workspace.getConfiguration("editor").get<number>("tabSize");
-        let insertTabAsSpaces = vscode.workspace.getConfiguration("editor").get<boolean>("insertSpaces");
+        let tabSize = <number> vscode.window.activeTextEditor.options.tabSize;
+        let insertTabAsSpaces = <boolean> vscode.window.activeTextEditor.options.insertSpaces;
 
         if (screenCharacters < 0) {
             screenCharacters = 0;

--- a/test/mode/modeNormal.test.ts
+++ b/test/mode/modeNormal.test.ts
@@ -1,6 +1,6 @@
 "use strict";
 
-import { setupWorkspace, cleanUpWorkspace, assertEqual } from './../testUtils';
+import { setupWorkspace, setTextEditorOptions, cleanUpWorkspace, assertEqual } from './../testUtils';
 import { ModeName } from '../../src/mode/mode';
 import { ModeHandler } from '../../src/mode/modeHandler';
 import { getTestingFunctions } from '../testSimplifier';
@@ -15,6 +15,7 @@ suite("Mode Normal", () => {
 
     setup(async () => {
         await setupWorkspace();
+        setTextEditorOptions(4, false);
     });
 
     teardown(cleanUpWorkspace);


### PR DESCRIPTION
Yay! We love PRs! 🎊

Please include a description of your change & check your PR against this list, thanks:

- [x] Commit message has a short title & issue references
- [x] Commits are squashed 
- [x] It builds and tests pass (e.g `gulp tslint`)

We were reading TextEditor options from configuration but there are some drawbacks:

1. We didn't monitor the configuration change (not sure if there is any event exposed)
2. VS Code puts a copy of the text editor related configuration in each Text Editor object and there is no bidirectional between them. If people change the configuration file, every copy of text editor option will be reloaded but if we change `vscode.window.activeTextEditor.options` through API on the fly, it's not synced back to `vscode.workspace.getConfiguration("editor")`. It does make sense because `vscode.workspace.getConfiguration("editor")` is likely representing the state of the configuration file.

Here I changed our logic to read from `vscode.window.activeTextEditor.options` always because we can't make sure we are the only one that modifies it. People might install other extensions that modify the options at runtime as well. `vscode.window.activeTextEditor.options` is our best choice now.

BTW, I'll raise the issue to @code team about the configuration sync issue because we are adding API support for other configuration part.