### PR TITLE
Fixed "d" and "D" in multicursor mode

### DIFF
--- a/src/actions/actions.ts
+++ b/src/actions/actions.ts
@@ -3700,7 +3700,7 @@ class ActionJoin extends BaseCommand {
 
     let resultLine = lineOne + (addSpace ? " " : "") + lineTwoTrimmedStart;
 
-    let newState = await new DeleteOperator(this.multicursorIndex).run(
+    let newState = await new DeleteOperator().run(
       vimState,
       position.getLineBegin(),
       lineTwo.length > 0 ?

--- a/src/actions/actions.ts
+++ b/src/actions/actions.ts
@@ -1670,7 +1670,7 @@ export class DeleteOperator extends BaseOperator {
         }
 
         if (yank) {
-          Register.put(text, vimState);
+          Register.put(text, vimState, this.multicursorIndex);
         }
 
         let diff = new PositionDiff(0, 0);
@@ -2555,13 +2555,16 @@ class CommandDeleteToLineEnd extends BaseCommand {
   modes = [ModeName.Normal];
   keys = ["D"];
   canBeRepeatedWithDot = true;
+  runsOnceForEveryCursor() { return true; }
 
   public async exec(position: Position, vimState: VimState): Promise<VimState> {
     if (position.isLineEnd()) {
       return vimState;
     }
+    let deleteOperator = new DeleteOperator();
+    deleteOperator.multicursorIndex = this.multicursorIndex;
 
-    return await new DeleteOperator().run(vimState, position, position.getLineEnd().getLeft());
+    return await deleteOperator.run(vimState, position, position.getLineEnd().getLeft());
   }
 }
 
@@ -4148,7 +4151,7 @@ export class YankVisualBlockMode extends BaseOperator {
         toCopy += line + '\n';
       }
 
-      Register.put(toCopy, vimState);
+      Register.put(toCopy, vimState, this.multicursorIndex);
 
       vimState.currentMode = ModeName.Normal;
       vimState.cursorPosition = start;

--- a/src/actions/actions.ts
+++ b/src/actions/actions.ts
@@ -428,6 +428,10 @@ export abstract class BaseCommand extends BaseAction {
 }
 
 export class BaseOperator extends BaseAction {
+    constructor(multicursorIndex?: number) {
+      super();
+      this.multicursorIndex = multicursorIndex;
+    }
     canBeRepeatedWithDot = true;
 
     /**
@@ -1721,7 +1725,7 @@ export class DeleteOperatorVisual extends BaseOperator {
     public modes = [ModeName.Visual, ModeName.VisualLine];
 
     public async run(vimState: VimState, start: Position, end: Position): Promise<VimState> {
-      return await new DeleteOperator().run(vimState, start, end);
+      return await new DeleteOperator(this.multicursorIndex).run(vimState, start, end);
     }
 }
 
@@ -1790,7 +1794,7 @@ export class DeleteOperatorXVisual extends BaseOperator {
     public modes = [ModeName.Visual, ModeName.VisualLine];
 
     public async run(vimState: VimState, start: Position, end: Position): Promise<VimState> {
-      return await new DeleteOperator().run(vimState, start, end);
+      return await new DeleteOperator(this.multicursorIndex).run(vimState, start, end);
     }
 }
 
@@ -1934,9 +1938,9 @@ export class ChangeOperator extends BaseOperator {
         // the line. We do want to run delete if it is a multiline change though ex. c}
         if (Position.getLineLength(TextEditor.getLineAt(start).lineNumber) !== 0 || (end.line !== start.line)) {
           if (isEndOfLine) {
-            state = await new DeleteOperator().run(vimState, start, end.getLeftThroughLineBreaks());
+            state = await new DeleteOperator(this.multicursorIndex).run(vimState, start, end.getLeftThroughLineBreaks());
           } else {
-            state = await new DeleteOperator().run(vimState, start, end);
+            state = await new DeleteOperator(this.multicursorIndex).run(vimState, start, end);
           }
         }
 
@@ -2211,7 +2215,7 @@ export class PutCommandVisual extends BaseCommand {
       [start, end] = [end, start];
     }
 
-    const result = await new DeleteOperator().run(vimState, start, end, false);
+    const result = await new DeleteOperator(this.multicursorIndex).run(vimState, start, end, false);
 
     return await new PutCommand().exec(start, result, true);
   }
@@ -2561,10 +2565,8 @@ class CommandDeleteToLineEnd extends BaseCommand {
     if (position.isLineEnd()) {
       return vimState;
     }
-    let deleteOperator = new DeleteOperator();
-    deleteOperator.multicursorIndex = this.multicursorIndex;
 
-    return await deleteOperator.run(vimState, position, position.getLineEnd().getLeft());
+    return await new DeleteOperator(this.multicursorIndex).run(vimState, position, position.getLineEnd().getLeft());
   }
 }
 
@@ -3629,7 +3631,7 @@ class ActionDeleteChar extends BaseCommand {
       return vimState;
     }
 
-    const state = await new DeleteOperator().run(vimState, position, position);
+    const state = await new DeleteOperator(this.multicursorIndex).run(vimState, position, position);
 
     state.currentMode = ModeName.Normal;
 
@@ -3650,7 +3652,7 @@ class ActionDeleteCharWithDeleteKey extends BaseCommand {
       return vimState;
     }
 
-    const state = await new DeleteOperator().run(vimState, position, position);
+    const state = await new DeleteOperator(this.multicursorIndex).run(vimState, position, position);
 
     state.currentMode = ModeName.Normal;
 
@@ -3669,7 +3671,7 @@ class ActionDeleteLastChar extends BaseCommand {
       return vimState;
     }
 
-    return await new DeleteOperator().run(vimState, position.getLeft(), position.getLeft());
+    return await new DeleteOperator(this.multicursorIndex).run(vimState, position.getLeft(), position.getLeft());
   }
 }
 
@@ -3698,7 +3700,7 @@ class ActionJoin extends BaseCommand {
 
     let resultLine = lineOne + (addSpace ? " " : "") + lineTwoTrimmedStart;
 
-    let newState = await new DeleteOperator().run(
+    let newState = await new DeleteOperator(this.multicursorIndex).run(
       vimState,
       position.getLineBegin(),
       lineTwo.length > 0 ?
@@ -3768,7 +3770,7 @@ class ActionJoinNoWhitespace extends BaseCommand {
 
     let resultLine = lineOne + lineTwo;
 
-    let newState = await new DeleteOperator().run(
+    let newState = await new DeleteOperator(this.multicursorIndex).run(
       vimState,
       position.getLineBegin(),
       lineTwo.length > 0 ?
@@ -4302,7 +4304,7 @@ class ActionDeleteLineVisualMode extends BaseCommand {
   keys = ["X"];
 
   public async exec(position: Position, vimState: VimState): Promise<VimState> {
-    return await new DeleteOperator().run(vimState, position.getLineBegin(), position.getLineEnd());
+    return await new DeleteOperator(this.multicursorIndex).run(vimState, position.getLineBegin(), position.getLineEnd());
   }
 }
 

--- a/test/mode/modeNormal.test.ts
+++ b/test/mode/modeNormal.test.ts
@@ -1363,4 +1363,24 @@ suite("Mode Normal", () => {
       keysPressed: '#',
       end: ['test aaa test aaa test aaa |test aaa test'],
     });
+
+    newTest({
+      title: "Can 'D'elete the characters under the cursor until the end of the line",
+      start: ['test aaa test aaa test aaa test |aaa test'],
+      keysPressed: 'D',
+      end: ['test aaa test aaa test aaa test| ']
+    });
+
+    newTest({
+      title: "Can 'D'elete the characters under multiple cursors until the end of the line",
+      start: [
+        'test aaa test aaa test aaa test |aaa test',
+        'test aaa test aaa test aaa test aaa test'
+      ],
+      keysPressed: '<C-alt+down>D<Esc>',
+      end: [
+        'test aaa test aaa test aaa tes|t ',
+        'test aaa test aaa test aaa test '
+      ]
+    });
 });


### PR DESCRIPTION
In Multi-Cursor mode "d" in Visual Mode and "D" in Normal-Mode is not working.
Added the current multicursorindex to the `Register.Put` method.
