### PR TITLE
fix quote match issue in visual mode

### DIFF
--- a/src/actions/actions.ts
+++ b/src/actions/actions.ts
@@ -3412,6 +3412,13 @@ abstract class MoveQuoteMatch extends BaseMovement {
 
     let startPos = new Position(position.line, start);
     let endPos = new Position(position.line, end);
+    let fullAction = vimState.currentFullAction;
+    let fullActionLength = fullAction.length;
+    if (fullAction[fullActionLength - 3] === "v"
+        && fullAction[fullActionLength - 2] === "i"
+        && ["\"", "'", "`"].indexOf(fullAction[fullActionLength - 1]) > -1) {
+      endPos = new Position(position.line, end + 1);
+    }
     if (!this.includeSurrounding) {
       startPos = startPos.getRight();
       endPos = endPos.getLeft();


### PR DESCRIPTION
- [x] Commit message has a short title & issue references
- [x] Each commit does a logical chunk of work.  
- [x] It builds and tests pass (e.g `gulp tslint`)

this PR should fix a trivial issue that when using `cmd+x` on OSX or `ctrl+x` on Windows after matching quotes like `"`, `'` and quasiquote.

before

![before](https://cloud.githubusercontent.com/assets/6234553/18169025/063ff752-708b-11e6-9528-cdfed095b057.gif)

after

![after](https://cloud.githubusercontent.com/assets/6234553/18169031/0bf45ff8-708b-11e6-8136-12c1377cb447.gif)

