### PR TITLE
Fix bug #613 ":wq command dows not work"

### DIFF
--- a/src/cmd_line/commands/quit.ts
+++ b/src/cmd_line/commands/quit.ts
@@ -27,7 +27,7 @@ export class QuitCommand extends node.CommandBase {
     return this._arguments;
   }
 
-  execute() : void {
+  async execute() : Promise<void> {
     if (this.activeTextEditor.document.isUntitled && !this._arguments.bang) {
       throw error.VimError.fromCode(error.ErrorCode.E32);
     }
@@ -36,6 +36,6 @@ export class QuitCommand extends node.CommandBase {
       throw error.VimError.fromCode(error.ErrorCode.E37);
     }
 
-    vscode.commands.executeCommand('workbench.action.closeActiveEditor');
+    await vscode.commands.executeCommand('workbench.action.closeActiveEditor');
   }
 }

--- a/src/cmd_line/commands/quit.ts
+++ b/src/cmd_line/commands/quit.ts
@@ -28,6 +28,10 @@ export class QuitCommand extends node.CommandBase {
   }
 
   execute() : void {
+    if (this.activeTextEditor.document.isUntitled && !this._arguments.bang) {
+      throw error.VimError.fromCode(error.ErrorCode.E32);
+    }
+
     if (this.activeTextEditor.document.isDirty && !this.arguments.bang) {
       throw error.VimError.fromCode(error.ErrorCode.E37);
     }

--- a/src/cmd_line/commands/write.ts
+++ b/src/cmd_line/commands/write.ts
@@ -37,7 +37,7 @@ export class WriteCommand extends node.CommandBase {
     return this._arguments;
   }
 
-  async execute(modeHandler : ModeHandler) {
+  async execute(modeHandler : ModeHandler) : Promise<void> {
     if (this.arguments.opt) {
       util.showError("Not implemented.");
       return;
@@ -74,7 +74,7 @@ export class WriteCommand extends node.CommandBase {
     }
   }
 
-  private async save(modeHandler : ModeHandler) {
+  private async save(modeHandler : ModeHandler) : Promise<void> {
     await this.activeTextEditor.document.save().then(
       (ok) => {
         modeHandler.setupStatusBarItem('"' + path.basename(this.activeTextEditor.document.fileName) +

--- a/src/cmd_line/commands/write.ts
+++ b/src/cmd_line/commands/write.ts
@@ -37,7 +37,7 @@ export class WriteCommand extends node.CommandBase {
     return this._arguments;
   }
 
-  execute(modeHandler : ModeHandler) : void {
+  async execute(modeHandler : ModeHandler) {
     if (this.arguments.opt) {
       util.showError("Not implemented.");
       return;
@@ -56,27 +56,27 @@ export class WriteCommand extends node.CommandBase {
       throw error.VimError.fromCode(error.ErrorCode.E32);
     }
 
-    fs.access(this.activeTextEditor.document.fileName, fs.W_OK, (accessErr) => {
-      if (accessErr) {
-        if (this.arguments.bang) {
-          fs.chmod(this.activeTextEditor.document.fileName, 666, (e) => {
-            if (e) {
-              modeHandler.setupStatusBarItem(e.message);
-            } else {
-              this.save(modeHandler);
-            }
-          });
-        } else {
-          modeHandler.setupStatusBarItem(accessErr.message);
-        }
+    try {
+      fs.accessSync(this.activeTextEditor.document.fileName, fs.W_OK);
+    } catch (accessErr) {
+      if (this.arguments.bang) {
+        fs.chmod(this.activeTextEditor.document.fileName, 666, (e) => {
+          if (e) {
+            modeHandler.setupStatusBarItem(e.message);
+          } else {
+            return this.save(modeHandler);
+          }
+        });
       } else {
-        this.save(modeHandler);
+        modeHandler.setupStatusBarItem(accessErr.message);
       }
-    });
+    }
+
+    return this.save(modeHandler);
   }
 
-  private save(modeHandler : ModeHandler) {
-    this.activeTextEditor.document.save().then(
+  private async save(modeHandler : ModeHandler) {
+    await this.activeTextEditor.document.save().then(
       (ok) => {
         modeHandler.setupStatusBarItem('"' + path.basename(this.activeTextEditor.document.fileName) +
         '" ' + this.activeTextEditor.document.lineCount + 'L ' +

--- a/src/cmd_line/commands/write.ts
+++ b/src/cmd_line/commands/write.ts
@@ -58,6 +58,7 @@ export class WriteCommand extends node.CommandBase {
 
     try {
       fs.accessSync(this.activeTextEditor.document.fileName, fs.W_OK);
+      return this.save(modeHandler);
     } catch (accessErr) {
       if (this.arguments.bang) {
         fs.chmod(this.activeTextEditor.document.fileName, 666, (e) => {
@@ -71,8 +72,6 @@ export class WriteCommand extends node.CommandBase {
         modeHandler.setupStatusBarItem(accessErr.message);
       }
     }
-
-    return this.save(modeHandler);
   }
 
   private async save(modeHandler : ModeHandler) {

--- a/src/cmd_line/commands/writequit.ts
+++ b/src/cmd_line/commands/writequit.ts
@@ -40,7 +40,7 @@ export class WriteQuitCommand extends node.CommandBase {
   }
 
   // Writing command. Taken as a basis from the "write.ts" file.
-  execute(modeHandler : ModeHandler) : void {
+  async execute(modeHandler : ModeHandler) : Promise<void> {
     let writeArgs : write.IWriteCommandArguments = {
       opt: this.arguments.opt,
       optValue: this.arguments.optValue,
@@ -50,16 +50,14 @@ export class WriteQuitCommand extends node.CommandBase {
     };
 
     let writeCmd = new write.WriteCommand(writeArgs);
-    writeCmd.execute(modeHandler).then(() => {
-      let quitArgs : quit.IQuitCommandArguments = {
-        //wq! fails when no file name is provided
-        bang: false,
-        range: this.arguments.range
-      };
+    await writeCmd.execute(modeHandler);
+    let quitArgs : quit.IQuitCommandArguments = {
+      //wq! fails when no file name is provided
+      bang: false,
+      range: this.arguments.range
+    };
 
-      let quitCmd = new quit.QuitCommand(quitArgs);
-      quitCmd.execute();
-    });
-
+    let quitCmd = new quit.QuitCommand(quitArgs);
+    await quitCmd.execute();
   }
 }

--- a/src/cmd_line/commands/writequit.ts
+++ b/src/cmd_line/commands/writequit.ts
@@ -1,8 +1,6 @@
 "use strict";
 
-import * as vscode from "vscode";
 import * as node from "../node";
-import * as error from "../../error";
 import {ModeHandler} from "../../mode/modeHandler";
 import * as write from "./write";
 import * as quit from "./quit";
@@ -52,7 +50,7 @@ export class WriteQuitCommand extends node.CommandBase {
     let writeCmd = new write.WriteCommand(writeArgs);
     await writeCmd.execute(modeHandler);
     let quitArgs : quit.IQuitCommandArguments = {
-      //wq! fails when no file name is provided
+      // wq! fails when no file name is provided
       bang: false,
       range: this.arguments.range
     };

--- a/src/cmd_line/commands/writequit.ts
+++ b/src/cmd_line/commands/writequit.ts
@@ -39,9 +39,8 @@ export class WriteQuitCommand extends node.CommandBase {
 
   // Writing command. Taken as a basis from the "write.ts" file.
   execute(modeHandler : ModeHandler) : void {
-    var filename : RegExp = new RegExp("Untitled-[0-9]*");
-    if (!this.activeTextEditor.document.isDirty) {
-      if (filename.test(this.activeTextEditor.document.fileName)) {
+    if (this.activeTextEditor.document.isDirty) {
+      if (this.activeTextEditor.document.isUntitled) {
         vscode.commands.executeCommand("workbench.action.files.saveAs");
       } else {
         vscode.commands.executeCommand("workbench.action.files.save");

--- a/test/cmd_line/writequit.test.ts
+++ b/test/cmd_line/writequit.test.ts
@@ -1,0 +1,58 @@
+"use strict";
+
+import { ModeHandler } from '../../src/mode/modeHandler';
+import { setupWorkspace, cleanUpWorkspace, assertEqualLines, assertEqual } from './../testUtils';
+import { runCmdLine } from '../../src/cmd_line/main';
+import * as vscode from "vscode";
+import {join} from 'path';
+import * as assert from 'assert';
+
+suite("Basic write-quit", () => {
+  let modeHandler: ModeHandler;
+
+  setup(async () => {
+    await setupWorkspace();
+    modeHandler = new ModeHandler();
+  });
+
+  teardown(cleanUpWorkspace);
+
+  test("Run write and quit", async () => {
+    await modeHandler.handleMultipleKeyEvents(['i', 'a', 'b', 'a', '<escape>']);
+    // await runCmdLine("%s/a/d", modeHandler);
+    await runCmdLine("wq", modeHandler);
+
+    // cleanUpWorkspace - testUtils.ts
+    let poll = new Promise((c, e) => {
+      if (vscode.window.visibleTextEditors.length === 0) {
+        return c();
+      }
+
+      let pollCount = 0;
+      // TODO: the visibleTextEditors variable doesn't seem to be
+      // up to date after a onDidChangeActiveTextEditor event, not
+      // even using a setTimeout 0... so we MUST poll :(
+      let interval = setInterval(() => {
+        // if visibleTextEditors is not updated after 1 sec
+        // we can expect that 'wq' failed
+        if (pollCount <= 100) {
+          pollCount++;
+          if (vscode.window.visibleTextEditors.length > 0) {
+            return;
+          }
+        }
+
+        clearInterval(interval);
+        c();
+      }, 10);
+    });
+
+    try {
+      await poll;
+    } catch (error) {
+      assert.fail(null, null, error.toString());
+    }
+
+    assertEqual(vscode.window.visibleTextEditors.length, 0, "Window after 1sec still open");
+  });
+});

--- a/test/cmd_line/writequit.test.ts
+++ b/test/cmd_line/writequit.test.ts
@@ -7,6 +7,39 @@ import * as vscode from "vscode";
 import {join} from 'path';
 import * as assert from 'assert';
 
+async function WaitForVsCodeClose() : Promise<void> {
+  // cleanUpWorkspace - testUtils.ts
+  let poll = new Promise((c, e) => {
+    if (vscode.window.visibleTextEditors.length === 0) {
+      return c();
+    }
+
+    let pollCount = 0;
+    // TODO: the visibleTextEditors variable doesn't seem to be
+    // up to date after a onDidChangeActiveTextEditor event, not
+    // even using a setTimeout 0... so we MUST poll :(
+    let interval = setInterval(() => {
+      // if visibleTextEditors is not updated after 1 sec
+      // we can expect that 'wq' failed
+      if (pollCount <= 100) {
+        pollCount++;
+        if (vscode.window.visibleTextEditors.length > 0) {
+          return;
+        }
+      }
+
+      clearInterval(interval);
+      c();
+    }, 10);
+  });
+
+  try {
+    await poll;
+  } catch (error) {
+    assert.fail(null, null, error.toString());
+  }
+}
+
 suite("Basic write-quit", () => {
   let modeHandler: ModeHandler;
 
@@ -19,39 +52,9 @@ suite("Basic write-quit", () => {
 
   test("Run write and quit", async () => {
     await modeHandler.handleMultipleKeyEvents(['i', 'a', 'b', 'a', '<escape>']);
-    // await runCmdLine("%s/a/d", modeHandler);
+
     await runCmdLine("wq", modeHandler);
-
-    // cleanUpWorkspace - testUtils.ts
-    let poll = new Promise((c, e) => {
-      if (vscode.window.visibleTextEditors.length === 0) {
-        return c();
-      }
-
-      let pollCount = 0;
-      // TODO: the visibleTextEditors variable doesn't seem to be
-      // up to date after a onDidChangeActiveTextEditor event, not
-      // even using a setTimeout 0... so we MUST poll :(
-      let interval = setInterval(() => {
-        // if visibleTextEditors is not updated after 1 sec
-        // we can expect that 'wq' failed
-        if (pollCount <= 100) {
-          pollCount++;
-          if (vscode.window.visibleTextEditors.length > 0) {
-            return;
-          }
-        }
-
-        clearInterval(interval);
-        c();
-      }, 10);
-    });
-
-    try {
-      await poll;
-    } catch (error) {
-      assert.fail(null, null, error.toString());
-    }
+    await WaitForVsCodeClose();
 
     assertEqual(vscode.window.visibleTextEditors.length, 0, "Window after 1sec still open");
   });


### PR DESCRIPTION
Bug fix is currently not working with Visual Studio Code - Insiders
>Version 1.5.0-insider
>Commit 3d9622208b2167921b6664e04fd1fbd51507a4a0  

it seems that the `isDirty` property of the `vscode.TextDocument` is set false for newly created document. Going to check it tomorrow with normal vscode.