### PR TITLE
Fix gt,gT numeric prefix

### DIFF
--- a/src/actions/actions.ts
+++ b/src/actions/actions.ts
@@ -1611,16 +1611,17 @@ class MoveToLeftPane  extends BaseCommand {
 
 class BaseTabCommand extends BaseCommand {
   modes = [ModeName.Normal, ModeName.Visual, ModeName.VisualLine];
+  canBePrefixedWithCount = true;
 }
 
 @RegisterAction
 class CommandTabNext extends BaseTabCommand {
   keys = ["g", "t"];
 
-  public async exec(position: Position, vimState: VimState): Promise<VimState> {
+  public async execCount(position: Position, vimState: VimState): Promise<VimState> {
     (new TabCommand({
       tab: Tab.Next,
-      count: 1
+      count: vimState.recordedState.count
     })).execute();
 
     return vimState;


### PR DESCRIPTION
Yay! We love PRs! 🎊

Please include a description of your change & check your PR against this list, thanks:

- [x] Commit message has a short title & issue references
- [x] Each commit does a logical chunk of work.  
- [x] It builds and tests pass (e.g `gulp tslint`)

gt and gT are handling numeric prefix totally diffrently. For gT, we are running `gT` `{count}` times while for gT, if there is no numeric prefix, we are navigating to next tab, but if there is a numeric prefix, we are navigating to No.{count} tab.

