### PR TITLE
Hack to mitigate #569 and prevent extension from locking up

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -73,10 +73,8 @@ gulp.task('tslint', ['fix-whitespace'], function() {
     return merge(srcs, tests);
 });
 
-gulp.task('compile', shell.task([
-  'node ./node_modules/vscode/bin/compile -p ./',
-]));
-
+gulp.task('compile', shell.task(['npm run vscode:prepublish']));
+gulp.task('watch', shell.task(['npm run compile']));
 gulp.task('init', ['typings']);
 gulp.task('default', ['tslint', 'compile']);
 gulp.task('release', ['default', 'patch']);

--- a/src/actions/actions.ts
+++ b/src/actions/actions.ts
@@ -573,6 +573,14 @@ class CommandHash extends BaseCommand {
 
     vimState.searchState = new SearchState(SearchDirection.Backward, vimState.cursorPosition, currentWord);
 
+    // hack start
+    // temporary fix for https://github.com/VSCodeVim/Vim/issues/569
+    let text = TextEditor.getText(new vscode.Range(vimState.cursorPosition, vimState.cursorPosition.getRight()));
+    if (text === " ") {
+      return vimState;
+    }
+    // hack end
+
     do {
       // use getWordLeft() on position to start at the beginning of the word.
       // this ensures that any matches happen ounside of the word currently selected,


### PR DESCRIPTION
* Small workaround to prevent extension from locking up when `#` on whitespace.
* Adding `gulp watch` command to auto-compile things on file changes.

The current implementation of `#` and `*` do not current map to the expected behaviour of vim and will require more time to fix.