### PR TITLE
Remapper fixes

### DIFF
--- a/extension.ts
+++ b/extension.ts
@@ -7,14 +7,13 @@
  */
 
 import * as vscode from 'vscode';
-import * as util from './src/util';
 import * as _ from "lodash";
 import { showCmdLine } from './src/cmd_line/main';
 import { ModeHandler } from './src/mode/modeHandler';
 import { TaskQueue } from './src/taskQueue';
 import { Position } from './src/motion/position';
 import { Globals } from './src/globals';
-
+import { AngleBracketNotation } from './src/notation';
 
 interface VSCodeKeybinding {
   key: string;
@@ -206,7 +205,7 @@ export async function activate(context: vscode.ExtensionContext) {
   });
 
   for (let { key } of packagejson.contributes.keybindings) {
-    let bracketedKey = util.translateToAngleBracketNotation(key);
+    let bracketedKey = AngleBracketNotation.Normalize(key);
     registerCommand(context, `extension.vim_${ key.toLowerCase() }`, () => handleKeyEvent(`${ bracketedKey }`));
   }
 

--- a/src/actions/actions.ts
+++ b/src/actions/actions.ts
@@ -90,9 +90,9 @@ export class BaseAction {
    * Can this action be paired with an operator (is it like w in dw)? All
    * BaseMovements can be, and some more sophisticated commands also can be.
    */
-  isMotion = false;
+  public isMotion = false;
 
-  canBeRepeatedWithDot = false;
+  public canBeRepeatedWithDot = false;
 
   /**
    * Modes that this action can be run in.

--- a/src/mode/remapper.ts
+++ b/src/mode/remapper.ts
@@ -1,8 +1,8 @@
 import * as vscode from 'vscode';
 import * as _ from 'lodash';
-import * as util from '../util';
 import { ModeName } from './mode';
 import { ModeHandler, VimState } from './modeHandler';
+import { AngleBracketNotation } from './../notation';
 
 interface IKeybinding {
   before: string[];
@@ -24,10 +24,10 @@ class Remapper {
 
     for (let remapping of remappings) {
       let before: string[] = [];
-      remapping.before.forEach(item => before.push(util.translateToAngleBracketNotation(item)));
+      remapping.before.forEach(item => before.push(AngleBracketNotation.Normalize(item)));
 
       let after: string[] = [];
-      remapping.after.forEach(item => after.push(util.translateToAngleBracketNotation(item)));
+      remapping.after.forEach(item => after.push(AngleBracketNotation.Normalize(item)));
 
       this._remappings.push(<IKeybinding> {
         before: before,

--- a/src/notation.ts
+++ b/src/notation.ts
@@ -1,0 +1,34 @@
+export class AngleBracketNotation {
+  private static _notationMap : { [key: string] : string[]; } = {
+    'C-': ['ctrl\\+', 'c\\-'],
+    'Esc': ['escape', 'esc'],
+    'BS': ['backspace', 'bs'],
+    'Del': ['delete', 'del'],
+  };
+
+  /**
+   * Normalizes key to AngleBracketNotation
+   * For instance, <ctrl+x>, Ctrl+x, <c-x> normalized to <C-x>
+   */
+  public static Normalize(key: string): string {
+    if (!this.isSurroundedByAngleBrackets(key) && key.length > 1) {
+      key = `<${ key.toLocaleLowerCase() }>`;
+    }
+
+    for (const notationMapKey in this._notationMap) {
+      if (this._notationMap.hasOwnProperty(notationMapKey)) {
+        const regex = new RegExp(this._notationMap[notationMapKey].join('|'), 'gi');
+        if (regex.test(key)) {
+          key = key.replace(regex, notationMapKey);
+          break;
+        }
+      }
+    }
+
+    return key;
+  }
+
+  private static isSurroundedByAngleBrackets(key: string): boolean {
+    return key.startsWith('<') && key.endsWith('>');
+  }
+}

--- a/src/util.ts
+++ b/src/util.ts
@@ -10,24 +10,3 @@ export async function showError(message : string): Promise<{}> {
   return vscode.window.showErrorMessage("Vim: " + message);
 }
 
-export function translateToAngleBracketNotation(key: string): string {
-    const angleBracketNotationMap = {
-      'ctrl+' : 'C-',
-      'escape': 'Esc',
-      'backspace': 'BS',
-      'delete': 'Del',
-    };
-
-    key = key.toLowerCase();
-    if (!(key.startsWith('<') && key.endsWith('>')) && key.length > 1) {
-      key = `<${ key }>`;
-    }
-
-    for (const searchKey in angleBracketNotationMap) {
-      if (angleBracketNotationMap.hasOwnProperty(searchKey)) {
-        key = key.replace(searchKey, angleBracketNotationMap[searchKey]);
-      }
-    }
-
-    return key;
-}

--- a/test/notation.test.ts
+++ b/test/notation.test.ts
@@ -1,0 +1,24 @@
+"use strict";
+
+import * as assert from 'assert';
+import { AngleBracketNotation } from '../src/notation';
+
+suite("Notation", () => {
+  test("Normalize", () => {
+    let testCases = {
+      '<cTrL+w>': '<C-w>',
+      'cTrL+x': '<C-x>',
+      'CtRl+y': '<C-y>',
+      'c-z': '<C-z>',
+    };
+
+    for (const test in testCases) {
+      if (testCases.hasOwnProperty(test)) {
+        let expected = testCases[test];
+
+        let actual = AngleBracketNotation.Normalize(test);
+        assert.equal(actual, expected);
+      }
+    }
+  });
+});


### PR DESCRIPTION
* Fix for #716. In the config, you can now set `<Esc>` or `<esc>`
* Moved angle notation stuff to it's own class