### PR TITLE
Updated useCtrlKeys default value

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ The following is a subset of the supported configurations; the full list is desc
     * `ctrl+b` => Half Page Forward
     * `ctrl+v` => Visual Block Mode
     * etc.
-  * Type: Boolean (Default: `false`)
+  * Type: Boolean (Default: `true`)
   * *Example:*
 
     ```


### PR DESCRIPTION
The README stated that the useCtrlKeys default is `false` while the default in package.json defines it as `true`. This PR makes the readme consistent with the settings in package.json.
