### PR TITLE
Fix handling of opener for nested text objects

### DIFF
--- a/src/actions/actions.ts
+++ b/src/actions/actions.ts
@@ -2246,7 +2246,7 @@ abstract class MoveInsideCharacter extends BaseMovement {
     const text = TextEditor.getLineAt(position).text;
 
     // First, search backwards for the opening character of the sequence
-    let startPos = position.lastIndexOf(this.charToMatch);
+    let startPos = PairMatcher.nextPairedChar(position, PairMatcher.pairings[this.charToMatch].match, false);
     const startPlusOne = new Position(startPos.line, startPos.character + 1);
 
     let endPos = PairMatcher.nextPairedChar(startPlusOne, this.charToMatch, false);

--- a/src/motion/position.ts
+++ b/src/motion/position.ts
@@ -636,14 +636,4 @@ export class Position extends vscode.Position {
 
     return position;
   }
-
-  public lastIndexOf(char: string): Position {
-    for (const current of Position.IterateDocument(this, false)) {
-      if (current.char === char) {
-        return current.pos;
-      }
-    }
-
-    return this;
-  }
 }

--- a/test/mode/modeNormal.test.ts
+++ b/test/mode/modeNormal.test.ts
@@ -236,6 +236,14 @@ suite("Mode Normal", () => {
     });
 
     newTest({
+      title: "Can handle 'ci(' backwards through nested parens",
+      start: ['call(() => |5)'],
+      keysPressed: 'ci(',
+      end: ['call(|)'],
+      endMode: ModeName.Insert
+    });
+
+    newTest({
       title: "Can handle 'ca(' spanning multiple lines",
       start: ['call(', '  |arg1)'],
       keysPressed: 'ca(',


### PR DESCRIPTION
Prior to this commit, we would naively search for the previous e.g. "{"
character when you wanted to "ci{".

However, if you were inside two levels of nesting:

```
  one {
    two {}
    // cursor here
  }
```

Then the backwards search would take you to the wrong place.

Switching to the same logic for forward searching, we now handle this
case properly.