### PR TITLE
Add support for `gd`

### DIFF
--- a/src/actions/actions.ts
+++ b/src/actions/actions.ts
@@ -1337,6 +1337,20 @@ class CommandExitVisualLineMode extends BaseCommand {
   }
 }
 
+@RegisterAction
+class CommandGoToDefinition extends BaseCommand {
+  modes = [ModeName.Normal];
+  keys = ["g", "d"];
+
+  public async exec(position: Position, vimState: VimState): Promise<VimState> {
+    await vscode.commands.executeCommand("editor.action.goToDeclaration");
+
+    vimState.focusChanged = true;
+    vimState.cursorPosition = Position.FromVSCodePosition(vscode.window.activeTextEditor.selection.start);
+    return vimState;
+  }
+}
+
 // begin insert commands
 
 @RegisterAction


### PR DESCRIPTION
This commit maps `gd` to VSCode's go to declaration action. Resolves #529.