### PR TITLE
fixes #905

### DIFF
--- a/extension.ts
+++ b/extension.ts
@@ -152,10 +152,11 @@ export async function activate(context: vscode.ExtensionContext) {
   vscode.workspace.onDidCloseTextDocument((event) => {
     const key = event.fileName + vscode.window.activeTextEditor.viewColumn;
 
-    modeHandlerToEditorIdentity[key].dispose();
-
-    // Remove modehandler for closed document
-    delete modeHandlerToEditorIdentity[key];
+    if (modeHandlerToEditorIdentity[key] !== undefined) {
+      modeHandlerToEditorIdentity[key].dispose();
+      // Remove modehandler for closed document
+      delete modeHandlerToEditorIdentity[key];
+    }
   });
 
   registerCommand(context, 'type', async (args) => {


### PR DESCRIPTION
Wasn't able to reproduce this when running from source, but based on the trace this should fix 905

The following was something I saw in my log as well, just like the issue

```
Cannot read property 'dispose' of undefined: TypeError: Cannot read property 'dispose' of undefined
    at vscode.workspace.onDidCloseTextDocument (/Users/sean/.vscode/extensions/vscodevim.vim-0.3.7/out/extension.js:127:45)
    at e.invoke (/Applications/Visual Studio Code.app/Contents/Resources/app/out/vs/workbench/node/extensionHostProcess.js:5:6321)
    at e.fire (/Applications/Visual Studio Code.app/Contents/Resources/app/out/vs/workbench/node/extensionHostProcess.js:5:14643)
    at t.$acceptModelRemoved (/Applications/Visual Studio Code.app/Contents/Resources/app/out/vs/workbench/node/extensionHostProcess.js:12:5814)
    at t.e.handle (/Applications/Visual Studio Code.app/Contents/Resources/app/out/vs/workbench/node/extensionHostProcess.js:11:11474)
    at s (/Applications/Visual Studio Code.app/Contents/Resources/app/out/vs/workbench/node/extensionHostProcess.js:8:2033)
    at p (/Applications/Visual Studio Code.app/Contents/Resources/app/out/vs/workbench/node/extensionHostProcess.js:8:2710)
    at _combinedTickCallback (internal/process/next_tick.js:67:7)
    at process._tickCallback (internal/process/next_tick.js:98:9)e.onUnexpectedError @ shell.ts:441
```