### PR TITLE
Screen lines and characters.

### DIFF
--- a/src/actions/actions.ts
+++ b/src/actions/actions.ts
@@ -1715,6 +1715,12 @@ class MoveScreenLineEnd extends MoveByScreenLine {
 }
 
 @RegisterAction
+class MoveScreenLienEndNonBlank extends MoveByScreenLine {
+  keys = ["g", "_"];
+  movementType = "wrappedLineLastNonWhitespaceCharacter";
+}
+
+@RegisterAction
 class MoveScreenLineCenter extends MoveByScreenLine {
   keys = ["g", "m"];
   movementType = "wrappedLineColumnCenter";

--- a/src/actions/actions.ts
+++ b/src/actions/actions.ts
@@ -1664,7 +1664,7 @@ abstract class MoveByScreenLine extends BaseMovement {
   public async execAction(position: Position, vimState: VimState): Promise<Position | IMovement> {
     await vscode.commands.executeCommand("cursorMove", {
       to: this.movementType,
-      inSelectionMode: vimState.currentMode !== ModeName.Normal,
+      select: vimState.currentMode !== ModeName.Normal,
       noOfLines: this.noOfLines
     });
 

--- a/src/mode/modeHandler.ts
+++ b/src/mode/modeHandler.ts
@@ -710,7 +710,7 @@ export class ModeHandler implements vscode.Disposable {
       if (result.failed) {
         vimState.recordedState = new RecordedState();
       }
-      
+
       vimState.cursorPosition    = result.stop;
       vimState.cursorStartPosition = result.start;
 


### PR DESCRIPTION
Yay! We love PRs! 🎊

Please include a description of your change & check your PR against this list, thanks:

- [x] Commit message has a short title & issue references
- [x] Commits are squashed 
- [x] It builds and tests pass (e.g `gulp tslint`)

We are adding APIs for screen lines/characters in Insider and this PR is integrating those APIs for following commands

- [x] `g0`
- [x] `g^`
- [x] :1234: `g$`
- [x] `gm`
- [x] :1234: `gk`
- [x] :1234: `gj`
- [x] :1234: `H`
- [x] `M`
- [x] :1234: `L`

As @johnfn mentioned while I did #478, the way we implment Movement in VSCodeVim is calculating the target Position or Selection and update the View in a central place (modelHandler). We are likely doing this from the very beginning.

While we are exposing commands in VS Code, we try to avoid exposing View Model information as they are way too complex and always require additional work. Take `scroll to next screen line` as example, we want VSCodeVim just provides the Position information and handle the movment ourselves, but for other extension authors or just users who want to customize key bindings, they have to leverage other APIs to move the cursor to target position.

So in this PR, I'm calling VS Code API to do the real movment or selection and return the correct Position/Movement information after the command is executed.