### PR TITLE
Fix % movement when not on opening character

### DIFF
--- a/src/actions/actions.ts
+++ b/src/actions/actions.ts
@@ -2224,7 +2224,9 @@ class MoveToMatchingBracket extends BaseMovement {
 
       for (let i = position.character; i < text.length; i++) {
         if (PairMatcher.pairings[text[i]]) {
-          return new Position(position.line, i);
+          // We found an opening char, now move to the matching closing char
+          const openPosition = new Position(position.line, i);
+          return PairMatcher.nextPairedChar(openPosition, text[i], true);
         }
       }
 

--- a/test/mode/modeNormal.test.ts
+++ b/test/mode/modeNormal.test.ts
@@ -44,6 +44,20 @@ suite("Mode Normal", () => {
     });
 
     newTest({
+      title: "Can handle % before opening brace",
+      start: ['|one (two)'],
+      keysPressed: '%',
+      end: ["one (two|)"],
+    });
+
+    newTest({
+      title: "Can handle % nested inside parens",
+      start: ['(|one { two })'],
+      keysPressed: '%',
+      end: ["(one { two |})"],
+    });
+
+    newTest({
       title: "Can handle dw",
       start: ['one |two three'],
       keysPressed: 'dw',


### PR DESCRIPTION
Vim's behavior is to move to the closing match, if available. Prior to
this commit, we were moving to the opening char.

Fixes #480