### PR TITLE
remove leading spaces when <Esc>... is pressed #685

### DIFF
--- a/test/mode/modeInsert.test.ts
+++ b/test/mode/modeInsert.test.ts
@@ -139,4 +139,14 @@ suite("Mode Insert", () => {
 
         assertEqual(TextEditor.getSelection().start.character, 3, "<BS> moved cursor to correct position");
     });
+
+    test("will not remove leading spaces input by user", async() => {
+        await modeHandler.handleMultipleKeyEvents([
+            'i',
+            ' ', ' ',
+            '<Esc>'
+        ]);
+
+        assertEqualLines(["  "]);
+    });
 });


### PR DESCRIPTION
fix #685 

I found it annoying that <Esc> doesn't remove leading spaces in insert mode. Today, I'm going to fix it myself, contributing to this aaaaaawesome project. You guys have done a great job. 👍 