### PR TITLE
Implement additional text object commands

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -268,14 +268,14 @@ Status | Command | Description
     | :1234:  ib	| Select "inner block" (from "[(" to "])")
     | :1234:  aB	| Select "a Block" (from "[{" to "]}")
     | :1234:  iB	| Select "inner Block" (from "[{" to "]}")
-    | :1234:  a>	| Select "a &lt;&gt; block"
-    | :1234:  i>	| Select "inner <> block"
+:warning:    | :1234:  a>	| Select "a &lt;&gt; block"
+:warning:    | :1234:  i>	| Select "inner <> block"
     | :1234:  at	| Select "a tag block" (from <aaa> to </aaa>)
     | :1234:  it	| Select "inner tag block" (from <aaa> to </aaa>)
-    | :1234:  a'	| Select "a single quoted string"
-    | :1234:  i'	| Select "inner single quoted string"
-    | :1234:  a"	| Select "a double quoted string"
-    | :1234:  i"	| Select "inner double quoted string"
+:warning:    | :1234:  a'	| Select "a single quoted string"
+:warning:    | :1234:  i'	| Select "inner single quoted string"
+:warning:    | :1234:  a"	| Select "a double quoted string"
+:warning:    | :1234:  i"	| Select "inner double quoted string"
     | :1234:  a`	| Select "a backward quoted string"
     | :1234:  i`	| Select "inner backward quoted string"
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -272,10 +272,10 @@ Status | Command | Description
 :warning:    | :1234:  i>	| Select "inner <> block"
     | :1234:  at	| Select "a tag block" (from <aaa> to </aaa>)
     | :1234:  it	| Select "inner tag block" (from <aaa> to </aaa>)
-:warning:    | :1234:  a'	| Select "a single quoted string"
-:warning:    | :1234:  i'	| Select "inner single quoted string"
-:warning:    | :1234:  a"	| Select "a double quoted string"
-:warning:    | :1234:  i"	| Select "inner double quoted string"
+    | :1234:  a'	| Select "a single quoted string"
+    | :1234:  i'	| Select "inner single quoted string"
+    | :1234:  a"	| Select "a double quoted string"
+    | :1234:  i"	| Select "inner double quoted string"
     | :1234:  a`	| Select "a backward quoted string"
     | :1234:  i`	| Select "inner backward quoted string"
 

