### PR TITLE
Undo behavior when position changes using arrows or mouse

### DIFF
--- a/package.json
+++ b/package.json
@@ -130,22 +130,22 @@
             {
                 "key": "left",
                 "command": "extension.vim_left",
-                "when": "editorTextFocus && vim.mode != 'Insert Mode'"
+                "when": "editorTextFocus"
             },
             {
                 "key": "right",
                 "command": "extension.vim_right",
-                "when": "editorTextFocus && vim.mode != 'Insert Mode'"
+                "when": "editorTextFocus"
             },
             {
                 "key": "up",
                 "command": "extension.vim_up",
-                "when": "editorTextFocus && vim.mode != 'Insert Mode'"
+                "when": "editorTextFocus"
             },
             {
                 "key": "down",
                 "command": "extension.vim_down",
-                "when": "editorTextFocus && vim.mode != 'Insert Mode'"
+                "when": "editorTextFocus"
             }
         ],
         "configuration": {

--- a/package.json
+++ b/package.json
@@ -130,22 +130,22 @@
             {
                 "key": "left",
                 "command": "extension.vim_left",
-                "when": "editorTextFocus"
+                "when": "editorTextFocus && vim.mode != 'Insert Mode'"
             },
             {
                 "key": "right",
                 "command": "extension.vim_right",
-                "when": "editorTextFocus"
+                "when": "editorTextFocus && vim.mode != 'Insert Mode'"
             },
             {
                 "key": "up",
                 "command": "extension.vim_up",
-                "when": "editorTextFocus"
+                "when": "editorTextFocus && vim.mode != 'Insert Mode'"
             },
             {
                 "key": "down",
                 "command": "extension.vim_down",
-                "when": "editorTextFocus"
+                "when": "editorTextFocus && vim.mode != 'Insert Mode'"
             }
         ],
         "configuration": {

--- a/src/history/historyTracker.ts
+++ b/src/history/historyTracker.ts
@@ -81,6 +81,11 @@ class HistoryStep {
   cursorStart: Position | undefined;
 
   /**
+   * The cursor position at the end of this history step so far.
+   */
+  cursorEnd: Position | undefined;
+
+  /**
    * The position of every mark at the start of this history step.
    */
   marks: IMark[] = [];
@@ -89,11 +94,13 @@ class HistoryStep {
     changes?: DocumentChange[],
     isFinished?: boolean,
     cursorStart?: Position | undefined,
+    cursorEnd?: Position | undefined,
     marks?: IMark[]
   }) {
     this.changes   = init.changes = [];
     this.isFinished  = init.isFinished || false;
     this.cursorStart = init.cursorStart || undefined;
+    this.cursorEnd = init.cursorEnd || undefined;
     this.marks     = init.marks || [];
   }
 
@@ -176,7 +183,8 @@ export class HistoryTracker {
     this.historySteps.push(new HistoryStep({
       changes  : [new DocumentChange(new Position(0, 0), TextEditor.getAllText(), true)],
       isFinished : true,
-      cursorStart: new Position(0, 0)
+      cursorStart: new Position(0, 0),
+      cursorEnd: new Position(0, 0)
     }));
 
     this.finishCurrentStep();
@@ -378,6 +386,7 @@ export class HistoryTracker {
       }
     }
 
+    this.currentHistoryStep.cursorEnd = cursorPosition;
     this.oldText = newText;
   }
 
@@ -475,6 +484,17 @@ export class HistoryTracker {
     }
 
     return step.cursorStart;
+  }
+
+  getLastHistoryEndPosition(): Position | undefined {
+    if (this.currentHistoryStepIndex === 0) {
+      return undefined;
+    }
+    return this.historySteps[this.currentHistoryStepIndex].cursorEnd;
+  }
+
+  setLastHistoryEndPosition(pos: Position) {
+    this.historySteps[this.currentHistoryStepIndex].cursorEnd = pos;
   }
 
   /**

--- a/src/mode/modeHandler.ts
+++ b/src/mode/modeHandler.ts
@@ -690,10 +690,15 @@ export class ModeHandler implements vscode.Disposable {
     let ranRepeatableAction = false;
     let ranAction = false;
 
-    // If arrow keys were used prior to entering characters while in insert mode, create an undo point, this needs to happen before any changes are made
-    if (this.createUndoPointForArrows(vimState)){
-      vimState.previousFullAction = recordedState;
-      vimState.historyTracker.finishCurrentStep();
+    // If arrow keys or mouse was used prior to entering characters while in insert mode, create an undo point
+    // this needs to happen before any changes are made
+    let prevPos = vimState.historyTracker.getLastHistoryEndPosition();
+    if (prevPos !== undefined) {
+      if (vimState.cursorPositionJustBeforeAnythingHappened.line !== prevPos.line ||
+        vimState.cursorPositionJustBeforeAnythingHappened.character !== prevPos.character) {
+        vimState.previousFullAction = recordedState;
+        vimState.historyTracker.finishCurrentStep();
+      }
     }
 
     if (action instanceof BaseMovement) {
@@ -808,6 +813,9 @@ export class ModeHandler implements vscode.Disposable {
         currentLineLength - 1
       );
     }
+
+    // Update the current history step to have the latest cursor position incase it is needed
+    vimState.historyTracker.setLastHistoryEndPosition(vimState.cursorPosition);
 
     return vimState;
   }
@@ -1077,25 +1085,6 @@ export class ModeHandler implements vscode.Disposable {
 
     ModeHandler._statusBarItem.text = text || '';
     ModeHandler._statusBarItem.show();
-  }
-
-  private createUndoPointForArrows(vimState: VimState): boolean {
-    // If arrow keys were used in insert, create new undo point
-    if (vimState.currentMode === ModeName.Insert) {
-      if (vimState.currentFullAction.length > 1) {
-        const prevKey = vimState.currentFullAction[vimState.currentFullAction.length - 2];
-        switch (prevKey) {
-          case "<up>":
-          case "<down>":
-          case "<left>":
-          case "<right>":
-            return true;
-          default:
-            return false;
-        }
-      }
-    }
-    return false;
   }
 
   dispose() {


### PR DESCRIPTION
This is to address issue #644 

I am not sure I like this approach and want to see if I can do something with cursor ending position vs start position so that it applies to mouse AND arrows without needing to register the keys the way I am.