### PR TITLE
WIP: Stay in Insert Mode When Selecting

### DIFF
--- a/src/actions/actions.ts
+++ b/src/actions/actions.ts
@@ -563,7 +563,13 @@ class CommandInsertInInsertMode extends BaseCommand {
     const char = this.keysPressed[this.keysPressed.length - 1];
 
     if (char === "<backspace>") {
-      if (position.character === 0) {
+      const selection = vscode.window.activeTextEditor.selection;
+      if (!selection.isEmpty) {
+        await TextEditor.delete(selection);
+
+        vimState.cursorStartPosition = Position.FromVSCodePosition(vscode.window.activeTextEditor.selection.end);
+        vimState.cursorPosition = Position.FromVSCodePosition(vscode.window.activeTextEditor.selection.end);
+      } else if (position.character === 0) {
         if (position.line > 0) {
           await TextEditor.delete(new vscode.Range(
             position.getPreviousLineBegin().getLineEnd(),
@@ -593,14 +599,15 @@ class CommandInsertInInsertMode extends BaseCommand {
       const selection = vscode.window.activeTextEditor.selection;
       if (selection.isEmpty) {
         await TextEditor.insert(char, vimState.cursorPosition);
+
+        vimState.cursorStartPosition = Position.FromVSCodePosition(vscode.window.activeTextEditor.selection.start);
+        vimState.cursorPosition = Position.FromVSCodePosition(vscode.window.activeTextEditor.selection.start);
       } else {
         await TextEditor.replace(selection, char);
+
+        vimState.cursorStartPosition = Position.FromVSCodePosition(vscode.window.activeTextEditor.selection.end);
+        vimState.cursorPosition = Position.FromVSCodePosition(vscode.window.activeTextEditor.selection.end);
       }
-
-      const cursorPosition = vscode.window.activeTextEditor.selection.end;
-
-      vimState.cursorStartPosition = Position.FromVSCodePosition(cursorPosition);
-      vimState.cursorPosition = Position.FromVSCodePosition(cursorPosition);
     }
 
     return vimState;

--- a/src/actions/actions.ts
+++ b/src/actions/actions.ts
@@ -590,10 +590,17 @@ class CommandInsertInInsertMode extends BaseCommand {
         vimState.cursorStartPosition = leftPosition;
       }
     } else {
-      await TextEditor.insert(char, vimState.cursorPosition);
+      const selection = vscode.window.activeTextEditor.selection;
+      if (selection.isEmpty) {
+        await TextEditor.insert(char, vimState.cursorPosition);
+      } else {
+        await TextEditor.replace(selection, char);
+      }
 
-      vimState.cursorStartPosition = Position.FromVSCodePosition(vscode.window.activeTextEditor.selection.start);
-      vimState.cursorPosition = Position.FromVSCodePosition(vscode.window.activeTextEditor.selection.start);
+      const cursorPosition = vscode.window.activeTextEditor.selection.end;
+
+      vimState.cursorStartPosition = Position.FromVSCodePosition(cursorPosition);
+      vimState.cursorPosition = Position.FromVSCodePosition(cursorPosition);
     }
 
     return vimState;

--- a/src/mode/modeHandler.ts
+++ b/src/mode/modeHandler.ts
@@ -124,8 +124,9 @@ export class VimState {
 
 export class VimSettings {
   useSolidBlockCursor = false;
-  scroll        = 20;
-  useCtrlKeys     = false;
+  scroll = 20;
+  useCtrlKeys = false;
+  switchToVisualOnSelection = false;
 }
 
 export enum SearchDirection {
@@ -459,7 +460,6 @@ export class ModeHandler implements vscode.Disposable {
 
         this._vimState.desiredColumn     = newPosition.character;
 
-        // start visual mode?
 
         if (!selection.anchor.isEqual(selection.active)) {
           var selectionStart = new Position(selection.anchor.line, selection.anchor.character);
@@ -474,7 +474,12 @@ export class ModeHandler implements vscode.Disposable {
             this._vimState.cursorStartPosition = this._vimState.cursorStartPosition.getLeft();
           }
 
-          if (this._vimState.currentMode !== ModeName.Visual &&
+          // start visual mode?
+
+          const stayInInsertModeWhenSelecting = this._vimState.settings.switchToVisualOnSelection ?
+            true : this._vimState.currentMode !== ModeName.Insert;
+          if (stayInInsertModeWhenSelecting &&
+            this._vimState.currentMode !== ModeName.Visual &&
             this._vimState.currentMode !== ModeName.VisualLine) {
 
             this._vimState.currentMode = ModeName.Visual;
@@ -497,6 +502,7 @@ export class ModeHandler implements vscode.Disposable {
       .get("useSolidBlockCursor", false);
     this._vimState.settings.scroll = vscode.workspace.getConfiguration("vim").get("scroll", 20) || 20;
     this._vimState.settings.useCtrlKeys = vscode.workspace.getConfiguration("vim").get("useCtrlKeys", false) || false;
+    this._vimState.settings.switchToVisualOnSelection = vscode.workspace.getConfiguration("vim").get("switchToVisualOnSelection", false) || false;
   }
 
   /**

--- a/src/mode/modeHandler.ts
+++ b/src/mode/modeHandler.ts
@@ -498,11 +498,14 @@ export class ModeHandler implements vscode.Disposable {
   }
 
   private loadSettings(): void {
-    this._vimState.settings.useSolidBlockCursor = vscode.workspace.getConfiguration("vim")
-      .get("useSolidBlockCursor", false);
-    this._vimState.settings.scroll = vscode.workspace.getConfiguration("vim").get("scroll", 20) || 20;
-    this._vimState.settings.useCtrlKeys = vscode.workspace.getConfiguration("vim").get("useCtrlKeys", false) || false;
-    this._vimState.settings.switchToVisualOnSelection = vscode.workspace.getConfiguration("vim").get("switchToVisualOnSelection", false) || false;
+    this._vimState.settings.useSolidBlockCursor =
+      vscode.workspace.getConfiguration("vim").get("useSolidBlockCursor", false);
+    this._vimState.settings.scroll =
+      vscode.workspace.getConfiguration("vim").get("scroll", 20) || 20;
+    this._vimState.settings.useCtrlKeys =
+      vscode.workspace.getConfiguration("vim").get("useCtrlKeys", false) || false;
+    this._vimState.settings.switchToVisualOnSelection =
+      vscode.workspace.getConfiguration("vim").get("switchToVisualOnSelection", false) || false;
   }
 
   /**

--- a/test/mode/modeNormal.test.ts
+++ b/test/mode/modeNormal.test.ts
@@ -1025,5 +1025,5 @@ suite("Mode Normal", () => {
       start: ["|blah blah"],
       keysPressed: "Yp",
       end: ["blah blah", "|blah blah"]
-    })
+    });
 });


### PR DESCRIPTION
As discussed in #479.

This adds a configuration option to restore the previous behaviour; just set `"vim.switchToVisualOnSelection": true`.

- [X] Option to stay in insert mode when selecting text; writing replaces selection
- [ ] Support wrapping selection in brackets (`(…)`, `[…]`, `{…}`, `<…>`) and quotes (`'…'`, `"…"`, <code>\`…\`</code>)

    If we need to implement this ourselves (instead of leveraging VSCode's default behaviour), we can probably also easily add a "surround" modifier (like [vim-surround](https://github.com/tpope/vim-surround) does), so you can `vsiw[` to surround the inner word with angular brackets.
- [ ] Tests