### PR TITLE
Insert Previous text

### DIFF
--- a/package.json
+++ b/package.json
@@ -151,7 +151,13 @@
                 "when": "editorTextFocus && vim.useCtrlKeys && !inDebugRepl"
             },
             {
+                "key": "ctrl+shift+2",
+                "command": "extension.vim_ctrl+shift+2",
+                "when": "editorTextFocus && vim.useCtrlKeys"
+            },
+            {
                 "key": "ctrl+t",
+
                 "command": "extension.vim_ctrl+t",
                 "when": "editorTextFocus && vim.useCtrlKeys && !inDebugRepl"
             },
@@ -168,22 +174,22 @@
             {
                 "key": "left",
                 "command": "extension.vim_left",
-                "when": "editorTextFocus && vim.mode != 'Insert Mode' && !inDebugRepl"
+                "when": "editorTextFocus && !inDebugRepl"
             },
             {
                 "key": "right",
                 "command": "extension.vim_right",
-                "when": "editorTextFocus && vim.mode != 'Insert Mode' && !inDebugRepl"
+                "when": "editorTextFocus && !inDebugRepl"
             },
             {
                 "key": "up",
                 "command": "extension.vim_up",
-                "when": "editorTextFocus && vim.mode != 'Insert Mode' && !inDebugRepl && !suggestWidgetVisible"
+                "when": "editorTextFocus && !inDebugRepl && !suggestWidgetVisible"
             },
             {
                 "key": "down",
                 "command": "extension.vim_down",
-                "when": "editorTextFocus && vim.mode != 'Insert Mode' && !inDebugRepl && !suggestWidgetVisible"
+                "when": "editorTextFocus && !inDebugRepl && !suggestWidgetVisible"
             }
         ],
         "configuration": {

--- a/src/actions/actions.ts
+++ b/src/actions/actions.ts
@@ -1031,7 +1031,6 @@ class CommandBackspaceInReplaceMode extends BaseCommand {
   canBeRepeatedWithDot = true;
 
   public async exec(position: Position, vimState: VimState): Promise<VimState> {
-    const char = this.keysPressed[0];
     const replaceState = vimState.replaceState!;
 
     if (position.isBeforeOrEqual(replaceState.replaceCursorStartPosition)) {
@@ -1330,7 +1329,6 @@ class CommandBackspaceinInsertMode extends BaseCommand {
   keys = ["<BS>"];
 
   public async exec(position: Position, vimState: VimState): Promise<VimState> {
-    const newPosition = await TextEditor.backspace(position);
     vimState.recordedState.transformations.push({
       type: "deleteText",
       position: position,

--- a/src/actions/actions.ts
+++ b/src/actions/actions.ts
@@ -780,7 +780,7 @@ export class CommandInsertPreviousText extends BaseCommand {
     // The first action is entering Insert Mode, which is not necessary in this case
     actions.shift();
     // The last action is leaving Insert Mode, which is not necessary in this case
-    actions.pop();
+    // actions.pop();
 
     if (actions.length > 0 && actions[0] instanceof ArrowsInInsertMode) {
       // Note, arrow keys are the only Insert action command that can't be repeated here as far as @rebornix knows.

--- a/src/globals.ts
+++ b/src/globals.ts
@@ -6,5 +6,7 @@ export class Globals {
   // true for running tests, false during regular runtime
   public static isTesting = false;
 
+  public static modeHandlerForTesting: any = undefined;
+
   public static WhitespaceRegExp = new RegExp("^ *$");
 }

--- a/src/history/historyTracker.ts
+++ b/src/history/historyTracker.ts
@@ -70,6 +70,7 @@ class HistoryStep {
    */
   changes: DocumentChange[];
 
+
   /**
    * Whether the user is still inserting or deleting for this history step.
    */
@@ -152,6 +153,9 @@ class HistoryStep {
 }
 
 export class HistoryTracker {
+  public lastContentChanges: vscode.TextDocumentContentChangeEvent[];
+  public currentContentChanges: vscode.TextDocumentContentChangeEvent[];
+
   /**
    * The entire Undo/Redo stack.
    */
@@ -201,6 +205,8 @@ export class HistoryTracker {
     this.finishCurrentStep();
 
     this.oldText = TextEditor.getAllText();
+    this.currentContentChanges = [];
+    this.lastContentChanges = [];
   }
 
   private _addNewHistoryStep(): void {

--- a/src/mode/modeHandler.ts
+++ b/src/mode/modeHandler.ts
@@ -678,15 +678,17 @@ export class ModeHandler implements vscode.Disposable {
           vimState.cursorPositionJustBeforeAnythingHappened.character !== prevPos.character) {
 
         vimState.previousFullAction = recordedState;
-
-        if (recordedState.isInsertion) {
-          Register.lastContentChange = recordedState;
-        }
-
         vimState.historyTracker.finishCurrentStep();
       }
     }
     */
+
+    let prevPos = vimState.historyTracker.getLastHistoryEndPosition();
+    if (prevPos !== undefined && !vimState.isRunningDotCommand) {
+        if (recordedState.isInsertion) {
+          Register.lastContentChange = recordedState;
+        }
+    }
 
     if (action instanceof BaseMovement) {
       ({ vimState, recordedState } = await this.executeMovement(vimState, action));

--- a/src/mode/modeHandler.ts
+++ b/src/mode/modeHandler.ts
@@ -25,12 +25,11 @@ import { VisualLineMode } from './modeVisualLine';
 import { HistoryTracker } from './../history/historyTracker';
 import {
   BaseMovement, BaseCommand, Actions, BaseAction,
-  BaseOperator, isIMovement,
-  KeypressState
-} from './../actions/actions';
+  BaseOperator, DocumentContentChangeAction, CommandInsertInInsertMode, CommandInsertPreviousText,
+  isIMovement, KeypressState } from './../actions/actions';
 import { Position, PositionDiff } from './../motion/position';
 import { Range } from './../motion/range';
-import { RegisterMode } from './../register/register';
+import { RegisterMode, Register } from './../register/register';
 import { showCmdLine } from '../../src/cmd_line/main';
 import { Configuration } from '../../src/configuration/configuration';
 import { PairMatcher } from './../matching/matcher';
@@ -256,10 +255,13 @@ export class RecordedState {
    */
   public operatorPositionDiff: PositionDiff | undefined;
 
+  public isInsertion = false;
+
   /**
    * If we're in Visual Block mode, the way in which we're inserting characters (either inserting
    * at the beginning or appending at the end).
    */
+
   public visualBlockInsertionType = VisualBlockInsertionType.Insert;
 
   /**
@@ -620,9 +622,36 @@ export class ModeHandler implements vscode.Disposable {
 
     let action = result as BaseAction;
 
-    recordedState.actionsRun.push(action);
+    if (recordedState.actionsRun.length === 0) {
+      recordedState.actionsRun.push(action);
+    } else {
+      let lastAction = recordedState.actionsRun[recordedState.actionsRun.length - 1];
+
+      if (lastAction instanceof DocumentContentChangeAction) {
+        if (action instanceof CommandInsertInInsertMode || action instanceof CommandInsertPreviousText) {
+          // does nothing
+        } else {
+          // Push real document content change to the stack
+          lastAction.contentChanges = lastAction.contentChanges.concat(vimState.historyTracker.currentContentChanges);
+          vimState.historyTracker.currentContentChanges = [];
+          recordedState.actionsRun.push(action);
+        }
+      } else {
+        if (action instanceof CommandInsertInInsertMode || action instanceof CommandInsertPreviousText) {
+          // This means we are already in Insert Mode but there is still not DocumentContentChangeAction in stack
+          vimState.historyTracker.currentContentChanges = [];
+          recordedState.actionsRun.push(new DocumentContentChangeAction());
+        } else {
+          recordedState.actionsRun.push(action);
+        }
+      }
+    }
 
     vimState = await this.runAction(vimState, recordedState, action);
+
+    if (vimState.currentMode === ModeName.Insert) {
+      recordedState.isInsertion = true;
+    }
 
     // Update view
     await this.updateView(vimState);
@@ -649,6 +678,11 @@ export class ModeHandler implements vscode.Disposable {
           vimState.cursorPositionJustBeforeAnythingHappened.character !== prevPos.character) {
 
         vimState.previousFullAction = recordedState;
+
+        if (recordedState.isInsertion) {
+          Register.lastContentChange = recordedState;
+        }
+
         vimState.historyTracker.finishCurrentStep();
       }
     }
@@ -671,6 +705,10 @@ export class ModeHandler implements vscode.Disposable {
       if (action.canBeRepeatedWithDot) {
         ranRepeatableAction = true;
       }
+    }
+
+    if (action instanceof DocumentContentChangeAction) {
+      vimState = await action.exec(vimState.cursorPosition, vimState);
     }
 
     // Update mode (note the ordering allows you to go into search mode,
@@ -709,6 +747,10 @@ export class ModeHandler implements vscode.Disposable {
     // Record down previous action and flush temporary state
     if (ranRepeatableAction) {
       vimState.previousFullAction = vimState.recordedState;
+
+      if (recordedState.isInsertion) {
+        Register.lastContentChange = recordedState;
+      }
     }
 
     if (ranAction) {

--- a/src/mode/modeHandler.ts
+++ b/src/mode/modeHandler.ts
@@ -683,13 +683,6 @@ export class ModeHandler implements vscode.Disposable {
     }
     */
 
-    let prevPos = vimState.historyTracker.getLastHistoryEndPosition();
-    if (prevPos !== undefined && !vimState.isRunningDotCommand) {
-        if (recordedState.isInsertion) {
-          Register.lastContentChange = recordedState;
-        }
-    }
-
     if (action instanceof BaseMovement) {
       ({ vimState, recordedState } = await this.executeMovement(vimState, action));
       ranAction = true;

--- a/src/register/register.ts
+++ b/src/register/register.ts
@@ -1,4 +1,4 @@
-import { VimState } from './../mode/modeHandler';
+import { VimState, RecordedState } from './../mode/modeHandler';
 import * as clipboard from 'copy-paste';
 
 /**
@@ -36,10 +36,13 @@ export class Register {
     '+': { text: "", registerMode: RegisterMode.CharacterWise, isClipboardRegister: true }
   };
 
+
   public static isClipboardRegister(registerName: string): boolean {
     const register = Register.registers[registerName];
     return register && register.isClipboardRegister;
   }
+
+  public static lastContentChange: RecordedState;
 
   public static isValidRegister(register: string): boolean {
     return register in Register.registers || /^[a-z0-9]+$/i.test(register);

--- a/test/mode/modeNormal.test.ts
+++ b/test/mode/modeNormal.test.ts
@@ -27,7 +27,7 @@ suite("Mode Normal", () => {
             await modeHandler.handleKeyEvent('i');
             await modeHandler.handleKeyEvent(key!);
 
-            assertEqual(modeHandler.currentMode.name, ModeName.Normal);
+            assertEqual(modeHandler.currentMode.name, ModeName.Normal, `${key} doesn't work.`);
         }
 
         await modeHandler.handleKeyEvent('v');

--- a/test/mode/normalModeTests/dot.test.ts
+++ b/test/mode/normalModeTests/dot.test.ts
@@ -68,3 +68,54 @@ suite("Dot Operator", () => {
     });
 
 });
+
+suite("Repeat content change", () => {
+  let modeHandler: ModeHandler = new ModeHandler();
+
+  let {
+    newTest,
+    newTestOnly
+  } = getTestingFunctions(modeHandler);
+
+  setup(async () => {
+    await setupWorkspace();
+    setTextEditorOptions(4, false);
+  });
+
+  teardown(cleanUpWorkspace);
+
+  newTest({
+    title: "Can repeat '<C-t>'",
+    start: ['on|e', 'two'],
+    keysPressed: 'a<C-t><Esc>j.',
+    end: ['\tone', '\ttw|o']
+  });
+
+  newTest({
+    title: "Can repeat insert change and '<C-t>'",
+    start: ['on|e', 'two'],
+    keysPressed: 'a<C-t>b<Esc>j.',
+    end: ['\toneb', '\ttwo|b']
+  });
+
+  newTest({
+    title: "Can repeat change by `<C-a>`",
+    start: ['on|e', 'two'],
+    keysPressed: 'a<C-t>b<Esc>ja<C-a><Esc>',
+    end: ['\toneb', '\ttwo|b']
+  });
+
+  newTest({
+    title: "Only one arrow key can be repeated in Insert Mode",
+    start: ['on|e', 'two'],
+    keysPressed: 'a<left><left>b<Esc>j$.',
+    end: ['obne', 'tw|bo']
+  });
+
+  newTest({
+    title: "Cached content change will be cleared by arrow keys",
+    start: ['on|e', 'two'],
+    keysPressed: 'a<C-t>b<left>c<Esc>j.',
+    end: ['\tonecb', 'tw|co']
+  });
+});

--- a/test/testSimplifier.ts
+++ b/test/testSimplifier.ts
@@ -7,6 +7,7 @@ import { ModeHandler } from '../src/mode/modeHandler';
 import { TextEditor } from '../src/textEditor';
 import { assertEqualLines } from './testUtils';
 import { waitForCursorUpdatesToHappen } from '../src/util';
+import { Globals } from '../src/globals';
 
 export function getTestingFunctions(modeHandler: ModeHandler) {
   let testWithObject = testIt.bind(null, modeHandler);
@@ -49,6 +50,7 @@ interface ITestObject {
   keysPressed: string;
   end: string[];
   endMode?: ModeName;
+  delay?: number;
 }
 
 class TestObjectHelper {
@@ -212,6 +214,8 @@ async function testIt(modeHandler: ModeHandler, testObj: ITestObject): Promise<v
   await modeHandler.handleMultipleKeyEvents(helper.getKeyPressesToMoveToStartPosition());
 
   await waitForCursorUpdatesToHappen();
+
+  Globals.modeHandlerForTesting = modeHandler;
 
   // assumes key presses are single characters for now
   await modeHandler.handleMultipleKeyEvents(tokenizeKeySequence(testObj.keysPressed));

--- a/test/testSimplifier.ts
+++ b/test/testSimplifier.ts
@@ -50,7 +50,6 @@ interface ITestObject {
   keysPressed: string;
   end: string[];
   endMode?: ModeName;
-  delay?: number;
 }
 
 class TestObjectHelper {


### PR DESCRIPTION
Yay! We love PRs! 🎊

Please include a description of your change & check your PR against this list, thanks:

- [x] Commit message has a short title & issue references
- [x] Each commit does a logical chunk of work.  
- [x] It builds and tests pass (e.g `gulp tslint`)

This PR implements `ctrl-A` and `ctrl-@` in Insert Mode, which inserts previously change. Instead of maintaining the change in history ourselves, I'm currently just leveraging `documentContentChangeEvent`. This way when we type `ab` and intellisense helps us autocomplete it to `abstract`, we can get the whole `abstract` through `contentChange`, not just `ab`.

@johnfn @xconverge this is totally a different way of handing last change which we currently maintained in HistorySteps, so for now I just put the plain array in HistoryTracker. Please take a look and see if it can inspire you on how to handle history.

The only catch here is there might be racing condition between `documentChange` and `type`. So basically if we write test cases for this feature and run case automatically, or a human types real quick, you might see bugs as `ctrl-A` may come before all `documentChange`.