### PR TITLE
Clear commandList after executing remapped commands

### DIFF
--- a/src/mode/remapper.ts
+++ b/src/mode/remapper.ts
@@ -117,6 +117,7 @@ class Remapper {
         for (const command of remapping.commands) {
           await vscode.commands.executeCommand(command.command, command.args);
         }
+        vimState.recordedState.commandList = [];
       }
 
       vimState.isCurrentlyPerformingRemapping = false;


### PR DESCRIPTION
#1236 

Previously executed remapped commands were leaving the keys inside commandList, resulting in an unmatched command the next time, i.e. `["-","-"]` instead of `["-"]`. Clearing the commandList after executing the commands seems to resolve the issue. 