### PR TITLE
Fix `#` and `*` Behaviour

### DIFF
--- a/src/actions/actions.ts
+++ b/src/actions/actions.ts
@@ -670,21 +670,17 @@ class CommandStar extends BaseCommand {
   isMotion = true;
   canBePrefixedWithCount = true;
 
-  public static GetWordAtPosition(position: Position): string {
-    const start = position.getWordLeft(true);
-    const end   = position.getCurrentWordEnd(true).getRight();
-
-    return TextEditor.getText(new vscode.Range(start, end));
-  }
-
   public async exec(position: Position, vimState: VimState): Promise<VimState> {
-    const currentWord = CommandStar.GetWordAtPosition(position);
+    const currentWord = TextEditor.getWord(position);
+    if (currentWord === undefined) {
+      return vimState;
+    }
 
     vimState.searchState = new SearchState(SearchDirection.Forward, vimState.cursorPosition, currentWord);
 
     do {
       vimState.cursorPosition = vimState.searchState.getNextSearchMatchPosition(vimState.cursorPosition).pos;
-    } while (CommandStar.GetWordAtPosition(vimState.cursorPosition) !== currentWord);
+    } while (TextEditor.getWord(vimState.cursorPosition) !== currentWord);
 
     return vimState;
   }
@@ -697,32 +693,20 @@ class CommandHash extends BaseCommand {
   isMotion = true;
   canBePrefixedWithCount = true;
 
-  public static GetWordAtPosition(position: Position): string {
-    const start = position.getWordLeft(true);
-    const end   = position.getCurrentWordEnd(true).getRight();
-
-    return TextEditor.getText(new vscode.Range(start, end));
-  }
-
   public async exec(position: Position, vimState: VimState): Promise<VimState> {
-    const currentWord = CommandStar.GetWordAtPosition(position);
-
-    vimState.searchState = new SearchState(SearchDirection.Backward, vimState.cursorPosition, currentWord);
-
-    // hack start
-    // temporary fix for https://github.com/VSCodeVim/Vim/issues/569
-    let text = TextEditor.getText(new vscode.Range(vimState.cursorPosition, vimState.cursorPosition.getRight()));
-    if (text === " ") {
+    const currentWord = TextEditor.getWord(position);
+    if (currentWord === undefined) {
       return vimState;
     }
-    // hack end
+
+    vimState.searchState = new SearchState(SearchDirection.Backward, vimState.cursorPosition, currentWord);
 
     do {
       // use getWordLeft() on position to start at the beginning of the word.
       // this ensures that any matches happen ounside of the word currently selected,
       // which are the desired semantics for this motion.
       vimState.cursorPosition = vimState.searchState.getNextSearchMatchPosition(vimState.cursorPosition.getWordLeft()).pos;
-    } while (CommandStar.GetWordAtPosition(vimState.cursorPosition) !== currentWord);
+    } while (TextEditor.getWord(vimState.cursorPosition) !== currentWord);
 
     return vimState;
   }

--- a/src/error.ts
+++ b/src/error.ts
@@ -10,6 +10,7 @@ export enum ErrorCode {
   E37 = 37,
   E32 = 32,
   E208 = 208,
+  E348 = 348,
   E488 = 488
 }
 
@@ -17,6 +18,7 @@ const errors : IVimErrors = {
   32: "No file name",
   37: "No write since last change (add ! to override)",
   208: "Error writing to file",
+  348: "No string under cursor",
   488: "Trailing characters"
 };
 

--- a/src/globals.ts
+++ b/src/globals.ts
@@ -5,4 +5,6 @@
 export class Globals {
   // true for running tests, false during regular runtime
   public static isTesting = false;
+
+  public static WhitespaceRegExp = new RegExp("^ *$");
 }

--- a/src/mode/modeHandler.ts
+++ b/src/mode/modeHandler.ts
@@ -665,8 +665,6 @@ export class ModeHandler implements vscode.Disposable {
     let result = Actions.getRelevantAction(recordedState.actionKeys, vimState);
 
     if (result === KeypressState.NoPossibleMatch) {
-      console.log("Nothing matched!");
-
       vimState.recordedState = new RecordedState();
       return vimState;
     } else if (result === KeypressState.WaitingOnKeys) {

--- a/src/motion/position.ts
+++ b/src/motion/position.ts
@@ -618,7 +618,7 @@ export class Position extends vscode.Position {
       let positions  = this.getAllPositions(TextEditor.getLineAt(new vscode.Position(currentLine, 0)).text, regex);
       let newCharacter = _.find(positions,
         index => ((index >  this.character && !inclusive)  ||
-              (index >= this.character &&  inclusive)) || currentLine !== this.line);
+              (index >= this.character && inclusive)) || currentLine !== this.line);
 
       if (newCharacter !== undefined) {
         return new Position(currentLine, newCharacter);

--- a/src/textEditor.ts
+++ b/src/textEditor.ts
@@ -4,6 +4,7 @@ import * as vscode from "vscode";
 import { ModeHandler } from './mode/modeHandler';
 import { Position } from './motion/position';
 import { Configuration } from './configuration/configuration';
+import { Globals } from './globals';
 
 export class TextEditor {
   // TODO: Refactor args
@@ -138,6 +139,31 @@ export class TextEditor {
 
   static getText(selection: vscode.Range): string {
     return vscode.window.activeTextEditor.document.getText(selection);
+  }
+
+  /**
+   *  Retrieves the current word at position.
+   *  If current position is whitespace, selects the right-closest word
+   */
+  static getWord(position: Position) : string | undefined {
+    let start = position;
+    let end = position.getRight();
+
+    const char = TextEditor.getText(new vscode.Range(start, end));
+    if (Globals.WhitespaceRegExp.test(char)) {
+      start = position.getWordRight();
+    } else {
+      start = position.getWordLeft(true);
+    }
+    end = start.getCurrentWordEnd(true).getRight();
+
+    const word = TextEditor.getText(new vscode.Range(start, end));
+
+    if (Globals.WhitespaceRegExp.test(word)) {
+      return undefined;
+    }
+
+    return word;
   }
 
   static isFirstLine(position : vscode.Position): boolean {

--- a/test/error.test.ts
+++ b/test/error.test.ts
@@ -1,6 +1,5 @@
 "use strict";
 
-// The module 'assert' provides assertion methods from node
 import * as assert from 'assert';
 import {VimError, ErrorCode} from '../src/error';
 
@@ -8,6 +7,8 @@ suite("ErrorCode", () => {
   test("contains known errors", () => {
     assert.equal(ErrorCode.E32, 32);
     assert.equal(ErrorCode.E37, 37);
+    assert.equal(ErrorCode.E208, 208);
+    assert.equal(ErrorCode.E348, 348);
     assert.equal(ErrorCode.E488, 488);
   });
 });

--- a/test/mode/modeNormal.test.ts
+++ b/test/mode/modeNormal.test.ts
@@ -917,7 +917,6 @@ suite("Mode Normal", () => {
       end: [' |one', 'two', ' three', '    one', ' two']
     });
 
-
     newTest({
       title: "Can repeat w",
       start: ['|one two three four'],

--- a/test/mode/normalModeTests/motions.test.ts
+++ b/test/mode/normalModeTests/motions.test.ts
@@ -264,35 +264,28 @@ suite("Motions in Normal Mode", () => {
   });
 
   newTest({
-    title: "Can run a basic search",
+    title: "Can run a forward search",
     start: ['|one two three'],
     keysPressed: '/thr\n',
     end: ['one two |three'],
   });
 
   newTest({
-    title: "Can run a basic search",
-    start: ['|one two three'],
-    keysPressed: '/thr\n',
-    end: ['one two |three'],
-  });
-
-  newTest({
-    title: "Can run a basic search",
+    title: "Can run a forward and find next search",
     start: ['|one two two two'],
     keysPressed: '/two\nn',
     end: ['one two |two two'],
   });
 
   newTest({
-    title: "Can run a basic search",
+    title: "Can run a reverse search",
     start: ['one two thre|e'],
     keysPressed: '?two\n',
     end: ['one |two three'],
   });
 
   newTest({
-    title: "Can run a basic search",
+    title: "Can run a reverse and find next search",
     start: ['one two two thre|e'],
     keysPressed: '?two\nn',
     end: ['one |two two three'],
@@ -387,6 +380,20 @@ suite("Motions in Normal Mode", () => {
     start: ['|blah duh blah duh blah'],
     keysPressed: '**',
     end: ['blah duh blah duh |blah']
+  });
+
+  newTest({
+    title: "Can handle # on whitespace",
+    start: ['abc abcdef| abc'],
+    keysPressed: '#',
+    end: ['|abc abcdef abc'],
+  });
+
+  newTest({
+    title: "Can handle # on EOL",
+    start: ['abc abcdef abc| '],
+    keysPressed: '#',
+    end: ['abc abcdef abc| '],
   });
 
   newTest({


### PR DESCRIPTION
Properly fixes https://github.com/VSCodeVim/Vim/issues/569. 

Behaviour of `#` and `*` is expected to be:
1) If cursor selects whitespace, the word closest to right is chosen
2) If there is no word to the right of the cursor, a VIM error is thrown
3) Otherwise, searches for currently selected word.