### PR TITLE
Add test-specific tslint

### DIFF
--- a/package.json
+++ b/package.json
@@ -172,6 +172,7 @@
         "gulp-tslint": "^5.0.0",
         "gulp-typescript": "^2.13.4",
         "gulp-typings": "^2.0.0",
+        "merge-stream": "^1.0.0",
         "tslint": "^3.10.2",
         "typescript": "2.0.0",
         "typings": "^1.0.4",

--- a/test/mode/modeNormal.test.ts
+++ b/test/mode/modeNormal.test.ts
@@ -10,7 +10,7 @@ suite("Mode Normal", () => {
 
     let {
         newTest,
-        // newTestOnly
+        newTestOnly
     } = getTestingFunctions(modeHandler);
 
     setup(async () => {

--- a/test/tslint.json
+++ b/test/tslint.json
@@ -1,0 +1,6 @@
+{
+  "extends": "../tslint.json",
+  "rules": {
+    "no-unused-variable": false
+  }
+}


### PR DESCRIPTION
This adds a test-specific tslint.json that allows for unused variables in tests. I verified manually.

NOTE: I'm a total gulp (and node) noob. I followed https://github.com/gulpjs/gulp/blob/master/docs/recipes/using-multiple-sources-in-one-task.md for how to get different behavior from multiple sources, but it feels silly to pull in the dependency just for this. LMK if there's a better way.

Fixes #379