### PR TITLE
add gh hover command

### DIFF
--- a/src/actions/actions.ts
+++ b/src/actions/actions.ts
@@ -4903,6 +4903,19 @@ class MoveAroundTag extends MoveTagMatch {
   includeTag = true;
 }
 
+@RegisterAction
+class ActionTriggerHover extends BaseCommand {
+  modes = [ModeName.Normal];
+  keys = ["g", "h"];
+  runsOnceForEveryCursor() { return false; }
+
+  public async exec(position: Position, vimState: VimState): Promise<VimState> {
+    await vscode.commands.executeCommand("editor.action.showHover");
+
+    return vimState;
+  }
+}
+
 /**
  * Multi-Cursor Command Overrides
  *


### PR DESCRIPTION
Yay! We love PRs! 🎊

Please include a description of your change and ensure:

- [ ] Commit message has a short title & issue references
- [ ] Each commit does a logical chunk of work.
- [ ] It builds and tests pass (e.g `gulp`)

More info can be found on our [contribution guide](https://github.com/VSCodeVim/Vim/blob/master/.github/CONTRIBUTING.md).

@johnfn After talking on the Slack channel (as willwow), here's a little PR to add a `gh` command to bring up the hover text when in normal mode. One thing that's annoying is that it seems that `showHover` takes focus away from the editor, so you have to press ESC to get back to normal mode (the same thing happens with the default VS Code shortcut). I'd think that ideally any other command would close that hover box, but I'm not sure how I'd set that up.

Thanks!