--- a/src/actions/actions.ts
+++ b/src/actions/actions.ts
@@ -2208,16 +2208,15 @@ abstract class MoveInsideCharacter extends BaseMovement {
   modes = [ModeName.Normal, ModeName.Visual, ModeName.VisualLine];
   protected charToMatch: string;
   protected includeSurrounding = false;
-  protected lineMatchOnly = false;
 
   public async execAction(position: Position, vimState: VimState): Promise<Position | IMovement> {
     const text = TextEditor.getLineAt(position).text;
 
     // First, search backwards for the opening character of the sequence
-    let startPos = position.lastIndexOf(this.charToMatch, this.lineMatchOnly);
+    let startPos = position.lastIndexOf(this.charToMatch);
     const startPlusOne = new Position(startPos.line, startPos.character + 1);
 
-    let endPos = PairMatcher.nextPairedChar(startPlusOne, this.charToMatch, false, this.lineMatchOnly);
+    let endPos = PairMatcher.nextPairedChar(startPlusOne, this.charToMatch, false);
 
     // Poor man's check for whether we found an opening character
     if (startPos === position && text[position.character] !== this.charToMatch) {
@@ -2320,36 +2319,6 @@ class MoveAClosingCaret extends MoveInsideCharacter {
   keys = ["a", ">"];
   charToMatch = "<";
   includeSurrounding = true;
-}
-
-@RegisterAction
-class MoveIDoubleQuote extends MoveInsideCharacter {
-  keys = ["i", "\""];
-  charToMatch = "\"";
-  lineMatchOnly = true;
-}
-
-@RegisterAction
-class MoveISingleQuote extends MoveInsideCharacter {
-  keys = ["i", "'"];
-  charToMatch = "'";
-  lineMatchOnly = true;
-}
-
-@RegisterAction
-class MoveADoubleQuote extends MoveInsideCharacter {
-  keys = ["a", "\""];
-  charToMatch = "\"";
-  includeSurrounding = true;
-  lineMatchOnly = true;
-}
-
-@RegisterAction
-class MoveASingleQuote extends MoveInsideCharacter {
-  keys = ["a", "'"];
-  charToMatch = "'";
-  includeSurrounding = true;
-  lineMatchOnly = true;
 }
 
 @RegisterAction

--- a/src/actions/actions.ts
+++ b/src/actions/actions.ts
@@ -3,6 +3,7 @@ import { ModeName } from './../mode/mode';
 import { TextEditor } from './../textEditor';
 import { Register, RegisterMode } from './../register/register';
 import { Position } from './../motion/position';
+import { PairMatcher } from './../matching/matcher';
 import * as vscode from 'vscode';
 
 const controlKeys: string[] = [
@@ -2170,68 +2171,17 @@ class MoveToMatchingBracket extends BaseMovement {
   modes = [ModeName.Normal, ModeName.Visual, ModeName.VisualLine];
   keys = ["%"];
 
-  pairings: { [key: string]: { match: string, nextMatchIsForward: boolean }} = {
-    "(" : { match: ")",  nextMatchIsForward: true  },
-    "{" : { match: "}",  nextMatchIsForward: true  },
-    "[" : { match: "]",  nextMatchIsForward: true  },
-    ")" : { match: "(",  nextMatchIsForward: false },
-    "}" : { match: "{",  nextMatchIsForward: false },
-    "]" : { match: "[",  nextMatchIsForward: false },
-    // "'" : { match: "'",  direction:  0 },
-    // "\"": { match: "\"", direction:  0 },
-  };
-
-  nextBracket(position: Position, charToMatch: string, toFind: { match: string, nextMatchIsForward: boolean }, closed: boolean = true) {
-      /**
-       * We do a fairly basic implementation that only tracks the state of the type of
-       * character you're over and its pair (e.g. "[" and "]"). This is similar to
-       * what Vim does.
-       *
-       * It can't handle strings very well - something like "|( ')' )" where | is the
-       * cursor will cause it to go to the ) in the quotes, even though it should skip over it.
-       *
-       * PRs welcomed! (TODO)
-       * Though ideally VSC implements https://github.com/Microsoft/vscode/issues/7177
-       */
-
-      let stackHeight = closed ? 0 : 1;
-      let matchedPosition: Position | undefined = undefined;
-
-      for (const { char, pos } of Position.IterateDocument(position, toFind.nextMatchIsForward)) {
-        if (char === charToMatch) {
-          stackHeight++;
-        }
-
-        if (char === this.pairings[charToMatch].match) {
-          stackHeight--;
-        }
-
-        if (stackHeight === 0) {
-          matchedPosition = pos;
-
-          break;
-        }
-      }
-
-      if (matchedPosition) {
-        return matchedPosition;
-      }
-
-      // TODO(bell)
-      return position;
-  }
-
   public async execAction(position: Position, vimState: VimState): Promise<Position> {
     const text = TextEditor.getLineAt(position).text;
     const charToMatch = text[position.character];
-    const toFind = this.pairings[charToMatch];
+    const toFind = PairMatcher.pairings[charToMatch];
 
-    if (!toFind) {
+    if (!toFind || !toFind.matchesWithPercentageMotion) {
       // If we're not on a match, go right until we find a
       // pairable character or hit the end of line.
 
       for (let i = position.character; i < text.length; i++) {
-        if (this.pairings[text[i]]) {
+        if (PairMatcher.pairings[text[i]]) {
           return new Position(position.line, i);
         }
       }
@@ -2240,8 +2190,8 @@ class MoveToMatchingBracket extends BaseMovement {
       return position;
     }
 
-    return this.nextBracket(position, charToMatch, toFind, true);
-}
+    return PairMatcher.nextPairedChar(position, charToMatch, true);
+  }
 
   public async execActionForOperator(position: Position, vimState: VimState): Promise<Position> {
     const result = await this.execAction(position, vimState);
@@ -2254,13 +2204,161 @@ class MoveToMatchingBracket extends BaseMovement {
   }
 }
 
+abstract class MoveInsideCharacter extends BaseMovement {
+  modes = [ModeName.Normal, ModeName.Visual, ModeName.VisualLine];
+  protected charToMatch: string;
+  protected includeSurrounding = false;
+  protected lineMatchOnly = false;
+
+  public async execAction(position: Position, vimState: VimState): Promise<Position | IMovement> {
+    const text = TextEditor.getLineAt(position).text;
+
+    // First, search backwards for the opening character of the sequence
+    let startPos = position.lastIndexOf(this.charToMatch, this.lineMatchOnly);
+    const startPlusOne = new Position(startPos.line, startPos.character + 1);
+
+    let endPos = PairMatcher.nextPairedChar(startPlusOne, this.charToMatch, false, this.lineMatchOnly);
+
+    // Poor man's check for whether we found an opening character
+    if (startPos === position && text[position.character] !== this.charToMatch) {
+      return position;
+    }
+    // Make sure the start position is inside the selection
+    if (startPos.isAfter(position) || endPos.isBefore(position)) {
+      return position;
+    }
+
+    if (this.includeSurrounding) {
+      endPos = new Position(endPos.line, endPos.character + 1);
+    } else {
+      startPos = startPlusOne;
+    }
+    // If the closing character is the first on the line, don't swallow it.
+    if (endPos.character === 0) {
+      endPos = endPos.getLeftThroughLineBreaks();
+    }
+    return {
+      start : startPos,
+      stop  : endPos,
+    };
+  }
+}
+
+@RegisterAction
+class MoveIParentheses extends MoveInsideCharacter {
+  keys = ["i", "("];
+  charToMatch = "(";
+}
+
+@RegisterAction
+class MoveIClosingParentheses extends MoveInsideCharacter {
+  keys = ["i", ")"];
+  charToMatch = "(";
+}
+
+@RegisterAction
+class MoveAParentheses extends MoveInsideCharacter {
+  keys = ["a", "("];
+  charToMatch = "(";
+  includeSurrounding = true;
+}
+
+@RegisterAction
+class MoveAClosingParentheses extends MoveInsideCharacter {
+  keys = ["a", ")"];
+  charToMatch = "(";
+  includeSurrounding = true;
+}
+
+@RegisterAction
+class MoveICurlyBrace extends MoveInsideCharacter {
+  keys = ["i", "{"];
+  charToMatch = "{";
+}
+
+@RegisterAction
+class MoveIClosingCurlyBrace extends MoveInsideCharacter {
+  keys = ["i", "}"];
+  charToMatch = "{";
+}
+
+@RegisterAction
+class MoveACurlyBrace extends MoveInsideCharacter {
+  keys = ["a", "{"];
+  charToMatch = "{";
+  includeSurrounding = true;
+}
+
+@RegisterAction
+class MoveAClosingCurlyBrace extends MoveInsideCharacter {
+  keys = ["a", "}"];
+  charToMatch = "{";
+  includeSurrounding = true;
+}
+
+@RegisterAction
+class MoveICaret extends MoveInsideCharacter {
+  keys = ["i", "<"];
+  charToMatch = "<";
+}
+
+@RegisterAction
+class MoveIClosingCaret extends MoveInsideCharacter {
+  keys = ["i", ">"];
+  charToMatch = "<";
+}
+
+@RegisterAction
+class MoveACaret extends MoveInsideCharacter {
+  keys = ["a", "<"];
+  charToMatch = "<";
+  includeSurrounding = true;
+}
+
+@RegisterAction
+class MoveAClosingCaret extends MoveInsideCharacter {
+  keys = ["a", ">"];
+  charToMatch = "<";
+  includeSurrounding = true;
+}
+
+@RegisterAction
+class MoveIDoubleQuote extends MoveInsideCharacter {
+  keys = ["i", "\""];
+  charToMatch = "\"";
+  lineMatchOnly = true;
+}
+
+@RegisterAction
+class MoveISingleQuote extends MoveInsideCharacter {
+  keys = ["i", "'"];
+  charToMatch = "'";
+  lineMatchOnly = true;
+}
+
+@RegisterAction
+class MoveADoubleQuote extends MoveInsideCharacter {
+  keys = ["a", "\""];
+  charToMatch = "\"";
+  includeSurrounding = true;
+  lineMatchOnly = true;
+}
+
+@RegisterAction
+class MoveASingleQuote extends MoveInsideCharacter {
+  keys = ["a", "'"];
+  charToMatch = "'";
+  includeSurrounding = true;
+  lineMatchOnly = true;
+}
+
 @RegisterAction
 class MoveToUnclosedRoundBracketBackward extends MoveToMatchingBracket {
   keys = ["[", "("];
 
   public async execAction(position: Position, vimState: VimState): Promise<Position> {
     const charToMatch = ")";
-    return this.nextBracket(position.getLeftThroughLineBreaks(), charToMatch, this.pairings[charToMatch], false);
+    return PairMatcher.nextPairedChar(position.getLeftThroughLineBreaks(), charToMatch, false);
   }
 }
 
@@ -2270,7 +2368,7 @@ class MoveToUnclosedRoundBracketForward extends MoveToMatchingBracket {
 
   public async execAction(position: Position, vimState: VimState): Promise<Position> {
     const charToMatch = "(";
-    return this.nextBracket(position.getRightThroughLineBreaks(), charToMatch, this.pairings[charToMatch], false);
+    return PairMatcher.nextPairedChar(position.getRightThroughLineBreaks(), charToMatch, false);
   }
 }
 
@@ -2280,7 +2378,7 @@ class MoveToUnclosedCurlyBracketBackward extends MoveToMatchingBracket {
 
   public async execAction(position: Position, vimState: VimState): Promise<Position> {
     const charToMatch = "}";
-    return this.nextBracket(position.getLeftThroughLineBreaks(), charToMatch, this.pairings[charToMatch], false);
+    return PairMatcher.nextPairedChar(position.getLeftThroughLineBreaks(), charToMatch, false);
   }
 }
 
@@ -2290,7 +2388,7 @@ class MoveToUnclosedCurlyBracketForward extends MoveToMatchingBracket {
 
   public async execAction(position: Position, vimState: VimState): Promise<Position> {
     const charToMatch = "{";
-    return this.nextBracket(position.getRightThroughLineBreaks(), charToMatch, this.pairings[charToMatch], false);
+    return PairMatcher.nextPairedChar(position.getRightThroughLineBreaks(), charToMatch, false);
   }
 }
 

--- a/src/matching/matcher.ts
+++ b/src/matching/matcher.ts
@@ -13,12 +13,13 @@ export class PairMatcher {
     "}" : { match: "{",  nextMatchIsForward: false, matchesWithPercentageMotion: true },
     "]" : { match: "[",  nextMatchIsForward: false, matchesWithPercentageMotion: true },
     // These characters can't be used for "%"-based matching, but are still
-    "'" : { match: "'",  nextMatchIsForward: true },
-    "\"": { match: "\"", nextMatchIsForward: true },
+    // useful for text objects.
+    // "'" : { match: "'",  nextMatchIsForward: true },
+    // "\"": { match: "\"", nextMatchIsForward: true },
     "<" : { match: ">",  nextMatchIsForward: true },
   };
 
-  static nextPairedChar(position: Position, charToMatch: string, closed: boolean = true, currentLineOnly: boolean = false): Position {
+  static nextPairedChar(position: Position, charToMatch: string, closed: boolean = true): Position {
     /**
      * We do a fairly basic implementation that only tracks the state of the type of
      * character you're over and its pair (e.g. "[" and "]"). This is similar to
@@ -36,10 +37,7 @@ export class PairMatcher {
     let matchedPosition: Position | undefined = undefined;
 
     for (const { char, pos } of Position.IterateDocument(position, toFind.nextMatchIsForward)) {
-      if (currentLineOnly && position.line < pos.line) {
-        break;
-      }
-      if (char === charToMatch && charToMatch !== toFind.match) {
+      if (char === charToMatch) {
         stackHeight++;
       }
 

--- a/src/matching/matcher.ts
+++ b/src/matching/matcher.ts
@@ -1,0 +1,64 @@
+import { Position } from './../motion/position';
+
+/**
+ * PairMatcher finds the position matching the given character, respecting nested
+ * instances of the pair.
+ */
+export class PairMatcher {
+  static pairings: { [key: string]: { match: string, nextMatchIsForward: boolean, matchesWithPercentageMotion?: boolean }} = {
+    "(" : { match: ")",  nextMatchIsForward: true,  matchesWithPercentageMotion: true },
+    "{" : { match: "}",  nextMatchIsForward: true,  matchesWithPercentageMotion: true },
+    "[" : { match: "]",  nextMatchIsForward: true,  matchesWithPercentageMotion: true },
+    ")" : { match: "(",  nextMatchIsForward: false, matchesWithPercentageMotion: true },
+    "}" : { match: "{",  nextMatchIsForward: false, matchesWithPercentageMotion: true },
+    "]" : { match: "[",  nextMatchIsForward: false, matchesWithPercentageMotion: true },
+    // These characters can't be used for "%"-based matching, but are still
+    "'" : { match: "'",  nextMatchIsForward: true },
+    "\"": { match: "\"", nextMatchIsForward: true },
+    "<" : { match: ">",  nextMatchIsForward: true },
+  };
+
+  static nextPairedChar(position: Position, charToMatch: string, closed: boolean = true, currentLineOnly: boolean = false): Position {
+    /**
+     * We do a fairly basic implementation that only tracks the state of the type of
+     * character you're over and its pair (e.g. "[" and "]"). This is similar to
+     * what Vim does.
+     *
+     * It can't handle strings very well - something like "|( ')' )" where | is the
+     * cursor will cause it to go to the ) in the quotes, even though it should skip over it.
+     *
+     * PRs welcomed! (TODO)
+     * Though ideally VSC implements https://github.com/Microsoft/vscode/issues/7177
+     */
+    const toFind = this.pairings[charToMatch];
+
+    let stackHeight = closed ? 0 : 1;
+    let matchedPosition: Position | undefined = undefined;
+
+    for (const { char, pos } of Position.IterateDocument(position, toFind.nextMatchIsForward)) {
+      if (currentLineOnly && position.line < pos.line) {
+        break;
+      }
+      if (char === charToMatch && charToMatch !== toFind.match) {
+        stackHeight++;
+      }
+
+      if (char === toFind.match) {
+        stackHeight--;
+      }
+
+      if (stackHeight === 0) {
+        matchedPosition = pos;
+
+        break;
+      }
+    }
+
+    if (matchedPosition) {
+      return matchedPosition;
+    }
+
+    // TODO(bell)
+    return position;
+  }
+}

--- a/src/motion/position.ts
+++ b/src/motion/position.ts
@@ -621,4 +621,19 @@ export class Position extends vscode.Position {
 
     return position;
   }
+
+  public lastIndexOf(char: string, currentLineOnly: boolean = false): Position {
+    for (const current of Position.IterateDocument(this, false)) {
+     if (currentLineOnly && this.line !== current.pos.line) {
+        // We've advanced past the current line and the caller doesn't want us to
+        return this;
+      }
+
+      if (current.char === char) {
+        return current.pos;
+      }
+    }
+
+    return this;
+  }
 }

--- a/src/motion/position.ts
+++ b/src/motion/position.ts
@@ -622,13 +622,8 @@ export class Position extends vscode.Position {
     return position;
   }
 
-  public lastIndexOf(char: string, currentLineOnly: boolean = false): Position {
+  public lastIndexOf(char: string): Position {
     for (const current of Position.IterateDocument(this, false)) {
-     if (currentLineOnly && this.line !== current.pos.line) {
-        // We've advanced past the current line and the caller doesn't want us to
-        return this;
-      }
-
       if (current.char === char) {
         return current.pos;
       }

--- a/test/mode/modeNormal.test.ts
+++ b/test/mode/modeNormal.test.ts
@@ -236,22 +236,6 @@ suite("Mode Normal", () => {
     });
 
     newTest({
-      title: "Can handle 'ci\"' inside a string",
-      start: ['"hel|lo" world'],
-      keysPressed: 'ci"',
-      end: ['"|" world'],
-      endMode: ModeName.Insert
-    });
-
-    newTest({
-      title: "Can handle \"ci'\" inside a string",
-      start: ['\'on|e\' two'],
-      keysPressed: 'ci\'',
-      end: ['\'|\' two'],
-      endMode: ModeName.Insert
-    });
-
-    newTest({
       title: "Can handle 'ca(' spanning multiple lines",
       start: ['call(', '  |arg1)'],
       keysPressed: 'ca(',

--- a/test/mode/modeNormal.test.ts
+++ b/test/mode/modeNormal.test.ts
@@ -220,6 +220,54 @@ suite("Mode Normal", () => {
     });
 
     newTest({
+      title: "Can handle 'ci(' on first parentheses",
+      start: ['print(|"hello")'],
+      keysPressed: 'ci(',
+      end: ['print(|)'],
+      endMode: ModeName.Insert
+    });
+
+    newTest({
+      title: "Can handle 'ci(' with nested parentheses",
+      start: ['call|(() => 5)'],
+      keysPressed: 'ci(',
+      end: ['call(|)'],
+      endMode: ModeName.Insert
+    });
+
+    newTest({
+      title: "Can handle 'ci\"' inside a string",
+      start: ['"hel|lo" world'],
+      keysPressed: 'ci"',
+      end: ['"|" world'],
+      endMode: ModeName.Insert
+    });
+
+    newTest({
+      title: "Can handle \"ci'\" inside a string",
+      start: ['\'on|e\' two'],
+      keysPressed: 'ci\'',
+      end: ['\'|\' two'],
+      endMode: ModeName.Insert
+    });
+
+    newTest({
+      title: "Can handle 'ca(' spanning multiple lines",
+      start: ['call(', '  |arg1)'],
+      keysPressed: 'ca(',
+      end: ['call|'],
+      endMode: ModeName.Insert
+    });
+
+    newTest({
+      title: "Can handle 'ci{' spanning multiple lines",
+      start: ['one {', '|', '}'],
+      keysPressed: 'ci{',
+      end: ['one {|}'],
+      endMode: ModeName.Insert
+    });
+
+    newTest({
       title: "Can handle 'df'",
       start: ['aext tex|t'],
       keysPressed: '^dft',


### PR DESCRIPTION
This allows for e.g. 'ci(' and 'da<' commands.

Fixes #449