### PR TITLE
[WIP] Fix whitespace/tab j/k issues

### DIFF
--- a/src/actions/actions.ts
+++ b/src/actions/actions.ts
@@ -2333,12 +2333,19 @@ class MoveDown extends BaseMovement {
   doesntChangeDesiredColumn = true;
 
   public async execAction(position: Position, vimState: VimState): Promise<Position> {
-    return position.getDown(vimState.desiredColumn);
+    const { newPosition, newDesiredColumn } = position.getDownWhileObservingTabstops(vimState.desiredColumn);
+
+    vimState.desiredColumn = newDesiredColumn;
+    return newPosition;
   }
 
   public async execActionForOperator(position: Position, vimState: VimState): Promise<Position> {
+    const { newPosition, newDesiredColumn } = position.getDownWhileObservingTabstops(vimState.desiredColumn);
+
+    vimState.desiredColumn = newDesiredColumn;
     vimState.currentRegisterMode = RegisterMode.LineWise;
-    return position.getDown(position.getLineEnd().character);
+
+    return newPosition;
   }
 }
 

--- a/src/configuration/configuration.ts
+++ b/src/configuration/configuration.ts
@@ -58,6 +58,9 @@ export class Configuration {
   smartcase: boolean = true;
   autoindent: boolean = true;
 
+  /**
+   * The width of a tab character in spaces.
+   */
   @overlapSetting({ codeName: "tabSize", default: 8})
   tabstop: number | undefined = undefined;
 

--- a/src/motion/position.ts
+++ b/src/motion/position.ts
@@ -366,6 +366,62 @@ export class Position extends vscode.Position {
   }
 
   /**
+   * Get the position of the line directly below the current line. The resulting
+   * position will be tabstop and whitespace aware, so that if you've mixed the two,
+   * it will still end up at the right place.
+   */
+  public getDownWhileObservingTabstops(desiredColumn: number): {
+    newPosition: Position;
+    newDesiredColumn: number;
+  } {
+    if (this.getDocumentEnd().line !== this.line) {
+      const nextLine = this.line + 1;
+      const nextLineLength = Position.getLineLength(nextLine);
+      const tabstop = Configuration.getInstance().tabstop;
+
+      const thisLineStr = TextEditor.getLineAt(this).text;
+      const nextLineStr = TextEditor.getLineAt(this.getNextLineBegin()).text;
+
+      const tabsInThisLine = thisLineStr.split("\t").length - 1;
+      const tabsInNextLine = nextLineStr.split("\t").length - 1;
+
+      const thisLineLenSpaceNormalized = thisLineStr.length - tabsInThisLine + tabsInThisLine * tabstop;
+      const nextLineLenSpaceNormalized = nextLineStr.length - tabsInNextLine + tabsInNextLine * tabstop;
+
+      let result = 0;
+
+      let iTabSpacesLeft = 0;
+      let jTabSpacesLeft = 0;
+
+      for (let i = 0, j = 0; i < thisLineLenSpaceNormalized && j < nextLineLenSpaceNormalized;) {
+        if (i === desiredColumn) {
+          result = j;
+          break;
+        }
+
+        if (thisLineStr[i] === "\t" && iTabSpacesLeft === 0) { iTabSpacesLeft = tabstop!; }
+        if (nextLineStr[j] === "\t" && jTabSpacesLeft === 0) { jTabSpacesLeft = tabstop!; }
+
+        if (iTabSpacesLeft > 0) { iTabSpacesLeft--; }
+        if (iTabSpacesLeft === 0) { i++; }
+
+        if (jTabSpacesLeft > 0) { jTabSpacesLeft--; }
+        if (jTabSpacesLeft === 0) { j++; }
+      }
+
+      return {
+        newPosition: new Position(nextLine, Math.min(nextLineLength, result)),
+        newDesiredColumn: result,
+      };
+    }
+
+    return {
+      newPosition: this,
+      newDesiredColumn: desiredColumn,
+    };
+  }
+
+  /**
    * Get the position of the line directly above the current line.
    */
   public getUp(desiredColumn: number) : Position {


### PR DESCRIPTION
This is an implementation that sort of works but is annoying. 

Does anyone know a better way to do this?
- @rebornix, others - `tabstop` does not always report the correct width of a tab - it seems like the setting can be overridden in-editor somehow. Do you know how to get the right width?
- anyone (but maybe @rebornix knows..?) - is there some provided way to move up/down through a document that has spaces and tabs while keeping the cursor on the right column? 
