### PR TITLE
Synonyms

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -339,9 +339,9 @@ Status | Command | Description
 :white_check_mark:  |    {visual}~	| switch case for highlighted text
 :white_check_mark:  |    {visual}u	| make highlighted text lowercase
 :white_check_mark:  |    {visual}U	| make highlighted text uppercase
-    |    g~{motion}     | switch case for the text that is moved over with {motion}
-    |    gu{motion}     | make the text that is moved over with {motion} lowercase
-    |    gU{motion}     | make the text that is moved over with {motion} uppercase
+:white_check_mark:  |    g~{motion}     | switch case for the text that is moved over with {motion}
+:white_check_mark:  |    gu{motion}     | make the text that is moved over with {motion} lowercase
+:white_check_mark:  |    gU{motion}     | make the text that is moved over with {motion} uppercase
 :arrow_down:    |    {visual}g?     | perform rot13 encoding on highlighted text
 :arrow_down:    |    g?{motion}     | perform rot13 encoding on the text that is moved over with {motion}
 :white_check_mark:    | :1234:  CTRL-A	| add N to the number at or after the cursor

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -396,12 +396,14 @@ Status | Command | Description
 :white_check_mark:    | :1234:  is	| Select "inner sentence"
     | :1234:  ap	| Select "a paragraph"
     | :1234:  ip	| Select "inner paragraph"
