### PR TITLE
Fix error when <BS> at beginning of document

### DIFF
--- a/src/motion/position.ts
+++ b/src/motion/position.ts
@@ -191,8 +191,7 @@ export class Position extends vscode.Position {
       return this.getLeft();
     }
 
-    return new Position(this.line - 1, 0)
-      .getLineEnd();
+    return this.getUp(0).getLineEnd();
   }
 
   public getRightThroughLineBreaks(): Position {


### PR DESCRIPTION
Fix crash when `<BS>` at beginning of document as it tries to move to a position that doesn't exist.

