### PR TITLE
new algorithm for [cd]it, fixes #971 and #1108

### DIFF
--- a/src/actions/actions.ts
+++ b/src/actions/actions.ts
@@ -5673,12 +5673,11 @@ abstract class MoveTagMatch extends BaseMovement {
   protected includeTag = false;
 
   public async execAction(position: Position, vimState: VimState): Promise<IMovement> {
-    const text = TextEditor.getLineAt(position).text;
-    const tagMatcher = new TagMatcher(text, position.character);
-    const start = tagMatcher.findOpening(this.includeTag);
-    const end = tagMatcher.findClosing(this.includeTag);
+    const tagMatcher = new TagMatcher(position);
+    const startPos = tagMatcher.findOpening(this.includeTag);
+    const endPos = tagMatcher.findClosing(this.includeTag);
 
-    if (start === undefined || end === undefined) {
+    if (startPos === undefined || endPos === undefined) {
       return {
         start: position,
         stop: position,
@@ -5686,16 +5685,13 @@ abstract class MoveTagMatch extends BaseMovement {
       };
     }
 
-    if (end === start) {
+    if (endPos.isBefore(startPos)) {
       return {
-        start:  new Position(position.line, start),
-        stop:   new Position(position.line, start),
-        failed: true,
+        start: startPos,
+        stop: startPos,
+        failed: true
       };
     }
-
-    let startPos = new Position(position.line, start);
-    let endPos = new Position(position.line, end - 1);
 
     if (position.isBefore(startPos)) {
       vimState.recordedState.operatorPositionDiff = startPos.subtract(position);

--- a/src/textEditor.ts
+++ b/src/textEditor.ts
@@ -88,6 +88,10 @@ export class TextEditor {
     return "";
   }
 
+  static getDocument(): vscode.TextDocument {
+      return vscode.window.activeTextEditor.document;
+  }
+
   static readLine(): string {
     const lineNo = vscode.window.activeTextEditor.selection.active.line;
 

--- a/test/mode/modeNormal.test.ts
+++ b/test/mode/modeNormal.test.ts
@@ -1342,6 +1342,38 @@ suite("Mode Normal", () => {
     });
 
     newTest({
+      title: "Can do cit on a multiline tag",
+      start: [" <blink>\nhe|llo\n </blink>"],
+      keysPressed: "cit",
+      end: [" <blink>|</blink>"],
+      endMode: ModeName.Insert
+    });
+
+    newTest({
+      title: "Can do cit inside of a tag with another non closing tag inside tags",
+      start: ["<blink>hello<br>wo|rld</blink>"],
+      keysPressed: "cit",
+      end: ["<blink>|</blink>"],
+      endMode: ModeName.Insert
+    });
+
+    newTest({
+      title: "Can do cit inside of a tag with another empty closing tag inside tags",
+      start: ["<blink>hel|lo</h1>world</blink>"],
+      keysPressed: "cit",
+      end: ["<blink>|</blink>"],
+      endMode: ModeName.Insert
+    });
+
+    newTest({
+      title: "Can do cit on empty tag block, cursor moves to inside",
+      start: ["<bli|nk></blink>"],
+      keysPressed: "dit",
+      end: ["<blink>|</blink>"],
+      endMode: ModeName.Normal
+    });
+
+    newTest({
       title: "Respects indentation with cc",
       start: ["{", "  int| a;"],
       keysPressed: "cc",


### PR DESCRIPTION
<!--
Yay! We love PRs! 🎊

Please include a description of your change and ensure:

- [x] Commit message has a short title & issue references
- [x] Each commit does a logical chunk of work.
- [x] It builds and tests pass (e.g `gulp`)

More info can be found on our [contribution guide](https://github.com/VSCodeVim/Vim/blob/master/.github/CONTRIBUTING.md).
-->

The algorithm is based on the same algorithm implemented
in the [IntelliJ IdeaVim plugin](https://github.com/JetBrains/ideavim)

I had to get access to the `document` so I wrote a getter in textEditor.ts. I am not so sure about that one.

There are still some minor things, where [cd]it does not work like the original Vim.
I am planning to get to them later.

Already in this form this feature should be usable.