### PR TITLE
Delete matching bracket upon backspace

### DIFF
--- a/src/matching/matcher.ts
+++ b/src/matching/matcher.ts
@@ -1,4 +1,5 @@
-import { Position } from './../motion/position';
+import { Position, PositionDiff } from './../motion/position';
+import * as vscode from 'vscode';
 
 /**
  * PairMatcher finds the position matching the given character, respecting nested
@@ -60,6 +61,31 @@ export class PairMatcher {
     }
 
     // TODO(bell)
+    return undefined;
+  }
+
+  /**
+   * Given a current position, find an immediate following bracket and return the range. If
+   * no matching bracket is found immediately following the opening bracket, return undefined.
+   */
+  static immediateMatchingBracket(currentPosition: Position): vscode.Range | undefined {
+    let deleteRange = new vscode.Range(currentPosition, currentPosition.getLeftThroughLineBreaks());
+    let deleteText = vscode.window.activeTextEditor.document.getText(deleteRange);
+    let matchRange: vscode.Range | undefined;
+    let isNextMatch = false;
+
+    if ("{[(<".indexOf(deleteText) > -1) {
+      let matchPosition = currentPosition.add(new PositionDiff(0, 1));
+      if (matchPosition) {
+        matchRange = new vscode.Range(matchPosition, matchPosition.getLeftThroughLineBreaks());
+        isNextMatch = vscode.window.activeTextEditor.document.getText(matchRange) === PairMatcher.pairings[deleteText].match;
+      }
+    }
+
+    if (isNextMatch && matchRange) {
+      return matchRange;
+    }
+
     return undefined;
   }
 }

--- a/src/matching/matcher.ts
+++ b/src/matching/matcher.ts
@@ -15,8 +15,13 @@ export class PairMatcher {
     "]" : { match: "[",  nextMatchIsForward: false, matchesWithPercentageMotion: true },
     // These characters can't be used for "%"-based matching, but are still
     // useful for text objects.
-    "<" : { match: ">",  nextMatchIsForward: true },
+    "<" : { match: ">",  nextMatchIsForward: true  },
     ">" : { match: "<",  nextMatchIsForward: false },
+    // These are useful for deleting closing and opening quotes, but don't seem to negatively
+    // affect how text objects such as `ci"` work, which was my worry.
+    '"' : { match: '"',  nextMatchIsForward: true  },
+    "'" : { match: "'",  nextMatchIsForward: true  },
+    "`" : { match: "`",  nextMatchIsForward: true  },
   };
 
   static nextPairedChar(position: Position, charToMatch: string, closed: boolean = true): Position | undefined {
@@ -77,7 +82,7 @@ export class PairMatcher {
     let matchRange: vscode.Range | undefined;
     let isNextMatch = false;
 
-    if ("{[(<".indexOf(deleteText) > -1) {
+    if ("{[(\"'`".indexOf(deleteText) > -1) {
       let matchPosition = currentPosition.add(new PositionDiff(0, 1));
       if (matchPosition) {
         matchRange = new vscode.Range(matchPosition, matchPosition.getLeftThroughLineBreaks());

--- a/src/matching/matcher.ts
+++ b/src/matching/matcher.ts
@@ -69,6 +69,9 @@ export class PairMatcher {
    * no matching bracket is found immediately following the opening bracket, return undefined.
    */
   static immediateMatchingBracket(currentPosition: Position): vscode.Range | undefined {
+    // Don't delete bracket unless autoClosingBrackets is set
+    if (!vscode.workspace.getConfiguration().get("editor.autoClosingBrackets")) { return undefined; }
+
     let deleteRange = new vscode.Range(currentPosition, currentPosition.getLeftThroughLineBreaks());
     let deleteText = vscode.window.activeTextEditor.document.getText(deleteRange);
     let matchRange: vscode.Range | undefined;

--- a/src/matching/matcher.ts
+++ b/src/matching/matcher.ts
@@ -77,17 +77,15 @@ export class PairMatcher {
     // Don't delete bracket unless autoClosingBrackets is set
     if (!vscode.workspace.getConfiguration().get("editor.autoClosingBrackets")) { return undefined; }
 
-    let deleteRange = new vscode.Range(currentPosition, currentPosition.getLeftThroughLineBreaks());
-    let deleteText = vscode.window.activeTextEditor.document.getText(deleteRange);
+    const deleteRange = new vscode.Range(currentPosition, currentPosition.getLeftThroughLineBreaks());
+    const deleteText = vscode.window.activeTextEditor.document.getText(deleteRange);
     let matchRange: vscode.Range | undefined;
     let isNextMatch = false;
 
     if ("{[(\"'`".indexOf(deleteText) > -1) {
-      let matchPosition = currentPosition.add(new PositionDiff(0, 1));
-      if (matchPosition) {
-        matchRange = new vscode.Range(matchPosition, matchPosition.getLeftThroughLineBreaks());
-        isNextMatch = vscode.window.activeTextEditor.document.getText(matchRange) === PairMatcher.pairings[deleteText].match;
-      }
+      const matchPosition = currentPosition.add(new PositionDiff(0, 1));
+      matchRange = new vscode.Range(matchPosition, matchPosition.getLeftThroughLineBreaks());
+      isNextMatch = vscode.window.activeTextEditor.document.getText(matchRange) === PairMatcher.pairings[deleteText].match;
     }
 
     if (isNextMatch && matchRange) {

--- a/src/mode/modeHandler.ts
+++ b/src/mode/modeHandler.ts
@@ -1291,6 +1291,8 @@ export class ModeHandler implements vscode.Disposable {
                 break;
 
               case "deleteText":
+                let matchRange = PairMatcher.immediateMatchingBracket(command.position);
+                if (matchRange) { edit.delete(matchRange); }
                 edit.delete(new vscode.Range(command.position, command.position.getLeftThroughLineBreaks()));
                 break;
 

--- a/test/mode/modeInsert.test.ts
+++ b/test/mode/modeInsert.test.ts
@@ -174,6 +174,24 @@ suite("Mode Insert", () => {
         assertEqualLines(["  "]);
     });
 
+    test("will remove closing bracket", async() => {
+        await modeHandler.handleMultipleKeyEvents([
+            'i',
+            '(',
+            '<Esc>'
+        ]);
+
+        assertEqualLines(["()"]);
+
+        await modeHandler.handleMultipleKeyEvents([
+            'a',
+            '<BS>',
+            '<Esc>'
+        ]);
+
+        assertEqualLines([""]);
+    });
+
     newTest({
       title: "Can perform <ctrl+o> to exit and perform one command in normal",
       start: ['testtest|'],


### PR DESCRIPTION
#1228 

When in insert mode, if a user is deleting an opening bracket, and a matching closing bracket is immediately after it, also delete the closing bracket. Corresponding test included.