### PR TITLE
Update internal cursor position when necessary

### DIFF
--- a/extension.ts
+++ b/extension.ts
@@ -93,7 +93,7 @@ export async function getAndUpdateModeHandler(): Promise<ModeHandler> {
   } else {
     previousActiveEditorId = activeEditorId;
 
-    await handler.updateView(handler.vimState);
+    await handler.updateView(handler.vimState, false);
   }
 
   if (oldHandler && oldHandler.vimState.focusChanged) {

--- a/src/mode/modeHandler.ts
+++ b/src/mode/modeHandler.ts
@@ -453,6 +453,7 @@ export class ModeHandler implements vscode.Disposable {
     if (vscode.window.activeTextEditor) {
       this._vimState.cursorStartPosition = Position.FromVSCodePosition(vscode.window.activeTextEditor.selection.start);
       this._vimState.cursorPosition = Position.FromVSCodePosition(vscode.window.activeTextEditor.selection.start);
+      this._vimState.whatILastSetTheSelectionTo = vscode.window.activeTextEditor.selection;
     }
 
     // Handle scenarios where mouse used to change current position.
@@ -466,6 +467,10 @@ export class ModeHandler implements vscode.Disposable {
     this._toBeDisposed.push(disposer);
   }
 
+  /**
+   * Anyone who wants to change the behavior of this method should make sure all selection related test cases pass.
+   * Follow this spec https://gist.github.com/rebornix/d21d1cc060c009d4430d3904030bd4c1 to perform the manual testing.
+   */
   private async handleSelectionChange(e: vscode.TextEditorSelectionChangeEvent): Promise<void> {
     let selection = e.selections[0];
 
@@ -496,7 +501,10 @@ export class ModeHandler implements vscode.Disposable {
       return;
     }
 
-    // Only handle mouse selections
+    /**
+     * We only trigger our view updating process if it's a mouse selection.
+     * Otherwise we only update our internal cursor postions accordingly.
+     */
     if (e.kind !== vscode.TextEditorSelectionChangeKind.Mouse) {
       if (selection) {
         this._vimState.cursorPosition = Position.FromVSCodePosition(selection.active);

--- a/src/mode/modeHandler.ts
+++ b/src/mode/modeHandler.ts
@@ -509,7 +509,8 @@ export class ModeHandler implements vscode.Disposable {
       if (selection) {
         if (this._vimState.getModeObject(this).isVisualMode) {
           /**
-           * In Visual Mode, our `cursorPosition` and `cursorStartPosition` can not refect `active`, `start`, `end` and `anchor` information in a selection.
+           * In Visual Mode, our `cursorPosition` and `cursorStartPosition` can not refect `active`,
+           * `start`, `end` and `anchor` information in a selection.
            * See `Fake block cursor with text decoration` section of `updateView` method.
            */
           return;

--- a/src/mode/modeHandler.ts
+++ b/src/mode/modeHandler.ts
@@ -496,20 +496,14 @@ export class ModeHandler implements vscode.Disposable {
       return;
     }
 
-    if (!e.kind || e.kind === vscode.TextEditorSelectionChangeKind.Command) {
-      // Whether e.kind is undefined or Command, it means the selection change is from Code.
+    // Only handle mouse selections
+    if (e.kind !== vscode.TextEditorSelectionChangeKind.Mouse) {
       if (selection) {
         this._vimState.cursorPosition = Position.FromVSCodePosition(selection.active);
         this._vimState.cursorStartPosition = Position.FromVSCodePosition(selection.start);
 
         this._vimState.desiredColumn = this._vimState.cursorPosition.character;
       }
-
-      return;
-    }
-
-    // Only handle mouse selections
-    if (e.kind !== vscode.TextEditorSelectionChangeKind.Mouse) {
       return;
     }
 

--- a/src/mode/modeHandler.ts
+++ b/src/mode/modeHandler.ts
@@ -508,10 +508,13 @@ export class ModeHandler implements vscode.Disposable {
     if (e.kind !== vscode.TextEditorSelectionChangeKind.Mouse) {
       if (selection) {
         if (this._vimState.getModeObject(this).isVisualMode) {
-          // In Visual Mode, our `cursorPosition` and `cursorStartPosition` can not refect
-          // `active`, `start`, `end` and `anchor` information in a selection
+          /**
+           * In Visual Mode, our `cursorPosition` and `cursorStartPosition` can not refect `active`, `start`, `end` and `anchor` information in a selection.
+           * See `Fake block cursor with text decoration` section of `updateView` method.
+           */
           return;
         }
+
         this._vimState.cursorPosition = Position.FromVSCodePosition(selection.active);
         this._vimState.cursorStartPosition = Position.FromVSCodePosition(selection.start);
 

--- a/src/mode/modeHandler.ts
+++ b/src/mode/modeHandler.ts
@@ -507,6 +507,11 @@ export class ModeHandler implements vscode.Disposable {
      */
     if (e.kind !== vscode.TextEditorSelectionChangeKind.Mouse) {
       if (selection) {
+        if (this._vimState.getModeObject(this).isVisualMode) {
+          // In Visual Mode, our `cursorPosition` and `cursorStartPosition` can not refect
+          // `active`, `start`, `end` and `anchor` information in a selection
+          return;
+        }
         this._vimState.cursorPosition = Position.FromVSCodePosition(selection.active);
         this._vimState.cursorStartPosition = Position.FromVSCodePosition(selection.start);
 

--- a/test/mode/modeVisualLine.test.ts
+++ b/test/mode/modeVisualLine.test.ts
@@ -5,9 +5,15 @@ import { ModeHandler } from '../../src/mode/modeHandler';
 import { setupWorkspace, cleanUpWorkspace, assertEqualLines, assertEqual } from './../testUtils';
 import { ModeName } from '../../src/mode/mode';
 import { TextEditor } from '../../src/textEditor';
+import { getTestingFunctions } from '../testSimplifier';
 
 suite("Mode Visual", () => {
-  let modeHandler: ModeHandler;
+  let modeHandler: ModeHandler = new ModeHandler();
+
+  let {
+    newTest,
+    newTestOnly,
+  } = getTestingFunctions(modeHandler);
 
   setup(async () => {
     await setupWorkspace();
@@ -236,6 +242,23 @@ suite("Mode Visual", () => {
       ]);
 
       assertEqualLines(["two"]);
+    });
+
+  });
+
+  suite("Arrow keys work perfectly in Visual Line Mode", () => {
+    newTest({
+      title: "Can handle <up> key",
+      start: ['blah', 'duh', '|dur', 'hur'],
+      keysPressed: 'V<up>x',
+      end: ['blah', '|hur']
+    });
+
+    newTest({
+      title: "Can handle <down> key",
+      start: ['blah', 'duh', '|dur', 'hur'],
+      keysPressed: 'V<down>x',
+      end: ['blah', '|duh']
     });
   });
 });

--- a/test/mode/normalModeTests/commands.test.ts
+++ b/test/mode/normalModeTests/commands.test.ts
@@ -213,6 +213,13 @@ suite("Mode Normal", () => {
     });
 
     newTest({
+      title: "Can handle 'J' with a following delete",
+      start: ['on|e', 'two'],
+      keysPressed: 'Jx',
+      end: ['one|two']
+    });
+
+    newTest({
       title: "Can handle 'gJ' once",
       start: ['|one', 'two'],
       keysPressed: 'kgJ',

--- a/test/mode/normalModeTests/dot.test.ts
+++ b/test/mode/normalModeTests/dot.test.ts
@@ -66,7 +66,6 @@ suite("Dot Operator", () => {
       keysPressed: 'Vj>.',
       end: ['        |one', '        two']
     });
-
 });
 
 suite("Repeat content change", () => {


### PR DESCRIPTION
Yay! We love PRs! 🎊

Please include a description of your change and ensure:

- [x] Commit message has a short title & issue references
- [x] Each commit does a logical chunk of work.
- [x] It builds and tests pass (e.g `gulp`)

I did two things here

1. Update internal cursor position whenever there is selection change.
2. Stop redrawing cursors when switching panes or tabs as Code is maintaining the cursor position for us.