### PR TITLE
Fix binding of control-keys

### DIFF
--- a/extension.ts
+++ b/extension.ts
@@ -189,7 +189,7 @@ export async function activate(context: vscode.ExtensionContext) {
 
   for (let { key } of packagejson.contributes.keybindings) {
     if (key.startsWith("ctrl+")) {
-      registerCommand(context, `extension.vim_${ key }`, () => handleKeyEvent(`ctrl+${ key }`));
+      registerCommand(context, `extension.vim_${ key }`, () => handleKeyEvent(key));
     } else {
       let bracketedKey = `<${ key.toLowerCase() }>`;
 


### PR DESCRIPTION
Seems to be a regression from recent refactor. Tested manually in debug
extension. Prior to this commit, ctrl+a/ctrl+x didn't work. Now they do.