### PR TITLE
minor fixes for # and * after using :nohl

### DIFF
--- a/src/actions/actions.ts
+++ b/src/actions/actions.ts
@@ -1548,6 +1548,9 @@ class CommandStar extends BaseCommand {
       vimState.cursorPosition = vimState.searchState.getNextSearchMatchPosition(vimState.cursorPosition).pos;
     } while (TextEditor.getWord(vimState.cursorPosition) !== currentWord);
 
+    // Turn one of the highlighting flags back on (turned off with :nohl)
+    Configuration.hl = true;
+
     return vimState;
   }
 }
@@ -1573,6 +1576,9 @@ class CommandHash extends BaseCommand {
       // which are the desired semantics for this motion.
       vimState.cursorPosition = vimState.searchState.getNextSearchMatchPosition(vimState.cursorPosition.getWordLeft(true)).pos;
     } while (TextEditor.getWord(vimState.cursorPosition) !== currentWord);
+
+    // Turn one of the highlighting flags back on (turned off with :nohl)
+    Configuration.hl = true;
 
     return vimState;
   }


### PR DESCRIPTION
Could be related to #1130, but I am unable to reproduce that specific issue yet so will not close it.

Highlighting works fine for me using * and #, this fixes highlighting ONLY in the case that :nohl had been used previously at some point.