### PR TITLE
fixes #1084

### DIFF
--- a/src/actions/actions.ts
+++ b/src/actions/actions.ts
@@ -527,6 +527,20 @@ export class CommandInsertInInsertMode extends BaseCommand {
           range: new Range(selection.start as Position, selection.end as Position),
         });
       } else {
+        // Check for matching character that was auto inserted ("" or [] and delete the closing char if the opening char is deleted)
+        const text = TextEditor.getLineAt(position).text;
+        const charToMatch = text[position.character - 1];
+        const toFind = PairMatcher.pairings[charToMatch];
+
+        if (toFind !== undefined) {
+          if (text[position.character] === toFind.match) {
+            vimState.recordedState.transformations.push({
+              type: "deleteRange",
+              range: new Range(position, new Position(position.line, position.character + 1)),
+            });
+          }
+        }
+
         vimState.recordedState.transformations.push({
           type: "deleteText",
           position: position,

--- a/src/matching/matcher.ts
+++ b/src/matching/matcher.ts
@@ -16,6 +16,8 @@ export class PairMatcher {
     // useful for text objects.
     "<" : { match: ">",  nextMatchIsForward: true },
     ">" : { match: "<",  nextMatchIsForward: false },
+    "\"" : { match: "\"",  nextMatchIsForward: true },
+    "\'" : { match: "\'",  nextMatchIsForward: true },
   };
 
   static nextPairedChar(position: Position, charToMatch: string, closed: boolean = true): Position | undefined {


### PR DESCRIPTION
Any thoughts on this? Seems like a positive effect?

When you enter a quote or parenthesis, vscode has an option to auto add the closing portion.

With this, when you remove the opening char, and the closing char is the immediate next character, it will remove the closing char as well.