-    | :1234:  ab	| Select "a block" (from "[(" to "])")
-    | :1234:  ib	| Select "inner block" (from "[(" to "])")
-    | :1234:  aB	| Select "a Block" (from "[{" to "]}")
-    | :1234:  iB	| Select "inner Block" (from "[{" to "]}")
-:white_check_mark:    | :1234:  a>	| Select "a &lt;&gt; block"
-:white_check_mark:    | :1234:  i>	| Select "inner <> block"
+:white_check_mark:    | :1234:  a], a[    | select '[' ']' blocks
+:white_check_mark:    | :1234:  i], i[    | select inner  '[' ']' blocks
+:white_check_mark:    | :1234:  ab, a(, a)	| Select "a block" (from "[(" to "])")
+:white_check_mark:    | :1234:  ib, i), i(	| Select "inner block" (from "[(" to "])")
+:white_check_mark:    | :1234:  a>, a<	| Select "a &lt;&gt; block"
+:white_check_mark:    | :1234:  i>, i<	| Select "inner <> block"
+:white_check_mark:    | :1234:  aB, a{, a}	| Select "a Block" (from "[{" to "]}")
+:white_check_mark:    | :1234:  iB, i{, i}	| Select "inner Block" (from "[{" to "]}")
     | :1234:  at	| Select "a tag block" (from <aaa> to </aaa>)
     | :1234:  it	| Select "inner tag block" (from <aaa> to </aaa>)
 :white_check_mark:    | :1234:  a'	| Select "a single quoted string"

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -336,9 +336,9 @@ Status | Command | Description
     |    {visual}c	| in Visual block mode: Change each of the selected lines with the entered text
     |    {visual}C	| in Visual block mode: Change each of the selected lines until end-of-line with the entered text
 :warning:    | :1234:  ~		| switch case for N characters and advance cursor
-    |    {visual}~	| switch case for highlighted text
-    |    {visual}u	| make highlighted text lowercase
-    |    {visual}U	| make highlighted text uppercase
+:white_check_mark:  |    {visual}~	| switch case for highlighted text
+:white_check_mark:  |    {visual}u	| make highlighted text lowercase
+:white_check_mark:  |    {visual}U	| make highlighted text uppercase
     |    g~{motion}     | switch case for the text that is moved over with {motion}
     |    gu{motion}     | make the text that is moved over with {motion} lowercase
     |    gU{motion}     | make the text that is moved over with {motion} uppercase

--- a/src/actions/actions.ts
+++ b/src/actions/actions.ts
@@ -3224,6 +3224,12 @@ class MoveIClosingParentheses extends MoveInsideCharacter {
 }
 
 @RegisterAction
+class MoveIClosingParenthesesBlock extends MoveInsideCharacter {
+  keys = ["i", "b"];
+  charToMatch = "(";
+}
+
+@RegisterAction
 class MoveAParentheses extends MoveInsideCharacter {
   keys = ["a", "("];
   charToMatch = "(";
@@ -3233,6 +3239,13 @@ class MoveAParentheses extends MoveInsideCharacter {
 @RegisterAction
 class MoveAClosingParentheses extends MoveInsideCharacter {
   keys = ["a", ")"];
+  charToMatch = "(";
+  includeSurrounding = true;
+}
+
+@RegisterAction
+class MoveAParenthesesBlock extends MoveInsideCharacter {
+  keys = ["a", "b"];
   charToMatch = "(";
   includeSurrounding = true;
 }
@@ -3250,6 +3263,12 @@ class MoveIClosingCurlyBrace extends MoveInsideCharacter {
 }
 
 @RegisterAction
+class MoveIClosingCurlyBraceBlock extends MoveInsideCharacter {
+  keys = ["i", "B"];
+  charToMatch = "{";
+}
+
+@RegisterAction
 class MoveACurlyBrace extends MoveInsideCharacter {
   keys = ["a", "{"];
   charToMatch = "{";
@@ -3259,6 +3278,13 @@ class MoveACurlyBrace extends MoveInsideCharacter {
 @RegisterAction
 class MoveAClosingCurlyBrace extends MoveInsideCharacter {
   keys = ["a", "}"];
+  charToMatch = "{";
+  includeSurrounding = true;
+}
+
+@RegisterAction
+class MoveAClosingCurlyBraceBlock extends MoveInsideCharacter {
+  keys = ["a", "B"];
   charToMatch = "{";
   includeSurrounding = true;
 }

--- a/src/actions/actions.ts
+++ b/src/actions/actions.ts
@@ -1907,11 +1907,11 @@ class MoveUpNonBlank extends BaseMovement {
 }
 
 @RegisterAction
-class MoveUpUnderscore extends BaseMovement {
+class MoveDownUnderscore extends BaseMovement {
   keys = ["_"];
 
   public async execActionWithCount(position: Position, vimState: VimState, count: number): Promise<Position | IMovement> {
-    return position.getUpByCount(Math.max(count - 1, 0))
+    return position.getDownByCount(Math.max(count - 1, 0))
              .getFirstLineNonBlankChar();
   }
 }

--- a/src/actions/actions.ts
+++ b/src/actions/actions.ts
@@ -1774,6 +1774,16 @@ class MoveLeftArrow extends MoveLeft {
 }
 
 @RegisterAction
+class BackSpaceInNormalMode extends BaseMovement {
+  modes = [ModeName.Normal];
+  keys = ["<backspace>"];
+
+  public async execAction(position: Position, vimState: VimState): Promise<Position> {
+    return position.getLeftThroughLineBreaks();
+  }
+}
+
+@RegisterAction
 class MoveUp extends BaseMovement {
   keys = ["k"];
   doesntChangeDesiredColumn = true;

--- a/src/actions/actions.ts
+++ b/src/actions/actions.ts
@@ -2108,6 +2108,13 @@ class MoveScreenLineEnd extends MoveByScreenLine {
 class MoveScreenLienEndNonBlank extends MoveByScreenLine {
   keys = ["g", "_"];
   movementType = "wrappedLineLastNonWhitespaceCharacter";
+  canBePrefixedWithCount = true;
+
+  public async execActionWithCount(position: Position, vimState: VimState, count: number): Promise<Position | IMovement> {
+    count = count || 1;
+    const pos = await this.execAction(position, vimState) as Position;
+    return pos.getDownByCount(count - 1);
+  }
 }
 
 @RegisterAction

--- a/src/actions/actions.ts
+++ b/src/actions/actions.ts
@@ -993,6 +993,12 @@ export class UpperCaseOperator extends BaseOperator {
 }
 
 @RegisterAction
+export class UpperCaseWithMotion extends UpperCaseOperator {
+  public keys = ["g", "U"];
+  public modes = [ModeName.Normal];
+}
+
+@RegisterAction
 export class LowerCaseOperator extends BaseOperator {
     public keys = ["u"];
     public modes = [ModeName.Visual, ModeName.VisualLine];
@@ -1008,6 +1014,12 @@ export class LowerCaseOperator extends BaseOperator {
 
       return vimState;
     }
+}
+
+@RegisterAction
+export class LowerCaseWithMotion extends LowerCaseOperator {
+  public keys = ["g", "u"];
+  public modes = [ModeName.Normal];
 }
 
 @RegisterAction
@@ -3469,6 +3481,12 @@ class ToggleCaseOperator extends BaseOperator {
 
     return vimState;
   }
+}
+
+@RegisterAction
+class ToggleCaseWithMotion extends ToggleCaseOperator {
+  public keys = ["g", "~"];
+  public modes = [ModeName.Normal];
 }
 
 @RegisterAction

--- a/test/mode/modeNormal.test.ts
+++ b/test/mode/modeNormal.test.ts
@@ -272,9 +272,25 @@ suite("Mode Normal", () => {
     });
 
     newTest({
+      title: "Can handle 'cib' on first parentheses",
+      start: ['print(|"hello")'],
+      keysPressed: 'cib',
+      end: ['print(|)'],
+      endMode: ModeName.Insert
+    });
+
+    newTest({
       title: "Can handle 'ca(' spanning multiple lines",
       start: ['call(', '  |arg1)'],
       keysPressed: 'ca(',
+      end: ['call|'],
+      endMode: ModeName.Insert
+    });
+
+    newTest({
+      title: "Can handle 'cab' spanning multiple lines",
+      start: ['call(', '  |arg1)'],
+      keysPressed: 'cab',
       end: ['call|'],
       endMode: ModeName.Insert
     });
@@ -296,6 +312,14 @@ suite("Mode Normal", () => {
     });
 
     newTest({
+      title: "Can handle 'ciB' spanning multiple lines",
+      start: ['one {', '|', '}'],
+      keysPressed: 'ciB',
+      end: ['one {|}'],
+      endMode: ModeName.Insert
+    });
+
+    newTest({
       title: "will fail when ca( with no ()",
       start: ['|blaaah'],
       keysPressed: 'ca(',
@@ -307,6 +331,14 @@ suite("Mode Normal", () => {
       title: "will fail when ca{ with no {}",
       start: ['|blaaah'],
       keysPressed: 'ca{',
+      end: ['|blaaah'],
+      endMode: ModeName.Normal
+    });
+
+    newTest({
+      title: "will fail when caB with no {}",
+      start: ['|blaaah'],
+      keysPressed: 'caB',
       end: ['|blaaah'],
       endMode: ModeName.Normal
     });
@@ -711,6 +743,20 @@ suite("Mode Normal", () => {
     });
 
     newTest({
+      title: "Can handle backspace",
+      start: ['text |text'],
+      keysPressed: '<backspace><backspace>',
+      end: ['tex|t text']
+    });
+
+    newTest({
+      title: "Can handle backspace across lines",
+      start: ['one', '|two'],
+      keysPressed: '<backspace><backspace>',
+      end: ['o|ne', 'two']
+    });
+
+    newTest({
       title: "Can handle A and backspace",
       start: ['|text text'],
       keysPressed: 'A<backspace><escape>',
@@ -961,6 +1007,20 @@ suite("Mode Normal", () => {
       start: ['|ABC DEF'],
       keysPressed: 'vwu',
       end: ['|abc dEF']
+    });
+
+    newTest({
+      title: "Can handle guw",
+      start: ['|ABC DEF'],
+      keysPressed: 'guw',
+      end: ['|abc DEF']
+    });
+
+    newTest({
+      title: "Can handle gUw",
+      start: ['|abc def'],
+      keysPressed: 'gUw',
+      end: ['|ABC def']
     });
 
     newTest({

--- a/test/mode/normalModeTests/commands.test.ts
+++ b/test/mode/normalModeTests/commands.test.ts
@@ -196,6 +196,13 @@ suite("Mode Normal", () => {
     });
 
     newTest({
+      title: "Can handle 'g~{motion}'",
+      start: ['|one two'],
+      keysPressed: 'g~w',
+      end: ['|ONE two']
+    });
+
+    newTest({
       title: "Can handle '<backspace>' in insert mode",
       start: ['one', '|'],
       keysPressed: 'i<backspace><escape>',

--- a/test/mode/normalModeTests/motions.test.ts
+++ b/test/mode/normalModeTests/motions.test.ts
@@ -477,7 +477,7 @@ suite("Motions in Normal Mode", () => {
     title: "Can handle _ with count prefix",
     start: ['blah', 'duh', '|dur', 'hur'],
     keysPressed: '2_',
-    end: ['blah', '|duh', 'dur', 'hur']
+    end: ['blah', 'duh', 'dur', '|hur']
   });
 
   newTest({

--- a/test/mode/normalModeTests/motions.test.ts
+++ b/test/mode/normalModeTests/motions.test.ts
@@ -481,6 +481,20 @@ suite("Motions in Normal Mode", () => {
   });
 
   newTest({
+    title: "Can handle g_",
+    start: ['blah', '|duh'],
+    keysPressed: 'g_',
+    end: ['blah', 'du|h']
+  });
+
+  newTest({
+    title: "Can handle g_ with count prefix",
+    start: ['blah', 'duh', '|dur', 'hur'],
+    keysPressed: '2g_',
+    end: ['blah', 'duh', 'dur', 'hu|r']
+  });
+
+  newTest({
     title: "Can handle <up> key",
     start: ['blah', 'duh', '|dur', 'hur'],
     keysPressed: '<up>',


### PR DESCRIPTION
Yay! We love PRs! 🎊

Please include a description of your change & check your PR against this list, thanks:

- [x] Commit message has a short title & issue references
- [x] Each commit does a logical chunk of work.  
- [x] It builds and tests pass (e.g `gulp tslint`)

While comparing our roadmap with Atom's atom-vim-mode-plus [keybindings](https://github.com/t9md/atom-vim-mode-plus/blob/master/keymaps/vim-mode-plus.cson), I found that we missed some synonyms for text object motions or so, so I added them real quick. Most of them are originally introduced by @sectioneight , kudos to you!