### PR TITLE
display register value in reg-cmd, fix #830

### DIFF
--- a/src/cmd_line/commands/register.ts
+++ b/src/cmd_line/commands/register.ts
@@ -8,7 +8,6 @@ import { Register} from '../../register/register';
 export interface IRegisterCommandArguments extends node.ICommandArgs {
   arg?: string;
 }
-
 export class RegisterCommand extends node.CommandBase {
   protected _arguments : IRegisterCommandArguments;
 
@@ -23,11 +22,18 @@ export class RegisterCommand extends node.CommandBase {
     return this._arguments;
   }
 
-  async displayRegisterValue(register: string): Promise<void> {
+  private async getRegisterDisplayValue(register: string) {
     let result = (await Register.getByKey(register)).text;
     if (result instanceof Array) {
       result = result.join("\n").substr(0, 100);
     }
+
+    return result;
+  }
+
+  async displayRegisterValue(register: string): Promise<void> {
+    let result = this.getRegisterDisplayValue(register);
+
     vscode.window.showInformationMessage(`${register} ${result}`);
   }
 
@@ -35,8 +41,23 @@ export class RegisterCommand extends node.CommandBase {
     if (this.arguments.arg !== undefined && this.arguments.arg.length > 0) {
       await this.displayRegisterValue(this.arguments.arg);
     } else {
-      vscode.window.showQuickPick(Register.getKeys()).then(async (val) => {
-        await this.displayRegisterValue(val);
+      const currentRegisterKeys = Register.getKeys();
+      const registerKeyAndContent = new Array<any>();
+
+      for (let registerKey of currentRegisterKeys) {
+        registerKeyAndContent.push(
+          {
+            label: registerKey,
+            description: await this.getRegisterDisplayValue(registerKey)
+          }
+        );
+      }
+
+      vscode.window.showQuickPick(registerKeyAndContent).then(async (val) => {
+        if (val) {
+          let result = val.description;
+          vscode.window.showInformationMessage(`${val.label} ${result}`);
+        }
       });
     }
   }


### PR DESCRIPTION
Please include a description of your change and ensure:

- [x] Commit message has a short title & issue references
- [x] Each commit does a logical chunk of work.
- [x] It builds and tests pass (e.g `gulp`)

---

Display register value in reg command. Also fixes #830.
![grafik](https://cloud.githubusercontent.com/assets/3358663/19342452/3e52e290-9132-11e6-8b10-d1ab03c5bb12.png)

