### PR TITLE
WIP: Fix selection on text objects

### DIFF
--- a/src/actions/actions.ts
+++ b/src/actions/actions.ts
@@ -2387,7 +2387,7 @@ class MoveToMatchingBracket extends BaseMovement {
   }
 }
 
-abstract class MoveInsideCharacter extends BaseMovement {
+abstract class MoveMatchingCharacter extends BaseMovement {
   modes = [ModeName.Normal, ModeName.Visual, ModeName.VisualLine];
   protected charToMatch: string;
   protected includeSurrounding = false;
@@ -2406,6 +2406,14 @@ abstract class MoveInsideCharacter extends BaseMovement {
 
     let endPos = PairMatcher.nextPairedChar(startPlusOne, this.charToMatch, false);
     if (endPos === undefined) { return failure; }
+    // Poor man's check for whether we found an opening character
+    if ((startPos === position && text[position.character] !== this.charToMatch) ||
+         // Make sure the start position is inside the selection
+         startPos.isAfter(position) ||
+         endPos.isBefore(position)) {
+
+      return failure;
+    }
 
     if (this.includeSurrounding) {
       endPos = new Position(endPos.line, endPos.character + 1);
@@ -2426,104 +2434,104 @@ abstract class MoveInsideCharacter extends BaseMovement {
 }
 
 @RegisterAction
-class MoveIParentheses extends MoveInsideCharacter {
+class MoveIParentheses extends MoveMatchingCharacter {
   keys = ["i", "("];
   charToMatch = "(";
 }
 
 @RegisterAction
-class MoveIClosingParentheses extends MoveInsideCharacter {
+class MoveIClosingParentheses extends MoveMatchingCharacter {
   keys = ["i", ")"];
   charToMatch = "(";
 }
 
 @RegisterAction
-class MoveAParentheses extends MoveInsideCharacter {
+class MoveAParentheses extends MoveMatchingCharacter {
   keys = ["a", "("];
   charToMatch = "(";
   includeSurrounding = true;
 }
 
 @RegisterAction
-class MoveAClosingParentheses extends MoveInsideCharacter {
+class MoveAClosingParentheses extends MoveMatchingCharacter {
   keys = ["a", ")"];
   charToMatch = "(";
   includeSurrounding = true;
 }
 
 @RegisterAction
-class MoveICurlyBrace extends MoveInsideCharacter {
+class MoveICurlyBrace extends MoveMatchingCharacter {
   keys = ["i", "{"];
   charToMatch = "{";
 }
 
 @RegisterAction
-class MoveIClosingCurlyBrace extends MoveInsideCharacter {
+class MoveIClosingCurlyBrace extends MoveMatchingCharacter {
   keys = ["i", "}"];
   charToMatch = "{";
 }
 
 @RegisterAction
-class MoveACurlyBrace extends MoveInsideCharacter {
+class MoveACurlyBrace extends MoveMatchingCharacter {
   keys = ["a", "{"];
   charToMatch = "{";
   includeSurrounding = true;
 }
 
 @RegisterAction
-class MoveAClosingCurlyBrace extends MoveInsideCharacter {
+class MoveAClosingCurlyBrace extends MoveMatchingCharacter {
   keys = ["a", "}"];
   charToMatch = "{";
   includeSurrounding = true;
 }
 
 @RegisterAction
-class MoveICaret extends MoveInsideCharacter {
+class MoveICaret extends MoveMatchingCharacter {
   keys = ["i", "<"];
   charToMatch = "<";
 }
 
 @RegisterAction
-class MoveIClosingCaret extends MoveInsideCharacter {
+class MoveIClosingCaret extends MoveMatchingCharacter {
   keys = ["i", ">"];
   charToMatch = "<";
 }
 
 @RegisterAction
-class MoveACaret extends MoveInsideCharacter {
+class MoveACaret extends MoveMatchingCharacter {
   keys = ["a", "<"];
   charToMatch = "<";
   includeSurrounding = true;
 }
 
 @RegisterAction
-class MoveAClosingCaret extends MoveInsideCharacter {
+class MoveAClosingCaret extends MoveMatchingCharacter {
   keys = ["a", ">"];
   charToMatch = "<";
   includeSurrounding = true;
 }
 
 @RegisterAction
-class MoveISquareBracket extends MoveInsideCharacter {
+class MoveISquareBracket extends MoveMatchingCharacter {
   keys = ["i", "["];
   charToMatch = "[";
 }
 
 @RegisterAction
-class MoveIClosingSquareBraket extends MoveInsideCharacter {
+class MoveIClosingSquareBraket extends MoveMatchingCharacter {
   keys = ["i", "]"];
   charToMatch = "[";
 }
 
 @RegisterAction
-class MoveASquareBracket extends MoveInsideCharacter {
+class MoveASquareBracket extends MoveMatchingCharacter {
   keys = ["a", "["];
   charToMatch = "[";
   includeSurrounding = true;
 }
 
 @RegisterAction
-class MoveAClosingSquareBracket extends MoveInsideCharacter {
+class MoveAClosingSquareBracket extends MoveMatchingCharacter {
   keys = ["a", "]"];
   charToMatch = "[";
   includeSurrounding = true;

--- a/test/mode/modeVisual.test.ts
+++ b/test/mode/modeVisual.test.ts
@@ -463,4 +463,22 @@ suite("Mode Visual", () => {
       endMode: ModeName.Normal
     });
   });
+
+  suite("handles i{ in visual mode", () => {
+    newTest({
+      title: "Can handle 'vi{d' on a single line",
+      start: ['{ one | } two'],
+      keysPressed: 'vi{d',
+      end: ['{|} two'],
+      endMode: ModeName.Normal
+    });
+
+    newTest({
+      title: "Can handle 'vi{d' across lines",
+      start: ['one |{', '', 'two }'],
+      keysPressed: 'vi{d',
+      end: ['one {|}'],
+      endMode: ModeName.Normal
+    });
+  });
 });


### PR DESCRIPTION
Using similar logic to `MovementIWordTextObject`, this properly handles
the visual selection e.g. `ci(` which previously selected the closing
bracket as well.

NOTE: This is sort of black magic to me. @rebornix helped me understand the way selections work a bit better, and I dug into why `viw` and `ciw` were working properly, but `vi(` and friends were not. There doesn't appear to be a way to test visual selections as part of the test suite. I'm open to ideas.