### PR TITLE
Respect indentation on cc and S

### DIFF
--- a/src/actions/actions.ts
+++ b/src/actions/actions.ts
@@ -1584,7 +1584,7 @@ class CommandClearLine extends BaseCommand {
   public async execCount(position: Position, vimState: VimState): Promise<VimState> {
     let count = this.canBePrefixedWithCount ? vimState.recordedState.count || 1 : 1;
     let end = position.getDownByCount(Math.max(0, count - 1)).getLineEnd().getLeft();
-    return new ChangeOperator().run(vimState, position.getLineBegin(), end);
+    return new ChangeOperator().run(vimState, position.getLineBeginRespectingIndent(), end);
   }
 }
 
@@ -2806,7 +2806,7 @@ class MoveCC extends BaseMovement {
 
   public async execActionWithCount(position: Position, vimState: VimState, count: number): Promise<IMovement> {
     return {
-      start       : position.getLineBegin(),
+      start       : position.getLineBeginRespectingIndent(),
       stop        : position.getDownByCount(Math.max(0, count - 1)).getLineEnd(),
       registerMode: RegisterMode.CharacterWise
     };

--- a/src/configuration/configuration.ts
+++ b/src/configuration/configuration.ts
@@ -55,6 +55,7 @@ export class Configuration {
   hlsearch: boolean = false;
   ignorecase: boolean = true;
   smartcase: boolean = true;
+  autoindent: boolean = true;
 
   @overlapSetting({ codeName: "tabSize", default: 8})
   tabstop: number | undefined = undefined;

--- a/src/motion/position.ts
+++ b/src/motion/position.ts
@@ -400,6 +400,18 @@ export class Position extends vscode.Position {
   }
 
   /**
+   * Get the beginning of the line, excluding preceeding whitespace.
+   * This respects the `noautoindent` setting, and returns `getLineBegin()` if auto-indent
+   * is disabled.
+   */
+  public getLineBeginRespectingIndent(): Position {
+    if (!Configuration.getInstance().autoindent) {
+      return this.getLineBegin();
+    }
+    return this.getFirstLineNonBlankChar();
+  }
+
+  /**
    * Get the beginning of the next line.
    */
   public getPreviousLineBegin(): Position {

--- a/test/mode/modeNormal.test.ts
+++ b/test/mode/modeNormal.test.ts
@@ -1153,7 +1153,7 @@ suite("Mode Normal", () => {
       title: "Can do S",
       start: ["    one", "    tw|o", "    three"],
       keysPressed: "2S",
-      end: ["    one", "|"]
+      end: ["    one", "        |"]
     });
 
     newTest({
@@ -1208,6 +1208,14 @@ suite("Mode Normal", () => {
       start: ["one <blink>he|llo</blink> two"],
       keysPressed: "cat",
       end: ["one | two"],
+      endMode: ModeName.Insert
+    });
+
+    newTest({
+      title: "Respects indentation with cc",
+      start: ["{", "  int| a;"],
+      keysPressed: "cc",
+      end: ["{", "  |"],
       endMode: ModeName.Insert
     });
 });

--- a/test/mode/modeNormal.test.ts
+++ b/test/mode/modeNormal.test.ts
@@ -1153,7 +1153,7 @@ suite("Mode Normal", () => {
       title: "Can do S",
       start: ["    one", "    tw|o", "    three"],
       keysPressed: "2S",
-      end: ["    one", "        |"]
+      end: ["    one", "    |"]
     });
 
     newTest({


### PR DESCRIPTION
This uses a new `autoindent` setting (default true) to determine whether
a line replacement should cut to the beginning of the line, or the first
non-whitespace char.

Fixes #626

Two things to note:

- We're not actually doing any smart indentation, we're just assuming they want to keep the original indentation that was on the line. This appears to be how Vim behaves as well.
- In Vim, `autoindent` is not enabled by default, but I think most people enable it and VSCode obviously has it on by default as well.