### PR TITLE
Unnecessary quit check on untitled files

### DIFF
--- a/src/cmd_line/commands/quit.ts
+++ b/src/cmd_line/commands/quit.ts
@@ -29,10 +29,6 @@ export class QuitCommand extends node.CommandBase {
   }
 
   async execute() : Promise<void> {
-    if (this.activeTextEditor.document.isUntitled && !this._arguments.bang) {
-      throw error.VimError.fromCode(error.ErrorCode.E32);
-    }
-
     if (this.activeTextEditor.document.isDirty && !this.arguments.bang) {
       throw error.VimError.fromCode(error.ErrorCode.E37);
     }


### PR DESCRIPTION
Is there a reason this was here? This PR is more of a question, but could be merged if it makes sense...

Shouldnt :q on a new untitled file work? On MacVim if I open it and immediately do :q it quits

This is also causing #846 