### PR TITLE
Add support for failed motions

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -9,5 +9,5 @@
 	"typescript.tsdk": "./node_modules/typescript/lib", // we want to use the TS server from our node_modules folder to control its version
 	"editor.tabSize": 2,
 	"editor.insertSpaces": true,
-	"files.trimTrailingWhitespace": false 
+	"files.trimTrailingWhitespace": true
 }

--- a/src/actions/actions.ts
+++ b/src/actions/actions.ts
@@ -62,6 +62,13 @@ export interface IMovement {
   start        : Position;
   stop         : Position;
 
+  /**
+   * Whether this motion succeeded. Some commands, like fx when 'x' can't be found,
+   * will not move the cursor. Furthermore, dfx won't delete *anything*, even though
+   * deleting to the current character would generally delete 1 character.
+   */
+  failed       : boolean;
+
   // It /so/ annoys me that I have to put this here.
   registerMode?: RegisterMode;
 }
@@ -1524,6 +1531,10 @@ class MoveFindForward extends BaseMovement {
     const toFind = this.keysPressed[1];
     let result = position.findForwards(toFind, count);
 
+    if (!result) {
+      return { start: position, stop: position, failed: true };
+    }
+
     if (vimState.recordedState.operator) {
       result = result.getRight();
     }
@@ -1541,6 +1552,10 @@ class MoveFindBackward extends BaseMovement {
     count = count || 1;
     const toFind = this.keysPressed[1];
     let result = position.findBackwards(toFind, count);
+
+    if (!result) {
+      return { start: position, stop: position, failed: true };
+    }
 
     if (vimState.recordedState.operator) {
       result = result.getLeft();
@@ -1561,6 +1576,10 @@ class MoveTilForward extends BaseMovement {
     const toFind = this.keysPressed[1];
     let result = position.tilForwards(toFind, count);
 
+    if (!result) {
+      return { start: position, stop: position, failed: true };
+    }
+
     if (vimState.recordedState.operator) {
       result = result.getRight();
     }
@@ -1578,6 +1597,10 @@ class MoveTilBackward extends BaseMovement {
     count = count || 1;
     const toFind = this.keysPressed[1];
     let result = position.tilBackwards(toFind, count);
+
+    if (!result) {
+      return { start: position, stop: position, failed: true };
+    }
 
     if (vimState.recordedState.operator) {
       result = result.getLeft();

--- a/src/mode/modeHandler.ts
+++ b/src/mode/modeHandler.ts
@@ -707,6 +707,10 @@ export class ModeHandler implements vscode.Disposable {
     if (result instanceof Position) {
       vimState.cursorPosition = result;
     } else if (isIMovement(result)) {
+      if (result.failed) {
+        vimState.recordedState = new RecordedState();
+      }
+      
       vimState.cursorPosition    = result.stop;
       vimState.cursorStartPosition = result.start;
 
@@ -740,8 +744,8 @@ export class ModeHandler implements vscode.Disposable {
   }
 
   private async executeOperator(vimState: VimState): Promise<VimState> {
-    let start     = vimState.cursorStartPosition;
-    let stop      = vimState.cursorPosition;
+    let start         = vimState.cursorStartPosition;
+    let stop          = vimState.cursorPosition;
     let recordedState = vimState.recordedState;
 
     if (!recordedState.operator) {
@@ -752,9 +756,10 @@ export class ModeHandler implements vscode.Disposable {
       [start, stop] = [stop, start];
     }
 
-    if (vimState.currentMode !== ModeName.Visual &&
-      vimState.currentMode !== ModeName.VisualLine &&
-      vimState.currentRegisterMode !== RegisterMode.LineWise) {
+    if (vimState.currentMode         !== ModeName.Visual &&
+        vimState.currentMode         !== ModeName.VisualLine &&
+        vimState.currentRegisterMode !== RegisterMode.LineWise) {
+
       if (Position.EarlierOf(start, stop) === start) {
         stop = stop.getLeft();
       } else {

--- a/src/motion/position.ts
+++ b/src/motion/position.ts
@@ -594,30 +594,30 @@ export class Position extends vscode.Position {
     return undefined;
   }
 
-  public tilForwards(char: string, count: number = 1): Position {
+  public tilForwards(char: string, count: number = 1): Position | null {
     const position = this.findHelper(char, count, +1);
-    if (!position) { return this; }
+    if (!position) { return null; }
 
     return new Position(this.line, position.character - 1);
   }
 
-  public tilBackwards(char: string, count: number = 1): Position {
+  public tilBackwards(char: string, count: number = 1): Position | null {
     const position = this.findHelper(char, count, -1);
-    if (!position) { return this; }
+    if (!position) { return null; }
 
     return new Position(this.line, position.character + 1);
   }
 
-  public findForwards(char: string, count: number = 1): Position {
+  public findForwards(char: string, count: number = 1): Position | null {
     const position = this.findHelper(char, count, +1);
-    if (!position) { return this; }
+    if (!position) { return null; }
 
     return new Position(this.line, position.character);
   }
 
-  public findBackwards(char: string, count: number = 1): Position {
+  public findBackwards(char: string, count: number = 1): Position | null {
     const position = this.findHelper(char, count, -1);
-    if (!position) { return this; }
+    if (!position) { return null; }
 
     return position;
   }

--- a/test/mode/modeNormal.test.ts
+++ b/test/mode/modeNormal.test.ts
@@ -252,6 +252,22 @@ suite("Mode Normal", () => {
     });
 
     newTest({
+      title: "will fail when ca( with no ()",
+      start: ['|blaaah'],
+      keysPressed: 'ca(',
+      end: ['|blaaah'],
+      endMode: ModeName.Normal
+    });
+
+    newTest({
+      title: "will fail when ca{ with no {}",
+      start: ['|blaaah'],
+      keysPressed: 'ca{',
+      end: ['|blaaah'],
+      endMode: ModeName.Normal
+    });
+
+    newTest({
       title: "Can handle 'df'",
       start: ['aext tex|t'],
       keysPressed: '^dft',


### PR DESCRIPTION
It's always a pleasant thing when a change that seems tricky ends up being very simple. 😃 

Fixes a bug I promised @sectioneight I'd get to where ci{ when you're not inside {} would cause you to switch into insert mode. Also fixes an old bug where dtx when x couldn't be found would delete a character.