### PR TITLE
Vim Settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ We're super friendly people if you want to drop by and talk to us on our [Slack 
 * Incremental search with `/` and `?` that works like Vim (doesn't just open the search box!)
 * Correct undo/redo state
 * Marks
+* Vim Options
 
 ## Roadmap
 
@@ -88,6 +89,16 @@ Put the following in your `settings.json`:
 ```    "vim.useCtrlKeys": true```
 
 and restart VSCode.
+
+#### Vim option override sequence.
+
+The way we load Vim options is slightly different from native Vim as there is some overlap between Code and Vim. The option loading sequence is as below.
+
+1. `:set {option}` on the fly
+2. [TODO] .vimrc.
+2. `vim.{option}` from user settings or workspace settings.
+3. VS Code configuration
+4. VSCodeVim flavored Vim option default values
 
 ## Contributing
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -447,7 +447,12 @@ Since the list is too long, now we just put those already supported options here
 Status | Command | Default Value | Description
 ---|--------|-------|------------------------------
 :white_check_mark:| tabstop (ts) | 4. we use Code's default value `tabSize` instead of Vim | number of spaces that <Tab> in file uses
-:white_check_mark:| expandtab (et) | True. we use Code's default value `inserSpaces` instead of Vim | use spaces when <Tab> is inserted
+:white_check_mark:| :white_check_mark:| hlsearch (hls) | false | When there is a previous search pattern, highlight all its matches.
+:white_check_mark:| ignorecase (ic) | false | Ignore case in search patterns.
+:white_check_mark:| smartcase (scs) | false | Override the 'ignorecase' option if the search pattern contains upper case characters.
+:white_check_mark:| iskeyword (isk) | `@,48-57,_,128-167,224-235` | keywords contain alphanumeric characters and '_'. If there is no user setting for `iskeyword`, we use `editor.wordSeparators` properties.
+:white_check_mark:| scroll (scr) | 20 | Number of lines to scroll with CTRL-U and CTRL-D commands.
+>expandtab (et) | True. we use Code's default value `inserSpaces` instead of Vim | use spaces when <Tab> is inserted
 
 ## Folding
 ### Fold methods
@@ -499,4 +504,3 @@ Status | Command | Description
 :x: | foldnestmax fdn | Maximum nesting for "indent" and "syntax" folding.
 :x: | foldopen fdo | Which kinds of commands open closed folds.
 :x: | foldclose fcl | When the folds not under the cursor are closed.
-

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -499,3 +499,4 @@ Status | Command | Description
 :x: | foldnestmax fdn | Maximum nesting for "indent" and "syntax" folding.
 :x: | foldopen fdo | Which kinds of commands open closed folds.
 :x: | foldclose fcl | When the folds not under the cursor are closed.
+

--- a/package.json
+++ b/package.json
@@ -166,6 +166,30 @@
                 "vim.scroll": {
                     "type": "number",
                     "description": "Number of lines to scroll with CTRL-U and CTRL-D commands."
+                },
+                "vim.tabstop": {
+                    "type": "number",
+                    "description": "Number of spaces that a <Tab> in the file counts for."
+                },
+                "vim.expandtab": {
+                    "type": "boolean",
+                    "description": "In Insert mode: Use the appropriate number of spaces to insert a <Tab>."
+                },
+                "vim.iskeyword": {
+                    "type": "string",
+                    "description": "keywords contain alphanumeric characters and '_'"
+                },
+                "vim.ignorecase": {
+                    "type": "boolean",
+                    "description": "Ignore case in search patterns."
+                },
+                "vim.smartcase": {
+                    "type": "boolean",
+                    "description": "Override the 'ignorecase' option if the search pattern contains upper case characters."
+                },
+                "vim.hlsearch": {
+                    "type": "boolean",
+                    "description": "When there is a previous search pattern, highlight all its matches."
                 }
             }
         }

--- a/package.json
+++ b/package.json
@@ -161,35 +161,33 @@
                 },
                 "vim.useSolidBlockCursor": {
                     "type": "boolean",
-                    "description": "Use a non blinking block cursor."
+                    "description": "Use a non blinking block cursor.",
+                    "default": false
                 },
                 "vim.scroll": {
                     "type": "number",
-                    "description": "Number of lines to scroll with CTRL-U and CTRL-D commands."
-                },
-                "vim.tabstop": {
-                    "type": "number",
-                    "description": "Number of spaces that a <Tab> in the file counts for."
-                },
-                "vim.expandtab": {
-                    "type": "boolean",
-                    "description": "In Insert mode: Use the appropriate number of spaces to insert a <Tab>."
+                    "description": "Number of lines to scroll with CTRL-U and CTRL-D commands.",
+                    "default": 20
                 },
                 "vim.iskeyword": {
                     "type": "string",
-                    "description": "keywords contain alphanumeric characters and '_'"
+                    "description": "keywords contain alphanumeric characters and '_'",
+                    "default": "/\\()\"':,.;<>~!@#$%^&*|+=[]{}`?-"
                 },
                 "vim.ignorecase": {
                     "type": "boolean",
-                    "description": "Ignore case in search patterns."
+                    "description": "Ignore case in search patterns.",
+                    "default": true
                 },
                 "vim.smartcase": {
                     "type": "boolean",
-                    "description": "Override the 'ignorecase' option if the search pattern contains upper case characters."
+                    "description": "Override the 'ignorecase' option if the search pattern contains upper case characters.",
+                    "default": true
                 },
                 "vim.hlsearch": {
                     "type": "boolean",
-                    "description": "When there is a previous search pattern, highlight all its matches."
+                    "description": "When there is a previous search pattern, highlight all its matches.",
+                    "default": true
                 }
             }
         }

--- a/src/actions/actions.ts
+++ b/src/actions/actions.ts
@@ -8,6 +8,7 @@ import { Position } from './../motion/position';
 import { PairMatcher } from './../matching/matcher';
 import { QuoteMatcher } from './../matching/quoteMatcher';
 import { Tab, TabCommand } from './../cmd_line/commands/tab';
