### PR TITLE
Use Angle Bracket Notation (Fixes #64)

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ On OS X, open Terminal and run the following command:
 defaults write com.microsoft.VSCode ApplePressAndHoldEnabled -bool false
 ```
 
-#### How can I bind `jj` to `<escape>`?
+#### How can I bind `jj` to `<Esc>`?
 
 1. Add the following to `settings.json` (open the Command Pallete and search for "User Settings"):
 
@@ -50,18 +50,18 @@ defaults write com.microsoft.VSCode ApplePressAndHoldEnabled -bool false
       "vim.insertModeKeyBindings": [
            {
                "before": ["j", "j"],
-               "after": ["<escape>"]
+               "after": ["<Esc>"]
            }
       ]
    ```
 
-2. If you want to press `jj` in modes which are not Insert Mode and still have it trigger `<escape>`, do the following as well:
+2. If you want to press `jj` in modes which are not Insert Mode and still have it trigger `<Esc>`, do the following as well:
 
    ```
       "vim.otherModesKeyBindings": [
            {
                "before": ["j", "j"],
-               "after": ["<escape>"]
+               "after": ["<Esc>"]
            }
       ]
 ```
@@ -83,7 +83,7 @@ Notice the problem is that if you did this normally, the `j` in `gj` would be ex
 
 Don't forget to restart!
 
-#### How can I enable `ctrl-c` or `ctrl-[` as an alternative to `<escape>`?
+#### How can I enable `ctrl-c` or `ctrl-[` as an alternative to `<Esc>`?
 
 Put the following in your `settings.json`:
 

--- a/extension.ts
+++ b/extension.ts
@@ -6,13 +6,14 @@
  * handleKeyEvent().
  */
 
-
 import * as vscode from 'vscode';
+import * as util from './src/util';
 import { showCmdLine } from './src/cmd_line/main';
 import { ModeHandler } from './src/mode/modeHandler';
 import { TaskQueue } from './src/taskQueue';
 import { Position } from './src/motion/position';
 import { Globals } from './src/globals';
+
 
 interface VSCodeKeybinding {
   key: string;
@@ -191,16 +192,9 @@ export async function activate(context: vscode.ExtensionContext) {
   });
 
   for (let { key } of packagejson.contributes.keybindings) {
-    if (key.startsWith("ctrl+")) {
-      registerCommand(context, `extension.vim_${ key }`, () => handleKeyEvent(key));
-    } else {
-      let bracketedKey = `<${ key.toLowerCase() }>`;
-
-      registerCommand(context, `extension.vim_${ key.toLowerCase() }`, () => handleKeyEvent(`${ bracketedKey }`));
-    }
+    let bracketedKey = util.translateToAngleBracketNotation(key);
+    registerCommand(context, `extension.vim_${ key }`, () => handleKeyEvent(`${ bracketedKey }`));
   }
-
-  registerCommand(context, `extension.vim_esc`, () => handleKeyEvent(`<escape>`));
 
   // Initialize mode handler for current active Text Editor at startup.
   if (vscode.window.activeTextEditor) {

--- a/src/actions/actions.ts
+++ b/src/actions/actions.ts
@@ -238,7 +238,7 @@ export abstract class BaseMovement extends BaseAction {
 }
 
 /**
- * A command is something like <escape>, :, v, i, etc.
+ * A command is something like <Esc>, :, v, i, etc.
  */
 export abstract class BaseCommand extends BaseAction {
   /**
@@ -413,7 +413,7 @@ class CommandEsc extends BaseCommand {
     ModeName.SearchInProgressMode,
     ModeName.Replace
   ];
-  keys = ["<escape>"];
+  keys = ["<Esc>"];
 
   public async exec(position: Position, vimState: VimState): Promise<VimState> {
     if (vimState.currentMode !== ModeName.Visual &&
@@ -435,13 +435,13 @@ class CommandEsc extends BaseCommand {
 
 @RegisterAction
 class CommandCtrlOpenBracket extends CommandEsc {
-  keys = ["ctrl+["];
+  keys = ["<C-[>"];
 }
 
 @RegisterAction
 class CommandCtrlW extends BaseCommand {
   modes = [ModeName.Insert];
-  keys = ["ctrl+w"];
+  keys = ["<C-w>"];
 
   public async exec(position: Position, vimState: VimState): Promise<VimState> {
     const wordBegin = position.getWordLeft();
@@ -456,7 +456,7 @@ class CommandCtrlW extends BaseCommand {
 @RegisterAction
 class CommandCtrlE extends BaseCommand {
   modes = [ModeName.Normal];
-  keys = ["ctrl+e"];
+  keys = ["<C-e>"];
 
   public async exec(position: Position, vimState: VimState): Promise<VimState> {
     await vscode.commands.executeCommand("scrollLineDown");
@@ -468,7 +468,7 @@ class CommandCtrlE extends BaseCommand {
 @RegisterAction
 class CommandCtrlY extends BaseCommand {
   modes = [ModeName.Normal];
-  keys = ["ctrl+y"];
+  keys = ["<C-y>"];
 
   public async exec(position: Position, vimState: VimState): Promise<VimState> {
     await vscode.commands.executeCommand("scrollLineUp");
@@ -479,7 +479,7 @@ class CommandCtrlY extends BaseCommand {
 
 @RegisterAction
 class CommandCtrlC extends CommandEsc {
-  keys = ["ctrl+c"];
+  keys = ["<C-c>"];
 }
 
 @RegisterAction
@@ -520,7 +520,7 @@ class CommandReplaceInReplaceMode extends BaseCommand {
 
     const replaceState = vimState.replaceState!;
 
-    if (char === "<backspace>") {
+    if (char === "<BS>") {
       if (position.isBeforeOrEqual(replaceState.replaceCursorStartPosition)) {
         vimState.cursorPosition = position.getLeft();
         vimState.cursorStartPosition = position.getLeft();
@@ -608,7 +608,7 @@ class CommandInsertInSearchMode extends BaseCommand {
     const searchState = vimState.searchState!;
 
     // handle special keys first
-    if (key === "<backspace>") {
+    if (key === "<BS>") {
       searchState.searchString = searchState.searchString.slice(0, -1);
     } else if (key === "\n") {
       vimState.currentMode = ModeName.Normal;
@@ -625,12 +625,12 @@ class CommandInsertInSearchMode extends BaseCommand {
       vimState.searchStatePrevious = searchState;
 
       return vimState;
-    } else if (key === "<escape>") {
+    } else if (key === "<Esc>") {
       vimState.currentMode = ModeName.Normal;
       vimState.searchState = undefined;
 
       return vimState;
-    } else if (key === "ctrl+v") {
+    } else if (key === "<C-v>") {
       const text = await new Promise<string>((resolve, reject) =>
         clipboard.paste((err, text) => err ? reject(err) : resolve(text))
       );
@@ -754,7 +754,7 @@ class CommandInsertInInsertMode extends BaseCommand {
   public async exec(position: Position, vimState: VimState): Promise<VimState> {
     const char   = this.keysPressed[this.keysPressed.length - 1];
 
-    if (char === "<backspace>") {
+    if (char === "<BS>") {
       const newPosition = await TextEditor.backspace(position);
 
       vimState.cursorPosition = newPosition;
@@ -1511,7 +1511,7 @@ class CommandUndo extends BaseCommand {
 @RegisterAction
 class CommandRedo extends BaseCommand {
   modes = [ModeName.Normal];
-  keys = ["ctrl+r"];
+  keys = ["<C-r>"];
 
   public async exec(position: Position, vimState: VimState): Promise<VimState> {
     const newPosition = await vimState.historyTracker.goForwardHistoryStep();
@@ -1527,7 +1527,7 @@ class CommandRedo extends BaseCommand {
 @RegisterAction
 class CommandMoveFullPageDown extends BaseCommand {
   modes = [ModeName.Normal, ModeName.Visual, ModeName.VisualLine, ModeName.VisualBlock];
-  keys = ["ctrl+f"];
+  keys = ["<C-f>"];
 
   public async exec(position: Position, vimState: VimState): Promise<VimState> {
     await vscode.commands.executeCommand("cursorPageDown");
@@ -1538,7 +1538,7 @@ class CommandMoveFullPageDown extends BaseCommand {
 @RegisterAction
 class CommandMoveFullPageUp extends BaseCommand {
   modes = [ModeName.Normal, ModeName.Visual, ModeName.VisualLine, ModeName.VisualBlock];
-  keys = ["ctrl+b"];
+  keys = ["<C-b>"];
 
   public async exec(position: Position, vimState: VimState): Promise<VimState> {
     await vscode.commands.executeCommand("cursorPageUp");
@@ -1548,7 +1548,7 @@ class CommandMoveFullPageUp extends BaseCommand {
 
 @RegisterAction
 class CommandMoveHalfPageDown extends BaseMovement {
-  keys = ["ctrl+d"];
+  keys = ["<C-d>"];
 
   public async execAction(position: Position, vimState: VimState): Promise<Position> {
     return new Position(
@@ -1560,7 +1560,7 @@ class CommandMoveHalfPageDown extends BaseMovement {
 
 @RegisterAction
 class CommandMoveHalfPageUp extends BaseMovement {
-  keys = ["ctrl+u"];
+  keys = ["<C-u>"];
 
   public async execAction(position: Position, vimState: VimState): Promise<Position> {
     return new Position(Math.max(0, position.line - Configuration.getInstance().scroll), position.character);
@@ -1641,7 +1641,7 @@ class CommandVisualMode extends BaseCommand {
 @RegisterAction
 class CommandVisualBlockMode extends BaseCommand {
   modes = [ModeName.Normal, ModeName.Visual, ModeName.VisualBlock];
-  keys = ["ctrl+v"];
+  keys = ["<C-v>"];
 
   public async exec(position: Position, vimState: VimState): Promise<VimState> {
 
@@ -1820,7 +1820,7 @@ class MoveLeftArrow extends MoveLeft {
 @RegisterAction
 class BackSpaceInNormalMode extends BaseMovement {
   modes = [ModeName.Normal];
-  keys = ["<backspace>"];
+  keys = ["<BS>"];
 
   public async execAction(position: Position, vimState: VimState): Promise<Position> {
     return position.getLeftThroughLineBreaks();
@@ -1896,7 +1896,7 @@ class MoveRightWithSpace extends BaseMovement {
 @RegisterAction
 class MoveToRightPane extends BaseCommand {
   modes = [ModeName.Normal, ModeName.Visual, ModeName.VisualLine];
-  keys = ["ctrl+w", "l"];
+  keys = ["<C-w>", "l"];
 
   public async exec(position: Position, vimState: VimState): Promise<VimState> {
     vimState.focusChanged = true;
@@ -1908,7 +1908,7 @@ class MoveToRightPane extends BaseCommand {
 @RegisterAction
 class MoveToLeftPane  extends BaseCommand {
   modes = [ModeName.Normal, ModeName.Visual, ModeName.VisualLine];
-  keys = ["ctrl+w", "h"];
+  keys = ["<C-w>", "h"];
 
   public async exec(position: Position, vimState: VimState): Promise<VimState> {
     vimState.focusChanged = true;
@@ -2505,7 +2505,7 @@ class ActionDeleteChar extends BaseCommand {
 @RegisterAction
 class ActionDeleteCharWithDeleteKey extends BaseCommand {
   modes = [ModeName.Normal];
-  keys = ["<delete>"];
+  keys = ["<Del>"];
   canBePrefixedWithCount = true;
   canBeRepeatedWithDot = true;
 
@@ -2788,14 +2788,14 @@ class InsertInInsertVisualBlockMode extends BaseCommand {
       return vimState;
     }
 
-    if (char === '<backspace>' && vimState.topLeft.character === 0) {
+    if (char === '<BS>' && vimState.topLeft.character === 0) {
       return vimState;
     }
 
     for (const { start, end } of Position.IterateLine(vimState)) {
       const insertPos = insertAtStart ? start : end;
 
-      if (char === '<backspace>') {
+      if (char === '<BS>') {
         await TextEditor.backspace(insertPos.getLeft());
 
         posChange = -1;
@@ -3626,13 +3626,13 @@ abstract class IncrementDecrementNumberAction extends BaseCommand {
 
 @RegisterAction
 class IncrementNumberAction extends IncrementDecrementNumberAction {
-  keys = ["ctrl+a"];
+  keys = ["<C-a>"];
   offset = +1;
 }
 
 @RegisterAction
 class DecrementNumberAction extends IncrementDecrementNumberAction {
-  keys = ["ctrl+x"];
+  keys = ["<C-x>"];
   offset = -1;
 }
 

--- a/src/history/historyTracker.ts
+++ b/src/history/historyTracker.ts
@@ -139,7 +139,7 @@ class HistoryStep {
         // collapse add+del into add. this might make current.text.length === 0, see beginning of loop
         current.text = current.text.slice(0, -next.text.length);
       } else {
-        // del+add must be two separate DocumentChanges. e.g. start with "a|b", do `i<backspace>x<escape>` you end up with "|xb"
+        // del+add must be two separate DocumentChanges. e.g. start with "a|b", do `i<BS>x<Esc>` you end up with "|xb"
         // also handles multiple changes in distant locations in the document
         merged.push(current);
         current = next;

--- a/src/mode/modeHandler.ts
+++ b/src/mode/modeHandler.ts
@@ -375,7 +375,7 @@ export class RecordedState {
   public get command(): BaseCommand {
     const list = _.filter(this.actionsRun, a => a instanceof BaseCommand);
 
-    // TODO - disregard <escape>, then assert this is of length 1.
+    // TODO - disregard <Esc>, then assert this is of length 1.
 
     return list[0] as any;
   }
@@ -625,16 +625,6 @@ export class ModeHandler implements vscode.Disposable {
   }
 
   async handleKeyEvent(key: string): Promise<Boolean> {
-    if (key === "<c-r>") { key = "ctrl+r"; } // TODO - temporary hack for tests only!
-    if (key === "<c-a>") { key = "ctrl+a"; } // TODO - temporary hack for tests only!
-    if (key === "<c-x>") { key = "ctrl+x"; } // TODO - temporary hack for tests only!
-
-    if (key === "<esc>") { key = "<escape>"; }
-
-    // Due to a limitation in Electron, en-US QWERTY char codes are used in international keyboards.
-    // We'll try to mitigate this problem until it's fixed upstream.
-    // https://github.com/Microsoft/vscode/issues/713
-
     this._vimState.cursorPositionJustBeforeAnythingHappened = this._vimState.cursorPosition;
 
     try {

--- a/src/mode/remapper.ts
+++ b/src/mode/remapper.ts
@@ -1,6 +1,6 @@
 import * as vscode from 'vscode';
 import * as _ from 'lodash';
-
+import * as util from '../util';
 import { ModeName } from './mode';
 import { ModeHandler, VimState } from './modeHandler';
 
@@ -11,18 +11,29 @@ interface IKeybinding {
 
 class Remapper {
   private _mostRecentKeys: string[] = [];
-
   private _remappings: IKeybinding[] = [];
-
   private _remappedModes: ModeName[];
-
   private _recursive: boolean;
 
   constructor(configKey: string, remappedModes: ModeName[], recursive: boolean) {
     this._recursive = recursive;
     this._remappedModes = remappedModes;
-    this._remappings = vscode.workspace.getConfiguration('vim')
+
+    let remappings = vscode.workspace.getConfiguration('vim')
       .get<IKeybinding[]>(configKey, []);
+
+    for (let remapping of remappings) {
+      let before: string[] = [];
+      remapping.before.forEach(item => before.push(util.translateToAngleBracketNotation(item)));
+
+      let after: string[] = [];
+      remapping.after.forEach(item => after.push(util.translateToAngleBracketNotation(item)));
+
+      this._remappings.push(<IKeybinding> {
+        before: before,
+        after: after,
+      });
+    }
   }
 
   private _longestKeySequence(): number {

--- a/src/util.ts
+++ b/src/util.ts
@@ -9,3 +9,21 @@ export async function showInfo(message : string): Promise<{}> {
 export async function showError(message : string): Promise<{}> {
   return vscode.window.showErrorMessage("Vim: " + message);
 }
+
+export function translateToAngleBracketNotation(key: string): string {
+    const angleBracketNotationMap = {
+      'ctrl+' : 'C-',
+      'escape': 'Esc',
+      'backspace': 'BS',
+      'delete': 'Del',
+    };
+
+    let bracketedKey = `<${ key.toLowerCase() }>`;
+    for (const searchKey in angleBracketNotationMap) {
+      if (angleBracketNotationMap.hasOwnProperty(searchKey)) {
+        bracketedKey = bracketedKey.replace(searchKey, angleBracketNotationMap[searchKey]);
+      }
+    }
+
+    return bracketedKey;
+}

--- a/test/cmd_line/substitute.test.ts
+++ b/test/cmd_line/substitute.test.ts
@@ -15,7 +15,7 @@ suite("Basic substitute", () => {
   teardown(cleanUpWorkspace);
 
   test("Replace single word once", async () => {
-    await modeHandler.handleMultipleKeyEvents(['i', 'a', 'b', 'a', '<escape>']);
+    await modeHandler.handleMultipleKeyEvents(['i', 'a', 'b', 'a', '<Esc>']);
     await runCmdLine("%s/a/d", modeHandler);
 
     assertEqualLines([
@@ -24,7 +24,7 @@ suite("Basic substitute", () => {
   });
 
   test("Replace with `g` flag", async () => {
-    await modeHandler.handleMultipleKeyEvents(['i', 'a', 'b', 'a', '<escape>']);
+    await modeHandler.handleMultipleKeyEvents(['i', 'a', 'b', 'a', '<Esc>']);
     await runCmdLine("%s/a/d/g", modeHandler);
 
     assertEqualLines([
@@ -33,7 +33,7 @@ suite("Basic substitute", () => {
   });
 
   test("Replace multiple lines", async () => {
-    await modeHandler.handleMultipleKeyEvents(['i', 'a', 'b', 'a', '<escape>', 'o', 'a', 'b']);
+    await modeHandler.handleMultipleKeyEvents(['i', 'a', 'b', 'a', '<Esc>', 'o', 'a', 'b']);
     await runCmdLine("%s/a/d/g", modeHandler);
 
     assertEqualLines([
@@ -43,7 +43,7 @@ suite("Basic substitute", () => {
   });
 
   test("Replace across specific lines", async () => {
-    await modeHandler.handleMultipleKeyEvents(['i', 'a', 'b', 'a', '<escape>', 'o', 'a', 'b']);
+    await modeHandler.handleMultipleKeyEvents(['i', 'a', 'b', 'a', '<Esc>', 'o', 'a', 'b']);
     await runCmdLine("1,1s/a/d/g", modeHandler);
 
     assertEqualLines([
@@ -53,7 +53,7 @@ suite("Basic substitute", () => {
   });
 
   test("Replace current line with no active selection", async () => {
-    await modeHandler.handleMultipleKeyEvents(['i', 'a', 'b', 'a', '<escape>', 'o', 'a', 'b', '<escape>']);
+    await modeHandler.handleMultipleKeyEvents(['i', 'a', 'b', 'a', '<Esc>', 'o', 'a', 'b', '<Esc>']);
     await runCmdLine("s/a/d/g", modeHandler);
 
     assertEqualLines([
@@ -63,7 +63,7 @@ suite("Basic substitute", () => {
   });
 
   test("Replace text in selection", async () => {
-    await modeHandler.handleMultipleKeyEvents(['i', 'a', 'b', 'a', '<escape>', 'o', 'a', 'b', '<escape>', '$', 'v', 'k', '0']);
+    await modeHandler.handleMultipleKeyEvents(['i', 'a', 'b', 'a', '<Esc>', 'o', 'a', 'b', '<Esc>', '$', 'v', 'k', '0']);
     await runCmdLine("'<,'>s/a/d/g", modeHandler);
 
     assertEqualLines([

--- a/test/cmd_line/writequit.test.ts
+++ b/test/cmd_line/writequit.test.ts
@@ -51,7 +51,7 @@ suite("Basic write-quit", () => {
   teardown(cleanUpWorkspace);
 
   test("Run write and quit", async () => {
-    await modeHandler.handleMultipleKeyEvents(['i', 'a', 'b', 'a', '<escape>']);
+    await modeHandler.handleMultipleKeyEvents(['i', 'a', 'b', 'a', '<Esc>']);
 
     await runCmdLine("wq", modeHandler);
     await WaitForVsCodeClose();

--- a/test/mode/modeInsert.test.ts
+++ b/test/mode/modeInsert.test.ts
@@ -23,7 +23,7 @@ suite("Mode Insert", () => {
             await modeHandler.handleKeyEvent(key);
             assertEqual(modeHandler.currentMode.name, ModeName.Insert);
 
-            await modeHandler.handleKeyEvent('<escape>');
+            await modeHandler.handleKeyEvent('<Esc>');
         }
     });
 
@@ -33,21 +33,21 @@ suite("Mode Insert", () => {
         return assertEqualLines(["!"]);
     });
 
-    test("<escape> should change cursor position", async () => {
+    test("<Esc> should change cursor position", async () => {
         await modeHandler.handleMultipleKeyEvents([
             'i',
             'h', 'e', 'l', 'l', 'o',
-            '<escape>'
+            '<Esc>'
         ]);
 
-        assertEqual(TextEditor.getSelection().start.character, 4, "<escape> moved cursor position.");
+        assertEqual(TextEditor.getSelection().start.character, 4, "<Esc> moved cursor position.");
     });
 
-    test("Can handle 'o'", async () => {
+    test("", async () => {
         await modeHandler.handleMultipleKeyEvents([
             'i',
             't', 'e', 'x', 't',
-            '<escape>',
+            '<Esc>',
             'o'
         ]);
 
@@ -58,7 +58,7 @@ suite("Mode Insert", () => {
         await modeHandler.handleMultipleKeyEvents([
             'i',
             't', 'e', 'x', 't',
-            '<escape>',
+            '<Esc>',
             'O'
         ]);
 
@@ -69,7 +69,7 @@ suite("Mode Insert", () => {
         await modeHandler.handleMultipleKeyEvents([
             'i',
             't', 'e', 'x', 't', 't', 'e', 'x', 't', // insert 'texttext'
-            '<escape>',
+            '<Esc>',
             '^', 'l', 'l', 'l', 'l',                // move to the 4th character
             'i',
             '!'                                     // insert a !
@@ -82,7 +82,7 @@ suite("Mode Insert", () => {
         await modeHandler.handleMultipleKeyEvents([
             'i',
             't', 'e', 'x', 't',
-            '<escape>',
+            '<Esc>',
             '^', 'l', 'l', 'l',
             'I',
             '!',
@@ -95,7 +95,7 @@ suite("Mode Insert", () => {
         await modeHandler.handleMultipleKeyEvents([
             'i',
             't', 'e', 'x', 't', 't', 'e', 'x', 't', // insert 'texttext'
-            '<escape>',
+            '<Esc>',
             '^', 'l', 'l', 'l', 'l',                // move to the 4th character
             'a',
             '!'                                     // append a !
@@ -108,7 +108,7 @@ suite("Mode Insert", () => {
         await modeHandler.handleMultipleKeyEvents([
             'i',
             't', 'e', 'x', 't',
-            '<escape>',
+            '<Esc>',
             '^',
             'A',
             '!',
@@ -117,11 +117,11 @@ suite("Mode Insert", () => {
         assertEqualLines(["text!"]);
     });
 
-    test("Can handle 'ctrl+w'", async () => {
+    test("Can handle '<C-w>'", async () => {
         await modeHandler.handleMultipleKeyEvents([
             'i',
             't', 'e', 'x', 't', ' ', 't', 'e', 'x', 't',
-            'ctrl+w',
+            '<C-w>',
         ]);
 
         assertEqualLines(["text "]);
@@ -132,11 +132,11 @@ suite("Mode Insert", () => {
             'i',
             'o', 'n', 'e', '\n', 't', 'w', 'o',
             '<left>', '<left>', '<left>',
-            '<backspace>'
+            '<BS>'
         ]);
 
         assertEqualLines(["onetwo"]);
 
-        assertEqual(TextEditor.getSelection().start.character, 3, "<backspace> moved cursor to correct position");
+        assertEqual(TextEditor.getSelection().start.character, 3, "<BS> moved cursor to correct position");
     });
 });

--- a/test/mode/modeNormal.test.ts
+++ b/test/mode/modeNormal.test.ts
@@ -21,7 +21,7 @@ suite("Mode Normal", () => {
     teardown(cleanUpWorkspace);
 
     test("can be activated", async () => {
-        let activationKeys = ['<escape>', 'ctrl+['];
+        let activationKeys = ['<Esc>', '<C-[>'];
 
         for (let key of activationKeys) {
             await modeHandler.handleKeyEvent('i');
@@ -766,21 +766,21 @@ suite("Mode Normal", () => {
     newTest({
       title: "Can handle backspace",
       start: ['text |text'],
-      keysPressed: '<backspace><backspace>',
+      keysPressed: '<BS><BS>',
       end: ['tex|t text']
     });
 
     newTest({
       title: "Can handle backspace across lines",
       start: ['one', '|two'],
-      keysPressed: '<backspace><backspace>',
+      keysPressed: '<BS><BS>',
       end: ['o|ne', 'two']
     });
 
     newTest({
       title: "Can handle A and backspace",
       start: ['|text text'],
-      keysPressed: 'A<backspace><escape>',
+      keysPressed: 'A<BS><Esc>',
       end: ['text te|x']
     });
 
@@ -935,14 +935,14 @@ suite("Mode Normal", () => {
     newTest({
       title: "I works correctly",
       start: ['|    one'],
-      keysPressed: 'Itest <escape>',
+      keysPressed: 'Itest <Esc>',
       end: ['    test| one']
     });
 
     newTest({
       title: "gI works correctly",
       start: ['|    one'],
-      keysPressed: 'gItest<escape>',
+      keysPressed: 'gItest<Esc>',
       end: ['tes|t    one']
     });
 
@@ -963,63 +963,63 @@ suite("Mode Normal", () => {
     newTest({
       title: "Undo 1",
       start: ['|'],
-      keysPressed: 'iabc<escape>adef<escape>uu',
+      keysPressed: 'iabc<Esc>adef<Esc>uu',
       end: ['|']
     });
 
     newTest({
       title: "Undo 2",
       start: ['|'],
-      keysPressed: 'iabc<escape>adef<escape>u',
+      keysPressed: 'iabc<Esc>adef<Esc>u',
       end: ['ab|c']
     });
 
     newTest({
       title: "Undo cursor",
       start: ['|'],
-      keysPressed: 'Iabc<escape>Idef<escape>Ighi<escape>uuu',
+      keysPressed: 'Iabc<Esc>Idef<Esc>Ighi<Esc>uuu',
       end: ['|']
     });
 
     newTest({
       title: "Undo cursor 2",
       start: ['|'],
-      keysPressed: 'Iabc<escape>Idef<escape>Ighi<escape>uu',
+      keysPressed: 'Iabc<Esc>Idef<Esc>Ighi<Esc>uu',
       end: ['|abc']
     });
 
     newTest({
       title: "Undo cursor 3",
       start: ['|'],
-      keysPressed: 'Iabc<escape>Idef<escape>Ighi<escape>u',
+      keysPressed: 'Iabc<Esc>Idef<Esc>Ighi<Esc>u',
       end: ['|defabc']
     });
 
     newTest({
       title: "Undo with movement first",
       start: ['|'],
-      keysPressed: 'iabc<escape>adef<escape>hlhlu',
+      keysPressed: 'iabc<Esc>adef<Esc>hlhlu',
       end: ['ab|c']
     });
 
     newTest({
       title: "Redo",
       start: ['|'],
-      keysPressed: 'iabc<escape>adef<escape>uu<c-r>',
+      keysPressed: 'iabc<Esc>adef<Esc>uu<C-r>',
       end: ['|abc']
     });
 
     newTest({
       title: "Redo",
       start: ['|'],
-      keysPressed: 'iabc<escape>adef<escape>uu<c-r><c-r>',
+      keysPressed: 'iabc<Esc>adef<Esc>uu<C-r><C-r>',
       end: ['abc|def']
     });
 
     newTest({
       title: "Redo",
       start: ['|'],
-      keysPressed: 'iabc<escape>adef<escape>uuhlhl<c-r><c-r>',
+      keysPressed: 'iabc<Esc>adef<Esc>uuhlhl<C-r><C-r>',
       end: ['abc|def']
     });
 
@@ -1054,7 +1054,7 @@ suite("Mode Normal", () => {
     newTest({
       title: "can handle s in visual mode",
       start: ["|abc def ghi"],
-      keysPressed: "vwshi <escape>",
+      keysPressed: "vwshi <Esc>",
       end: ["hi| ef ghi"]
     });
 
@@ -1082,7 +1082,7 @@ suite("Mode Normal", () => {
     newTest({
       title: "can repeat backspace twice",
       start: ["|11223344"],
-      keysPressed: "A<backspace><backspace><escape>0.",
+      keysPressed: "A<BS><BS><Esc>0.",
       end: ["112|2"]
     });
 
@@ -1117,56 +1117,56 @@ suite("Mode Normal", () => {
     newTest({
       title: "can ctrl-a correctly behind a word",
       start: ["|one 9"],
-      keysPressed: "<c-a>",
+      keysPressed: "<C-a>",
       end: ["one 1|0"]
     });
 
     newTest({
       title: "can ctrl-a on word",
       start: ["one -|11"],
-      keysPressed: "<c-a>",
+      keysPressed: "<C-a>",
       end: ["one -1|0"]
     });
 
     newTest({
       title: "can ctrl-a on a hex number",
       start: ["|0xf"],
-      keysPressed: "<c-a>",
+      keysPressed: "<C-a>",
       end: ["0x1|0"]
     });
 
     newTest({
       title: "can ctrl-a on decimal",
       start: ["1|1.123"],
-      keysPressed: "<c-a>",
+      keysPressed: "<C-a>",
       end: ["1|2.123"]
     });
 
     newTest({
       title: "can ctrl-a with numeric prefix",
       start: ["|-10"],
-      keysPressed: "15<c-a>",
+      keysPressed: "15<C-a>",
       end: ["|5"]
     });
 
     newTest({
       title: "can ctrl-a on a decimal",
       start: ["-10.|1"],
-      keysPressed: "10<c-a>",
+      keysPressed: "10<C-a>",
       end: ["-10.1|1"]
     });
 
     newTest({
       title: "can ctrl-a on an octal ",
       start: ["07|"],
-      keysPressed: "<c-a>",
+      keysPressed: "<C-a>",
       end: ["01|0"]
     });
 
     newTest({
       title: "can ctrl-x correctly behind a word",
       start: ["|one 10"],
-      keysPressed: "<c-x>",
+      keysPressed: "<C-x>",
       end: ["one |9"]
     });
 

--- a/test/mode/modeReplace.test.ts
+++ b/test/mode/modeReplace.test.ts
@@ -43,42 +43,42 @@ suite("Mode Replace", () => {
     newTest({
       title: "Can handle backspace",
       start: ['123|456'],
-      keysPressed: 'Rabc<backspace><backspace><backspace>',
+      keysPressed: 'Rabc<BS><BS><BS>',
       end: ["123|456"]
     });
 
     newTest({
       title: "Can handle backspace",
       start: ['123|456'],
-      keysPressed: 'Rabcd<backspace><backspace><backspace><backspace><backspace>',
+      keysPressed: 'Rabcd<BS><BS><BS><BS><BS>',
       end: ["12|3456"]
     });
 
     newTest({
       title: "Can handle backspace across lines",
       start: ['123|456'],
-      keysPressed: 'Rabcd\nef<backspace><backspace><backspace><backspace><backspace>',
+      keysPressed: 'Rabcd\nef<BS><BS><BS><BS><BS>',
       end: ["123ab|6"]
     });
 
     newTest({
       title: "Can handle arrows",
       start: ['123|456'],
-      keysPressed: 'Rabc<left><backspace><backspace>',
+      keysPressed: 'Rabc<left><BS><BS>',
       end: ["123|abc"]
     });
 
     newTest({
       title: "Can handle .",
       start: ['123|456', '123456'],
-      keysPressed: 'Rabc<escape>j0.',
+      keysPressed: 'Rabc<Esc>j0.',
       end: ["123abc", "ab|c456"]
     });
 
     newTest({
       title: "Can handle . across lines",
       start: ['123|456', '123456'],
-      keysPressed: 'Rabc\ndef<escape>j0.',
+      keysPressed: 'Rabc\ndef<Esc>j0.',
       end: ["123abc", "def", "abc", "de|f"]
     });
 });

--- a/test/mode/modeVisual.test.ts
+++ b/test/mode/modeVisual.test.ts
@@ -32,7 +32,7 @@ suite("Mode Visual", () => {
   test("Can handle w", async () => {
     await modeHandler.handleMultipleKeyEvents("itest test test\ntest\n".split(""));
     await modeHandler.handleMultipleKeyEvents([
-      '<escape>', 'g', 'g',
+      '<Esc>', 'g', 'g',
       'v', 'w'
     ]);
 
@@ -50,7 +50,7 @@ suite("Mode Visual", () => {
   test("Can handle wd", async () => {
     await modeHandler.handleMultipleKeyEvents("ione two three".split(""));
     await modeHandler.handleMultipleKeyEvents([
-      '<escape>', '^',
+      '<Esc>', '^',
       'v', 'w', 'd'
     ]);
 
@@ -60,7 +60,7 @@ suite("Mode Visual", () => {
   test("Can handle x", async () => {
     await modeHandler.handleMultipleKeyEvents("ione two three".split(""));
     await modeHandler.handleMultipleKeyEvents([
-      '<escape>', '^',
+      '<Esc>', '^',
       'v', 'x'
     ]);
 
@@ -72,7 +72,7 @@ suite("Mode Visual", () => {
   test("Can handle x across a selection", async () => {
     await modeHandler.handleMultipleKeyEvents("ione two three".split(""));
     await modeHandler.handleMultipleKeyEvents([
-      '<escape>', '^',
+      '<Esc>', '^',
       'v', 'w', 'x'
     ]);
 
@@ -84,7 +84,7 @@ suite("Mode Visual", () => {
   test("Can do vwd in middle of sentence", async () => {
     await modeHandler.handleMultipleKeyEvents("ione two three foar".split(""));
     await modeHandler.handleMultipleKeyEvents([
-      '<escape>', '^',
+      '<Esc>', '^',
       'l', 'l', 'l', 'l',
       'v', 'w', 'd'
     ]);
@@ -95,7 +95,7 @@ suite("Mode Visual", () => {
   test("Can do vwd in middle of sentence", async () => {
     await modeHandler.handleMultipleKeyEvents("ione two three".split(""));
     await modeHandler.handleMultipleKeyEvents([
-      '<escape>', '^',
+      '<Esc>', '^',
       'l', 'l', 'l', 'l',
       'v', 'w', 'd'
     ]);
@@ -106,7 +106,7 @@ suite("Mode Visual", () => {
   test("Can do vwd multiple times", async () => {
     await modeHandler.handleMultipleKeyEvents("ione two three four".split(""));
     await modeHandler.handleMultipleKeyEvents([
-      '<escape>', '^',
+      '<Esc>', '^',
       'v', 'w', 'd',
       'v', 'w', 'd',
       'v', 'w', 'd'
@@ -118,7 +118,7 @@ suite("Mode Visual", () => {
   test("handles case where we go from selecting on right side to selecting on left side", async () => {
     await modeHandler.handleMultipleKeyEvents("ione two three".split(""));
     await modeHandler.handleMultipleKeyEvents([
-      '<escape>', '^',
+      '<Esc>', '^',
       'l', 'l', 'l', 'l',
       'v', 'w', 'b', 'b', 'd'
     ]);
@@ -129,7 +129,7 @@ suite("Mode Visual", () => {
   test("handles case where we delete over a newline", async () => {
     await modeHandler.handleMultipleKeyEvents("ione two\n\nthree four".split(""));
     await modeHandler.handleMultipleKeyEvents([
-      '<escape>', '0', 'k', 'k',
+      '<Esc>', '0', 'k', 'k',
       'v', '}', 'd'
     ]);
 
@@ -139,7 +139,7 @@ suite("Mode Visual", () => {
   test("handles change operator", async () => {
     await modeHandler.handleMultipleKeyEvents("ione two three".split(""));
     await modeHandler.handleMultipleKeyEvents([
-      '<escape>', '^',
+      '<Esc>', '^',
       'v', 'w', 'c'
     ]);
 
@@ -155,7 +155,7 @@ suite("Mode Visual", () => {
       );
 
       await modeHandler.handleMultipleKeyEvents([
-        '<escape>',
+        '<Esc>',
         '^', 'g', 'g',
         'v', 'l', 'l', 'l',
         'd'
@@ -170,7 +170,7 @@ suite("Mode Visual", () => {
       );
 
       await modeHandler.handleMultipleKeyEvents([
-        '<escape>',
+        '<Esc>',
         'g', 'g',
         'l', 'v', 'l', 'l',
         'd'
@@ -185,7 +185,7 @@ suite("Mode Visual", () => {
       );
 
       await modeHandler.handleMultipleKeyEvents([
-        '<escape>',
+        '<Esc>',
         'g', 'g',
         'd', '$'
       ]);
@@ -199,7 +199,7 @@ suite("Mode Visual", () => {
       );
 
       await modeHandler.handleMultipleKeyEvents([
-        '<escape>',
+        '<Esc>',
         'g', 'g',
         'v', '$', 'd'
       ]);

--- a/test/mode/modeVisualLine.test.ts
+++ b/test/mode/modeVisualLine.test.ts
@@ -27,7 +27,7 @@ suite("Mode Visual", () => {
   test("Can handle w", async () => {
     await modeHandler.handleMultipleKeyEvents("itest test test\ntest\n".split(""));
     await modeHandler.handleMultipleKeyEvents([
-      '<escape>', 'g', 'g',
+      '<Esc>', 'g', 'g',
       'v', 'w'
     ]);
 
@@ -45,7 +45,7 @@ suite("Mode Visual", () => {
   test("Can handle wd", async () => {
     await modeHandler.handleMultipleKeyEvents("ione two three".split(""));
     await modeHandler.handleMultipleKeyEvents([
-      '<escape>', '^',
+      '<Esc>', '^',
       'v', 'w', 'd'
     ]);
 
@@ -55,7 +55,7 @@ suite("Mode Visual", () => {
   test("Can handle x", async () => {
     await modeHandler.handleMultipleKeyEvents("ione two three".split(""));
     await modeHandler.handleMultipleKeyEvents([
-      '<escape>', '^',
+      '<Esc>', '^',
       'v', 'x'
     ]);
 
@@ -67,7 +67,7 @@ suite("Mode Visual", () => {
   test("Can handle U", async () => {
     await modeHandler.handleMultipleKeyEvents("ione two three".split(""));
     await modeHandler.handleMultipleKeyEvents([
-       '<escape>', '^',
+       '<Esc>', '^',
       'v', 'U'
     ]);
 
@@ -79,7 +79,7 @@ suite("Mode Visual", () => {
   test("Can handle x across a selection", async () => {
     await modeHandler.handleMultipleKeyEvents("ione two three".split(""));
     await modeHandler.handleMultipleKeyEvents([
-      '<escape>', '^',
+      '<Esc>', '^',
       'v', 'w', 'x'
     ]);
 
@@ -91,7 +91,7 @@ suite("Mode Visual", () => {
   test("Can do vwd in middle of sentence", async () => {
     await modeHandler.handleMultipleKeyEvents("ione two three foar".split(""));
     await modeHandler.handleMultipleKeyEvents([
-      '<escape>', '^',
+      '<Esc>', '^',
       'l', 'l', 'l', 'l',
       'v', 'w', 'd'
     ]);
@@ -102,7 +102,7 @@ suite("Mode Visual", () => {
   test("Can do vwd in middle of sentence", async () => {
     await modeHandler.handleMultipleKeyEvents("ione two three".split(""));
     await modeHandler.handleMultipleKeyEvents([
-      '<escape>', '^',
+      '<Esc>', '^',
       'l', 'l', 'l', 'l',
       'v', 'w', 'd'
     ]);
@@ -113,7 +113,7 @@ suite("Mode Visual", () => {
   test("Can do vwd multiple times", async () => {
     await modeHandler.handleMultipleKeyEvents("ione two three four".split(""));
     await modeHandler.handleMultipleKeyEvents([
-      '<escape>', '^',
+      '<Esc>', '^',
       'v', 'w', 'd',
       'v', 'w', 'd',
       'v', 'w', 'd'
@@ -125,7 +125,7 @@ suite("Mode Visual", () => {
   test("Can handle U across a selection", async () => {
     await modeHandler.handleMultipleKeyEvents("ione two three".split(""));
     await modeHandler.handleMultipleKeyEvents([
-      '<escape>', '^',
+      '<Esc>', '^',
       'v', 'l', 'l', 'l', 'l', 'U'
     ]);
 
@@ -137,7 +137,7 @@ suite("Mode Visual", () => {
   test("Can handle U across a selection in reverse order", async () => {
     await modeHandler.handleMultipleKeyEvents("ione two three".split(""));
     await modeHandler.handleMultipleKeyEvents([
-      '<escape>', '^',
+      '<Esc>', '^',
       'w', 'v', 'h', 'h', 'U'
     ]);
 
@@ -149,7 +149,7 @@ suite("Mode Visual", () => {
   test("handles case where we go from selecting on right side to selecting on left side", async () => {
     await modeHandler.handleMultipleKeyEvents("ione two three".split(""));
     await modeHandler.handleMultipleKeyEvents([
-      '<escape>', '^',
+      '<Esc>', '^',
       'l', 'l', 'l', 'l',
       'v', 'w', 'b', 'b', 'd'
     ]);
@@ -160,7 +160,7 @@ suite("Mode Visual", () => {
   test("handles case where we delete over a newline", async () => {
     await modeHandler.handleMultipleKeyEvents("ione two\n\nthree four".split(""));
     await modeHandler.handleMultipleKeyEvents([
-      '<escape>', '0', 'k', 'k',
+      '<Esc>', '0', 'k', 'k',
       'v', '}', 'd'
     ]);
 
@@ -170,7 +170,7 @@ suite("Mode Visual", () => {
   test("handles change operator", async () => {
     await modeHandler.handleMultipleKeyEvents("ione two three".split(""));
     await modeHandler.handleMultipleKeyEvents([
-      '<escape>', '^',
+      '<Esc>', '^',
       'v', 'w', 'c'
     ]);
 
@@ -186,7 +186,7 @@ suite("Mode Visual", () => {
       );
 
       await modeHandler.handleMultipleKeyEvents([
-        '<escape>',
+        '<Esc>',
         '^', 'g', 'g',
         'v', 'l', 'l', 'l',
         'd'
@@ -201,7 +201,7 @@ suite("Mode Visual", () => {
       );
 
       await modeHandler.handleMultipleKeyEvents([
-        '<escape>',
+        '<Esc>',
         'g', 'g',
         'l', 'v', 'l', 'l',
         'd'
@@ -216,7 +216,7 @@ suite("Mode Visual", () => {
       );
 
       await modeHandler.handleMultipleKeyEvents([
-        '<escape>',
+        '<Esc>',
         'g', 'g',
         'd', '$'
       ]);
@@ -230,7 +230,7 @@ suite("Mode Visual", () => {
       );
 
       await modeHandler.handleMultipleKeyEvents([
-        '<escape>',
+        '<Esc>',
         'g', 'g',
         'v', '$', 'd'
       ]);

--- a/test/mode/normalModeTests/commands.test.ts
+++ b/test/mode/normalModeTests/commands.test.ts
@@ -40,44 +40,44 @@ suite("Mode Normal", () => {
     });
 
     newTest({
-      title: "Can handle '<delete>'",
+      title: "Can handle '<Del>'",
       start: ['te|xt'],
-      keysPressed: '<delete>',
+      keysPressed: '<Del>',
       end: ["te|t"],
     });
 
     newTest({
-      title: "Can handle 'N<delete>', which should be a no-op",
+      title: "Can handle 'N<Del>', which should be a no-op",
       start: ['te|xt'],
-      keysPressed: '2<delete>',
+      keysPressed: '2<Del>',
       end: ["te|xt"],
     });
 
     newTest({
-      title: "Can handle '<delete>' at end of line",
+      title: "Can handle '<Del>' at end of line",
       start: ['one tw|o'],
-      keysPressed: '^ll<delete><delete><delete><delete><delete><delete><delete><delete><delete>',
+      keysPressed: '^ll<Del><Del><Del><Del><Del><Del><Del><Del><Del>',
       end: ['|'],
     });
 
     newTest({
       title: "Can handle 'cc'",
       start: ['one', '|one two', 'three'],
-      keysPressed: 'cca<escape>',
+      keysPressed: 'cca<Esc>',
       end: ["one", "|a", "three"],
     });
 
     newTest({
       title: "Can handle 'Ncc'",
       start: ['one', '|one two', 'three four', 'five'],
-      keysPressed: '2cca<escape>',
+      keysPressed: '2cca<Esc>',
       end: ["one", "|a", "five"]
     });
 
     newTest({
       title: "Can handle 'yy'",
       start: ['|one'],
-      keysPressed: 'yyO<escape>p',
+      keysPressed: 'yyO<Esc>p',
       end: ["", "|one", "one"],
     });
 
@@ -203,9 +203,9 @@ suite("Mode Normal", () => {
     });
 
     newTest({
-      title: "Can handle '<backspace>' in insert mode",
+      title: "Can handle '<BS>' in insert mode",
       start: ['one', '|'],
-      keysPressed: 'i<backspace><escape>',
+      keysPressed: 'i<BS><Esc>',
       end: ['on|e']
     });
 

--- a/test/mode/normalModeTests/dot.test.ts
+++ b/test/mode/normalModeTests/dot.test.ts
@@ -42,14 +42,14 @@ suite("Dot Operator", () => {
     newTest({
       title: "Can handle dot with A",
       start: ['|one', 'two', 'three'],
-      keysPressed: 'A!<escape>j.j.',
+      keysPressed: 'A!<Esc>j.j.',
       end: ['one!', 'two!', 'three|!']
     });
 
     newTest({
       title: "Can handle dot with I",
       start: ['on|e', 'two', 'three'],
-      keysPressed: 'I!<escape>j.j.',
+      keysPressed: 'I!<Esc>j.j.',
       end: ['!one', '!two', '|!three']
     });
 

--- a/test/mode/normalModeTests/motions.test.ts
+++ b/test/mode/normalModeTests/motions.test.ts
@@ -8,7 +8,8 @@ suite("Motions in Normal Mode", () => {
   let modeHandler: ModeHandler = new ModeHandler();
 
   let {
-    newTest
+    newTest,
+    newTestOnly,
   } = getTestingFunctions(modeHandler);
 
   setup(async () => {
@@ -342,14 +343,14 @@ suite("Motions in Normal Mode", () => {
   newTest({
     title: "Can handle dot with A",
     start: ['|one', 'two', 'three'],
-    keysPressed: 'A!<escape>j.j.',
+    keysPressed: 'A!<Esc>j.j.',
     end: ['one!', 'two!', 'three|!']
   });
 
   newTest({
     title: "Can handle dot with I",
     start: ['on|e', 'two', 'three'],
-    keysPressed: 'I!<escape>j.j.',
+    keysPressed: 'I!<Esc>j.j.',
     end: ['!one', '!two', '|!three']
   });
 

--- a/test/operator/put.test.ts
+++ b/test/operator/put.test.ts
@@ -21,7 +21,7 @@ suite("put operator", () => {
     );
 
     await modeHandler.handleMultipleKeyEvents([
-      '<escape>',
+      '<Esc>',
       '^', 'D', 'p', 'p'
     ]);
 
@@ -34,7 +34,7 @@ suite("put operator", () => {
     );
 
     await modeHandler.handleMultipleKeyEvents([
-      '<escape>',
+      '<Esc>',
       '^', 'y', 'y', 'p'
     ]);
 
@@ -47,7 +47,7 @@ suite("put operator", () => {
     );
 
     await modeHandler.handleMultipleKeyEvents([
-      '<escape>',
+      '<Esc>',
       'g', 'g', 'y', 'y', 'p'
     ]);
 
@@ -60,7 +60,7 @@ suite("put operator", () => {
     );
 
     await modeHandler.handleMultipleKeyEvents([
-      '<escape>',
+      '<Esc>',
       'k', 'y', 'y', 'p'
     ]);
 

--- a/test/testSimplifier.ts
+++ b/test/testSimplifier.ts
@@ -146,7 +146,7 @@ class TestObjectHelper {
 }
 
 /**
- * Tokenize a string like "abc<escape>d<c-c>" into ["a", "b", "c", "<escape>", "d", "<c-c>"]
+ * Tokenize a string like "abc<Esc>d<C-c>" into ["a", "b", "c", "<Esc>", "d", "<C-c>"]
  */
 function tokenizeKeySequence(sequence: string): string[] {
   let isBracketedKey = false;
@@ -181,7 +181,7 @@ async function testIt(modeHandler: ModeHandler, testObj: ITestObject): Promise<v
   // Don't try this at home, kids.
   (modeHandler as any)._vimState.cursorPosition = new Position(0, 0);
 
-  await modeHandler.handleKeyEvent('<escape>');
+  await modeHandler.handleKeyEvent('<Esc>');
 
   // start:
   //
@@ -189,7 +189,7 @@ async function testIt(modeHandler: ModeHandler, testObj: ITestObject): Promise<v
 
   // keysPressed:
   //
-  await modeHandler.handleKeyEvent('<escape>');
+  await modeHandler.handleKeyEvent('<Esc>');
   // move cursor to start position using 'hjkl'
   await modeHandler.handleMultipleKeyEvents(helper.getKeyPressesToMoveToStartPosition());
 


### PR DESCRIPTION
Easing myself back into the project after a short hiatus with this simple change. 

Update: Translating key presses to Vim's angle bracket notation:

`ctrl+*` becomes `<C-*>`
`escape` becomes `<Esc>`
`backspace` becomes `<BS>`
`delete` becomes `<Del>`