### PR TITLE
Fix #438 - Limit the number of matches, and try to only recalculate when the searchString changes, or the document changes

### DIFF
--- a/src/actions/actions.ts
+++ b/src/actions/actions.ts
@@ -1,4 +1,4 @@
-import { VimSpecialCommands, VimState, SearchState } from './../mode/modeHandler';
+import { VimSpecialCommands, VimState, SearchState, SearchDirection } from './../mode/modeHandler';
 import { ModeName } from './../mode/mode';
 import { TextEditor } from './../textEditor';
 import { Register, RegisterMode } from './../register/register';
@@ -490,7 +490,7 @@ class CommandStar extends BaseCommand {
   public async exec(position: Position, vimState: VimState): Promise<VimState> {
     const currentWord = CommandStar.GetWordAtPosition(position);
 
-    vimState.searchState = new SearchState(+1, vimState.cursorPosition, currentWord);
+    vimState.searchState = new SearchState(SearchDirection.Forward, vimState.cursorPosition, currentWord);
 
     do {
       vimState.cursorPosition = vimState.searchState.getNextSearchMatchPosition(vimState.cursorPosition).pos;
@@ -517,7 +517,7 @@ class CommandHash extends BaseCommand {
   public async exec(position: Position, vimState: VimState): Promise<VimState> {
     const currentWord = CommandStar.GetWordAtPosition(position);
 
-    vimState.searchState = new SearchState(-1, vimState.cursorPosition, currentWord);
+    vimState.searchState = new SearchState(SearchDirection.Backward, vimState.cursorPosition, currentWord);
 
     do {
       // use getWordLeft() on position to start at the beginning of the word.
@@ -606,7 +606,7 @@ export class CommandSearchForwards extends BaseCommand {
   isMotion = true;
 
   public async exec(position: Position, vimState: VimState): Promise<VimState> {
-    vimState.searchState = new SearchState(+1, vimState.cursorPosition);
+    vimState.searchState = new SearchState(SearchDirection.Forward, vimState.cursorPosition);
     vimState.currentMode = ModeName.SearchInProgressMode;
 
     return vimState;
@@ -620,7 +620,7 @@ export class CommandSearchBackwards extends BaseCommand {
   isMotion = true;
 
   public async exec(position: Position, vimState: VimState): Promise<VimState> {
-    vimState.searchState = new SearchState(-1, vimState.cursorPosition);
+    vimState.searchState = new SearchState(SearchDirection.Backward, vimState.cursorPosition);
     vimState.currentMode = ModeName.SearchInProgressMode;
 
     return vimState;

--- a/src/mode/modeHandler.ts
+++ b/src/mode/modeHandler.ts
@@ -160,11 +160,11 @@ export class SearchState {
   public set searchString(search: string){
     if (this._searchString !== search) {
       this._searchString = search;
-      this._recalculateSearchRanges(/*forceRecalc=*/true);
+      this._recalculateSearchRanges({ forceRecalc: true });
     }
   }
 
-  private _recalculateSearchRanges(forceRecalc?: boolean): void {
+  private _recalculateSearchRanges({ forceRecalc }: { forceRecalc?: boolean } = {}): void {
     const search = this.searchString;
 
     if (search === "") { return; }
@@ -174,12 +174,17 @@ export class SearchState {
       this._matchesDocVersion = TextEditor.getDocumentVersion();
       this._matchRanges = [];
 
-      for (let lineIdx = 0; lineIdx < TextEditor.getLineCount() && this._matchRanges.length < SearchState.MAX_SEARCH_RANGES; lineIdx++) {
+      outer:
+      for (let lineIdx = 0; lineIdx < TextEditor.getLineCount(); lineIdx++) {
         const line = TextEditor.getLineAt(new Position(lineIdx, 0)).text;
 
         let i = line.indexOf(search);
 
-        for (; i !== -1 && this._matchRanges.length < SearchState.MAX_SEARCH_RANGES; i = line.indexOf(search, i + search.length)) {
+        for (; i !== -1; i = line.indexOf(search, i + search.length)) {
+          if (this._matchRanges.length >= SearchState.MAX_SEARCH_RANGES) {
+            break outer;
+          }
+
           this._matchRanges.push(new vscode.Range(
             new Position(lineIdx, i),
             new Position(lineIdx, i + search.length)

--- a/src/textEditor.ts
+++ b/src/textEditor.ts
@@ -42,6 +42,10 @@ export class TextEditor {
     });
   }
 
+  static getDocumentVersion(): number {
+    return vscode.window.activeTextEditor.document.version;
+  }
+
   /**
    * Removes all text in the entire document.
    */


### PR DESCRIPTION
`document.version` is incremented each time the document is changed. Using a regex might be faster too, and since `/` is supposed to be a regex search, that's another thing that could be done. But you'll need to handle invalid regexes and stuff and I didn't want to do it in this change.