### PR TITLE
SearchState - Fixed isRegex not set on search

### DIFF
--- a/src/state/searchState.ts
+++ b/src/state/searchState.ts
@@ -151,7 +151,7 @@ export class SearchState {
   constructor(direction: SearchDirection, startPosition: Position, searchString = "", { isRegex = false } = {}) {
     this._searchDirection = direction;
     this._searchCursorStartPosition = startPosition;
-    this.searchString = searchString;
     this.isRegex = isRegex;
+    this.searchString = searchString;
   }
 }


### PR DESCRIPTION
Yay! We love PRs! 🎊

Please include a description of your change and ensure:

- [x] Commit message has a short title & issue references
- [x] Each commit does a logical chunk of work.
- [x] It builds and tests pass (e.g `gulp`)

More info can be found on our [contribution guide](https://github.com/VSCodeVim/Vim/blob/master/.github/CONTRIBUTING.md).

Currently, when a SearchState object is defined, the searching begins before this.isRegex is set. This is because the setter, `searchString` runs the search function, and it is set in the constructor before isRegex is set, which means it will be undefined during the search.
This PR makes sure isRegex is set and available during the search by defining it before searchString.