### PR TITLE
Draw multicursor correctly in Visual Mode

### DIFF
--- a/src/mode/modeHandler.ts
+++ b/src/mode/modeHandler.ts
@@ -1353,7 +1353,9 @@ export class ModeHandler implements vscode.Disposable {
       // Fake block cursor with text decoration. Unfortunately we can't have a cursor
       // in the middle of a selection natively, which is what we need for Visual Mode.
 
-      rangesToDraw.push(new vscode.Range(stop, stop.getRight()));
+      for (const { stop: cursorStop } of vimState.allCursors) {
+        rangesToDraw.push(new vscode.Range(cursorStop, cursorStop.getRight()));
+      }
     }
 
     // Draw marks

--- a/src/mode/modeHandler.ts
+++ b/src/mode/modeHandler.ts
@@ -1239,37 +1239,32 @@ export class ModeHandler implements vscode.Disposable {
   }
 
   public async updateView(vimState: VimState, drawSelection = true): Promise<void> {
-    // Update cursor position
-
-    let start = vimState.cursorStartPosition;
-    let stop  = vimState.cursorPosition;
-
-    if (vimState.currentMode === ModeName.Visual) {
-
-      /**
-       * Always select the letter that we started visual mode on, no matter
-       * if we are in front or behind it. Imagine that we started visual mode
-       * with some text like this:
-       *
-       *   abc|def
-       *
-       * (The | represents the cursor.) If we now press w, we'll select def,
-       * but if we hit b we expect to select abcd, so we need to getRight() on the
-       * start of the selection when it precedes where we started visual mode.
-       */
-
-      if (start.compareTo(stop) > 0) {
-        start = start.getRight();
-      }
-    }
-
     // Draw selection (or cursor)
 
     if (drawSelection) {
       let selections: vscode.Selection[];
 
       if (!vimState.isMultiCursor) {
+        let start = vimState.cursorStartPosition;
+        let stop = vimState.cursorPosition;
+
         if (vimState.currentMode === ModeName.Visual) {
+          /**
+           * Always select the letter that we started visual mode on, no matter
+           * if we are in front or behind it. Imagine that we started visual mode
+           * with some text like this:
+           *
+           *   abc|def
+           *
+           * (The | represents the cursor.) If we now press w, we'll select def,
+           * but if we hit b we expect to select abcd, so we need to getRight() on the
+           * start of the selection when it precedes where we started visual mode.
+           */
+
+          if (start.compareTo(stop) > 0) {
+            start = start.getRight();
+          }
+
           selections = [ new vscode.Selection(start, stop) ];
         } else if (vimState.currentMode === ModeName.VisualLine) {
           selections = [ new vscode.Selection(
@@ -1294,7 +1289,11 @@ export class ModeHandler implements vscode.Disposable {
         if (vimState.currentMode === ModeName.Visual) {
           selections = [];
 
-          for (const { start: cursorStart, stop: cursorStop } of vimState.allCursors) {
+          for (let { start: cursorStart, stop: cursorStop } of vimState.allCursors) {
+            if (cursorStart.compareTo(cursorStop) > 0) {
+              cursorStart = cursorStart.getRight();
+            }
+
             selections.push(new vscode.Selection(cursorStart, cursorStop));
           }
         } else if (vimState.currentMode === ModeName.Normal ||


### PR DESCRIPTION
Please include a description of your change and ensure:

- [x] Commit message has a short title & issue references
- [x] Each commit does a logical chunk of work.
- [x] It builds and tests pass (e.g `gulp`)

---

I did not create an issue for that, so here is the thing. In Visual Multicursor Mode no decorator for multicursor where drawn, and also the selection start was not drawn correctly.

![gif](https://cloud.githubusercontent.com/assets/3358663/19377723/b1158722-91e8-11e6-8e54-975b9cd0d999.gif)

Now it looks like:
![gif](https://cloud.githubusercontent.com/assets/3358663/19377656/57ac4fb8-91e8-11e6-8927-d0da5438c9e1.gif)

