### PR TITLE
Numbered, upper case and multicursor register

### DIFF
--- a/src/actions/actions.ts
+++ b/src/actions/actions.ts
@@ -3856,6 +3856,33 @@ class ActionDVisualBlock extends ActionXVisualBlock {
 }
 
 @RegisterAction
+class ActionSVisualBlock extends BaseCommand {
+  modes = [ModeName.VisualBlock];
+  keys = [["s"], ["S"]];
+  canBeRepeatedWithDot = true;
+  runsOnceForEveryCursor() { return false; }
+
+  public async exec(position: Position, vimState: VimState): Promise<VimState> {
+    for (const { start, end } of Position.IterateLine(vimState)) {
+      vimState.recordedState.transformations.push({
+        type  : "deleteRange",
+        range : new Range(start, end),
+        manuallySetCursorPositions: true,
+      });
+    }
+
+    if (vimState.cursorPosition.character < vimState.cursorStartPosition.character) {
+      vimState.cursorPosition = vimState.cursorPosition.getRight();
+    }
+
+    vimState.currentMode = ModeName.VisualBlockInsertMode;
+    vimState.recordedState.visualBlockInsertionType = VisualBlockInsertionType.Insert;
+    vimState.cursorPosition = vimState.cursorPosition.getLeft();
+    return vimState;
+  }
+}
+
+@RegisterAction
 class ActionGoToInsertVisualBlockMode extends BaseCommand {
   modes = [ModeName.VisualBlock];
   keys = ["I"];

--- a/src/actions/actions.ts
+++ b/src/actions/actions.ts
@@ -587,7 +587,7 @@ class CommandNumber extends BaseCommand {
 }
 
 @RegisterAction
-class CommandRegister extends BaseCommand {
+export class CommandRegister extends BaseCommand {
   modes = [ModeName.Normal, ModeName.Visual, ModeName.VisualLine];
   keys = ["\"", "<character>"];
   isCompleteAction = false;

--- a/src/actions/actions.ts
+++ b/src/actions/actions.ts
@@ -1712,15 +1712,7 @@ export class YankOperator extends BaseOperator {
         text = text + "\n";
       }
 
-      if (!vimState.isMultiCursor) {
-        Register.put(text, vimState);
-      } else {
-        if (this.multicursorIndex === 0) {
-          Register.put([], vimState);
-        }
-
-        Register.add(text, vimState);
-      }
+      Register.put(text, vimState, this.multicursorIndex);
 
       vimState.currentMode = ModeName.Normal;
       vimState.cursorStartPosition = start;
@@ -1943,7 +1935,7 @@ export class PutCommand extends BaseCommand {
             replay: "keystrokes"
           });
           return vimState;
-        } else if (typeof register.text === "object") {
+        } else if (typeof register.text === "object" && vimState.currentMode === ModeName.VisualBlock) {
           return await this.execVisualBlockPaste(register.text, position, vimState, after);
         }
 
@@ -3973,10 +3965,10 @@ export class YankVisualBlockMode extends BaseOperator {
     runsOnceForEveryCursor() { return false; }
 
     public async run(vimState: VimState, start: Position, end: Position): Promise<VimState> {
-      let toCopy: string[] = [];
+      let toCopy: string = "";
 
       for ( const { line } of Position.IterateLine(vimState)) {
-        toCopy.push(line);
+        toCopy += line + '\n';
       }
 
       Register.put(toCopy, vimState);

--- a/src/cmd_line/commands/register.ts
+++ b/src/cmd_line/commands/register.ts
@@ -28,6 +28,7 @@ export class RegisterCommand extends node.CommandBase {
       result = result.join("\n").substr(0, 100);
     } else if (result instanceof RecordedState) {
       // TODO
+      result = "";
     }
 
     return result;

--- a/src/register/register.ts
+++ b/src/register/register.ts
@@ -268,7 +268,8 @@ export class Register {
     } else if (baseOperator instanceof DeleteOperator) {
       // shift 'delete-history' register
       for (let index = 9; index > 1; index--) {
-        Register.registers[String(index)] = Register.registers[String(index - 1)];
+        Register.registers[String(index)].text = Register.registers[String(index - 1)].text;
+        Register.registers[String(index)].registerMode = Register.registers[String(index - 1)].registerMode;
       }
 
       // Paste last delete into register '1'

--- a/src/register/register.ts
+++ b/src/register/register.ts
@@ -111,7 +111,7 @@ export class Register {
   /**
    * Handles special cases for Yank- and DeleteOperator.
    */
-  private static ProcessNumberedRegister(content: string | string[], vimState: VimState): void {
+  private static ProcessNumberedRegister(content: RegisterContent, vimState: VimState): void {
     // Find the BaseOperator of the current actions
     const baseOperator = vimState.recordedState.actionsRun.find( (value) => {
       return value instanceof BaseOperator;

--- a/src/register/register.ts
+++ b/src/register/register.ts
@@ -108,7 +108,7 @@ export class Register {
   /**
    * Puts the content at the specified index of the multicursor Register.
    *
-   * `REMARKS:` This Procedure asume that you pass an valid register.
+   * `REMARKS:` This Procedure assume that you pass an valid register.
    */
   private static putMulticursorRegister(content: RegisterContent, register: string, vimState: VimState, multicursorIndex: number): void {
     if (multicursorIndex === 0) {
@@ -142,7 +142,7 @@ export class Register {
   /**
    * Appends the content at the specified index of the multicursor Register.
    *
-   * `REMARKS:` This Procedure asume that you pass an valid uppercase register.
+   * `REMARKS:` This Procedure assume that you pass an valid uppercase register.
    */
   private static appendMulticursorRegister(content: RegisterContent, register: string, vimState: VimState, multicursorIndex: number): void {
     let appendToRegister = Register.registers[register.toLowerCase()];
@@ -183,7 +183,7 @@ export class Register {
   /**
    * Puts the content in the specified Register.
    *
-   * `REMARKS:` This Procedure asume that you pass an valid register.
+   * `REMARKS:` This Procedure assume that you pass an valid register.
    */
   private static putNormalRegister(content: RegisterContent, register: string, vimState: VimState): void {
     if (Register.isClipboardRegister(register)) {
@@ -202,7 +202,7 @@ export class Register {
   /**
    * Appends the content at the specified index of the multicursor Register.
    *
-   * `REMARKS:` This Procedure asume that you pass an valid uppercase register.
+   * `REMARKS:` This Procedure assume that you pass an valid uppercase register.
    */
   private static appendNormalRegister(content: RegisterContent, register: string, vimState: VimState): void {
     let appendToRegister = Register.registers[register.toLowerCase()];

--- a/src/register/register.ts
+++ b/src/register/register.ts
@@ -209,18 +209,18 @@ export class Register {
     let currentRegisterMode = vimState.effectiveRegisterMode();
 
     // Check if appending to a multicursor register or normal
-    if (typeof appendToRegister.text === "object") {
+    if (appendToRegister.text instanceof Array) {
       if (appendToRegister.registerMode === RegisterMode.CharacterWise && currentRegisterMode === RegisterMode.CharacterWise) {
-        (appendToRegister.text as string[]).forEach(element => {
-          element += '\n' + content;
-        });
+        for (let i = 0; i < appendToRegister.text.length; i++) {
+          appendToRegister.text[i] += content;
+        }
       } else {
-        (appendToRegister.text as string[]).forEach(element => {
-          element += '\n' + content;
-        });
+        for (let i = 0; i < appendToRegister.text.length; i++) {
+          appendToRegister.text[i] += '\n' + content;
+        }
         appendToRegister.registerMode = currentRegisterMode;
       }
-    } else {
+    } else if (typeof appendToRegister.text === 'string') {
       if (appendToRegister.registerMode === RegisterMode.CharacterWise && currentRegisterMode === RegisterMode.CharacterWise) {
         appendToRegister.text = appendToRegister.text + content;
       } else {

--- a/src/register/register.ts
+++ b/src/register/register.ts
@@ -1,5 +1,6 @@
 import { VimState, RecordedState } from './../mode/modeHandler';
 import * as clipboard from 'copy-paste';
+import { YankOperator, BaseOperator, CommandRegister, DeleteOperator } from './../actions/actions';
 
 /**
  * There are two different modes of copy/paste in Vim - copy by character
@@ -35,7 +36,17 @@ export class Register {
   private static registers: { [key: string]: IRegisterContent } = {
     '"': { text: "", registerMode: RegisterMode.CharacterWise, isClipboardRegister: false },
     '*': { text: "", registerMode: RegisterMode.CharacterWise, isClipboardRegister: true },
-    '+': { text: "", registerMode: RegisterMode.CharacterWise, isClipboardRegister: true }
+    '+': { text: "", registerMode: RegisterMode.CharacterWise, isClipboardRegister: true },
+    '0': { text: "", registerMode: RegisterMode.CharacterWise, isClipboardRegister: false },
+    '1': { text: "", registerMode: RegisterMode.CharacterWise, isClipboardRegister: false },
+    '2': { text: "", registerMode: RegisterMode.CharacterWise, isClipboardRegister: false },
+    '3': { text: "", registerMode: RegisterMode.CharacterWise, isClipboardRegister: false },
+    '4': { text: "", registerMode: RegisterMode.CharacterWise, isClipboardRegister: false },
+    '5': { text: "", registerMode: RegisterMode.CharacterWise, isClipboardRegister: false },
+    '6': { text: "", registerMode: RegisterMode.CharacterWise, isClipboardRegister: false },
+    '7': { text: "", registerMode: RegisterMode.CharacterWise, isClipboardRegister: false },
+    '8': { text: "", registerMode: RegisterMode.CharacterWise, isClipboardRegister: false },
+    '9': { text: "", registerMode: RegisterMode.CharacterWise, isClipboardRegister: false }
   };
 
 
@@ -77,6 +88,8 @@ export class Register {
       registerMode       : vimState.effectiveRegisterMode(),
       isClipboardRegister: Register.isClipboardRegister(register),
     };
+
+    Register.ProcessNumberedRegister(content, vimState);
   }
 
   public static putByKey(content: RegisterContent, register = '"', registerMode = RegisterMode.FigureItOutFromCurrentMode): void {
@@ -93,6 +106,43 @@ export class Register {
       registerMode       : registerMode || RegisterMode.FigureItOutFromCurrentMode,
       isClipboardRegister: Register.isClipboardRegister(register),
     };
+  }
+
+  /**
+   * Handles special cases for Yank- and DeleteOperator.
+   */
+  private static ProcessNumberedRegister(content: string | string[], vimState: VimState): void {
+    // Find the BaseOperator of the current actions
+    const baseOperator = vimState.recordedState.actionsRun.find( (value) => {
+      return value instanceof BaseOperator;
+    });
+
+    if (baseOperator instanceof YankOperator) {
+      // 'yank' to 0 only if no register was specified
+      const registerCommand = vimState.recordedState.actionsRun.find( (value) => {
+        return value instanceof CommandRegister;
+      });
+
+      if (!registerCommand) {
+        Register.registers["0"] = {
+          text               : content,
+          registerMode       : vimState.effectiveRegisterMode(),
+          isClipboardRegister: Register.isClipboardRegister("0"),
+        };
+      }
+    } else if (baseOperator instanceof DeleteOperator) {
+      // shift 'delete-history' register
+      for (let index = 9; index > 1; index--) {
+        Register.registers[String(index)] = Register.registers[String(index - 1)];
+      }
+
+      // Paste last delete into register '1'
+      Register.registers["1"] = {
+        text               : content,
+        registerMode       : vimState.effectiveRegisterMode(),
+        isClipboardRegister: Register.isClipboardRegister("1"),
+      };
+    }
   }
 
   public static add(content: string, vimState: VimState): void {

--- a/src/register/register.ts
+++ b/src/register/register.ts
@@ -262,11 +262,8 @@ export class Register {
       });
 
       if (!registerCommand) {
-        Register.registers["0"] = {
-          text               : content,
-          registerMode       : vimState.effectiveRegisterMode(),
-          isClipboardRegister: Register.isClipboardRegister("0"),
-        };
+        Register.registers['0'].text = content;
+        Register.registers['0'].registerMode = vimState.effectiveRegisterMode();
       }
     } else if (baseOperator instanceof DeleteOperator) {
       // shift 'delete-history' register
@@ -275,11 +272,8 @@ export class Register {
       }
 
       // Paste last delete into register '1'
-      Register.registers["1"] = {
-        text               : content,
-        registerMode       : vimState.effectiveRegisterMode(),
-        isClipboardRegister: Register.isClipboardRegister("1"),
-      };
+      Register.registers['1'].text = content;
+      Register.registers['1'].registerMode = vimState.effectiveRegisterMode();
     }
   }
 

--- a/test/register/register.test.ts
+++ b/test/register/register.test.ts
@@ -49,4 +49,52 @@ suite("register", () => {
     end: ["one", "two", "one", "|two"],
   });
 
+  test("Yank stores text in Register '0'", async () => {
+    await modeHandler.handleMultipleKeyEvents(
+      'itest1\ntest2\ntest3'.split('')
+    );
+
+    await modeHandler.handleMultipleKeyEvents([
+      '<Esc>',
+      'g', 'g',
+      'y', 'y',
+      'j',
+      'y', 'y',
+      'g', 'g',
+      'd', 'd',
+      '"', '0',
+      'P'
+    ]);
+
+    assertEqualLines([
+      'test2',
+      'test2',
+      'test3'
+    ]);
+  });
+
+  test("Register '1'-'9' stores delete content", async () => {
+    await modeHandler.handleMultipleKeyEvents(
+      'itest1\ntest2\ntest3\n'.split('')
+    );
+
+    await modeHandler.handleMultipleKeyEvents([
+      '<Esc>',
+      'g', 'g',
+      'd', 'd',
+      'd', 'd',
+      'd', 'd',
+      '"', '1', 'p',
+      '"', '2', 'p',
+      '"', '3', 'p'
+    ]);
+
+    assertEqualLines([
+      '',
+      'test3',
+      'test2',
+      'test1'
+    ]);
+  });
+
 });

--- a/test/register/register.test.ts
+++ b/test/register/register.test.ts
@@ -97,4 +97,54 @@ suite("register", () => {
     ]);
   });
 
+  test("\"A appends linewise text to \"a", async() => {
+    await modeHandler.handleMultipleKeyEvents(
+      'itest1\ntest2\ntest3'.split('')
+    );
+
+    await modeHandler.handleMultipleKeyEvents([
+      '<Esc>',
+      'g', 'g',
+      'v', 'l', 'l',
+      '"', 'a', 'y',
+      'j',
+      'V',
+      '"', 'A', 'y',
+      'j',
+      '"', 'a', 'p'
+    ]);
+
+    assertEqualLines([
+    'test1',
+    'test2',
+    'test3',
+    'tes',
+    'test2'
+    ]);
+  });
+
+  test("\"A appends character wise text to \"a", async() => {
+    await modeHandler.handleMultipleKeyEvents(
+      'itest1\ntest2\n'.split('')
+    );
+
+    await modeHandler.handleMultipleKeyEvents([
+      '<Esc>',
+      'g', 'g',
+      'v', 'l', 'l', 'l', 'l',
+      '"', 'a', 'y',
+      'j',
+      'v', 'l', 'l', 'l', 'l',
+      '"', 'A', 'y',
+      'j',
+      '"', 'a', 'p'
+    ]);
+
+    assertEqualLines([
+    'test1',
+    'test2',
+    'test1test2',
+    ]);
+  });
+
 });


### PR DESCRIPTION
Implements basic functionality for numbered registers (#500)
- `0` for last yanked text
- `1` to `9` delete history

Implements appending to register with uppercase letter
- for `single` to `single` cursor register
- for `single` to `multi` cursor register
- for `multi` to `multi` cursor register (if line count match)

![gif](https://cloud.githubusercontent.com/assets/3358663/19634173/e3b48a52-99b8-11e6-93dc-40a8bf883897.gif)

Closes PR #918 because i was to stupid to rebase that branch...