### PR TITLE
fixes #1271

### DIFF
--- a/src/actions/actions.ts
+++ b/src/actions/actions.ts
@@ -6401,7 +6401,7 @@ class CommandSurroundAddToReplacement extends BaseCommand {
     let   firstRangeEnd   = start.getRightThroughLineBreaks();
 
     let   secondRangeStart = stop.getLeftThroughLineBreaks();
-    const secondRangeEnd   = stop.getLeftThroughLineBreaks();
+    const secondRangeEnd   = stop.getLeftThroughLineBreaks().getRight();
 
     if (firstRangeEnd.isEqual(secondRangeStart)) { return; }
 
@@ -6416,6 +6416,9 @@ class CommandSurroundAddToReplacement extends BaseCommand {
            !secondRangeStart.isLineBeginning()) {
       secondRangeStart = secondRangeStart.getLeftThroughLineBreaks(false);
     }
+
+    // Adjust range start based on found position
+    secondRangeStart = secondRangeStart.getRight();
 
     const firstRange  = new Range(firstRangeStart, firstRangeEnd);
     const secondRange = new Range(secondRangeStart, secondRangeEnd);


### PR DESCRIPTION
this was also impacting other surround actions ```cs{"``` in this case would have had similar results

sorry for such a silly fix...really just playing whack-a-mole here :)