### PR TITLE
Editor Scroll

### DIFF
--- a/src/actions/actions.ts
+++ b/src/actions/actions.ts
@@ -1724,6 +1724,28 @@ class CommandCenterScroll extends BaseCommand {
 }
 
 @RegisterAction
+class COmmandTopScroll extends BaseCommand {
+  modes = [ModeName.Normal];
+  keys = ["z", "t"];
+
+  public async exec(position: Position, vimState: VimState): Promise<VimState> {
+    await vscode.commands.executeCommand('revealLine', {lineNumber: 1, at: 'top'});
+    return vimState;
+  }
+}
+
+@RegisterAction
+class CommandBottomScroll extends BaseCommand {
+  modes = [ModeName.Normal];
+  keys = ["z", "b"];
+
+  public async exec(position: Position, vimState: VimState): Promise<VimState> {
+    await vscode.commands.executeCommand('revealLine', {lineNumber: 10, at: 'bottom'});
+    return vimState;
+  }
+}
+
+@RegisterAction
 class CommandGoToOtherEndOfHighlightedText extends BaseCommand {
   modes = [ModeName.Visual, ModeName.VisualLine];
   keys = ["o"];

--- a/src/actions/actions.ts
+++ b/src/actions/actions.ts
@@ -1724,7 +1724,7 @@ class CommandCenterScroll extends BaseCommand {
 }
 
 @RegisterAction
-class COmmandTopScroll extends BaseCommand {
+class CommandTopScroll extends BaseCommand {
   modes = [ModeName.Normal];
   keys = ["z", "t"];
 

--- a/src/actions/actions.ts
+++ b/src/actions/actions.ts
@@ -1,7 +1,7 @@
 import { VimSpecialCommands, VimState, SearchState, SearchDirection, ReplaceState } from './../mode/modeHandler';
 import { ModeName } from './../mode/mode';
 import { VisualBlockInsertionType } from './../mode/modeVisualBlock';
-import { TextEditor } from './../textEditor';
+import { TextEditor, EditorScrollByUnit, EditorScrollDirection, CursorMovePosition, CursorMoveByUnit } from './../textEditor';
 import { Register, RegisterMode } from './../register/register';
 import { NumericString } from './../number/numericString';
 import { Position } from './../motion/position';
@@ -526,12 +526,12 @@ abstract class CommandEditorScroll extends BaseCommand {
   modes = [ModeName.Normal];
   canBePrefixedWithCount = true;
   keys: string[];
-  to: string;
-  by: string;
+  to: EditorScrollDirection;
+  by: EditorScrollByUnit;
 
   public async exec(position: Position, vimState: VimState): Promise<VimState> {
     vimState.postponedCodeViewChanges.push({
-      name: "editorScroll",
+      command: "editorScroll",
       args: {
         to: this.to,
         by: this.by,
@@ -547,7 +547,7 @@ abstract class CommandEditorScroll extends BaseCommand {
     let timesToRepeat = this.canBePrefixedWithCount ? vimState.recordedState.count || 1 : 1;
 
     vimState.postponedCodeViewChanges.push({
-      name: "editorScroll",
+      command: "editorScroll",
       args: {
         to: this.to,
         by: this.by,
@@ -563,7 +563,7 @@ abstract class CommandEditorScroll extends BaseCommand {
 @RegisterAction
 class CommandInsertBelowChar extends BaseCommand {
   modes = [ModeName.Insert];
-  keys = ["ctrl+e"];
+  keys = ["<C-e>"];
 
   public async exec(position: Position, vimState: VimState): Promise<VimState> {
     if (TextEditor.isLastLine(position)) {
@@ -635,49 +635,50 @@ class CommandDeleteIndentInCurrentLine extends BaseCommand {
   }
 }
 
+@RegisterAction
 class CommandCtrlE extends CommandEditorScroll {
   keys = ["<C-e>"];
-  to = "down";
-  by = "line";
+  to: EditorScrollDirection = "down";
+  by: EditorScrollByUnit = "line";
 }
 
 @RegisterAction
 class CommandCtrlY extends CommandEditorScroll {
   keys = ["<C-y>"];
-  to = "up";
-  by = "line";
+  to: EditorScrollDirection = "up";
+  by: EditorScrollByUnit = "line";
 }
 
 @RegisterAction
 class CommandMoveFullPageUp extends CommandEditorScroll {
   modes = [ModeName.Normal, ModeName.Visual, ModeName.VisualLine, ModeName.VisualBlock];
   keys = ["<C-b>"];
-  to = "up";
-  by = "page";
+  to: EditorScrollDirection = "up";
+  by: EditorScrollByUnit = "page";
 }
 
 @RegisterAction
 class CommandMoveFullPageDown extends CommandEditorScroll {
   modes = [ModeName.Normal, ModeName.Visual, ModeName.VisualLine, ModeName.VisualBlock];
   keys = ["<C-f>"];
-  to = "down";
-  by = "page";
+  to: EditorScrollDirection = "down";
+  by: EditorScrollByUnit = "page";
 }
 
 @RegisterAction
 class CommandMoveHalfPageDown extends CommandEditorScroll {
   modes = [ModeName.Normal, ModeName.Visual, ModeName.VisualLine, ModeName.VisualBlock];
   keys = ["<C-d>"];
-  to = "down";
-  by = "halfPage";
+  to: EditorScrollDirection = "down";
+  by: EditorScrollByUnit = "halfPage";
 }
 
 @RegisterAction
 class CommandMoveHalfPageUp extends CommandEditorScroll {
   modes = [ModeName.Normal, ModeName.Visual, ModeName.VisualLine, ModeName.VisualBlock];
   keys = ["<C-u>"];
-  to = "up";
-  by = "halfPage";
+  to: EditorScrollDirection = "up";
+  by: EditorScrollByUnit = "halfPage";
 }
 
 @RegisterAction
@@ -1746,10 +1747,10 @@ class CommandTopScroll extends BaseCommand {
 
   public async exec(position: Position, vimState: VimState): Promise<VimState> {
     vimState.postponedCodeViewChanges.push({
-      name: "revealLine",
+      command: "revealLine",
       args: {
         lineNumber: position.line,
-        at: 'top'
+        at: "top"
       }
     });
 
@@ -1764,10 +1765,10 @@ class CommandBottomScroll extends BaseCommand {
 
   public async exec(position: Position, vimState: VimState): Promise<VimState> {
     vimState.postponedCodeViewChanges.push({
-      name: "revealLine",
+      command: "revealLine",
       args: {
         lineNumber: position.line,
-        at: 'bottom'
+        at: "bottom"
       }
     });
 
@@ -2426,8 +2427,8 @@ class MoveLineBegin extends BaseMovement {
 
 abstract class MoveByScreenLine extends BaseMovement {
   modes = [ModeName.Normal, ModeName.Visual, ModeName.VisualLine];
-  movementType: string;
-  by: string;
+  movementType: CursorMovePosition;
+  by: CursorMoveByUnit;
   value: number = 1;
 
   public async execAction(position: Position, vimState: VimState): Promise<Position | IMovement> {
@@ -2470,25 +2471,25 @@ abstract class MoveByScreenLine extends BaseMovement {
 @RegisterAction
 class MoveScreenLineBegin extends MoveByScreenLine {
   keys = ["g", "0"];
-  movementType = "wrappedLineStart";
+  movementType: CursorMovePosition = "wrappedLineStart";
 }
 
 @RegisterAction
 class MoveScreenNonBlank extends MoveByScreenLine {
   keys = ["g", "^"];
-  movementType = "wrappedLineFirstNonWhitespaceCharacter";
+  movementType: CursorMovePosition = "wrappedLineFirstNonWhitespaceCharacter";
 }
 
 @RegisterAction
 class MoveScreenLineEnd extends MoveByScreenLine {
   keys = ["g", "$"];
-  movementType = "wrappedLineEnd";
+  movementType: CursorMovePosition = "wrappedLineEnd";
 }
 
 @RegisterAction
 class MoveScreenLienEndNonBlank extends MoveByScreenLine {
   keys = ["g", "_"];
-  movementType = "wrappedLineLastNonWhitespaceCharacter";
+  movementType: CursorMovePosition = "wrappedLineLastNonWhitespaceCharacter";
   canBePrefixedWithCount = true;
 
   public async execActionWithCount(position: Position, vimState: VimState, count: number): Promise<Position | IMovement> {
@@ -2501,15 +2502,15 @@ class MoveScreenLienEndNonBlank extends MoveByScreenLine {
 @RegisterAction
 class MoveScreenLineCenter extends MoveByScreenLine {
   keys = ["g", "m"];
-  movementType = "wrappedLineColumnCenter";
+  movementType: CursorMovePosition = "wrappedLineColumnCenter";
 }
 
 @RegisterAction
 class MoveUpByScreenLine extends MoveByScreenLine {
   modes = [ModeName.Insert, ModeName.Normal, ModeName.Visual, ModeName.VisualLine];
   keys = ["g", "k"];
-  movementType = "up";
-  by = "wrappedLine";
+  movementType: CursorMovePosition = "up";
+  by: CursorMoveByUnit = "wrappedLine";
   value = 1;
 }
 
@@ -2517,16 +2518,16 @@ class MoveUpByScreenLine extends MoveByScreenLine {
 class MoveDownByScreenLine extends MoveByScreenLine {
   modes = [ModeName.Insert, ModeName.Normal, ModeName.Visual, ModeName.VisualLine];
   keys = ["g", "j"];
-  movementType = "down";
-  by = "wrappedLine";
+  movementType: CursorMovePosition = "down";
+  by: CursorMoveByUnit = "wrappedLine";
   value = 1;
 }
 
 @RegisterAction
 class MoveToLineFromViewPortTop extends MoveByScreenLine {
   keys = ["H"];
-  movementType = "viewPortTop";
-  by = "line";
+  movementType: CursorMovePosition = "viewPortTop";
+  by: CursorMoveByUnit = "line";
   value = 1;
   canBePrefixedWithCount = true;
 
@@ -2539,8 +2540,8 @@ class MoveToLineFromViewPortTop extends MoveByScreenLine {
 @RegisterAction
 class MoveToLineFromViewPortBottom extends MoveByScreenLine {
   keys = ["L"];
-  movementType = "viewPortBottom";
-  by = "line";
+  movementType: CursorMovePosition = "viewPortBottom";
+  by: CursorMoveByUnit = "line";
   value = 1;
   canBePrefixedWithCount = true;
 
@@ -2553,8 +2554,8 @@ class MoveToLineFromViewPortBottom extends MoveByScreenLine {
 @RegisterAction
 class MoveToMiddleLineInViewPort extends MoveByScreenLine {
   keys = ["M"];
-  movementType = "viewPortCenter";
-  by = "line";
+  movementType: CursorMovePosition = "viewPortCenter";
+  by: CursorMoveByUnit = "line";
 }
 
 @RegisterAction

--- a/src/actions/actions.ts
+++ b/src/actions/actions.ts
@@ -530,16 +530,32 @@ abstract class CommandEditorScroll extends BaseCommand {
   by: string;
 
   public async exec(position: Position, vimState: VimState): Promise<VimState> {
-    await vscode.commands.executeCommand("editorScroll", {to: this.to, by: this.by, value: 1, revealCursor: true});
-    vimState.cursorRevealed = true;
+    vimState.postponedCodeViewChanges.push({
+      name: "editorScroll",
+      args: {
+        to: this.to,
+        by: this.by,
+        value: 1,
+        revealCursor: true
+      }
+    });
+
     return vimState;
   }
 
   public async execCount(position: Position, vimState: VimState): Promise<VimState> {
     let timesToRepeat = this.canBePrefixedWithCount ? vimState.recordedState.count || 1 : 1;
 
-    await vscode.commands.executeCommand("editorScroll", {to: this.to, by: this.by, value: timesToRepeat, revealCursor: true});
-    vimState.cursorRevealed = true;
+    vimState.postponedCodeViewChanges.push({
+      name: "editorScroll",
+      args: {
+        to: this.to,
+        by: this.by,
+        value: timesToRepeat,
+        revealCursor: true
+      }
+    });
+
     return vimState;
   }
 }
@@ -1729,7 +1745,14 @@ class CommandTopScroll extends BaseCommand {
   keys = ["z", "t"];
 
   public async exec(position: Position, vimState: VimState): Promise<VimState> {
-    await vscode.commands.executeCommand('revealLine', {lineNumber: position.line, at: 'top'});
+    vimState.postponedCodeViewChanges.push({
+      name: "revealLine",
+      args: {
+        lineNumber: position.line,
+        at: 'top'
+      }
+    });
+
     return vimState;
   }
 }
@@ -1740,7 +1763,14 @@ class CommandBottomScroll extends BaseCommand {
   keys = ["z", "b"];
 
   public async exec(position: Position, vimState: VimState): Promise<VimState> {
-    await vscode.commands.executeCommand('revealLine', {lineNumber: position.line, at: 'bottom'});
+    vimState.postponedCodeViewChanges.push({
+      name: "revealLine",
+      args: {
+        lineNumber: position.line,
+        at: 'bottom'
+      }
+    });
+
     return vimState;
   }
 }

--- a/src/actions/actions.ts
+++ b/src/actions/actions.ts
@@ -1729,7 +1729,7 @@ class COmmandTopScroll extends BaseCommand {
   keys = ["z", "t"];
 
   public async exec(position: Position, vimState: VimState): Promise<VimState> {
-    await vscode.commands.executeCommand('revealLine', {lineNumber: 1, at: 'top'});
+    await vscode.commands.executeCommand('revealLine', {lineNumber: position.line, at: 'top'});
     return vimState;
   }
 }
@@ -1740,7 +1740,7 @@ class CommandBottomScroll extends BaseCommand {
   keys = ["z", "b"];
 
   public async exec(position: Position, vimState: VimState): Promise<VimState> {
-    await vscode.commands.executeCommand('revealLine', {lineNumber: 10, at: 'bottom'});
+    await vscode.commands.executeCommand('revealLine', {lineNumber: position.line, at: 'bottom'});
     return vimState;
   }
 }

--- a/src/actions/actions.ts
+++ b/src/actions/actions.ts
@@ -522,14 +522,24 @@ class CommandCtrlW extends BaseCommand {
   }
 }
 
-@RegisterAction
-class CommandCtrlE extends BaseCommand {
+abstract class CommandEditorScroll extends BaseCommand {
   modes = [ModeName.Normal];
-  keys = ["<C-e>"];
+  canBePrefixedWithCount = true;
+  keys: string[];
+  to: string;
+  by: string;
 
   public async exec(position: Position, vimState: VimState): Promise<VimState> {
-    await vscode.commands.executeCommand("editorScroll", {to: 'down', by: 'line', value: 1, revealCursor: true});
+    await vscode.commands.executeCommand("editorScroll", {to: this.to, by: this.by, value: 1, revealCursor: true});
+    vimState.cursorRevealed = true;
+    return vimState;
+  }
 
+  public async execCount(position: Position, vimState: VimState): Promise<VimState> {
+    let timesToRepeat = this.canBePrefixedWithCount ? vimState.recordedState.count || 1 : 1;
+
+    await vscode.commands.executeCommand("editorScroll", {to: this.to, by: this.by, value: timesToRepeat, revealCursor: true});
+    vimState.cursorRevealed = true;
     return vimState;
   }
 }
@@ -609,16 +619,49 @@ class CommandDeleteIndentInCurrentLine extends BaseCommand {
   }
 }
 
+class CommandCtrlE extends CommandEditorScroll {
+  keys = ["<C-e>"];
+  to = "down";
+  by = "line";
+}
+
 @RegisterAction
-class CommandCtrlY extends BaseCommand {
-  modes = [ModeName.Normal];
+class CommandCtrlY extends CommandEditorScroll {
   keys = ["<C-y>"];
+  to = "up";
+  by = "line";
+}
 
-  public async exec(position: Position, vimState: VimState): Promise<VimState> {
-    await vscode.commands.executeCommand("editorScroll", {to: 'up', by: 'line', value: 1, revealCursor: true});
+@RegisterAction
+class CommandMoveFullPageUp extends CommandEditorScroll {
+  modes = [ModeName.Normal, ModeName.Visual, ModeName.VisualLine, ModeName.VisualBlock];
+  keys = ["<C-b>"];
+  to = "up";
+  by = "page";
+}
 
-    return vimState;
-  }
+@RegisterAction
+class CommandMoveFullPageDown extends CommandEditorScroll {
+  modes = [ModeName.Normal, ModeName.Visual, ModeName.VisualLine, ModeName.VisualBlock];
+  keys = ["<C-f>"];
+  to = "down";
+  by = "page";
+}
+
+@RegisterAction
+class CommandMoveHalfPageDown extends CommandEditorScroll {
+  modes = [ModeName.Normal, ModeName.Visual, ModeName.VisualLine, ModeName.VisualBlock];
+  keys = ["<C-d>"];
+  to = "down";
+  by = "halfPage";
+}
+
+@RegisterAction
+class CommandMoveHalfPageUp extends CommandEditorScroll {
+  modes = [ModeName.Normal, ModeName.Visual, ModeName.VisualLine, ModeName.VisualBlock];
+  keys = ["<C-u>"];
+  to = "up";
+  by = "halfPage";
 }
 
 @RegisterAction
@@ -1722,49 +1765,6 @@ class CommandRedo extends BaseCommand {
     }
     vimState.alteredHistory = true;
     return vimState;
-  }
-}
-
-@RegisterAction
-class CommandMoveFullPageDown extends BaseCommand {
-  modes = [ModeName.Normal, ModeName.Visual, ModeName.VisualLine, ModeName.VisualBlock];
-  keys = ["<C-f>"];
-
-  public async exec(position: Position, vimState: VimState): Promise<VimState> {
-    await vscode.commands.executeCommand("editorScroll", {to: 'down', by: 'page', value: 1, revealCursor: true});
-    return vimState;
-  }
-}
-
-@RegisterAction
-class CommandMoveFullPageUp extends BaseCommand {
-  modes = [ModeName.Normal, ModeName.Visual, ModeName.VisualLine, ModeName.VisualBlock];
-  keys = ["<C-b>"];
-
-  public async exec(position: Position, vimState: VimState): Promise<VimState> {
-    await vscode.commands.executeCommand("editorScroll", {to: 'up', by: 'page', value: 1, revealCursor: true});
-    return vimState;
-  }
-}
-
-@RegisterAction
-class CommandMoveHalfPageDown extends BaseMovement {
-  keys = ["<C-d>"];
-
-  public async execAction(position: Position, vimState: VimState): Promise<Position> {
-    return new Position(
-      Math.min(TextEditor.getLineCount() - 1, position.line + Configuration.getInstance().scroll),
-      position.character
-    );
-  }
-}
-
-@RegisterAction
-class CommandMoveHalfPageUp extends BaseMovement {
-  keys = ["<C-u>"];
-
-  public async execAction(position: Position, vimState: VimState): Promise<Position> {
-    return new Position(Math.max(0, position.line - Configuration.getInstance().scroll), position.character);
   }
 }
 

--- a/src/actions/actions.ts
+++ b/src/actions/actions.ts
@@ -528,7 +528,7 @@ class CommandCtrlE extends BaseCommand {
   keys = ["<C-e>"];
 
   public async exec(position: Position, vimState: VimState): Promise<VimState> {
-    await vscode.commands.executeCommand("scrollLineDown");
+    await vscode.commands.executeCommand("editorScroll", {to: 'down', by: 'line', value: 1, revealCursor: true});
 
     return vimState;
   }
@@ -615,7 +615,7 @@ class CommandCtrlY extends BaseCommand {
   keys = ["<C-y>"];
 
   public async exec(position: Position, vimState: VimState): Promise<VimState> {
-    await vscode.commands.executeCommand("scrollLineUp");
+    await vscode.commands.executeCommand("editorScroll", {to: 'up', by: 'line', value: 1, revealCursor: true});
 
     return vimState;
   }
@@ -1731,7 +1731,7 @@ class CommandMoveFullPageDown extends BaseCommand {
   keys = ["<C-f>"];
 
   public async exec(position: Position, vimState: VimState): Promise<VimState> {
-    await vscode.commands.executeCommand("cursorPageDown");
+    await vscode.commands.executeCommand("editorScroll", {to: 'down', by: 'page', value: 1, revealCursor: true});
     return vimState;
   }
 }
@@ -1742,7 +1742,7 @@ class CommandMoveFullPageUp extends BaseCommand {
   keys = ["<C-b>"];
 
   public async exec(position: Position, vimState: VimState): Promise<VimState> {
-    await vscode.commands.executeCommand("cursorPageUp");
+    await vscode.commands.executeCommand("editorScroll", {to: 'up', by: 'page', value: 1, revealCursor: true});
     return vimState;
   }
 }

--- a/src/mode/modeHandler.ts
+++ b/src/mode/modeHandler.ts
@@ -34,7 +34,7 @@ export enum VimSpecialCommands {
 }
 
 export class ViewChange {
-  public name: string;
+  public command: string;
   public args: any;
 }
 
@@ -1100,14 +1100,12 @@ export class ModeHandler implements vscode.Disposable {
 
     vscode.window.activeTextEditor.setDecorations(this._caretDecoration, rangesToDraw);
 
-    if (this.vimState.postponedCodeViewChanges.length > 0) {
-      for (let i = 0; i < this.vimState.postponedCodeViewChanges.length; i++) {
-        let viewChange = this.vimState.postponedCodeViewChanges[i];
-        await vscode.commands.executeCommand(viewChange.name, viewChange.args);
-      }
-
-      this.vimState.postponedCodeViewChanges = [];
+    for (let i = 0; i < this.vimState.postponedCodeViewChanges.length; i++) {
+      let viewChange = this.vimState.postponedCodeViewChanges[i];
+      await vscode.commands.executeCommand(viewChange.command, viewChange.args);
     }
+
+    this.vimState.postponedCodeViewChanges = [];
 
     if (this.currentMode.name === ModeName.SearchInProgressMode) {
       this.setupStatusBarItem(`Searching for: ${ this.vimState.searchState!.searchString }`);

--- a/src/mode/modeHandler.ts
+++ b/src/mode/modeHandler.ts
@@ -68,6 +68,8 @@ export class VimState {
 
   public focusChanged = false;
 
+  public cursorRevealed = false;
+
   /**
    * Used to prevent non-recursive remappings from looping.
    */
@@ -705,7 +707,11 @@ export class ModeHandler implements vscode.Disposable {
     }
 
     // Update view
-    await this.updateView(vimState);
+    if (!vimState.cursorRevealed) {
+      await this.updateView(vimState);
+    } else {
+      vimState.cursorRevealed = false;
+    }
 
     return vimState;
   }

--- a/src/textEditor.ts
+++ b/src/textEditor.ts
@@ -224,3 +224,29 @@ export class TextEditor {
   }
 }
 
+/**
+ * Directions in the view for editor scroll command.
+ */
+export type EditorScrollDirection = 'up' | 'down';
+
+/**
+ * Units for editor scroll 'by' argument
+ */
+export type EditorScrollByUnit = 'line' | 'wrappedLine' | 'page' | 'halfPage';
+
+/**
+ * Values for reveal line 'at' argument
+ */
+export type RevealLineAtArgument = 'top' | 'center' | 'bottom';
+/**
+ * Positions in the view for cursor move command.
+ */
+export type CursorMovePosition = 'left' | 'right' | 'up' | 'down' |
+  'wrappedLineStart' |'wrappedLineFirstNonWhitespaceCharacter' |
+  'wrappedLineColumnCenter' | 'wrappedLineEnd' | 'wrappedLineLastNonWhitespaceCharacter' |
+  'viewPortTop' | 'viewPortCenter' | 'viewPortBottom' | 'viewPortIfOutside';
+
+/**
+ * Units for Cursor move 'by' argument
+ */
+export type CursorMoveByUnit = 'line' | 'wrappedLine' | 'character' | 'halfLine';


### PR DESCRIPTION
Add editor scroll commands. The trick in this PR is disabling view updating for editor scrolling as Code already does it for us, re-updating the view will lead to unexpected result of layout redraw.

This PR should fix #672, #673, #675, #676 .