### PR TITLE
Fix delete line with CRLF (#743)

### DIFF
--- a/src/actions/actions.ts
+++ b/src/actions/actions.ts
@@ -1063,7 +1063,7 @@ export class DeleteOperator extends BaseOperator {
 
         if (registerMode === RegisterMode.LineWise) {
           // slice final newline in linewise mode - linewise put will add it back.
-          text = text[text.length - 2] === '\r' ? text.slice(0, -2) : text.slice(0, -1);
+          text = text.endsWith("\r\n") ? text.slice(0, -2) : text.slice(0, -1);
         }
 
         if (yank) {

--- a/src/actions/actions.ts
+++ b/src/actions/actions.ts
@@ -1062,7 +1062,8 @@ export class DeleteOperator extends BaseOperator {
         let text = vscode.window.activeTextEditor.document.getText(new vscode.Range(start, end));
 
         if (registerMode === RegisterMode.LineWise) {
-          text = text.slice(0, -1); // slice final newline in linewise mode - linewise put will add it back.
+          // slice final newline in linewise mode - linewise put will add it back.
+          text = text[text.length - 2] === '\r' ? text.slice(0, -2) : text.slice(0, -1);
         }
 
         if (yank) {

--- a/test/mode/modeNormal.test.ts
+++ b/test/mode/modeNormal.test.ts
@@ -135,6 +135,13 @@ suite("Mode Normal", () => {
     });
 
     newTest({
+      title: "Can handle ddp",
+      start: ['|one', 'two'],
+      keysPressed: 'ddp',
+      end: ["two", "|one"],
+    });
+
+    newTest({
       title: "Can handle 'de'",
       start: ['text tex|t'],
       keysPressed: '^de',

--- a/test/register/register.test.ts
+++ b/test/register/register.test.ts
@@ -26,13 +26,6 @@ suite("register", () => {
     end: ["two", "|one"],
   });
 
-  newTest({
-    title: "Can copy to a register",
-    start: ['|one', 'two'],
-    keysPressed: '"add"ap',
-    end: ["two", "|one"],
-  });
-
   clipboard.copy("12345");
   newTest({
     title: "Can access '*' (clipboard) register",


### PR DESCRIPTION
Fixes #743.

Delete was not taking a possible `\r` into consideration when performing a linewise delete, which resulted in an extra linebreak being appended to the line if it later was pasted.

Also removed a duplicate test related to this functionality (`"Can copy to a register"`). That test was failing on Windows with `"files.eol": "crlf"`, but now passes after this change.