### PR TITLE
Make j and k commands fold frinedly!

### DIFF
--- a/src/actions/actions.ts
+++ b/src/actions/actions.ts
@@ -164,6 +164,11 @@ export abstract class BaseMovement extends BaseAction {
   }
 
   /**
+   * Whether this action has violated general principal doing no real movement.
+   */
+  public hasUpdatedView = false;
+
+  /**
    * Whether we should change desiredColumn in VimState.
    */
   public doesntChangeDesiredColumn = false;
@@ -1842,6 +1847,15 @@ class MoveUp extends BaseMovement {
     });
     const nextLine = vscode.window.activeTextEditor.selection.active.line;
     const nextLineLength = Position.getLineLength(nextLine);
+    const desiredColumn = Math.min(nextLineLength, vimState.desiredColumn);
+    const currentColumn = vscode.window.activeTextEditor.selection.active.character;
+    // await vscode.commands.executeCommand("cursorMove", {
+    //   to: "left",
+    //   by: "character",
+    //   select: select,
+    //   value: currentColumn
+    // });
+    this.hasUpdatedView = true;
     return new Position(nextLine, Math.min(nextLineLength, vimState.desiredColumn));
   }
 }
@@ -1869,6 +1883,7 @@ class MoveDown extends BaseMovement {
       select: select,
       value: count
     });
+    this.hasUpdatedView = true;
     const nextLine = vscode.window.activeTextEditor.selection.active.line;
     const nextLineLength = Position.getLineLength(nextLine);
     return new Position(nextLine, Math.min(nextLineLength, vimState.desiredColumn));

--- a/src/mode/modeHandler.ts
+++ b/src/mode/modeHandler.ts
@@ -569,7 +569,8 @@ export class ModeHandler implements vscode.Disposable {
         this._vimState.cursorPosition    = newPosition;
         this._vimState.cursorStartPosition = newPosition;
 
-        this._vimState.desiredColumn     = newPosition.character;
+        // TODO: find a way to update desiredColumn on mouse clicks.
+        // this._vimState.desiredColumn     = newPosition.character;
 
         // start visual mode?
 

--- a/src/mode/modeHandler.ts
+++ b/src/mode/modeHandler.ts
@@ -697,8 +697,10 @@ export class ModeHandler implements vscode.Disposable {
       }
     }
 
-    // Update view
-    await this.updateView(vimState);
+    if (!(movement && movement.hasUpdatedView)) {
+      // Update view
+      await this.updateView(vimState);
+    }
 
     return vimState;
   }

--- a/src/motion/position.ts
+++ b/src/motion/position.ts
@@ -216,6 +216,56 @@ export class Position extends vscode.Position {
   }
 
   /**
+   * Get the position of the line directly below the current line that is not folded.
+   */
+  public async getDownNotFolded(desiredColumn: number, lines: number, select: boolean) : Promise<Position> {
+    if (this.getDocumentEnd().line !== this.line) {
+      await vscode.commands.executeCommand("cursorMove", {
+        to: "down",
+        by: "wrappedLine",
+        select: select,
+        value: lines
+      });
+      const nextLine = vscode.window.activeTextEditor.selection.active.line;
+      const nextLineLength = Position.getLineLength(nextLine);
+      await vscode.commands.executeCommand("cursorMove", {
+        to: "up",
+        by: "wrappedLine",
+        select: select,
+        value: lines
+      });
+      return new Position(nextLine, Math.min(nextLineLength, desiredColumn));
+    }
+
+    return this;
+  }
+
+  /**
+   * Get the position of the line directly above the current line that is not folded
+   */
+  public async getUpNotFolded(desiredColumn: number, lines: number, select: boolean) : Promise<Position> {
+    if (this.getDocumentEnd().line !== 0) {
+      await vscode.commands.executeCommand("cursorMove", {
+        to: "up",
+        by: "wrappedLine",
+        select: select,
+        value: lines
+      });
+      const nextLine = vscode.window.activeTextEditor.selection.active.line;
+      const nextLineLength = Position.getLineLength(nextLine);
+      await vscode.commands.executeCommand("cursorMove", {
+        to: "down",
+        by: "wrappedLine",
+        select: select,
+        value: lines
+      });
+      return new Position(nextLine, Math.min(nextLineLength, desiredColumn));
+    }
+
+    return this;
+  }
+
+  /**
    * Get the position of the line directly below the current line.
    */
   public getDown(desiredColumn: number) : Position {

--- a/src/motion/position.ts
+++ b/src/motion/position.ts
@@ -216,56 +216,6 @@ export class Position extends vscode.Position {
   }
 
   /**
-   * Get the position of the line directly below the current line that is not folded.
-   */
-  public async getDownNotFolded(desiredColumn: number, lines: number, select: boolean) : Promise<Position> {
-    if (this.getDocumentEnd().line !== this.line) {
-      await vscode.commands.executeCommand("cursorMove", {
-        to: "down",
-        by: "wrappedLine",
-        select: select,
-        value: lines
-      });
-      const nextLine = vscode.window.activeTextEditor.selection.active.line;
-      const nextLineLength = Position.getLineLength(nextLine);
-      await vscode.commands.executeCommand("cursorMove", {
-        to: "up",
-        by: "wrappedLine",
-        select: select,
-        value: lines
-      });
-      return new Position(nextLine, Math.min(nextLineLength, desiredColumn));
-    }
-
-    return this;
-  }
-
-  /**
-   * Get the position of the line directly above the current line that is not folded
-   */
-  public async getUpNotFolded(desiredColumn: number, lines: number, select: boolean) : Promise<Position> {
-    if (this.getDocumentEnd().line !== 0) {
-      await vscode.commands.executeCommand("cursorMove", {
-        to: "up",
-        by: "wrappedLine",
-        select: select,
-        value: lines
-      });
-      const nextLine = vscode.window.activeTextEditor.selection.active.line;
-      const nextLineLength = Position.getLineLength(nextLine);
-      await vscode.commands.executeCommand("cursorMove", {
-        to: "down",
-        by: "wrappedLine",
-        select: select,
-        value: lines
-      });
-      return new Position(nextLine, Math.min(nextLineLength, desiredColumn));
-    }
-
-    return this;
-  }
-
-  /**
    * Get the position of the line directly below the current line.
    */
   public getDown(desiredColumn: number) : Position {


### PR DESCRIPTION
Right now fold commands are practically useless, because as soon as you start `jjjjj` or `kkkk` ing over them, they open 😢 

The only possible solution is to use `cursorMove` command (unfortunately) ... and this is not going to change with upcoming api changes 😞 

@johnfn So with this PR i have tried to fix moving around with `j` and `k` keys.

Note, if you try `moveup` and then `movedown` to get the position of previous visible line, it causes `kkkk` ing around slow.

There is also a minor fix for `zc` command which for no good reason puts cursor into visual mode.

@johnfn Let me know if you need me to change something.