### PR TITLE
Fix for cc to prevent deletion of empty line

### DIFF
--- a/src/actions/actions.ts
+++ b/src/actions/actions.ts
@@ -1621,7 +1621,18 @@ export class DeleteOperator extends BaseOperator {
           end   = end.getLineEnd();
         }
 
-        end = new Position(end.line, end.character + 1);
+        // Idea here is to make sure that one character delete in these cases
+        // - 'cc' on empty line
+        // - 'dl' on empty line
+        // won't delete current line.
+        if (registerMode === RegisterMode.CharacterWise
+          && end.getLineEnd().character === end.character
+          && start.line === end.line
+          && start.character === end.character) {
+          end = new Position(end.line, end.character);
+        } else {
+          end = new Position(end.line, end.character + 1);
+        }
 
         const isOnLastLine = end.line === TextEditor.getLineCount() - 1;
 


### PR DESCRIPTION
Fix for issue:
"cc on end of line eats currentline" #727

One character deletes with some actions ("cc" or "dl")  on an empty line can delete current line. Added small check into delete operator so that line won't be deleted.