### PR TITLE
No need for "i" flag on a numerical only regex

### DIFF
--- a/src/number/numericString.ts
+++ b/src/number/numericString.ts
@@ -8,7 +8,7 @@ export class NumericString {
     { regex: /^([-+])?0([0-7]+)$/, base: 8, prefix: "0" },
     { regex: /^([-+])?(\d+)$/, base: 10, prefix: "" },
     { regex: /^([-+])?0x([\da-fA-F]+)$/, base: 16, prefix: "0x" },
-    { regex: /\d/i, base: 10, prefix: "" }
+    { regex: /\d/, base: 10, prefix: "" }
   ];
 
   static parse(input: string): NumericString | null {


### PR DESCRIPTION
Yay! We love PRs! 🎊

Please include a description of your change and ensure:

- [√] Commit message has a short title & issue references
- [√] Each commit does a logical chunk of work.
- [√] It builds and tests pass (e.g `gulp`)

More info can be found on our [contribution guide](https://github.com/VSCodeVim/Vim/blob/master/.github/CONTRIBUTING.md).

