### PR TITLE
control key bindings respect the useCtrlKey setting

### DIFF
--- a/package.json
+++ b/package.json
@@ -119,7 +119,7 @@
       {
         "key": "ctrl+r",
         "command": "extension.vim_ctrl+r",
-        "when": "editorTextFocus && !inDebugRepl"
+        "when": "editorTextFocus && vim.useCtrlKeys && !inDebugRepl"
       },
       {
         "key": "ctrl+f",
@@ -129,22 +129,22 @@
       {
         "key": "ctrl+b",
         "command": "extension.vim_ctrl+b",
-        "when": "editorTextFocus && vim.mode != 'Insert' && !inDebugRepl"
+        "when": "editorTextFocus && vim.useCtrlKeys && vim.mode != 'Insert' && !inDebugRepl"
       },
       {
         "key": "ctrl+j",
         "command": "extension.vim_ctrl+j",
-        "when": "editorTextFocus && vim.mode != 'Insert' && !inDebugRepl"
+        "when": "editorTextFocus && vim.useCtrlKeys && vim.mode != 'Insert' && !inDebugRepl"
       },
       {
         "key": "ctrl+k",
         "command": "extension.vim_ctrl+k",
-        "when": "editorTextFocus && vim.mode != 'Insert' && !inDebugRepl"
+        "when": "editorTextFocus && vim.useCtrlKeys && vim.mode != 'Insert' && !inDebugRepl"
       },
       {
         "key": "ctrl+h",
         "command": "extension.vim_ctrl+h",
-        "when": "editorTextFocus && vim.mode == 'Insert' && !inDebugRepl"
+        "when": "editorTextFocus && vim.useCtrlKeys && vim.mode == 'Insert' && !inDebugRepl"
       },
       {
         "key": "ctrl+e",
@@ -159,7 +159,7 @@
       {
         "key": "ctrl+u",
         "command": "extension.vim_ctrl+u",
-        "when": "editorTextFocus && !inDebugRepl"
+        "when": "editorTextFocus && vim.useCtrlKeys && !inDebugRepl"
       },
       {
         "key": "ctrl+v",
@@ -179,7 +179,7 @@
       {
         "key": "ctrl+w",
         "command": "extension.vim_ctrl+w",
-        "when": "editorTextFocus && !inDebugRepl"
+        "when": "editorTextFocus && vim.useCtrlKeys && !inDebugRepl"
       },
       {
         "key": "ctrl+c",
@@ -199,12 +199,12 @@
       {
         "key": "ctrl+n",
         "command": "extension.vim_ctrl+n",
-        "when": "suggestWidgetVisible"
+        "when": "suggestWidgetVisible && vim.useCtrlKeys"
       },
       {
         "key": "ctrl+p",
         "command": "extension.vim_ctrl+p",
-        "when": "suggestWidgetVisible"
+        "when": "suggestWidgetVisible && vim.useCtrlKeys"
       },
       {
         "key": "ctrl+x",


### PR DESCRIPTION
These keybindings are all used in the default bindings (on linux) and so should respect the `vim.useCtrlKeys` setting.