### PR TITLE
Set correct cursor and selection after code format.

### DIFF
--- a/src/actions/actions.ts
+++ b/src/actions/actions.ts
@@ -610,6 +610,15 @@ class CommandFormatCode extends BaseCommand {
 
   public async exec(position: Position, vimState: VimState): Promise<VimState> {
     await vscode.commands.executeCommand("editor.action.format");
+    let line = vimState.cursorStartPosition.line;
+
+    if (vimState.cursorStartPosition.isAfter(vimState.cursorPosition)) {
+      line = vimState.cursorPosition.line;
+    }
+
+    let newCursorPosition = new Position(line, 0);
+    vimState.cursorPosition = newCursorPosition;
+    vimState.cursorStartPosition = newCursorPosition;
     vimState.currentMode = ModeName.Normal;
     return vimState;
   }


### PR DESCRIPTION
Yay! We love PRs! 🎊

Please include a description of your change & check your PR against this list, thanks:

- [x] Commit message has a short title & issue references
- [x] Commits are squashed 
- [x] It builds and tests pass (e.g `gulp tslint`)

After code format, the cursor should be set to the first character of the first line of original selection.