### PR TITLE
CommandFold should be available in Normal mode

### DIFF
--- a/src/actions/actions.ts
+++ b/src/actions/actions.ts
@@ -1094,12 +1094,12 @@ class CommandDot extends BaseCommand {
 
 @RegisterAction
 class CommandFold extends BaseCommand {
-  modes = [ModeName.Visual, ModeName.VisualLine];
+  modes = [ModeName.Normal];
   keys = ["z", "c"];
 
   public async exec(position: Position, vimState: VimState): Promise<VimState> {
     await vscode.commands.executeCommand("editor.fold");
-
+    vimState.currentMode = ModeName.Normal;
     return vimState;
   }
 }

--- a/src/actions/actions.ts
+++ b/src/actions/actions.ts
@@ -1094,7 +1094,7 @@ class CommandDot extends BaseCommand {
 
 @RegisterAction
 class CommandFold extends BaseCommand {
-  modes = [ModeName.Normal];
+  modes = [ModeName.Normal, ModeName.Visual, ModeName.VisualLine];
   keys = ["z", "c"];
 
   public async exec(position: Position, vimState: VimState): Promise<VimState> {
@@ -1121,12 +1121,12 @@ class CommandCenterScroll extends BaseCommand {
 
 @RegisterAction
 class CommandUnfold extends BaseCommand {
-  modes = [ModeName.Normal];
+  modes = [ModeName.Normal, ModeName.Visual, ModeName.VisualLine];
   keys = ["z", "o"];
 
   public async exec(position: Position, vimState: VimState): Promise<VimState> {
     await vscode.commands.executeCommand("editor.unfold");
-
+    vimState.currentMode = ModeName.Normal;
     return vimState;
   }
 }


### PR DESCRIPTION
This PR changes CommandFold to be used in Normal mode, just like all other fold commands.

Note that i am explicitly setting `vimState.currentMode = ModeName.Normal`, the reason is that *vscode* sometimes changes to Visual mode when folding the block:

Fore example this works fine.
<img width="148" alt="screen shot 2016-07-21 at 4 15 59 pm" src="https://cloud.githubusercontent.com/assets/2920178/17021661/ada4b710-4f5e-11e6-83e1-b7b5eb491140.png">
<img width="136" alt="screen shot 2016-07-21 at 4 16 13 pm" src="https://cloud.githubusercontent.com/assets/2920178/17021660/ada1d9d2-4f5e-11e6-856e-8ea63a9eacf5.png">

But when the cursor is on the beginning line it goes to Visual mode!

<img width="145" alt="screen shot 2016-07-21 at 4 16 30 pm" src="https://cloud.githubusercontent.com/assets/2920178/17021662/ada651ce-4f5e-11e6-81cd-e12e2368d9d9.png">
<img width="145" alt="screen shot 2016-07-21 at 4 16 42 pm" src="https://cloud.githubusercontent.com/assets/2920178/17021659/ada1a6b0-4f5e-11e6-9863-4ae2fd3562a9.png">

