### PR TITLE
Hide the info line in issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,6 +1,6 @@
+<!--
 For questions, ask us on [Slack](https://vscodevim-slackin.azurewebsites.net/) 👫. Found a bug? Delete this line and fill out the sections below.
-
-------
+-->
 
 Please *thumbs-up* 👍 this issue if it personally affects you! You can do this by clicking on the emoji-face on the top right of this post. Issues with more thumbs-up will be prioritized.
 


### PR DESCRIPTION
Learned this trick from TypeScript's issue template: https://github.com/Microsoft/TypeScript/issues/new

The top line won't be rendered, but will be visible when issue gets reported.