### PR TITLE
Fix regressions in text objects

### DIFF
--- a/src/actions/actions.ts
+++ b/src/actions/actions.ts
@@ -2244,9 +2244,11 @@ abstract class MoveInsideCharacter extends BaseMovement {
 
   public async execAction(position: Position, vimState: VimState): Promise<Position | IMovement> {
     const text = TextEditor.getLineAt(position).text;
+    const closingChar = PairMatcher.pairings[this.charToMatch].match;
+    const closedMatch = text[position.character] === closingChar;
 
     // First, search backwards for the opening character of the sequence
-    let startPos = PairMatcher.nextPairedChar(position, PairMatcher.pairings[this.charToMatch].match, false);
+    let startPos = PairMatcher.nextPairedChar(position, closingChar, closedMatch);
     const startPlusOne = new Position(startPos.line, startPos.character + 1);
 
     let endPos = PairMatcher.nextPairedChar(startPlusOne, this.charToMatch, false);

--- a/src/matching/matcher.ts
+++ b/src/matching/matcher.ts
@@ -17,6 +17,7 @@ export class PairMatcher {
     // "'" : { match: "'",  nextMatchIsForward: true },
     // "\"": { match: "\"", nextMatchIsForward: true },
     "<" : { match: ">",  nextMatchIsForward: true },
+    ">" : { match: "<",  nextMatchIsForward: false },
   };
 
   static nextPairedChar(position: Position, charToMatch: string, closed: boolean = true): Position {

--- a/test/mode/modeNormal.test.ts
+++ b/test/mode/modeNormal.test.ts
@@ -260,6 +260,14 @@ suite("Mode Normal", () => {
     });
 
     newTest({
+      title: "Can handle 'ci(' on the closing bracket",
+      start: ['(one|)'],
+      keysPressed: 'ci(',
+      end: ['(|)'],
+      endMode: ModeName.Insert
+    });
+
+    newTest({
       title: "will fail when ca( with no ()",
       start: ['|blaaah'],
       keysPressed: 'ca(',


### PR DESCRIPTION
This PR fixes a regression in text objects when positioned over the final character.

It also fixes a regression with `<` objects, which is unfortunately not easy to test right now due to the way test cases are tokenized. I'd like to follow up and make it testable and add the appropriate tests, but I also want to leave master in a stable state.

I am starting to appreciate just how much vim does under the hood :)