### PR TITLE
Keep cursor position when `gd` opens a new file

### DIFF
--- a/extension.ts
+++ b/extension.ts
@@ -69,8 +69,7 @@ let extensionContext: vscode.ExtensionContext;
 let modeHandlerToEditorIdentity: { [key: string]: ModeHandler } = {};
 let previousActiveEditorId: EditorIdentity = new EditorIdentity();
 
-export async function getAndUpdateModeHandler(): Promise<ModeHandler> {
-  const oldHandler = modeHandlerToEditorIdentity[previousActiveEditorId.toString()];
+export function getModeHandlerForActiveEditor(): ModeHandler {
   const activeEditorId = new EditorIdentity(vscode.window.activeTextEditor);
 
   if (!modeHandlerToEditorIdentity[activeEditorId.toString()]) {
@@ -79,8 +78,13 @@ export async function getAndUpdateModeHandler(): Promise<ModeHandler> {
     modeHandlerToEditorIdentity[activeEditorId.toString()] = newModeHandler;
     extensionContext.subscriptions.push(newModeHandler);
   }
+  return modeHandlerToEditorIdentity[activeEditorId.toString()]
+}
 
-  const handler = modeHandlerToEditorIdentity[activeEditorId.toString()];
+export async function getAndUpdateModeHandler(): Promise<ModeHandler> {
+  const oldHandler = modeHandlerToEditorIdentity[previousActiveEditorId.toString()];
+  const activeEditorId = new EditorIdentity(vscode.window.activeTextEditor);
+  const handler = getModeHandlerForActiveEditor()
 
   if (previousActiveEditorId.hasSameBuffer(activeEditorId)) {
     if (!previousActiveEditorId.isEqual(activeEditorId)) {


### PR DESCRIPTION
This fixes the issue #1171, but is neither elegant nor robust. The tests are spitting out a _lot_ of noise like `invalid value for set cursor position. This is probably bad?` and `Error: Illegal value for line`which makes me quite nervous, but they seem to do this on the master branch as well.

There are also 2 failing tests (edit: these don't seem to fail on Travis 😕 ) , which seem like they _could_ be legitimate failures, but I really can't tell:

```
  2 failing
  1) Motions in Normal Mode Remembers a reverse search from another editor:
      AssertionError: Cursor CHARACTER position is wrong.
      + expected - actual
      -18
      +11

  2) Motions in Normal Mode Shares reverse search history from another editor:
      AssertionError: Cursor CHARACTER position is wrong.
      + expected - actual
      -18
      +11
```

As I understand it, this is meant to test that all editors share the the current search term when using `?`. E.g. `?blah<Enter><C-w><C-w>n` will jump backwards from the current cursor position to the first preceding instance of `blah`.
 
I did some manual testing of this feature locally (doing reverse searches in split editors working on the same file), and couldn't replicate the behaviour of the tests (that is, reverse search seems to work perfectly across editors).

### Checklist

- [x] Commit message has a short title & issue references
- [x] Each commit does a logical chunk of work.
- [x] Also went through https://gist.github.com/rebornix/d21d1cc060c009d4430d3904030bd4c1 for good measure.
- [ ] It builds and tests pass (e.g `gulp`)
