### PR TITLE
Make <delete> repeatable in Normal Mode. Fix #394

### DIFF
--- a/extension.ts
+++ b/extension.ts
@@ -174,6 +174,7 @@ export async function activate(context: vscode.ExtensionContext) {
 
   registerCommand(context, 'extension.vim_esc', () => handleKeyEvent("<esc>"));
   registerCommand(context, 'extension.vim_backspace', () => handleKeyEvent("<backspace>"));
+  registerCommand(context, 'extension.vim_delete', () => handleKeyEvent("<delete>"));
 
   registerCommand(context, 'extension.showCmdLine', () => {
     showCmdLine("", modeHandlerToEditorIdentity[new EditorIdentity(vscode.window.activeTextEditor).toString()]);

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
             {
                 "key": "Delete",
                 "command": "extension.vim_delete",
-                "when": "editorTextFocus"
+                "when": "editorTextFocus && vim.mode == 'Normal Mode'"
             },
             {
                 "key": "ctrl+r",

--- a/package.json
+++ b/package.json
@@ -53,6 +53,11 @@
                 "when": "editorTextFocus"
             },
             {
+                "key": "Delete",
+                "command": "extension.vim_delete",
+                "when": "editorTextFocus"
+            },
+            {
                 "key": "ctrl+r",
                 "command": "extension.vim_ctrl+r",
                 "when": "editorTextFocus"

--- a/src/actions/actions.ts
+++ b/src/actions/actions.ts
@@ -1960,6 +1960,11 @@ class ActionDeleteChar extends BaseCommand {
 }
 
 @RegisterAction
+class ActionDeleteCharWithDeleteKey extends ActionDeleteChar {
+  keys = ["<delete>"];
+}
+
+@RegisterAction
 class ActionDeleteLastChar extends BaseCommand {
   modes = [ModeName.Normal];
   keys = ["X"];

--- a/src/actions/actions.ts
+++ b/src/actions/actions.ts
@@ -1960,8 +1960,24 @@ class ActionDeleteChar extends BaseCommand {
 }
 
 @RegisterAction
-class ActionDeleteCharWithDeleteKey extends ActionDeleteChar {
+class ActionDeleteCharWithDeleteKey extends BaseCommand {
+  modes = [ModeName.Normal];
   keys = ["<delete>"];
+  canBePrefixedWithCount = true;
+  canBeRepeatedWithDot = true;
+
+  public async execCount(position: Position, vimState: VimState): Promise<VimState> {
+    // N<del> is a no-op in Vim
+    if (vimState.recordedState.count !== 0) {
+      return vimState;
+    }
+
+    const state = await new DeleteOperator().run(vimState, position, position);
+
+    state.currentMode = ModeName.Normal;
+
+    return state;
+  }
 }
 
 @RegisterAction

--- a/test/mode/normalModeTests/commands.test.ts
+++ b/test/mode/normalModeTests/commands.test.ts
@@ -19,9 +19,16 @@ suite("Mode Normal", () => {
     teardown(cleanUpWorkspace);
 
     newTest({
-      title: "Can handle x",
+      title: "Can handle 'x'",
       start: ['te|xt'],
       keysPressed: 'x',
+      end: ["te|t"],
+    });
+
+    newTest({
+      title: "Can handle '<delete>'",
+      start: ['te|xt'],
+      keysPressed: '<delete>',
       end: ["te|t"],
     });
 
@@ -61,9 +68,16 @@ suite("Mode Normal", () => {
     });
 
     newTest({
-      title: "Can handle x at end of line",
+      title: "Can handle 'x' at end of line",
       start: ['one tw|o'],
       keysPressed: '^llxxxxxxxxx',
+      end: ['|'],
+    });
+
+    newTest({
+      title: "Can handle '<delete>' at end of line",
+      start: ['one tw|o'],
+      keysPressed: '^ll<delete><delete><delete><delete><delete><delete><delete><delete><delete>',
       end: ['|'],
     });
 
@@ -168,7 +182,7 @@ suite("Mode Normal", () => {
     });
 
     newTest({
-      title: "Can backspace in insert mode",
+      title: "Can handle '<backspace>' in insert mode",
       start: ['one', '|'],
       keysPressed: 'i<backspace><esc>',
       end: ['on|e']

--- a/test/mode/normalModeTests/commands.test.ts
+++ b/test/mode/normalModeTests/commands.test.ts
@@ -26,10 +26,38 @@ suite("Mode Normal", () => {
     });
 
     newTest({
+      title: "Can handle 'Nx'",
+      start: ['te|xt'],
+      keysPressed: '2x',
+      end: ["t|e"],
+    });
+
+    newTest({
+      title: "Can handle 'x' at end of line",
+      start: ['one tw|o'],
+      keysPressed: '^llxxxxxxxxx',
+      end: ['|'],
+    });
+
+    newTest({
       title: "Can handle '<delete>'",
       start: ['te|xt'],
       keysPressed: '<delete>',
       end: ["te|t"],
+    });
+
+    newTest({
+      title: "Can handle 'N<delete>', which should be a no-op",
+      start: ['te|xt'],
+      keysPressed: '2<delete>',
+      end: ["te|xt"],
+    });
+
+    newTest({
+      title: "Can handle '<delete>' at end of line",
+      start: ['one tw|o'],
+      keysPressed: '^ll<delete><delete><delete><delete><delete><delete><delete><delete><delete>',
+      end: ['|'],
     });
 
     newTest({
@@ -65,20 +93,6 @@ suite("Mode Normal", () => {
       start: ['tex|t'],
       keysPressed: '^llDD',
       end: ['|t'],
-    });
-
-    newTest({
-      title: "Can handle 'x' at end of line",
-      start: ['one tw|o'],
-      keysPressed: '^llxxxxxxxxx',
-      end: ['|'],
-    });
-
-    newTest({
-      title: "Can handle '<delete>' at end of line",
-      start: ['one tw|o'],
-      keysPressed: '^ll<delete><delete><delete><delete><delete><delete><delete><delete><delete>',
-      end: ['|'],
     });
 
     newTest({


### PR DESCRIPTION
Yay! We love PRs! 🎊

Please include a description of your change & check your PR against this list, thanks:

- [x] Commit message has a short title & issue references
- [x] Commits are squashed 
- [x] It builds and tests pass (e.g `gulp tslint`)

Previously `<delete>` key works in Normal Mode but is not repeatable.
This PR makes it repeatable, so commands like `5<delete>` would work like `5x`.