### PR TITLE
Support "+ system clipboard register (#780)

### DIFF
--- a/src/register/register.ts
+++ b/src/register/register.ts
@@ -15,9 +15,9 @@ export enum RegisterMode {
 };
 
 export interface IRegisterContent {
-  text                : string | string[];
-  registerMode        : RegisterMode;
-  isClipboardRegister?: boolean;
+  text               : string | string[];
+  registerMode       : RegisterMode;
+  isClipboardRegister: boolean;
 }
 
 export class Register {
@@ -31,19 +31,14 @@ export class Register {
    *  '#' is the name of last edited file. (low priority)
    */
   private static registers: { [key: string]: IRegisterContent } = {
-    '"': { text: "", registerMode: RegisterMode.CharacterWise },
+    '"': { text: "", registerMode: RegisterMode.CharacterWise, isClipboardRegister: false },
     '*': { text: "", registerMode: RegisterMode.CharacterWise, isClipboardRegister: true },
     '+': { text: "", registerMode: RegisterMode.CharacterWise, isClipboardRegister: true }
   };
 
   public static isClipboardRegister(registerName: string): boolean {
     const register = Register.registers[registerName];
-
-    if (register && register.isClipboardRegister) {
-      return true;
-    }
-
-    return false;
+    return register && register.isClipboardRegister;
   }
 
   public static isValidRegister(register: string): boolean {
@@ -104,8 +99,14 @@ export class Register {
       throw new Error(`Invalid register ${register}`);
     }
 
+    // Clipboard registers are always defined, so if a register doesn't already
+    // exist we can be sure it's not a clipboard one
     if (!Register.registers[register]) {
-      Register.registers[register] = { text: "", registerMode: RegisterMode.CharacterWise };
+      Register.registers[register] = {
+        text               : "",
+        registerMode       : RegisterMode.CharacterWise,
+        isClipboardRegister: false
+      };
     }
 
     /* Read from system clipboard */

--- a/src/register/register.ts
+++ b/src/register/register.ts
@@ -1,5 +1,6 @@
 import { VimState } from './../mode/modeHandler';
 import * as clipboard from 'copy-paste';
+
 /**
  * There are two different modes of copy/paste in Vim - copy by character
  * and copy by line. Copy by line typically happens in Visual Line mode, but
@@ -21,7 +22,7 @@ export interface IRegisterContent {
 export class Register {
   /**
    * The '"' is the unnamed register.
-   * The '*' is the special register for stroing into system clipboard.
+   * The '*' and '+' are special registers for accessing the system clipboard.
    * TODO: Read-Only registers
    *  '.' register has the last inserted text.
    *  '%' register has the current file path.
@@ -30,8 +31,15 @@ export class Register {
    */
   private static registers: { [key: string]: IRegisterContent } = {
     '"': { text: "", registerMode: RegisterMode.CharacterWise },
-    '*': { text: "", registerMode: RegisterMode.CharacterWise }
+    '*': { text: "", registerMode: RegisterMode.CharacterWise },
+    '+': { text: "", registerMode: RegisterMode.CharacterWise }
   };
+
+  private static systemClipboardRegisters: string[] = ["*", "+"];
+
+  public static isSystemClipboardRegister(register: string): boolean {
+    return Register.systemClipboardRegisters.indexOf(register) !== -1;
+  }
 
   public static isValidRegister(register: string): boolean {
     return register in Register.registers || /^[a-z0-9]+$/i.test(register);
@@ -48,7 +56,7 @@ export class Register {
       throw new Error(`Invalid register ${register}`);
     }
 
-    if (register === '*') {
+    if (Register.isSystemClipboardRegister(register)) {
       clipboard.copy(content);
     }
 
@@ -65,7 +73,7 @@ export class Register {
       throw new Error(`Invalid register ${register}`);
     }
 
-    if (register === '*') {
+    if (Register.isSystemClipboardRegister(register)) {
       clipboard.copy(content);
     }
 
@@ -94,7 +102,7 @@ export class Register {
     }
 
     /* Read from system clipboard */
-    if (register === '*') {
+    if (Register.isSystemClipboardRegister(register)) {
       const text = await new Promise<string>((resolve, reject) =>
         clipboard.paste((err, text) => {
           if (err) {

--- a/test/register/register.test.ts
+++ b/test/register/register.test.ts
@@ -27,10 +27,18 @@ suite("register", () => {
   });
 
   clipboard.copy("12345");
+
   newTest({
     title: "Can access '*' (clipboard) register",
     start: ['|one'],
     keysPressed: '"*P',
+    end: ["1234|5one"],
+  });
+
+  newTest({
+    title: "Can access '+' (clipboard) register",
+    start: ['|one'],
+    keysPressed: '"+P',
     end: ["1234|5one"],
   });
 


### PR DESCRIPTION
This adds support for accessing the system clipboard using the `"+` register, addressing #780.

The `"+` register is basically an alias for the `"*` register, so I didn't make any changes to [how the `useClipboard` setting is handled](https://github.com/VSCodeVim/Vim/blob/master/src/mode/modeHandler.ts#L372).