### PR TITLE
Fix race condition with switching active text editor.

### DIFF
--- a/extension.ts
+++ b/extension.ts
@@ -247,9 +247,11 @@ async function handleActiveEditorChange(): Promise<void> {
 
   taskQueue.enqueueTask({
     promise: async () => {
-      const mh = await getAndUpdateModeHandler();
+      if (vscode.window.activeTextEditor !== undefined) {
+        const mh = await getAndUpdateModeHandler();
 
-      mh.updateView(mh.vimState, false);
+        mh.updateView(mh.vimState, false);
+      }
     },
     isRunning: false
   });

--- a/extension.ts
+++ b/extension.ts
@@ -245,10 +245,14 @@ async function handleActiveEditorChange(): Promise<void> {
     return;
   }
 
-  if (vscode.window.activeTextEditor !== undefined) {
-    const mh = await getAndUpdateModeHandler();
-    mh.updateView(mh.vimState, false);
-  }
+  taskQueue.enqueueTask({
+    promise: async () => {
+      const mh = await getAndUpdateModeHandler();
+
+      mh.updateView(mh.vimState, false);
+    },
+    isRunning: false
+  });
 }
 
 process.on('unhandledRejection', function(reason: any, p: any) {

--- a/src/mode/modeHandler.ts
+++ b/src/mode/modeHandler.ts
@@ -798,7 +798,7 @@ export class ModeHandler implements vscode.Disposable {
       vimState.historyTracker.finishCurrentStep();
     }
 
-    // console.log(vimState.historyTracker.toString());
+    //  console.log(vimState.historyTracker.toString());
 
     recordedState.actionKeys = [];
     vimState.currentRegisterMode = RegisterMode.FigureItOutFromCurrentMode;


### PR DESCRIPTION
When you `ctrl-w h` into another editor, the undo history states of the two editors would become intertwined. It could also cause VSCodeVim to crash if they were big enough, because it'd attempt to diff them against each other and take a really long time.