### PR TITLE
Fix replace in visual, visual line, and visual block mode

### DIFF
--- a/src/actions/actions.ts
+++ b/src/actions/actions.ts
@@ -3852,18 +3852,12 @@ class ActionReplaceCharacterVisual extends BaseCommand {
     let end = vimState.cursorPosition;
 
     // If selection is reversed, reorganize it so that the text replace logic always works
-    if (start.line > end.line || ((start.line === end.line)
-      && (start.character > end.character))) {
-      let tmp = start;
-      start = end;
-      end = tmp;
-      visualSelectionOffset = 0;
+    if (end.isBeforeOrEqual(start)) {
+      [start, end] = [end, start];
     }
 
-    // Visual line includes EOL so we do not want to modify the selection at all
-    if (vimState.currentMode === ModeName.VisualLine) {
-      visualSelectionOffset = 0;
-    }
+    // Limit to not replace EOL
+    end = new Position(end.line, Math.min(end.character, TextEditor.getLineAt(end).text.length - 1));
 
     // Iterate over every line in the current selection
     for (var lineNum = start.line; lineNum <= end.line; lineNum++) {

--- a/src/actions/actions.ts
+++ b/src/actions/actions.ts
@@ -3845,7 +3845,7 @@ class ActionReplaceCharacterVisual extends BaseCommand {
   canBeRepeatedWithDot = true;
 
   public async exec(position: Position, vimState: VimState): Promise<VimState> {
-    const toInsert   = this.keysPressed[1];
+    const toInsert = this.keysPressed[1];
 
     let visualSelectionOffset = 1;
     let start = vimState.cursorStartPosition;

--- a/src/mode/modeHandler.ts
+++ b/src/mode/modeHandler.ts
@@ -1211,14 +1211,14 @@ export class ModeHandler implements vscode.Disposable {
 
     const selections = vscode.window.activeTextEditor.selections;
     const firstTransformation = transformations[0];
-    const manuallySetCursorPositions = firstTransformation.type === "deleteRange" &&
-                                       firstTransformation.manuallySetCursorPositions;
+    const manuallySetCursorPositions = ((firstTransformation.type === "deleteRange" || firstTransformation.type === "replaceText")
+      && firstTransformation.manuallySetCursorPositions);
 
     // We handle multiple cursors in a different way in visual block mode, unfortunately.
     // TODO - refactor that out!
     if (vimState.currentMode !== ModeName.VisualBlockInsertMode &&
-        vimState.currentMode !== ModeName.VisualBlock &&
-        !manuallySetCursorPositions) {
+      vimState.currentMode !== ModeName.VisualBlock &&
+      !manuallySetCursorPositions) {
       vimState.allCursors = [];
 
       const resultingCursors: Range[] = [];
@@ -1366,6 +1366,9 @@ export class ModeHandler implements vscode.Disposable {
             Position.EarlierOf(start, stop).getLineBegin(),
             Position.LaterOf(start, stop).getLineEnd()
           ) ];
+          vimState.cursorStartPosition = selections[0].start as Position;
+          vimState.cursorPosition = selections[0].end as Position;
+
         } else if (vimState.currentMode === ModeName.VisualBlock) {
           selections = [];
 

--- a/src/motion/position.ts
+++ b/src/motion/position.ts
@@ -192,6 +192,41 @@ export class Position extends vscode.Position {
   }
 
   /**
+   * Iterate over every position in the selection defined by the two positions passed in.
+   */
+  public static *IterateSelection(topLeft: Position, bottomRight: Position): Iterable<{ line: string, char: string, pos: Position }> {
+    for (let lineIndex = topLeft.line; lineIndex <= bottomRight.line; lineIndex++) {
+      const line = TextEditor.getLineAt(new Position(lineIndex, 0)).text;
+
+      if (lineIndex === topLeft.line) {
+        for (let charIndex = topLeft.character; charIndex < line.length + 1; charIndex++) {
+          yield {
+            line: line,
+            char: line[charIndex],
+            pos: new Position(lineIndex, charIndex)
+          };
+        }
+      } else if (lineIndex === bottomRight.line) {
+        for (let charIndex = 0; charIndex < bottomRight.character + 1; charIndex++) {
+          yield {
+            line: line,
+            char: line[charIndex],
+            pos: new Position(lineIndex, charIndex)
+          };
+        }
+      } else {
+        for (let charIndex = 0; charIndex < line.length + 1; charIndex++) {
+          yield {
+            line: line,
+            char: line[charIndex],
+            pos: new Position(lineIndex, charIndex)
+          };
+        }
+      }
+    }
+  }
+
+  /**
    * Iterate over every line in the block defined by the two positions passed in.
    *
    * This is intended for visual block mode.

--- a/src/transformations/transformations.ts
+++ b/src/transformations/transformations.ts
@@ -75,6 +75,11 @@ export interface ReplaceTextTransformation {
    * If you don't know what this is, just ignore it. You probably don't need it.
    */
   diff?: PositionDiff;
+
+  /**
+   * Please don't use this! It's a hack.
+   */
+  manuallySetCursorPositions?: boolean;
 }
 
 /**

--- a/test/mode/modeVisual.test.ts
+++ b/test/mode/modeVisual.test.ts
@@ -549,4 +549,23 @@ suite("Mode Visual", () => {
       endMode: ModeName.Normal
     });
   });
+
+  suite("handles replace in visual mode", () => {
+    newTest({
+      title: "Can do a single line replace",
+      start: ["one |two three four five"],
+      keysPressed: "vwwer1",
+      end: ["one |11111111111111 five"],
+      endMode: ModeName.Normal
+    });
+
+    newTest({
+      title: "Can do a multi line replace",
+      start: ["one |two three four five", "one two three four five"],
+      keysPressed: "vjer1",
+      end: ["one |1111111111111111111", "1111111 three four five"],
+      endMode: ModeName.Normal
+    });
+  });
+
 });

--- a/test/mode/modeVisualBlock.test.ts
+++ b/test/mode/modeVisualBlock.test.ts
@@ -56,4 +56,12 @@ suite("Mode Visual Block", () => {
     end: ['t123est', 't123|est'],
   });
 
+   newTest({
+      title: "Can do a multi line replace",
+      start: ["one |two three four five", "one two three four five"],
+      keysPressed: "<C-v>jeer1",
+      end: ["one |111111111 four five", "one 111111111 four five"],
+      endMode: ModeName.Normal
+    });
+
 });

--- a/test/mode/modeVisualLine.test.ts
+++ b/test/mode/modeVisualLine.test.ts
@@ -261,4 +261,22 @@ suite("Mode Visual", () => {
       end: ['blah', '|duh']
     });
   });
+
+   suite("handles replace in visual line mode", () => {
+    newTest({
+      title: "Can do a single line replace",
+      start: ["one |two three four five", "one two three four five"],
+      keysPressed: "Vr1",
+      end: ["|111111111111111111111111", "one two three four five"],
+      endMode: ModeName.Normal
+    });
+
+    newTest({
+      title: "Can do a multi visual line replace",
+      start: ["one |two three four five", "one two three four five"],
+      keysPressed: "Vjr1",
+      end: ["|11111111111111111111111", "11111111111111111111111"],
+      endMode: ModeName.Normal
+    });
+  });
 });

--- a/test/mode/modeVisualLine.test.ts
+++ b/test/mode/modeVisualLine.test.ts
@@ -262,6 +262,36 @@ suite("Mode Visual", () => {
     });
   });
 
+  suite("Can handle d correctly in Visual Line Mode", () => {
+    newTest({
+      title: "Can handle d key",
+      start: ['|{', '  a = 1;', '}'],
+      keysPressed: 'VGdp',
+      end: ['', '|{', '  a = 1;', '}']
+    });
+
+    newTest({
+      title: "Can handle d key",
+      start: ['|{', '  a = 1;', '}'],
+      keysPressed: 'VGdP',
+      end: ['|{', '  a = 1;', '}', '']
+    });
+
+    newTest({
+      title: "Can handle d key",
+      start: ['1', '2', '|{', '  a = 1;', '}'],
+      keysPressed: 'VGdp',
+      end: ['1', '2', '|{', '  a = 1;', '}']
+    });
+
+    newTest({
+      title: "Can handle d key",
+      start: ['1', '2', '|{', '  a = 1;', '}'],
+      keysPressed: 'VGdP',
+      end: ['1', '|{', '  a = 1;', '}', '2']
+    });
+  });
+
   suite("handles replace in visual line mode", () => {
     newTest({
       title: "Can do a single line replace",
@@ -278,35 +308,6 @@ suite("Mode Visual", () => {
       end: ["|11111111111111111111111", "11111111111111111111111"],
       endMode: ModeName.Normal
     });
-
-    suite("Can handle d correctly in Visual Line Mode", () => {
-      newTest({
-        title: "Can handle d key",
-        start: ['|{', '  a = 1;', '}'],
-        keysPressed: 'VGdp',
-        end: ['', '|{', '  a = 1;', '}']
-      });
-
-      newTest({
-        title: "Can handle d key",
-        start: ['|{', '  a = 1;', '}'],
-        keysPressed: 'VGdP',
-        end: ['|{', '  a = 1;', '}', '']
-      });
-
-      newTest({
-        title: "Can handle d key",
-        start: ['1', '2', '|{', '  a = 1;', '}'],
-        keysPressed: 'VGdp',
-        end: ['1', '2', '|{', '  a = 1;', '}']
-      });
-
-      newTest({
-        title: "Can handle d key",
-        start: ['1', '2', '|{', '  a = 1;', '}'],
-        keysPressed: 'VGdP',
-        end: ['1', '|{', '  a = 1;', '}', '2']
-      });
-    });
   });
+
 });

--- a/test/mode/modeVisualLine.test.ts
+++ b/test/mode/modeVisualLine.test.ts
@@ -297,7 +297,7 @@ suite("Mode Visual", () => {
       title: "Can do a single line replace",
       start: ["one |two three four five", "one two three four five"],
       keysPressed: "Vr1",
-      end: ["|111111111111111111111111", "one two three four five"],
+      end: ["|11111111111111111111111", "one two three four five"],
       endMode: ModeName.Normal
     });
 


### PR DESCRIPTION
Any feedback on better ways of doing any of this?

1. Visual block mode returns correctly after running "r" instead of having a few cursors left around
2. Replace does not replace unless there is a character, this applies to line, block, and regular visual
3. Replace added to visual and visual line with ~~an IterateSelection position function~~ selective replace transforms in chunks
