### PR TITLE
Ignore KeyBindings when in 'SearchInProgressMode'. Fixes #495

### DIFF
--- a/src/mode/remapper.ts
+++ b/src/mode/remapper.ts
@@ -32,7 +32,8 @@ class Remapper {
 
   public async sendKey(key: string, modeHandler: ModeHandler, vimState: VimState): Promise<boolean> {
     if ((vimState.currentMode === ModeName.Insert && !this._isInsertModeRemapping) ||
-      (vimState.currentMode !== ModeName.Insert && this._isInsertModeRemapping)) {
+      (vimState.currentMode !== ModeName.Insert && this._isInsertModeRemapping) ||
+      (vimState.currentMode === ModeName.SearchInProgressMode)) {
 
       this._reset();
 


### PR DESCRIPTION
Simply exits the sendKey function when vimState.currentMode === ModeName.SearchInProgress.

Couldn't find any test that work with KeyBindings, if you want me to add a test for this please direct me to where.

Its tested with:

```
"vim.otherModesKeyBindings": [
  { "before": ["B"], "after": ["^"] },
]
```

with the text:
``` asdasdasdBestasdasd ```
you can now write '/Best' and it will find the 'Best' in the string instead of searching for '/^est'