### PR TITLE
build on extension/test launch

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,30 +1,28 @@
 // A launch configuration that compiles the extension and then opens it inside a new window
 {
-	"version": "0.1.0",
-	"configurations": [
-		{
-			"name": "Launch Extension",
-			"type": "extensionHost",
-			"request": "launch",
-			"runtimeExecutable": "${execPath}",
-			"args": ["--extensionDevelopmentPath=${workspaceRoot}" ],
-            // "runtimeArgs": ["--harmony-default-parameters", "--harmony-rest-parameters"],
-			"stopOnEntry": false,
-			"sourceMaps": true,
-			"outDir": "${workspaceRoot}/out"
-			// "preLaunchTask": "npm"
-		},
-		{
-			"name": "Launch Tests",
-			"type": "extensionHost",
-			"request": "launch",
-			"runtimeExecutable": "${execPath}",
-			"args": ["--extensionDevelopmentPath=${workspaceRoot}", "--extensionTestsPath=${workspaceRoot}/out/test" ],
-            // "runtimeArgs": ["--js-flags=\"--harmony --harmony-default-parameters\""],
-			"stopOnEntry": false,
-			"sourceMaps": true,
-			"outDir": "${workspaceRoot}/out"
-			// "preLaunchTask": "npm"
-		}
-	]
+  "version": "0.1.0",
+  "configurations": [
+    {
+       "name": "Launch Extension",
+       "type": "extensionHost",
+       "request": "launch",
+       "runtimeExecutable": "${execPath}",
+       "args": ["--extensionDevelopmentPath=${workspaceRoot}" ],
+       "stopOnEntry": false,
+       "sourceMaps": true,
+       "outDir": "${workspaceRoot}/out",
+       "preLaunchTask": "build"
+   },
+   {
+       "name": "Launch Tests",
+       "type": "extensionHost",
+       "request": "launch",
+       "runtimeExecutable": "${execPath}",
+       "args": ["--extensionDevelopmentPath=${workspaceRoot}", "--extensionTestsPath=${workspaceRoot}/out/test" ],
+       "stopOnEntry": false,
+       "sourceMaps": true,
+       "outDir": "${workspaceRoot}/out",
+       "preLaunchTask": "build"
+    }
+  ]
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -6,25 +6,18 @@
 // ${fileExtname}: the current opened file's extension
 // ${cwd}: the current working directory of the spawned process
 
-// A task runner that calls a custom npm script that compiles the extension.
 {
-	"version": "0.1.0",
-
-	// we want to run npm
-	"command": "npm",
-
-	// the command is a shell script
-	"isShellCommand": true,
-
-	// show the output window only if unrecognized errors occur.
-	"showOutput": "silent",
-
-	// we run the custom script "compile" as defined in package.json
-	"args": ["run", "compile", "--loglevel", "silent"],
-
-	// The tsc compiler is started in watching mode
-	"isWatching": true,
-
-	// use the standard tsc in watch mode problem matcher to find compile problems in the output.
-	"problemMatcher": "$tsc-watch"
+  "version": "0.1.0",
+  "command": "gulp",
+  "isShellCommand": true,
+  "suppressTaskName": true,
+  "tasks": [
+  {
+      "taskName": "build",
+      "args": [],
+      "isBuildCommand": true,
+      "isWatching": false,
+      "problemMatcher": "$tsc-watch"
+    }
+  ]
 }


### PR DESCRIPTION
Request for comment cc: @johnfn @rebornix 

Force a build via `gulp` on extension launch/test. I tend to forget to run `gulp watch` manually; often times I would change the source, run it, and wonder why the behaviour didn't change before the duh moment.

With this change,

* Pro: Guaranteed that the TS is compiled; no need to run `gulp watch` or `npm compile` manually and check console if things compiled correctly. auto-runs tslint.
* Con: Adds build time (5s right now) before you can launch the extension/run tests