### PR TITLE
Fix incorrect cursor location after deleting linebreak (fixes #550)

### DIFF
--- a/src/actions/actions.ts
+++ b/src/actions/actions.ts
@@ -590,13 +590,15 @@ class CommandInsertInInsertMode extends BaseCommand {
     if (char === "<backspace>") {
       if (position.character === 0) {
         if (position.line > 0) {
+          const prevEndOfLine = position.getPreviousLineBegin().getLineEnd();
+
           await TextEditor.delete(new vscode.Range(
             position.getPreviousLineBegin().getLineEnd(),
             position.getLineBegin()
           ));
 
-          vimState.cursorPosition      = position.getPreviousLineBegin().getLineEnd();
-          vimState.cursorStartPosition = position.getPreviousLineBegin().getLineEnd();
+          vimState.cursorPosition      = prevEndOfLine;
+          vimState.cursorStartPosition = prevEndOfLine;
         }
       } else {
         let leftPosition = position.getLeft();

--- a/test/mode/modeInsert.test.ts
+++ b/test/mode/modeInsert.test.ts
@@ -126,4 +126,17 @@ suite("Mode Insert", () => {
 
         assertEqualLines(["text "]);
     });
+
+    test("Correctly places the cursor after deleting the previous line break", async() => {
+        await modeHandler.handleMultipleKeyEvents([
+            'i',
+            'o', 'n', 'e', '\n', 't', 'w', 'o',
+            '<left>', '<left>', '<left>',
+            '<backspace>'
+        ]);
+
+        assertEqualLines(["onetwo"]);
+
+        assertEqual(TextEditor.getSelection().start.character, 3, "<backspace> moved cursor to correct position");
+    });
 });


### PR DESCRIPTION
This fixes the issue I reported in #550, and adds a test to prevent regressions.