### PR TITLE
Add autoindent to README, fix hlsearch default

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,10 @@ The following is a subset of the supported configurations; the full list is desc
 
 * hlsearch
   * When there is a previous search pattern, highlight all its matches
+  * Type: Boolean (Default: `false`)
+
+* autoindent
+  * Copy indent from current line when starting a new line
   * Type: Boolean (Default: `true`)
 
 ## F.A.Q.


### PR DESCRIPTION
I believe [hlsearch is false by default](https://github.com/VSCodeVim/Vim/blob/214619d8d61524960c2c4d099a6a120e3a0e91a2/src/configuration/configuration.ts#L56).

Trivial change, haven't run tests 😃 