### PR TITLE
Add support for appending to named registers

### DIFF
--- a/src/register/register.ts
+++ b/src/register/register.ts
@@ -61,7 +61,7 @@ export class Register {
         if (typeof existingText === 'string') {
           content = existingText + (existingText.endsWith('\n') ? '' : '\n') + content;
         } else {
-          content = existingText.concat(content.split('\n'))
+          content = existingText.concat(content.split('\n'));
         }
       } else {
         if (typeof existingText === 'string') {

--- a/src/register/register.ts
+++ b/src/register/register.ts
@@ -90,7 +90,7 @@ export class Register {
       throw new Error(`Invalid register ${register}`);
     }
 
-    // Register names are case-insensitive.
+    // Retrieving register content is case-insensitive
     if (/^[A-Z]$/.test(register)) {
       register = register.toLowerCase();
     }

--- a/src/register/register.ts
+++ b/src/register/register.ts
@@ -61,7 +61,7 @@ export class Register {
         if (typeof existingText === 'string') {
           content = existingText + (existingText.endsWith('\n') ? '' : '\n') + content;
         } else {
-          content = existingText.join('\n') + '\n' + content;
+          content = existingText.concat(content.split('\n'))
         }
       } else {
         if (typeof existingText === 'string') {

--- a/test/register/register.test.ts
+++ b/test/register/register.test.ts
@@ -48,4 +48,18 @@ suite("register", () => {
     end: ["one", "two", "one", "|two"],
   });
 
+  newTest({
+    title: "Can append content to register",
+    start: ['|one', "two"],
+    keysPressed: '"ayyj"Ayy$"ap',
+    end: ["one", "two", "|one", "two"],
+  });
+
+  newTest({
+    title: "Can replace register contents after append",
+    start: ['|one', "two", "three"],
+    keysPressed: '"ayyj"Ayyj"ayy$"ap',
+    end: ["one", "two", "three", "|three"],
+  });
+
 });


### PR DESCRIPTION
Named registers should be case insensitive, with lower case denoting replace register contents, and upper case denoting append to register contents.

[Vim documentation, Named Registers](http://vimdoc.sourceforge.net/htmldoc/change.html#quote_alpha)