### PR TITLE
Fix autoindent when opening a line above

### DIFF
--- a/src/actions/actions.ts
+++ b/src/actions/actions.ts
@@ -3004,13 +3004,14 @@ class CommandInsertNewLineAbove extends BaseCommand {
   runsOnceForEveryCursor() { return false; }
 
   public async exec(position: Position, vimState: VimState): Promise<VimState> {
+    let indentationWidth = TextEditor.getIndentationLevel(TextEditor.getLineAt(position).text);
     vimState.currentMode = ModeName.Insert;
 
     vimState.recordedState.transformations.push({
       type: "insertText",
-      text: "\n",
+      text: TextEditor.setIndentationLevel("V", indentationWidth).replace("V", "\n"),
       position: new Position(vimState.cursorPosition.line, 0),
-      diff: new PositionDiff(-1, 0),
+      diff: new PositionDiff(-1, indentationWidth),
     });
 
     return vimState;


### PR DESCRIPTION
Re [#862](https://github.com/VSCodeVim/Vim/issues/862#issuecomment-274751266). I rewrote `CommandInsertNewLineAbove` to mirror `CommandInsertNewLineBefore`, just using `editor.action.insertLineBefore` as the editor command to execute.