### PR TITLE
allow remapping of ctrl-j and ctrl-k in settings.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -101,6 +101,16 @@
                 "when": "editorTextFocus && vim.mode != 'Insert Mode' && !inDebugRepl"
             },
             {
+                "key": "ctrl+j",
+                "command": "extension.vim_ctrl+j",
+                "when": "editorTextFocus && vim.mode != 'Insert Mode' && !inDebugRepl"
+            },
+            {
+                "key": "ctrl+k",
+                "command": "extension.vim_ctrl+k",
+                "when": "editorTextFocus && vim.mode != 'Insert Mode' && !inDebugRepl"
+            },
+            {
                 "key": "ctrl+h",
                 "command": "extension.vim_ctrl+h",
                 "when": "editorTextFocus && vim.mode == 'Insert Mode' && !inDebugRepl"


### PR DESCRIPTION
Edit package.json to allow `ctrl-j` and `ctrl-k` to be mapped in settings.json

