### PR TITLE
Remove unused modehandlers when tabs are closed

### DIFF
--- a/extension.ts
+++ b/extension.ts
@@ -127,6 +127,11 @@ export async function activate(context: vscode.ExtensionContext) {
     }, 0);
   });
 
+  vscode.workspace.onDidCloseTextDocument((event) => {
+    // Remove modehandler for closed document
+    delete modeHandlerToEditorIdentity[event.fileName + vscode.window.activeTextEditor.viewColumn];
+  })
+
   registerCommand(context, 'type', async (args) => {
     taskQueue.enqueueTask({
       promise: async () => {


### PR DESCRIPTION
Woops, closed PR #863 by accident when cleaning up my fork with a git reset --hard to get back in sync with the VSCodeVim repo.

This mitigates when bad things happen in a modehandler, you can close the tab and when you reopen the file you can start again...
