### PR TITLE
Implements Global state

### DIFF
--- a/src/actions/actions.ts
+++ b/src/actions/actions.ts
@@ -726,7 +726,7 @@ class CommandInsertRegisterContentInSearchMode extends BaseCommand {
       text += "\n";
     }
 
-    const searchState = vimState.searchState!;
+    const searchState = vimState.globalState.searchState!;
     searchState.searchString += text;
     return vimState;
   }
@@ -878,8 +878,8 @@ class CommandEsc extends BaseCommand {
     }
 
     if (vimState.currentMode === ModeName.SearchInProgressMode) {
-      if (vimState.searchState) {
-        vimState.cursorPosition = vimState.searchState.searchCursorStartPosition;
+      if (vimState.globalState.searchState) {
+        vimState.cursorPosition = vimState.globalState.searchState.searchCursorStartPosition;
       }
     }
 
@@ -1421,7 +1421,7 @@ class CommandInsertInSearchMode extends BaseCommand {
 
   public async exec(position: Position, vimState: VimState): Promise<VimState> {
     const key = this.keysPressed[0];
-    const searchState = vimState.searchState!;
+    const searchState = vimState.globalState.searchState!;
 
     // handle special keys first
     if (key === "<BS>" || key === "<shift+BS>") {
@@ -1431,56 +1431,56 @@ class CommandInsertInSearchMode extends BaseCommand {
 
       // Repeat the previous search if no new string is entered
       if (searchState.searchString === "") {
-        const prevSearchList = vimState.searchStatePrevious!;
+        const prevSearchList = vimState.globalState.searchStatePrevious!;
         if (prevSearchList.length > 0) {
           searchState.searchString = prevSearchList[prevSearchList.length - 1].searchString;
         }
       }
 
       // Store this search if different than previous
-      if (vimState.searchStatePrevious.length !== 0) {
-        let previousSearchState = vimState.searchStatePrevious;
+      if (vimState.globalState.searchStatePrevious.length !== 0) {
+        let previousSearchState = vimState.globalState.searchStatePrevious;
         if (searchState.searchString !== previousSearchState[previousSearchState.length - 1]!.searchString) {
           previousSearchState.push(searchState);
         }
       } else {
-        vimState.searchStatePrevious.push(searchState);
+        vimState.globalState.searchStatePrevious.push(searchState);
       }
 
       // Make sure search history does not exceed configuration option
-      if (vimState.searchStatePrevious.length > Configuration.history) {
-        vimState.searchStatePrevious.splice(0, 1);
+      if (vimState.globalState.searchStatePrevious.length > Configuration.history) {
+        vimState.globalState.searchStatePrevious.splice(0, 1);
       }
 
       // Update the index to the end of the search history
-      vimState.searchStateIndex = vimState.searchStatePrevious.length - 1;
+      vimState.globalState.searchStateIndex = vimState.globalState.searchStatePrevious.length - 1;
 
       // Move cursor to next match
       vimState.cursorPosition = searchState.getNextSearchMatchPosition(vimState.cursorPosition).pos;
 
       return vimState;
     } else if (key === "<up>") {
-      const prevSearchList = vimState.searchStatePrevious!;
-      if (prevSearchList[vimState.searchStateIndex] !== undefined) {
-        searchState.searchString = prevSearchList[vimState.searchStateIndex].searchString;
-        vimState.searchStateIndex -= 1;
+      const prevSearchList = vimState.globalState.searchStatePrevious!;
+      if (prevSearchList[vimState.globalState.searchStateIndex] !== undefined) {
+        searchState.searchString = prevSearchList[vimState.globalState.searchStateIndex].searchString;
+        vimState.globalState.searchStateIndex -= 1;
       }
     } else if (key === "<down>") {
-      const prevSearchList = vimState.searchStatePrevious!;
-      if (prevSearchList[vimState.searchStateIndex] !== undefined) {
-        searchState.searchString = prevSearchList[vimState.searchStateIndex].searchString;
-        vimState.searchStateIndex += 1;
+      const prevSearchList = vimState.globalState.searchStatePrevious!;
+      if (prevSearchList[vimState.globalState.searchStateIndex] !== undefined) {
+        searchState.searchString = prevSearchList[vimState.globalState.searchStateIndex].searchString;
+        vimState.globalState.searchStateIndex += 1;
       }
     } else {
       searchState.searchString += this.keysPressed[0];
     }
 
     // Clamp the history index to stay within bounds of search history length
-    if (vimState.searchStateIndex > vimState.searchStatePrevious.length - 1) {
-      vimState.searchStateIndex = vimState.searchStatePrevious.length - 1;
+    if (vimState.globalState.searchStateIndex > vimState.globalState.searchStatePrevious.length - 1) {
+      vimState.globalState.searchStateIndex = vimState.globalState.searchStatePrevious.length - 1;
     }
-    if (vimState.searchStateIndex < 0) {
-      vimState.searchStateIndex = 0;
+    if (vimState.globalState.searchStateIndex < 0) {
+      vimState.globalState.searchStateIndex = 0;
     }
 
     return vimState;
@@ -1495,7 +1495,7 @@ class CommandEscInSearchMode extends BaseCommand {
 
   public async exec(position: Position, vimState: VimState): Promise<VimState> {
     vimState.currentMode = ModeName.Normal;
-    vimState.searchState = undefined;
+    vimState.globalState.searchState = undefined;
 
     return vimState;
   }
@@ -1508,7 +1508,7 @@ class CommandCtrlVInSearchMode extends BaseCommand {
   runsOnceForEveryCursor() { return this.keysPressed[0] === '\n'; }
 
   public async exec(position: Position, vimState: VimState): Promise<VimState> {
-    const searchState = vimState.searchState!;
+    const searchState = vimState.globalState.searchState!;
     const textFromClipboard = await new Promise<string>((resolve, reject) =>
       clipboard.paste((err, text) => err ? reject(err) : resolve(text))
     );
@@ -1525,7 +1525,7 @@ class CommandCmdVInSearchMode extends BaseCommand {
   runsOnceForEveryCursor() { return this.keysPressed[0] === '\n'; }
 
   public async exec(position: Position, vimState: VimState): Promise<VimState> {
-    const searchState = vimState.searchState!;
+    const searchState = vimState.globalState.searchState!;
     const textFromClipboard = await new Promise<string>((resolve, reject) =>
       clipboard.paste((err, text) => err ? reject(err) : resolve(text))
     );
@@ -1540,7 +1540,7 @@ class CommandNextSearchMatch extends BaseMovement {
   keys = ["n"];
 
   public async execAction(position: Position, vimState: VimState): Promise<Position> {
-    const searchState = vimState.searchState;
+    const searchState = vimState.globalState.searchState;
 
     if (!searchState || searchState.searchString === "") {
       return position;
@@ -1580,10 +1580,10 @@ class CommandStar extends BaseCommand {
       return vimState;
     }
 
-    vimState.searchState = new SearchState(SearchDirection.Forward, vimState.cursorPosition, currentWord);
+    vimState.globalState.searchState = new SearchState(SearchDirection.Forward, vimState.cursorPosition, currentWord);
 
     do {
-      vimState.cursorPosition = vimState.searchState.getNextSearchMatchPosition(vimState.cursorPosition).pos;
+      vimState.cursorPosition = vimState.globalState.searchState.getNextSearchMatchPosition(vimState.cursorPosition).pos;
     } while (TextEditor.getWord(vimState.cursorPosition) !== currentWord);
 
     // Turn one of the highlighting flags back on (turned off with :nohl)
@@ -1606,13 +1606,13 @@ class CommandHash extends BaseCommand {
       return vimState;
     }
 
-    vimState.searchState = new SearchState(SearchDirection.Backward, vimState.cursorPosition, currentWord);
+    vimState.globalState.searchState = new SearchState(SearchDirection.Backward, vimState.cursorPosition, currentWord);
 
     do {
       // use getWordLeft() on position to start at the beginning of the word.
       // this ensures that any matches happen ounside of the word currently selected,
       // which are the desired semantics for this motion.
-      vimState.cursorPosition = vimState.searchState.getNextSearchMatchPosition(vimState.cursorPosition.getWordLeft(true)).pos;
+      vimState.cursorPosition = vimState.globalState.searchState.getNextSearchMatchPosition(vimState.cursorPosition.getWordLeft(true)).pos;
     } while (TextEditor.getWord(vimState.cursorPosition) !== currentWord);
 
     // Turn one of the highlighting flags back on (turned off with :nohl)
@@ -1627,7 +1627,7 @@ class CommandPreviousSearchMatch extends BaseMovement {
   keys = ["N"];
 
   public async execAction(position: Position, vimState: VimState): Promise<Position> {
-    const searchState = vimState.searchState;
+    const searchState = vimState.globalState.searchState;
 
     if (!searchState || searchState.searchString === "") {
       return position;
@@ -1702,11 +1702,11 @@ export class CommandSearchForwards extends BaseCommand {
   isMotion = true;
 
   public async exec(position: Position, vimState: VimState): Promise<VimState> {
-    vimState.searchState = new SearchState(SearchDirection.Forward, vimState.cursorPosition, "", { isRegex: true });
+    vimState.globalState.searchState = new SearchState(SearchDirection.Forward, vimState.cursorPosition, "", { isRegex: true });
     vimState.currentMode = ModeName.SearchInProgressMode;
 
     // Reset search history index
-    vimState.searchStateIndex = vimState.searchStatePrevious.length - 1;
+    vimState.globalState.searchStateIndex = vimState.globalState.searchStatePrevious.length - 1;
 
     Configuration.hl = true;
 
@@ -1721,11 +1721,11 @@ export class CommandSearchBackwards extends BaseCommand {
   isMotion = true;
 
   public async exec(position: Position, vimState: VimState): Promise<VimState> {
-    vimState.searchState = new SearchState(SearchDirection.Backward, vimState.cursorPosition, "", { isRegex: true });
+    vimState.globalState.searchState = new SearchState(SearchDirection.Backward, vimState.cursorPosition, "", { isRegex: true });
     vimState.currentMode = ModeName.SearchInProgressMode;
 
     // Reset search history index
-    vimState.searchStateIndex = vimState.searchStatePrevious.length - 1;
+    vimState.globalState.searchStateIndex = vimState.globalState.searchStatePrevious.length - 1;
 
     Configuration.hl = true;
 

--- a/src/actions/actions.ts
+++ b/src/actions/actions.ts
@@ -1439,8 +1439,9 @@ class CommandInsertInSearchMode extends BaseCommand {
 
       // Store this search if different than previous
       if (vimState.searchStatePrevious.length !== 0) {
-        if (searchState.searchString !== vimState.searchStatePrevious[vimState.searchStatePrevious.length - 1]!.searchString) {
-          vimState.searchStatePrevious.push(searchState);
+        let previousSearchState = vimState.searchStatePrevious;
+        if (searchState.searchString !== previousSearchState[previousSearchState.length - 1]!.searchString) {
+          previousSearchState.push(searchState);
         }
       } else {
         vimState.searchStatePrevious.push(searchState);

--- a/src/mode/modeHandler.ts
+++ b/src/mode/modeHandler.ts
@@ -139,6 +139,22 @@ export class VimState {
     GlobalState.previousFullAction = state;
   }
 
+  public get searchState(): SearchState | undefined {
+    return GlobalState.searchState;
+  }
+
+  public set searchState(state : SearchState | undefined) {
+    GlobalState.searchState = state;
+  }
+
+  public get searchStateIndex(): number {
+    return GlobalState.searchStateIndex;
+  }
+
+  public set searchStateIndex(state : number) {
+    GlobalState.searchStateIndex = state;
+  }
+
   /**
    * The position the cursor will be when this action finishes.
    */
@@ -183,13 +199,6 @@ export class VimState {
   }
 
   public cursorPositionJustBeforeAnythingHappened = [ new Position(0, 0) ];
-
-  public searchState: SearchState | undefined = undefined;
-
-  /**
-   *  Index used for navigating search history with <up> and <down> when searching
-   */
-  public searchStateIndex: number = 0;
 
   public isRecordingMacro: boolean = false;
 

--- a/src/mode/modeHandler.ts
+++ b/src/mode/modeHandler.ts
@@ -38,6 +38,7 @@ import { PairMatcher } from './../matching/matcher';
 import { Globals } from '../../src/globals';
 import { SearchState } from './../state/searchState';
 import { ReplaceState } from './../state/replaceState';
+import { GlobalState } from './../state/globalState';
 
 export class ViewChange {
   public command: string;
@@ -88,11 +89,7 @@ export class VimState {
 
   public lastMovementFailed: boolean = false;
 
-  /**
-   * The keystroke sequence that made up our last complete action (that can be
-   * repeated with '.').
-   */
-  public previousFullAction: RecordedState | undefined = undefined;
+  public static globals: GlobalState = GlobalState;
 
   public alteredHistory = false;
 
@@ -122,6 +119,25 @@ export class VimState {
    * The current full action we are building up.
    */
   public currentFullAction: string[] = [];
+
+  /**
+   * Getters and setters for changing global state
+   */
+  public get searchStatePrevious(): SearchState[]{
+    return GlobalState.searchStatePrevious;
+  }
+
+  public set searchStatePrevious(states: SearchState[]) {
+    GlobalState.searchStatePrevious = this.searchStatePrevious.concat(states);
+  }
+
+  public get previousFullAction(): RecordedState | undefined {
+    return GlobalState.previousFullAction;
+  }
+
+  public set previousFullAction(state : RecordedState | undefined) {
+    GlobalState.previousFullAction = state;
+  }
 
   /**
    * The position the cursor will be when this action finishes.
@@ -174,11 +190,6 @@ export class VimState {
    *  Index used for navigating search history with <up> and <down> when searching
    */
   public searchStateIndex: number = 0;
-
-  /**
-   * Previous searches performed
-   */
-  public searchStatePrevious: SearchState[] = [];
 
   public isRecordingMacro: boolean = false;
 

--- a/src/state/globalState.ts
+++ b/src/state/globalState.ts
@@ -1,9 +1,5 @@
-// import * as vscode from 'vscode';
 import { SearchState } from './searchState';
 import { RecordedState } from '../mode/modeHandler';
-// import { Position } from './../motion/position';
-// import { TextEditor } from './../textEditor';
-// import { Configuration } from '../../src/configuration/configuration';
 
 /**
  * State which stores global state (across editors)
@@ -13,20 +9,55 @@ export class GlobalState {
    * The keystroke sequence that made up our last complete action (that can be
    * repeated with '.').
    */
-  public static previousFullAction: RecordedState | undefined = undefined;
+  private static _previousFullAction: RecordedState | undefined = undefined;
 
   /**
    * Previous searches performed
    */
-  public static searchStatePrevious: SearchState[] = [];
+  private static _searchStatePrevious: SearchState[] = [];
 
   /**
    * Last search state for running n and N commands
    */
-  public static searchState: SearchState | undefined = undefined;
+  private static _searchState: SearchState | undefined = undefined;
 
   /**
    *  Index used for navigating search history with <up> and <down> when searching
    */
-  public static searchStateIndex: number = 0;
+  private static _searchStateIndex: number = 0;
+
+  /**
+   * Getters and setters for changing global state
+   */
+  public get searchStatePrevious(): SearchState[]{
+    return GlobalState._searchStatePrevious;
+  }
+
+  public set searchStatePrevious(states: SearchState[]) {
+    GlobalState._searchStatePrevious = GlobalState._searchStatePrevious.concat(states);
+  }
+
+  public get previousFullAction(): RecordedState | undefined {
+    return GlobalState._previousFullAction;
+  }
+
+  public set previousFullAction(state : RecordedState | undefined) {
+    GlobalState._previousFullAction = state;
+  }
+
+  public get searchState(): SearchState | undefined {
+    return GlobalState._searchState;
+  }
+
+  public set searchState(state : SearchState | undefined) {
+    GlobalState._searchState = state;
+  }
+
+  public get searchStateIndex(): number {
+    return GlobalState._searchStateIndex;
+  }
+
+  public set searchStateIndex(state : number) {
+    GlobalState._searchStateIndex = state;
+  }
 }

--- a/src/state/globalState.ts
+++ b/src/state/globalState.ts
@@ -19,4 +19,14 @@ export class GlobalState {
    * Previous searches performed
    */
   public static searchStatePrevious: SearchState[] = [];
+
+  /**
+   * Last search state for running n and N commands
+   */
+  public static searchState: SearchState | undefined = undefined;
+
+  /**
+   *  Index used for navigating search history with <up> and <down> when searching
+   */
+  public static searchStateIndex: number = 0;
 }

--- a/src/state/globalState.ts
+++ b/src/state/globalState.ts
@@ -1,0 +1,22 @@
+// import * as vscode from 'vscode';
+import { SearchState } from './searchState';
+import { RecordedState } from '../mode/modeHandler';
+// import { Position } from './../motion/position';
+// import { TextEditor } from './../textEditor';
+// import { Configuration } from '../../src/configuration/configuration';
+
+/**
+ * State which stores global state (across editors)
+ */
+export class GlobalState {
+  /**
+   * The keystroke sequence that made up our last complete action (that can be
+   * repeated with '.').
+   */
+  public static previousFullAction: RecordedState | undefined = undefined;
+
+  /**
+   * Previous searches performed
+   */
+  public static searchStatePrevious: SearchState[] = [];
+}

--- a/src/state/searchState.ts
+++ b/src/state/searchState.ts
@@ -30,6 +30,7 @@ export class SearchState {
   }
 
   private _cachedDocumentVersion: number;
+  private _cachedDocumentName: String;
   private _searchDirection: SearchDirection = SearchDirection.Forward;
   private isRegex: boolean;
 
@@ -52,9 +53,13 @@ export class SearchState {
 
     if (search === "") { return; }
 
-    if (this._cachedDocumentVersion !== TextEditor.getDocumentVersion() || forceRecalc) {
+    // checking if the tab that is worked on has changed, or the file version has changed
+    const shouldRecalculate = (this._cachedDocumentName !== TextEditor.getDocumentName()) ||
+      (this._cachedDocumentVersion !== TextEditor.getDocumentVersion()) || forceRecalc;
+    if (shouldRecalculate) {
       // Calculate and store all matching ranges
       this._cachedDocumentVersion = TextEditor.getDocumentVersion();
+      this._cachedDocumentName = TextEditor.getDocumentName();
       this._matchRanges = [];
 
       /*

--- a/src/textEditor.ts
+++ b/src/textEditor.ts
@@ -56,6 +56,10 @@ export class TextEditor {
     return vscode.window.activeTextEditor.document.version;
   }
 
+  static getDocumentName(): String {
+    return vscode.window.activeTextEditor.document.fileName;
+  }
+
   /**
    * Removes all text in the entire document.
    */

--- a/src/util.ts
+++ b/src/util.ts
@@ -31,14 +31,15 @@ export async function waitForCursorUpdatesToHappen(): Promise<void> {
 }
 
 /**
- * FOR TESTING PURPOSES ONLY
  * Waits for the tabs to change after a command like 'gt' or 'gT' is run.
  * Sometimes it is not immediate, so we must busy wait
- * Caveat: Use only it tests. This promise does not timeout. Awaiting this promise
- * in extension code is dangerous
+ * On certain versions, the tab changes are synchronous
+ * For those, a timeout is given
  */
 export async function waitForTabChange(): Promise<void> {
   await new Promise((resolve, reject) => {
+    setTimeout(resolve, 100);
+
     const disposer = vscode.window.onDidChangeActiveTextEditor((textEditor) => {
       disposer.dispose();
 

--- a/src/util.ts
+++ b/src/util.ts
@@ -30,6 +30,23 @@ export async function waitForCursorUpdatesToHappen(): Promise<void> {
   });
 }
 
+/**
+ * FOR TESTING PURPOSES ONLY
+ * Waits for the tabs to change after a command like 'gt' or 'gT' is run.
+ * Sometimes it is not immediate, so we must busy wait
+ * Caveat: Use only it tests. This promise does not timeout. Awaiting this promise
+ * in extension code is dangerous
+ */
+export async function waitForTabChange(): Promise<void> {
+  await new Promise((resolve, reject) => {
+    const disposer = vscode.window.onDidChangeActiveTextEditor((textEditor) => {
+      disposer.dispose();
+
+      resolve(textEditor);
+    });
+  });
+}
+
 export async function allowVSCodeToPropagateCursorUpdatesAndReturnThem(): Promise<Range[]> {
   await waitForCursorUpdatesToHappen();
 

--- a/test/mode/normalModeTests/dot.test.ts
+++ b/test/mode/normalModeTests/dot.test.ts
@@ -2,7 +2,7 @@
 
 import { setupWorkspace, cleanUpWorkspace, setTextEditorOptions, assertEqualLines } from './../../testUtils';
 import { ModeHandler } from '../../../src/mode/modeHandler';
-import { allowVSCodeToPropagateCursorUpdatesAndReturnThem } from '../../../src/util';
+import { waitForTabChange } from '../../../src/util';
 import * as assert from 'assert';
 import { getTestingFunctions } from '../../testSimplifier';
 
@@ -30,18 +30,15 @@ suite("Dot Operator", () => {
       await setupWorkspace();
       setTextEditorOptions(5, false);
       await modeHandler.handleMultipleKeyEvents(firstTabKeys.concat(['<Esc>']));
-      await allowVSCodeToPropagateCursorUpdatesAndReturnThem();
       await modeHandler.handleMultipleKeyEvents(['<Esc>', 'g', 'T']);
-      await allowVSCodeToPropagateCursorUpdatesAndReturnThem();
+      await waitForTabChange();
       await modeHandler.handleMultipleKeyEvents(secondTabKeys.concat(['<Esc>']));
-      await allowVSCodeToPropagateCursorUpdatesAndReturnThem();
 
       // running an action in second tab and repeating in first tab
       await modeHandler.handleMultipleKeyEvents(['g', 'g', 'd' , 'd']);
       await assertEqualLines(['test', 'def', 'end']);
-      await allowVSCodeToPropagateCursorUpdatesAndReturnThem();
       await modeHandler.handleMultipleKeyEvents(['g', 't']);
-      await allowVSCodeToPropagateCursorUpdatesAndReturnThem();
+      await waitForTabChange();
       await modeHandler.handleMultipleKeyEvents(['<Esc>', 'g', 'g', '.']);
       await assertEqualLines(['test', 'abc', 'end']);
     });

--- a/test/mode/normalModeTests/dot.test.ts
+++ b/test/mode/normalModeTests/dot.test.ts
@@ -1,7 +1,9 @@
 "use strict";
 
-import { setupWorkspace, cleanUpWorkspace, setTextEditorOptions } from './../../testUtils';
+import { setupWorkspace, cleanUpWorkspace, setTextEditorOptions, assertEqualLines } from './../../testUtils';
 import { ModeHandler } from '../../../src/mode/modeHandler';
+import { allowVSCodeToPropagateCursorUpdatesAndReturnThem } from '../../../src/util';
+import * as assert from 'assert';
 import { getTestingFunctions } from '../../testSimplifier';
 
 suite("Dot Operator", () => {
@@ -18,6 +20,31 @@ suite("Dot Operator", () => {
     });
 
     teardown(cleanUpWorkspace);
+
+    test('repeats actions across editors ', async () => {
+      // setting the content of the first 2 tabs
+      const firstTabContent = 'some\ntest\nabc\nend';
+      const secondTabContent = 'another\ntest\ndef\nend';
+      const firstTabKeys = ['<Esc>', 'a'].concat(firstTabContent.split(''));
+      const secondTabKeys = ['<Esc>', 'a'].concat(secondTabContent.split(''));
+      await setupWorkspace();
+      setTextEditorOptions(5, false);
+      await modeHandler.handleMultipleKeyEvents(firstTabKeys.concat(['<Esc>']));
+      await allowVSCodeToPropagateCursorUpdatesAndReturnThem();
+      await modeHandler.handleMultipleKeyEvents(['<Esc>', 'g', 'T']);
+      await allowVSCodeToPropagateCursorUpdatesAndReturnThem();
+      await modeHandler.handleMultipleKeyEvents(secondTabKeys.concat(['<Esc>']));
+      await allowVSCodeToPropagateCursorUpdatesAndReturnThem();
+
+      // running an action in second tab and repeating in first tab
+      await modeHandler.handleMultipleKeyEvents(['g', 'g', 'd' , 'd']);
+      await assertEqualLines(['test', 'def', 'end']);
+      await allowVSCodeToPropagateCursorUpdatesAndReturnThem();
+      await modeHandler.handleMultipleKeyEvents(['g', 't']);
+      await allowVSCodeToPropagateCursorUpdatesAndReturnThem();
+      await modeHandler.handleMultipleKeyEvents(['<Esc>', 'g', 'g', '.']);
+      await assertEqualLines(['test', 'abc', 'end']);
+    });
 
     newTest({
       title: "Can repeat '~' with <num>",

--- a/test/mode/normalModeTests/motions.test.ts
+++ b/test/mode/normalModeTests/motions.test.ts
@@ -278,7 +278,7 @@ suite("Motions in Normal Mode", () => {
     end: ['one two |two two'],
   });
 
-  test('Remembers a forward search from another editor', async () => {
+  test('Remembers a forward search from another editor', async function() {
     // adding another editor
     await setupWorkspace();
 
@@ -297,7 +297,7 @@ suite("Motions in Normal Mode", () => {
       title: "",
       start: ['|three four two one'],
       keysPressed: '<Esc>n',
-      end: ['three four |two two'],
+      end: ['three four |two one'],
     });
   });
 
@@ -320,13 +320,7 @@ suite("Motions in Normal Mode", () => {
       title: "",
       start: ['|three four two one'],
       keysPressed: '/\n',
-      end: ['three four |two two'],
-    });
-
-    await new Promise((resolve, reject) => {
-      setTimeout(() => {
-        resolve(modeHandler);
-      }, 3000);
+      end: ['three four |two one'],
     });
   });
 
@@ -387,12 +381,6 @@ suite("Motions in Normal Mode", () => {
       start: ['three four two one|'],
       keysPressed: '?\n',
       end: ['three four |two one'],
-    });
-
-    await new Promise((resolve, reject) => {
-      setTimeout(() => {
-        resolve(modeHandler);
-      }, 3000);
     });
   });
 

--- a/test/mode/normalModeTests/motions.test.ts
+++ b/test/mode/normalModeTests/motions.test.ts
@@ -2,7 +2,8 @@
 
 import { setupWorkspace, cleanUpWorkspace } from './../../testUtils';
 import { ModeHandler } from '../../../src/mode/modeHandler';
-import { getTestingFunctions } from '../../testSimplifier';
+import { getTestingFunctions, testIt } from '../../testSimplifier';
+import { waitForTabChange } from '../../../src/util';
 
 suite("Motions in Normal Mode", () => {
   let modeHandler: ModeHandler = new ModeHandler();
@@ -277,6 +278,58 @@ suite("Motions in Normal Mode", () => {
     end: ['one two |two two'],
   });
 
+  test('Remembers a forward search from another editor', async () => {
+    // adding another editor
+    await setupWorkspace();
+
+    await testIt(modeHandler, {
+      title: "",
+      start: ['|one two two two'],
+      keysPressed: '/two\n',
+      end: ['one |two two two'],
+    });
+
+    await modeHandler.handleMultipleKeyEvents(['g', 'T', '<Esc>']);
+
+    await waitForTabChange();
+
+    await testIt(modeHandler, {
+      title: "",
+      start: ['|three four two one'],
+      keysPressed: '<Esc>n',
+      end: ['three four |two two'],
+    });
+  });
+
+  test('Shares forward search history from another editor', async () => {
+    // adding another editor
+    await setupWorkspace();
+
+    await testIt(modeHandler, {
+      title: "",
+      start: ['|one two two two'],
+      keysPressed: '/two\n',
+      end: ['one |two two two'],
+    });
+
+    await modeHandler.handleMultipleKeyEvents(['g', 'T', '<Esc>']);
+
+    await waitForTabChange();
+
+    await testIt(modeHandler, {
+      title: "",
+      start: ['|three four two one'],
+      keysPressed: '/\n',
+      end: ['three four |two two'],
+    });
+
+    await new Promise((resolve, reject) => {
+      setTimeout(() => {
+        resolve(modeHandler);
+      }, 3000);
+    });
+  });
+
   newTest({
     title: "Can run a reverse search",
     start: ['one two thre|e'],
@@ -290,6 +343,59 @@ suite("Motions in Normal Mode", () => {
     keysPressed: '?two\nn',
     end: ['one |two two three'],
   });
+
+  test('Remembers a reverse search from another editor', async () => {
+    // adding another editor
+    await setupWorkspace();
+
+    await testIt(modeHandler, {
+      title: "",
+      start: ['one two two two|'],
+      keysPressed: '?two\n',
+      end: ['one two two |two'],
+    });
+
+    await modeHandler.handleMultipleKeyEvents(['g', 'T', '<Esc>']);
+
+    await waitForTabChange();
+
+    await testIt(modeHandler, {
+      title: "",
+      start: ['three four two one|'],
+      keysPressed: '<Esc>n',
+      end: ['three four |two one'],
+    });
+  });
+
+  test('Shares reverse search history from another editor', async () => {
+    // adding another editor
+    await setupWorkspace();
+
+    await testIt(modeHandler, {
+      title: "",
+      start: ['one two two two|'],
+      keysPressed: '?two\n',
+      end: ['one two two |two'],
+    });
+
+    await modeHandler.handleMultipleKeyEvents(['g', 'T', '<Esc>']);
+
+    await waitForTabChange();
+
+    await testIt(modeHandler, {
+      title: "",
+      start: ['three four two one|'],
+      keysPressed: '?\n',
+      end: ['three four |two one'],
+    });
+
+    await new Promise((resolve, reject) => {
+      setTimeout(() => {
+        resolve(modeHandler);
+      }, 3000);
+    });
+  });
+
 
   newTest({
     title: "maintains column position correctly",


### PR DESCRIPTION
Holds state of repeat "." actions and search globally (across editors), and added tests for each in their respective test files.

Should fix #1081 and #1156 issues
