### PR TITLE
Implement :wa[ll] command (write all)

### DIFF
--- a/src/cmd_line/commands/wall.ts
+++ b/src/cmd_line/commands/wall.ts
@@ -1,0 +1,34 @@
+"use strict";
+
+import * as vscode from "vscode";
+import * as node from "../node";
+
+export interface IWallCommandArguments extends node.ICommandArgs {
+  bang?: boolean;
+  range?: node.LineRange;
+}
+
+//
+//  Implements :wall (write all)
+//  http://vimdoc.sourceforge.net/htmldoc/editing.html#:wall
+//
+export class WallCommand extends node.CommandBase {
+  protected _arguments : IWallCommandArguments;
+
+  constructor(args : IWallCommandArguments) {
+    super();
+
+    this._name = 'wall';
+    this._shortName = 'wa';
+    this._arguments = args;
+  }
+
+  get arguments() : IWallCommandArguments {
+    return this._arguments;
+  }
+
+  async execute() : Promise<void> {
+    // TODO : overwrite readonly files when bang? == true
+    await vscode.workspace.saveAll(false);
+  }
+}

--- a/src/cmd_line/subparser.ts
+++ b/src/cmd_line/subparser.ts
@@ -2,6 +2,7 @@
 
 import {parseQuitCommandArgs} from './subparsers/quit';
 import {parseWriteCommandArgs} from './subparsers/write';
+import {parseWallCommandArgs} from './subparsers/wall';
 import {parseWriteQuitCommandArgs} from './subparsers/writequit';
 import * as tabCmd from './subparsers/tab';
 import * as fileCmd from './subparsers/file';
@@ -12,6 +13,9 @@ import {parseSubstituteCommandArgs} from './subparsers/substitute';
 export const commandParsers = {
   w: parseWriteCommandArgs,
   write: parseWriteCommandArgs,
+
+  wa: parseWallCommandArgs,
+  wall: parseWallCommandArgs,
 
   quit: parseQuitCommandArgs,
   q: parseQuitCommandArgs,

--- a/src/cmd_line/subparsers/wall.ts
+++ b/src/cmd_line/subparsers/wall.ts
@@ -1,0 +1,25 @@
+"use strict";
+
+import * as node from "../commands/wall";
+import {Scanner} from '../scanner';
+import {VimError, ErrorCode} from '../../error';
+
+export function parseWallCommandArgs(args : string) : node.WallCommand {
+  if (!args) {
+    return new node.WallCommand({});
+  }
+  var scannedArgs : node.IWallCommandArguments = {};
+  var scanner = new Scanner(args);
+  const c = scanner.next();
+  if (c === '!') {
+    scannedArgs.bang = true;
+    scanner.ignore();
+  } else if (c !== ' ') {
+    throw VimError.fromCode(ErrorCode.E488);
+  }
+  scanner.skipWhiteSpace();
+  if (!scanner.isAtEof) {
+    throw VimError.fromCode(ErrorCode.E488);
+  }
+  return new node.WallCommand(scannedArgs);
+}


### PR DESCRIPTION
Implements a basic `:wa[ll]` command (http://vimdoc.sourceforge.net/htmldoc/editing.html#:wall)
It currently just triggers vscode's `workbench.action.files.saveAll` command, so the bang version (`wa!`) doesn't overwrite readonly files.

Yay! We love PRs! 🎊

Please include a description of your change & check your PR against this list, thanks:

- [x] Commit message has a short title & issue references
- [x] Each commit does a logical chunk of work.  
- [x] It builds and tests pass (e.g `gulp tslint`)

More info can be found by clicking the "guidelines for contributing" link above.