+import { Configuration } from './../configuration/configuration';
 import * as vscode from 'vscode';
 
 const controlKeys: string[] = [
@@ -1487,7 +1488,10 @@ class CommandMoveHalfPageDown extends BaseMovement {
   keys = ["ctrl+d"];
 
   public async execAction(position: Position, vimState: VimState): Promise<Position> {
-    return new Position(Math.min(TextEditor.getLineCount() - 1, position.line + vimState.settings.scroll), position.character);
+    return new Position(
+      Math.min(TextEditor.getLineCount() - 1, position.line + <number> Configuration.getInstance().get("scroll")),
+      position.character
+    );
   }
 }
 
@@ -1496,7 +1500,7 @@ class CommandMoveHalfPageUp extends BaseMovement {
   keys = ["ctrl+u"];
 
   public async execAction(position: Position, vimState: VimState): Promise<Position> {
-    return new Position(Math.max(0, position.line - vimState.settings.scroll), position.character);
+    return new Position(Math.max(0, position.line - <number> Configuration.getInstance().get("scroll")), position.character);
   }
 }
 

--- a/src/actions/actions.ts
+++ b/src/actions/actions.ts
@@ -1489,7 +1489,7 @@ class CommandMoveHalfPageDown extends BaseMovement {
 
   public async execAction(position: Position, vimState: VimState): Promise<Position> {
     return new Position(
-      Math.min(TextEditor.getLineCount() - 1, position.line + <number> Configuration.getInstance().get("scroll")),
+      Math.min(TextEditor.getLineCount() - 1, position.line + Configuration.getInstance().scroll),
       position.character
     );
   }
@@ -1500,7 +1500,7 @@ class CommandMoveHalfPageUp extends BaseMovement {
   keys = ["ctrl+u"];
 
   public async execAction(position: Position, vimState: VimState): Promise<Position> {
-    return new Position(Math.max(0, position.line - <number> Configuration.getInstance().get("scroll")), position.character);
+    return new Position(Math.max(0, position.line - Configuration.getInstance().scroll), position.character);
   }
 }
 

--- a/src/cmd_line/commands/setoptions.ts
+++ b/src/cmd_line/commands/setoptions.ts
@@ -1,0 +1,68 @@
+"use strict";
+
+import * as node from "../node";
+import { Configuration } from '../../configuration/configuration';
+
+export enum SetOptionOperator {
+  /*
+   * Set string or number option to {value}.
+   * White space between {option} and '=' is allowed and will be ignored.  White space between '=' and {value} is not allowed.
+   */
+  Equal,
+  /*
+   * Toggle option: set, switch it on.
+   * Number option: show value.
+   * String option: show value.
+   */
+  Set,
+  /*
+   * Toggle option: Reset, switch it off.
+   */
+  Reset,
+  /*
+   * Add the {value} to a number option, or append the {value} to a string option.
+   * When the option is a comma separated list, a comma is added, unless the value was empty.
+   */
+  Append,
+  /*
+   * Subtract the {value} from a number option, or remove the {value} from a string option, if it is there.
+   */
+  Subtract
+}
+
+export interface IOptionArgs extends node.ICommandArgs {
+  name?: string;
+  operator?: SetOptionOperator;
+  value?: string | number | boolean;
+}
+
+export class SetOptionsCommand extends node.CommandBase {
+  protected _arguments: IOptionArgs;
+
+  constructor(args : IOptionArgs) {
+    super();
+    this._name = 'setoptions';
+    this._shortName = 'option';
+    this._arguments = args;
+  }
+
+  get arguments() : IOptionArgs {
+    return this._arguments;
+  }
+
+  async execute(): Promise<void> {
+    switch (this._arguments.operator) {
+      case SetOptionOperator.Set:
+        Configuration.getInstance().set(this._arguments.name!, true);
+        break;
+      case SetOptionOperator.Reset:
+        Configuration.getInstance().set(this._arguments.name!, false);
+        break;
+      case SetOptionOperator.Equal:
+        Configuration.getInstance().set(this._arguments.name!, this._arguments.value);
+        break;
+      default:
+        break;
+    }
+  }
+}

--- a/src/cmd_line/commands/setoptions.ts
+++ b/src/cmd_line/commands/setoptions.ts
@@ -65,13 +65,13 @@ export class SetOptionsCommand extends node.CommandBase {
   async execute(): Promise<void> {
     switch (this._arguments.operator) {
       case SetOptionOperator.Set:
-        Configuration.getInstance().set(this._arguments.name!, true);
+        Configuration.getInstance()[this._arguments.name!] = true;
         break;
       case SetOptionOperator.Reset:
-        Configuration.getInstance().set(this._arguments.name!, false);
+        Configuration.getInstance()[this._arguments.name!] = false;
         break;
       case SetOptionOperator.Equal:
-        Configuration.getInstance().set(this._arguments.name!, this._arguments.value!);
+        Configuration.getInstance()[this._arguments.name!] = this._arguments.value!;
         break;
       default:
         break;

--- a/src/cmd_line/commands/setoptions.ts
+++ b/src/cmd_line/commands/setoptions.ts
@@ -63,18 +63,22 @@ export class SetOptionsCommand extends node.CommandBase {
   }
 
   async execute(): Promise<void> {
+    if (!this._arguments.name) {
+      throw new Error("Unknown option");
+    }
+
     switch (this._arguments.operator) {
       case SetOptionOperator.Set:
-        Configuration.getInstance()[this._arguments.name!] = true;
+        Configuration.getInstance()[this._arguments.name] = true;
         break;
       case SetOptionOperator.Reset:
-        Configuration.getInstance()[this._arguments.name!] = false;
+        Configuration.getInstance()[this._arguments.name] = false;
         break;
       case SetOptionOperator.Equal:
-        Configuration.getInstance()[this._arguments.name!] = this._arguments.value!;
+        Configuration.getInstance()[this._arguments.name] = this._arguments.value!;
         break;
       case SetOptionOperator.Invert:
-        Configuration.getInstance()[this._arguments.name!] = !Configuration.getInstance()[this._arguments.name!];
+        Configuration.getInstance()[this._arguments.name] = !Configuration.getInstance()[this._arguments.name];
         break;
       default:
         break;

--- a/src/cmd_line/commands/setoptions.ts
+++ b/src/cmd_line/commands/setoptions.ts
@@ -59,7 +59,7 @@ export class SetOptionsCommand extends node.CommandBase {
         Configuration.getInstance().set(this._arguments.name!, false);
         break;
       case SetOptionOperator.Equal:
-        Configuration.getInstance().set(this._arguments.name!, this._arguments.value);
+        Configuration.getInstance().set(this._arguments.name!, this._arguments.value!);
         break;
       default:
         break;

--- a/src/cmd_line/commands/setoptions.ts
+++ b/src/cmd_line/commands/setoptions.ts
@@ -19,6 +19,10 @@ export enum SetOptionOperator {
    * Toggle option: Reset, switch it off.
    */
   Reset,
+  /**
+   * Toggle option: Insert value.
+   */
+  Invert,
   /*
    * Add the {value} to a number option, or append the {value} to a string option.
    * When the option is a comma separated list, a comma is added, unless the value was empty.
@@ -27,7 +31,15 @@ export enum SetOptionOperator {
   /*
    * Subtract the {value} from a number option, or remove the {value} from a string option, if it is there.
    */
-  Subtract
+  Subtract,
+  /**
+   * Multiply the {value} to a number option, or prepend the {value} to a string option.
+   */
+  Multiply,
+  /**
+   * Show value of {option}.
+   */
+  Info
 }
 
 export interface IOptionArgs extends node.ICommandArgs {

--- a/src/cmd_line/commands/setoptions.ts
+++ b/src/cmd_line/commands/setoptions.ts
@@ -73,6 +73,9 @@ export class SetOptionsCommand extends node.CommandBase {
       case SetOptionOperator.Equal:
         Configuration.getInstance()[this._arguments.name!] = this._arguments.value!;
         break;
+      case SetOptionOperator.Invert:
+        Configuration.getInstance()[this._arguments.name!] = !Configuration.getInstance()[this._arguments.name!];
+        break;
       default:
         break;
     }

--- a/src/cmd_line/scanner.ts
+++ b/src/cmd_line/scanner.ts
@@ -23,8 +23,9 @@ export class Scanner {
   }
 
   // Returns the next word in the input, or EOF.
-  nextWord(): string {
-    this.skipWhiteSpace();
+  nextWord(wordSeparators: string[] = [" ", "\t"]): string {
+    this.skipRun(wordSeparators);
+
     if (this.isAtEof) {
       this.pos = this.input.length;
       return Scanner.EOF;
@@ -36,7 +37,7 @@ export class Scanner {
     while (!this.isAtEof) {
       c = this.next();
 
-      if (!(c !== Scanner.EOF && c !== ' ' && c !== '\t')) {
+      if (c === Scanner.EOF || wordSeparators.indexOf(c) !== -1) {
         break;
       }
 
@@ -46,8 +47,6 @@ export class Scanner {
     if (c && c !== Scanner.EOF) {
       this.backup();
     }
-
-    this.pos += result.length;
 
     this.ignore();
     return result;

--- a/src/cmd_line/scanner.ts
+++ b/src/cmd_line/scanner.ts
@@ -44,7 +44,7 @@ export class Scanner {
       result += c;
     }
 
-    if (c && c !== Scanner.EOF) {
+    if (c && wordSeparators.indexOf(c) !== -1) {
       this.backup();
     }
 

--- a/src/cmd_line/subparser.ts
+++ b/src/cmd_line/subparser.ts
@@ -5,6 +5,7 @@ import {parseWriteCommandArgs} from './subparsers/write';
 import {parseWriteQuitCommandArgs} from './subparsers/writequit';
 import * as tabCmd from './subparsers/tab';
 import * as fileCmd from './subparsers/file';
+import {parseOptionsCommandArgs} from './subparsers/setoptions';
 import {parseSubstituteCommandArgs} from './subparsers/substitute';
 
 // maps command names to parsers for said commands.
@@ -49,5 +50,8 @@ export const commandParsers = {
   s: parseSubstituteCommandArgs,
   vsp: fileCmd.parseEditFileInNewWindowCommandArgs,
   vne: fileCmd.parseEditNewFileInNewWindowCommandArgs,
-  vnew: fileCmd.parseEditNewFileInNewWindowCommandArgs
+  vnew: fileCmd.parseEditNewFileInNewWindowCommandArgs,
+
+  set: parseOptionsCommandArgs,
+  se: parseOptionsCommandArgs
 };

--- a/src/cmd_line/subparsers/setoptions.ts
+++ b/src/cmd_line/subparsers/setoptions.ts
@@ -1,0 +1,54 @@
+"use strict";
+
+import * as node from "../commands/setoptions";
+import {Scanner} from '../scanner';
+
+export function parseOption(args: string) : node.IOptionArgs {
+  let scanner = new Scanner(args);
+  scanner.skipWhiteSpace();
+
+  if (scanner.isAtEof) {
+    return {};
+  }
+
+  let option = scanner.nextWord();
+
+  if (option.startsWith("no")) {
+    // :se[t] no{option}  Toggle option: Reset, switch it off.
+    return {
+      name: option.substring(2, option.length),
+      operator: node.SetOptionOperator.Reset
+    };
+  }
+
+  if (option.includes('=')) {
+    // :se[t] {option}={value} Set string or number option to {value}.
+    let equalSign = option.indexOf('=');
+    return {
+      name: option.substring(0, equalSign),
+      value: option.substring(equalSign + 1, option.length),
+      operator: node.SetOptionOperator.Equal
+    };
+  }
+
+  if (option.includes(':')) {
+    // :se[t] {option}:{value} Set string or number option to {value}.
+    let equalSign = option.indexOf(':');
+    return {
+      name: option.substring(0, equalSign),
+      value: option.substring(equalSign + 1, option.length),
+      operator: node.SetOptionOperator.Equal
+    };
+  }
+
+  // :se[t] {option}
+  return {
+    name: option,
+    operator: node.SetOptionOperator.Set
+  };
+}
+
+export function parseOptionsCommandArgs(args : string) : node.SetOptionsCommand {
+  let option = parseOption(args);
+  return new node.SetOptionsCommand(option);
+}

--- a/src/configuration/configuration.ts
+++ b/src/configuration/configuration.ts
@@ -66,7 +66,6 @@ export class BaseOptionDetails {
   }
 
   public source: OptionValueSource = OptionValueSource.Default;
-  public shouldUpdateView: boolean;
   static globalOptionUpdateHandler: () => void;
 }
 
@@ -95,6 +94,12 @@ class OptionUseControlKeys extends BaseOptionDetails {
 class OptionScroll extends BaseOptionDetails {
   id = "scroll";
   defaultValue = 20;
+}
+
+@RegisterOption
+class OptionHightlightSearch extends BaseOptionDetails {
+  id = "hlsearch";
+  defaultValue = false;
 }
 
 @RegisterOption
@@ -235,10 +240,10 @@ export class Configuration {
     return Configuration._instance;
   }
 
-  set(option: string, value?: number | string | boolean, source?: OptionValueSource): void {
+  set(option: string, value: number | string | boolean, source?: OptionValueSource): void {
     let targetOption = OptionMap.allOptions[option];
 
-    if (!value) {
+    if (!targetOption) {
       return;
     }
 

--- a/src/configuration/configuration.ts
+++ b/src/configuration/configuration.ts
@@ -4,235 +4,41 @@ import * as vscode from 'vscode';
 
 export type OptionValue = number | string | boolean;
 
-enum OptionValueSource {
-  Runtime,
-  UserSetting, // How can we know if it's frm User Setting or Workspace or Code's Default?
-  Default
-}
-
 /**
  * Every Vim option we support should
  * 1. Be added to contribution section of `package.json`.
  * 2. Named as `vim.{optionName}`, `optionName` is the name we use in Vim.
- * 3. Define a subclass below, inherited from `BaseOptionDetails`.
+ * 3. Define a public property in `Configuration `with the same name and a default value.
+ *    Or define a private propery and define customized Getter/Setter accessors for it.
+ *    Always remember to decorate Getter accessor as @enumerable()
  * 4. If user doesn't set the option explicitly
  *    a. we don't have a similar setting in Code, initialize the option as default value.
- *    b. we have a similar setting in Code, use Code's setting.'
- */
-export class BaseOptionDetails {
-  id: string;
-  defaultValue: OptionValue;
-  protected _value: OptionValue;
-
-  // By default, we are fetching options from `vim` section but when we have overlap
-  // between Code and Vim, eg `tabstop`, we may want to override this method.
-  protected fetchCodeConfiguration() {
-    return vscode.workspace.getConfiguration("vim").get<OptionValue>(this.id, this.defaultValue);
-  }
-
-  /**
-   * Defualt constructor only fetches option value from Code and does nothing more.
-   * But if there is any overlap between Vim option and Code option, we need to do handle
-   * the option overriden correctly. That's why we need another custom `initialize()` here.
-   * Example:
-   *   Vim has an option called `tabstop`, which is used to define number of spaces that a Tab uses.
-   *   Code has a config called `tabSize` which reprents totally the same thing.
-   *   If user defines `vim.tabstop` explicitly in `settings.json`, we need to update Code's `tabSize`
-   *   accordingly to take effect.
-   */
-  public initialize() {
-    let res: OptionValue;
-    res = this.fetchCodeConfiguration();
-
-    if (res !== undefined) {
-      this._value = res;
-      this.source = OptionValueSource.UserSetting;
-    } else {
-      this._value = this.defaultValue;
-      this.source = OptionValueSource.Default;
-    }
- }
-
-  public get value() {
-    return  this._value;
-  }
-
-  public set value(value: OptionValue) {
-    this._value = value;
-    this.source = OptionValueSource.Runtime;
-  }
-
-  public source: OptionValueSource = OptionValueSource.Default  ;
-  static globalOptionUpdateHandler: () => void;
-}
-
-export class OptionMap {
-  public static allOptions: { [key: string]: BaseOptionDetails } = {};
-}
-
-export function RegisterOption(optionDetails: typeof BaseOptionDetails): void {
-  let newOption = new optionDetails();
-  newOption.initialize();
-  OptionMap.allOptions[newOption.id] = newOption;
-}
-
-@RegisterOption
-class OptionUseSolidBlockCursor extends BaseOptionDetails {
-  id = "useSolidBlockCursor";
-  defaultValue = false;
-}
-
-@RegisterOption
-class OptionUseControlKeys extends BaseOptionDetails {
-  id = "useCtrlKeys";
-  defaultValue = false;
-}
-
-@RegisterOption
-class OptionScroll extends BaseOptionDetails {
-  id = "scroll";
-  defaultValue = 20;
-}
-
-@RegisterOption
-class OptionHightlightSearch extends BaseOptionDetails {
-  id = "hlsearch";
-  defaultValue = false;
-}
-
-@RegisterOption
-class OptionIgnoreCase extends BaseOptionDetails {
-  id = "ignorecase";
-  defaultValue = true;
-}
-
-@RegisterOption
-class OptionSmartCase extends BaseOptionDetails {
-  id = "smartcase";
-  defaultValue = true;
-}
-
-@RegisterOption
-class OptionTabStop extends BaseOptionDetails {
-  id = "tabstop"; // aka, tabSize
-  defaultValue = 8; // Vim default value but here we always use Code configuration
-
-  fetchCodeConfiguration() {
-    const vimOptionInCode = vscode.workspace.getConfiguration("vim").get<number>(this.id, undefined);
-
-    return vimOptionInCode !== undefined ? vimOptionInCode : this.getTabSizeFromCode();
-  }
-
-  initialize() {
-    super.initialize();
-    // TODO we should update through API instead of tweaking editor's copy of config.
-    const options = vscode.window.activeTextEditor.options;
-    options.tabSize = this.value as number;
-    vscode.window.activeTextEditor.options = options;
-  }
-
-  public get value() {
-    if (this.source === OptionValueSource.Runtime) {
-      return this._value;
-    } else {
-      return this.getTabSizeFromCode();
-    }
-  }
-
-  public set value(value: OptionValue) {
-    super.value = value;
-
-    if (!vscode.window.activeTextEditor) {
-      // TODO: We should set configuration by API, which is not currently supported.
-      return;
-    }
-
-    const oldOptions = vscode.window.activeTextEditor.options;
-    oldOptions.tabSize = value as number;
-    vscode.window.activeTextEditor.options = oldOptions;
-  }
-
-  private getTabSizeFromCode(): number {
-    if (vscode.window.activeTextEditor) {
-      return vscode.window.activeTextEditor.options.tabSize! as number;
-    } else {
-      return vscode.workspace.getConfiguration("editor").get("tabSize", this.defaultValue);
-    }
-  }
-}
-
-@RegisterOption
-class OptionInsertSpaces extends BaseOptionDetails {
-  id = "expandtab"; // aka insertSpaces
-  defaultValue = false;
-
-  fetchCodeConfiguration() {
-    const vimOptionInCode = vscode.workspace.getConfiguration("vim").get<boolean>(this.id, undefined);
-    return vimOptionInCode !== undefined ? vimOptionInCode : this.getInsertSpaccesFromCode();
-  }
-
-  initialize() {
-    super.initialize();
-    const options = vscode.window.activeTextEditor.options;
-    options.insertSpaces = this.value as boolean;
-    vscode.window.activeTextEditor.options = options;
-  }
-
-  public get value() {
-    if (this.source === OptionValueSource.Runtime) {
-      return this._value;
-    } else {
-      return this.getInsertSpaccesFromCode();
-    }
-  }
-
-  public set value(value: OptionValue) {
-    super.value = value;
-    const oldOptions = vscode.window.activeTextEditor.options;
-    oldOptions.insertSpaces = <boolean> value;
-    vscode.window.activeTextEditor.options = oldOptions;
-  }
-
-  private getInsertSpaccesFromCode(): boolean {
-    if (vscode.window.activeTextEditor) {
-      return vscode.window.activeTextEditor.options.insertSpaces! as boolean;
-    } else {
-      return vscode.workspace.getConfiguration("editor").get("insertSpaces", this.defaultValue);
-    }
-  }
-}
-
-@RegisterOption
-class OptionIskeyword extends BaseOptionDetails {
-  id = "iskeyword";
-  defaultValue = "/\\()\"':,.;<>~!@#$%^&*|+=[]{}`?-";
-
-  fetchCodeConfiguration() {
-    const vimOptionInCode = vscode.workspace.getConfiguration("vim").get<boolean>(this.id, undefined);
-    return vimOptionInCode !== undefined ?
-      vimOptionInCode :
-      vscode.workspace.getConfiguration("editor").get("wordSeparators", this.defaultValue);
-  }
-
-  initialize() {
-    super.initialize();
-    // TODO: modify Code's wordSeparators configuration.
-  }
-}
-
-/**
+ *    b. we have a similar setting in Code, use Code's setting.
+ *
  * Vim option override sequence.
  * 1. `:set {option}` on the fly
- * 2. VS Code Vim configuration section && overlap configurations between Code and Vim
- * 3. TODO .vimrc.
+ * 2. TODO .vimrc.
+ * 2. `vim.{option}`
+ * 3. VS Code configuration
  * 4. VSCodeVim flavored Vim option default values
+ *
  */
 export class Configuration {
   private static _instance: Configuration | null;
 
   constructor() {
-    // TODO: Read the real Vim config and override existing configration.
-    // Besides, vimrc settings' priority should be between Default and User Settings.
+    /**
+     * Load Vim options from User Settings.
+     */
+    let vimOptions = vscode.workspace.getConfiguration("vim");
+    /* tslint:disable:forin */
+    // Disable forin rule here as we make accessors enumerable.`
+    for (const option in this) {
+      const vimOptionValue = vimOptions[option];
+      if (vimOptionValue !== null && vimOptionValue !== undefined) {
+        this[option] = vimOptionValue;
+      }
+    }
   }
 
   public static getInstance(): Configuration {
@@ -243,38 +49,91 @@ export class Configuration {
     return Configuration._instance;
   }
 
-  set(option: string, value: OptionValue, source?: OptionValueSource): void {
-    let targetOption = OptionMap.allOptions[option];
-
-    if (!targetOption) {
-      return;
-    }
-
-    if (value === targetOption.value) {
-      targetOption.source = OptionValueSource.Runtime;
-      return;
-    }
-
-    targetOption.value = value;
+  set(option: string, value: OptionValue): void {
+    this[option] = value;
   }
+
+  useSolidBlockCursor: boolean = false;
+  useCtrlKeys: boolean = false;
+  scroll: number = 20;
+  hlsearch: boolean = false;
+  ignorecase: boolean = true;
+  smartcase: boolean = true;
 
   /**
-   * Return a value of option from vim settings.
-   * @param vim option.
-   * @param defaultValue A value should be returned when no value could be found, is `undefined`.
+   * Intersection of Vim options and Code configuration.
    */
-  get(option: string, defaultValue?: OptionValue): OptionValue | undefined {
-    let targetOption = OptionMap.allOptions[option];
-
-    if (targetOption) {
-      // Return directly if the option from Runtime (including VimRc)
-      // as in these two senarios configurations are updated automatically.
-      return targetOption.value;
+  private _tabstop: number;
+  public set tabstop(tabstop: number) {
+    this._tabstop = tabstop;
+    if (!vscode.window.activeTextEditor) {
+      // TODO: We should set configuration by API, which is not currently supported.
+      return;
     }
 
-    // TODO: Not sure if there is only overlap between Code's `editor` section and Vim.
-    // Not sure if auto update of VS Code configuration is necessary
-    // maybe we can just require users to restart VS Code after they update User Setting?
-    return vscode.workspace.getConfiguration("editor").get(option, defaultValue);
+    const oldOptions = vscode.window.activeTextEditor.options;
+    oldOptions.tabSize = tabstop;
+    vscode.window.activeTextEditor.options = oldOptions;
   }
+
+  @enumerable()
+  public get tabstop() {
+    if (this._tabstop !== undefined) {
+      return this._tabstop;
+    } else {
+      if (vscode.window.activeTextEditor) {
+        return vscode.window.activeTextEditor.options.tabSize as number;
+      } else {
+        return 8;
+      }
+    }
+  }
+
+  private _expandtab: boolean;
+  public set expandtab(expand: boolean) {
+    this._expandtab = expand;
+
+    if (!vscode.window.activeTextEditor) {
+      // TODO: We should set configuration by API, which is not currently supported.
+      return;
+    }
+
+    const oldOptions = vscode.window.activeTextEditor.options;
+    oldOptions.insertSpaces = expand;
+    vscode.window.activeTextEditor.options = oldOptions;
+  }
+
+  @enumerable()
+  public get expandtab() {
+    if (this._expandtab !== undefined) {
+      return this._expandtab;
+    } else {
+      if (vscode.window.activeTextEditor) {
+        return vscode.window.activeTextEditor.options.insertSpaces as boolean;
+      } else {
+        // Default value.
+        return false;
+      }
+    }
+  }
+
+  private _iskeyword: string;
+  public set iskeyword(keyword) {
+    this._iskeyword = keyword;
+  }
+
+  @enumerable()
+  public get iskeyword() {
+    if (this._iskeyword) {
+      return this._iskeyword;
+    } else {
+      return vscode.workspace.getConfiguration("editor").get("wordSeparators", "/\\()\"':,.;<>~!@#$%^&*|+=[]{}`?");
+    }
+  }
+}
+
+function enumerable() {
+  return function (target: any, propertyKey: string, descriptor: PropertyDescriptor) {
+    descriptor.enumerable = true;
+  };
 }

--- a/src/configuration/configuration.ts
+++ b/src/configuration/configuration.ts
@@ -57,13 +57,12 @@ export class Configuration {
   smartcase: boolean = true;
 
   @overlapSetting({ codeName: "tabSize", default: 8})
-  tabstop: number;
+  tabstop: number | undefined = undefined;
 
   @overlapSetting({ codeName: "insertSpaces", default: false})
-  expandtab: boolean;
+  expandtab: boolean | undefined = undefined;
 
-  @overlapSetting({ codeName: "wordSeparators", default: "/\\()\"':,.;<>~!@#$%^&*|+=[]{}`?"})
-  iskeyword: string;
+  iskeyword: string = "/\\()\"':,.;<>~!@#$%^&*|+=[]{}`?-";
 }
 
 function overlapSetting(args: {codeName: string, default: OptionValue}) {
@@ -76,7 +75,9 @@ function overlapSetting(args: {codeName: string, default: OptionValue}) {
 
         return vscode.workspace.getConfiguration("editor").get(args.codeName, args.default);
       },
-      set: function (value) { this["_" + propertyKey] = value; },
+      set: function (value) {
+        this["_" + propertyKey] = value;
+      },
       enumerable: true,
       configurable: true
     });

--- a/src/configuration/configuration.ts
+++ b/src/configuration/configuration.ts
@@ -1,0 +1,272 @@
+"use strict";
+
+import * as vscode from 'vscode';
+
+export type OptionHandler = () => {};
+export type OptionValue = number | string | boolean;
+
+enum OptionValueSource {
+  Runtime,
+  UserSetting, // How can we know if it's frm User Setting or Workspace or Code's Default?
+  Default
+}
+
+/**
+ * Every Vim option we support should
+ * 1. Be added to contribution section of `package.json`.
+ * 2. Named as `vim.{optionName}`, `optionName` is the name we use in Vim.
+ * 3. Define a subclass below, inherited from `BaseOptionDetails`.
+ * 4. If user doesn't set the option explicitly, initialize the option as default value.
+ */
+export class BaseOptionDetails {
+  id: string;
+  defaultValue: OptionValue;
+  protected _value: OptionValue;
+
+  constructor() {
+    let res: OptionValue;
+    res = this.fetchCodeConfiguration();
+
+    if (res) {
+      this._value = res;
+      this.source = OptionValueSource.UserSetting;
+    } else {
+      this._value = this.defaultValue;
+      this.source = OptionValueSource.Default;
+    }
+
+    this.initialize();
+  }
+
+  // By default, we are fetching options from `vim` section but when we have overlap
+  // between Code and Vim, eg `tabstop`, we may want to override this method.
+  protected fetchCodeConfiguration() {
+    return vscode.workspace.getConfiguration("vim").get<OptionValue>(this.id);
+  }
+
+  /**
+   * Defualt constructor only fetches option value from Code and does nothing more.
+   * But if there is any overlap between Vim option and Code option, we need to do handle
+   * the option overriden correctly. That's why we need another custom `initialize()` here.
+   * Example:
+   *   Vim has an option called `tabstop`, which is used to define number of spaces that a Tab uses.
+   *   Code has a config called `tabSize` which reprents totally the same thing.
+   *   If user defines `vim.tabstop` explicitly in `settings.json`, we need to update Code's `tabSize`
+   *   accordingly to take effect.
+   */
+  protected initialize() { return; }
+
+  public get value() {
+    return  this._value;
+  }
+
+  public set value(value: number | string | boolean) {
+    this._value = value;
+    this.source = OptionValueSource.Runtime;
+  }
+
+  public source: OptionValueSource = OptionValueSource.Default;
+  public shouldUpdateView: boolean;
+  static globalOptionUpdateHandler: () => void;
+}
+
+export class OptionMap {
+  public static allOptions: { [key: string]: BaseOptionDetails } = {};
+}
+
+export function RegisterOption(optionDetails: typeof BaseOptionDetails): void {
+  let newOption = new optionDetails();
+  OptionMap.allOptions[newOption.id] = newOption;
+}
+
+@RegisterOption
+class OptionUseSolidBlockCursor extends BaseOptionDetails {
+  id = "useSolidBlockCursor";
+  defaultValue = false;
+}
+
+@RegisterOption
+class OptionUseControlKeys extends BaseOptionDetails {
+  id = "useCtrlKeys";
+  defaultValue = false;
+}
+
+@RegisterOption
+class OptionScroll extends BaseOptionDetails {
+  id = "scroll";
+  defaultValue = 20;
+}
+
+@RegisterOption
+class OptionIgnoreCase extends BaseOptionDetails {
+  id = "ignorecase";
+  defaultValue = true;
+}
+
+@RegisterOption
+class OptionSmartCase extends BaseOptionDetails {
+  id = "smartcase";
+  defaultValue = true;
+}
+
+@RegisterOption
+class OptionTabStop extends BaseOptionDetails {
+  id = "tabstop"; // aka, tabSize
+  defaultValue = 8; // Vim default value but here we always use Code configuration
+
+  fetchCodeConfiguration() {
+    const vimOptionInCode = vscode.workspace.getConfiguration("vim").get<number>(this.id);
+
+    return vimOptionInCode ? vimOptionInCode : this.getTabSizeFromCode();
+  }
+
+  initialize() {
+    // TODO we should update through API instead of tweaking editor's copy of config.
+    const options = vscode.window.activeTextEditor.options;
+    options.tabSize = this.value as number;
+    vscode.window.activeTextEditor.options = options;
+  }
+
+  public get value() {
+    if (this.source === OptionValueSource.Runtime) {
+      return this._value;
+    } else {
+      return this.getTabSizeFromCode();
+    }
+  }
+
+  public set value(value: number | string | boolean) {
+    super.value = value;
+
+    if (!vscode.window.activeTextEditor) {
+      // TODO: We should set configuration by API, which is not currently supported.
+      return;
+    }
+
+    const oldOptions = vscode.window.activeTextEditor.options;
+    oldOptions.tabSize = value as number;
+    vscode.window.activeTextEditor.options = oldOptions;
+  }
+
+  private getTabSizeFromCode(): number {
+    if (vscode.window.activeTextEditor) {
+      return vscode.window.activeTextEditor.options.tabSize! as number;
+    } else {
+      return vscode.workspace.getConfiguration("editor").get("tabSize", this.defaultValue);
+    }
+  }
+}
+
+@RegisterOption
+class OptionInsertSpaces extends BaseOptionDetails {
+  id = "expandtab"; // aka insertSpaces
+  defaultValue = false;
+
+  fetchCodeConfiguration() {
+    const vimOptionInCode = vscode.workspace.getConfiguration("vim").get<boolean>(this.id);
+    return vimOptionInCode ? vimOptionInCode : this.getInsertSpaccesFromCode();
+  }
+
+  initialize() {
+    const options = vscode.window.activeTextEditor.options;
+    options.insertSpaces = this.value as boolean;
+    vscode.window.activeTextEditor.options = options;
+  }
+
+  public get value() {
+    if (this.source === OptionValueSource.Runtime) {
+      return this._value;
+    } else {
+      return this.getInsertSpaccesFromCode();
+    }
+  }
+
+  public set value(value: number | string | boolean) {
+    super.value = value;
+    const oldOptions = vscode.window.activeTextEditor.options;
+    oldOptions.insertSpaces = <boolean> value;
+    vscode.window.activeTextEditor.options = oldOptions;
+  }
+
+  private getInsertSpaccesFromCode(): boolean {
+    if (vscode.window.activeTextEditor) {
+      return vscode.window.activeTextEditor.options.insertSpaces! as boolean;
+    } else {
+      return vscode.workspace.getConfiguration("editor").get("insertSpaces", this.defaultValue);
+    }
+  }
+}
+
+@RegisterOption
+class OptionIskeyword extends BaseOptionDetails {
+  id = "iskeyword";
+  defaultValue = "/\\()\"':,.;<>~!@#$%^&*|+=[]{}`?-";
+
+  fetchCodeConfiguration() {
+    const vimOptionInCode = vscode.workspace.getConfiguration("vim").get<boolean>(this.id);
+    return vimOptionInCode ? vimOptionInCode : vscode.workspace.getConfiguration("editor").get("wordSeparators", this.defaultValue);
+  }
+
+  initialize() {
+    // TODO: modify Code's wordSeparators configuration.
+  }
+}
+
+/**
+ * Vim option override sequence.
+ * 1. `:set {option}` on the fly
+ * 2. VS Code Vim configuration section && overlap configurations between Code and Vim
+ * 3. TODO .vimrc.
+ * 4. VSCodeVim flavored Vim option default values
+ */
+export class Configuration {
+  private static _instance: Configuration;
+
+  constructor() {
+    // TODO: Read the real Vim config and override existing configration.
+    // Besides, vimrc settings' priority should be between Default and User Settings.
+  }
+
+  public static getInstance(): Configuration {
+    if (Configuration._instance == null) {
+      Configuration._instance = new Configuration();
+    }
+
+    return Configuration._instance;
+  }
+
+  set(option: string, value?: number | string | boolean, source?: OptionValueSource): void {
+    let targetOption = OptionMap.allOptions[option];
+
+    if (!value) {
+      return;
+    }
+
+    if (value === targetOption.value) {
+      targetOption.source = OptionValueSource.Runtime;
+      return;
+    }
+
+    targetOption.value = value;
+  }
+
+  /**
+   * Return a value of option from vim settings.
+   * @param vim option.
+   * @param defaultValue A value should be returned when no value could be found, is `undefined`.
+   */
+  get(option: string, defaultValue?: number | string | boolean): number | string | boolean {
+    let targetOption = OptionMap.allOptions[option];
+
+    if (targetOption) {
+      // Return directly if the option from Runtime (including VimRc)
+      // as in these two senarios configurations are updated automatically.
+      return targetOption.value;
+    }
+
+    // TODO: Not sure if there is only overlap between Code's `editor` section and Vim.
+    // Not sure if auto update of VS Code configuration is necessary
+    // maybe we can just require users to restart VS Code after they update User Setting?
+    return vscode.workspace.getConfiguration("editor").get(option, defaultValue);
+  }
+}

--- a/src/configuration/configuration.ts
+++ b/src/configuration/configuration.ts
@@ -49,10 +49,6 @@ export class Configuration {
     return Configuration._instance;
   }
 
-  set(option: string, value: OptionValue): void {
-    this[option] = value;
-  }
-
   useSolidBlockCursor: boolean = false;
   useCtrlKeys: boolean = false;
   scroll: number = 20;

--- a/src/configuration/configuration.ts
+++ b/src/configuration/configuration.ts
@@ -62,7 +62,7 @@ export class Configuration {
   @overlapSetting({ codeName: "insertSpaces", default: false})
   expandtab: boolean;
 
-  @overlapSetting({ codeName: "wordSepatators", default: "/\\()\"':,.;<>~!@#$%^&*|+=[]{}`?"})
+  @overlapSetting({ codeName: "wordSeparators", default: "/\\()\"':,.;<>~!@#$%^&*|+=[]{}`?"})
   iskeyword: string;
 }
 

--- a/src/mode/modeHandler.ts
+++ b/src/mode/modeHandler.ts
@@ -23,6 +23,7 @@ import {
 import { Position } from './../motion/position';
 import { RegisterMode } from './../register/register';
 import { showCmdLine } from '../../src/cmd_line/main';
+import { Configuration } from '../../src/configuration/configuration';
 
 export enum VimSpecialCommands {
   Nothing,
@@ -145,6 +146,7 @@ export class VimState {
    * by us or by a mouse action.
    */
   public whatILastSetTheSelectionTo: vscode.Selection;
+<<<<<<< b9a0b15742532ecc54e66ee04c417d82e70d29dc
 
   public settings = new VimSettings();
 }
@@ -153,6 +155,8 @@ export class VimSettings {
   useSolidBlockCursor = false;
   scroll              = 20;
   useCtrlKeys         = false;
+=======
+>>>>>>> Vim Settings
 }
 
 export enum SearchDirection {
@@ -478,8 +482,6 @@ export class ModeHandler implements vscode.Disposable {
       this._vimState.cursorPosition = Position.FromVSCodePosition(vscode.window.activeTextEditor.selection.start);
     }
 
-    this.loadSettings();
-
     // Handle scenarios where mouse used to change current position.
     vscode.window.onDidChangeTextEditorSelection(async (e) => {
       let selection = e.selections[0];
@@ -556,6 +558,7 @@ export class ModeHandler implements vscode.Disposable {
     });
   }
 
+<<<<<<< b9a0b15742532ecc54e66ee04c417d82e70d29dc
   private loadSettings(): void {
     this._vimState.settings.useSolidBlockCursor = vscode.workspace.getConfiguration("vim")
       .get("useSolidBlockCursor", false);
@@ -564,6 +567,8 @@ export class ModeHandler implements vscode.Disposable {
   }
 
 
+=======
+>>>>>>> Vim Settings
   /**
    * The active mode.
    */
@@ -969,7 +974,7 @@ export class ModeHandler implements vscode.Disposable {
 
     // Draw block cursor.
 
-    if (vimState.settings.useSolidBlockCursor) {
+    if (Configuration.getInstance().get("useSolidBlockCursor", false)) {
       if (this.currentMode.name !== ModeName.Insert) {
         rangesToDraw.push(new vscode.Range(
           vimState.cursorPosition,
@@ -1033,7 +1038,7 @@ export class ModeHandler implements vscode.Disposable {
     }
 
     vscode.commands.executeCommand('setContext', 'vim.mode', this.currentMode.text);
-    vscode.commands.executeCommand('setContext', 'vim.useCtrlKeys', this.vimState.settings.useCtrlKeys);
+    vscode.commands.executeCommand('setContext', 'vim.useCtrlKeys', Configuration.getInstance().get("useCtrlKeys", false));
   }
 
   async handleMultipleKeyEvents(keys: string[]): Promise<void> {

--- a/src/mode/modeHandler.ts
+++ b/src/mode/modeHandler.ts
@@ -166,6 +166,7 @@ export enum SearchDirection {
 
 export class SearchState {
   private static readonly MAX_SEARCH_RANGES = 1000;
+  private static specialCharactersRegex: RegExp = /[\-\[\]{}()*+?.,\\\^$|#\s]/g;
 
   /**
    * Every range in the document that matches the search string.
@@ -207,7 +208,7 @@ export class SearchState {
 
       /* Decide whether the search is case sensitive.
        * If ignorecase is false, the search is case sensitive.
-       * If ignorecase is true, the search should be case insenstive.
+       * If ignorecase is true, the search should be case insensitive.
        * If both ignorecase and smartcase are true, the search is case sensitive only when the search string contains UpperCase character.
        */
       let ignorecase = Configuration.getInstance().ignorecase;
@@ -216,7 +217,7 @@ export class SearchState {
         ignorecase = false;
       }
 
-      const regex = new RegExp(search.replace(/[\-\[\]{}()*+?.,\\\^$|#\s]/g, "\\$&"), ignorecase ? 'gi' : 'g');
+      const regex = new RegExp(search.replace(SearchState.specialCharactersRegex, "\\$&"), ignorecase ? 'gi' : 'g');
 
       outer:
       for (let lineIdx = 0; lineIdx < TextEditor.getLineCount(); lineIdx++) {

--- a/src/mode/modeHandler.ts
+++ b/src/mode/modeHandler.ts
@@ -146,17 +146,6 @@ export class VimState {
    * by us or by a mouse action.
    */
   public whatILastSetTheSelectionTo: vscode.Selection;
-<<<<<<< b9a0b15742532ecc54e66ee04c417d82e70d29dc
-
-  public settings = new VimSettings();
-}
-
-export class VimSettings {
-  useSolidBlockCursor = false;
-  scroll              = 20;
-  useCtrlKeys         = false;
-=======
->>>>>>> Vim Settings
 }
 
 export enum SearchDirection {
@@ -577,17 +566,6 @@ export class ModeHandler implements vscode.Disposable {
     });
   }
 
-<<<<<<< b9a0b15742532ecc54e66ee04c417d82e70d29dc
-  private loadSettings(): void {
-    this._vimState.settings.useSolidBlockCursor = vscode.workspace.getConfiguration("vim")
-      .get("useSolidBlockCursor", false);
-    this._vimState.settings.scroll = vscode.workspace.getConfiguration("vim").get("scroll", 20) || 20;
-    this._vimState.settings.useCtrlKeys = vscode.workspace.getConfiguration("vim").get("useCtrlKeys", false) || false;
-  }
-
-
-=======
->>>>>>> Vim Settings
   /**
    * The active mode.
    */

--- a/src/mode/modeHandler.ts
+++ b/src/mode/modeHandler.ts
@@ -1015,7 +1015,8 @@ export class ModeHandler implements vscode.Disposable {
 
     // Draw search highlight
 
-    if (this.currentMode.name === ModeName.SearchInProgressMode) {
+    if (this.currentMode.name === ModeName.SearchInProgressMode ||
+      (Configuration.getInstance().get("hlsearch") && vimState.searchState)) {
       const searchState = vimState.searchState!;
 
       rangesToDraw.push.apply(rangesToDraw, searchState.matchRanges);

--- a/src/mode/modeHandler.ts
+++ b/src/mode/modeHandler.ts
@@ -974,7 +974,7 @@ export class ModeHandler implements vscode.Disposable {
 
     // Draw block cursor.
 
-    if (Configuration.getInstance().get("useSolidBlockCursor", false)) {
+    if (Configuration.getInstance().useSolidBlockCursor) {
       if (this.currentMode.name !== ModeName.Insert) {
         rangesToDraw.push(new vscode.Range(
           vimState.cursorPosition,
@@ -1016,7 +1016,7 @@ export class ModeHandler implements vscode.Disposable {
     // Draw search highlight
 
     if (this.currentMode.name === ModeName.SearchInProgressMode ||
-      (Configuration.getInstance().get("hlsearch") && vimState.searchState)) {
+      (Configuration.getInstance().hlsearch && vimState.searchState)) {
       const searchState = vimState.searchState!;
 
       rangesToDraw.push.apply(rangesToDraw, searchState.matchRanges);
@@ -1039,7 +1039,7 @@ export class ModeHandler implements vscode.Disposable {
     }
 
     vscode.commands.executeCommand('setContext', 'vim.mode', this.currentMode.text);
-    vscode.commands.executeCommand('setContext', 'vim.useCtrlKeys', Configuration.getInstance().get("useCtrlKeys", false));
+    vscode.commands.executeCommand('setContext', 'vim.useCtrlKeys', Configuration.getInstance().useCtrlKeys);
   }
 
   async handleMultipleKeyEvents(keys: string[]): Promise<void> {

--- a/src/motion/position.ts
+++ b/src/motion/position.ts
@@ -8,7 +8,7 @@ import { VisualBlockMode } from './../mode/modeVisualBlock';
 import { Configuration } from "./../configuration/configuration";
 
 export class Position extends vscode.Position {
-  private static NonWordCharacters = Configuration.getInstance().get("iskeyword") as string; // ";
+  private static NonWordCharacters = Configuration.getInstance().iskeyword;
   private static NonBigWordCharacters = "";
 
   private _nonWordCharRegex : RegExp;

--- a/src/motion/position.ts
+++ b/src/motion/position.ts
@@ -5,9 +5,10 @@ import * as vscode from "vscode";
 import { TextEditor } from "./../textEditor";
 import { VimState } from './../mode/modeHandler';
 import { VisualBlockMode } from './../mode/modeVisualBlock';
+import { Configuration } from "./../configuration/configuration";
 
 export class Position extends vscode.Position {
-  private static NonWordCharacters = "/\\()\"':,.;<>~!@#$%^&*|+=[]{}`?-";
+  private static NonWordCharacters = Configuration.getInstance().get("iskeyword") as string; // ";
   private static NonBigWordCharacters = "";
 
   private _nonWordCharRegex : RegExp;

--- a/src/motion/position.ts
+++ b/src/motion/position.ts
@@ -8,7 +8,7 @@ import { VisualBlockMode } from './../mode/modeVisualBlock';
 import { Configuration } from "./../configuration/configuration";
 
 export class Position extends vscode.Position {
-  private static NonWordCharacters = Configuration.getInstance().iskeyword;
+  private static NonWordCharacters = Configuration.getInstance().iskeyword!;
   private static NonBigWordCharacters = "";
 
   private _nonWordCharRegex : RegExp;

--- a/src/textEditor.ts
+++ b/src/textEditor.ts
@@ -3,6 +3,7 @@
 import * as vscode from "vscode";
 import { ModeHandler } from './mode/modeHandler';
 import { Position } from './motion/position';
+import { Configuration } from './configuration/configuration';
 
 export class TextEditor {
   // TODO: Refactor args
@@ -148,7 +149,7 @@ export class TextEditor {
   }
 
   static getIndentationLevel(line: string): number {
-    let tabSize = vscode.workspace.getConfiguration("editor").get<number>("tabSize");
+    let tabSize = <number> Configuration.getInstance().get("tabSize");
     let firstNonWhiteSpace = line.match(/^\s*/)[0].length;
     let visibleColumn: number = 0;
 
@@ -173,8 +174,8 @@ export class TextEditor {
   }
 
   static setIndentationLevel(line: string, screenCharacters: number): string {
-    let tabSize = <number> vscode.window.activeTextEditor.options.tabSize;
-    let insertTabAsSpaces = <boolean> vscode.window.activeTextEditor.options.insertSpaces;
+    let tabSize = <number> Configuration.getInstance().get("tabstop");
+    let insertTabAsSpaces = <boolean> Configuration.getInstance().get("expandtab");
 
     if (screenCharacters < 0) {
       screenCharacters = 0;

--- a/src/textEditor.ts
+++ b/src/textEditor.ts
@@ -149,7 +149,7 @@ export class TextEditor {
   }
 
   static getIndentationLevel(line: string): number {
-    let tabSize = <number> Configuration.getInstance().get("tabSize");
+    let tabSize = Configuration.getInstance().tabstop;
     let firstNonWhiteSpace = line.match(/^\s*/)[0].length;
     let visibleColumn: number = 0;
 
@@ -174,8 +174,8 @@ export class TextEditor {
   }
 
   static setIndentationLevel(line: string, screenCharacters: number): string {
-    let tabSize = <number> Configuration.getInstance().get("tabstop");
-    let insertTabAsSpaces = <boolean> Configuration.getInstance().get("expandtab");
+    let tabSize = Configuration.getInstance().tabstop;
+    let insertTabAsSpaces = Configuration.getInstance().expandtab;
 
     if (screenCharacters < 0) {
       screenCharacters = 0;

--- a/test/mode/normalModeTests/dot.test.ts
+++ b/test/mode/normalModeTests/dot.test.ts
@@ -1,6 +1,6 @@
 "use strict";
 
-import { setupWorkspace, cleanUpWorkspace } from './../../testUtils';
+import { setupWorkspace, cleanUpWorkspace, setTextEditorOptions } from './../../testUtils';
 import { ModeHandler } from '../../../src/mode/modeHandler';
 import { getTestingFunctions } from '../../testSimplifier';
 
@@ -13,6 +13,7 @@ suite("Dot Operator", () => {
 
     setup(async () => {
         await setupWorkspace();
+        setTextEditorOptions(4, false);
     });
 
     teardown(cleanUpWorkspace);
@@ -56,7 +57,7 @@ suite("Dot Operator", () => {
       title: "Can repeat actions that require selections",
       start: ['on|e', 'two'],
       keysPressed: 'Vj>.',
-      end: ['    |one', '    two']
+      end: ['        |one', '        two']
     });
 
 });

--- a/test/testUtils.ts
+++ b/test/testUtils.ts
@@ -6,6 +6,7 @@ import * as assert from 'assert';
 import {join} from 'path';
 import * as os from 'os';
 import * as fs from 'fs';
+import { Configuration } from '../src/configuration/configuration';
 
 function rndName() {
   return Math.random().toString(36).replace(/[^a-z]+/g, '').substr(0, 10);
@@ -80,9 +81,7 @@ export async function cleanUpWorkspace(): Promise<any> {
   });
 }
 
-export function setTextEditorOptions(tabSize: number | string, insertSpaces: boolean | string): void {
-  vscode.window.activeTextEditor.options = {
-    tabSize,
-    insertSpaces
-  };
+export function setTextEditorOptions(tabSize: number, insertSpaces: boolean): void {
+  Configuration.getInstance().tabstop = tabSize;
+  Configuration.getInstance().expandtab = insertSpaces;
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,6 +4,7 @@
     "target": "es6",
     "outDir": "out",
     "noImplicitAny": true,
+    "suppressImplicitAnyIndexErrors": true,
     "noLib": true,
     "sourceMap": true,
     "strictNullChecks": true,


### PR DESCRIPTION
- [x] Commit message has a short title & issue references
- [x] Commits are squashed 
- [x] It builds and tests pass (e.g `gulp tslint`)

This feature is related to #433, #463, #487 and #481. The basic idea is maintaining a singleton of Vim Settings. This Vim Seting object reads configuration from User Settings, `.vimrc`, Code configuration then our own (VSCodeVim) default value.

- [x] Singleton Vim Settings
- [x] Load `vim.{xxx}` section
- [x] Map Vim configure to Code if there is any overlap
- [x] Fix #487
- [x] Fix #481
- [ ] `.vimrc` loading
- [ ] Auto update (monitoring both Code's configuration and `.vimrc`)