### PR TITLE
Support exact and inexact current word search

### DIFF
--- a/src/actions/actions.ts
+++ b/src/actions/actions.ts
@@ -1587,9 +1587,7 @@ class CommandSearchCurrentWordExactForward extends BaseCommand {
       SearchDirection.Forward, vimState.cursorPosition, `\\b${currentWord}\\b`, { isRegex: true }
     );
 
-    do {
-      vimState.cursorPosition = vimState.globalState.searchState.getNextSearchMatchPosition(vimState.cursorPosition).pos;
-    } while (TextEditor.getWord(vimState.cursorPosition) !== currentWord);
+    vimState.cursorPosition = vimState.globalState.searchState.getNextSearchMatchPosition(vimState.cursorPosition).pos;
 
     // Turn one of the highlighting flags back on (turned off with :nohl)
     Configuration.hl = true;
@@ -1613,9 +1611,7 @@ class CommandSearchCurrentWordForward extends BaseCommand {
 
     vimState.globalState.searchState = new SearchState(SearchDirection.Forward, vimState.cursorPosition, currentWord);
 
-    do {
-      vimState.cursorPosition = vimState.globalState.searchState.getNextSearchMatchPosition(vimState.cursorPosition).pos;
-    } while (TextEditor.getWord(vimState.cursorPosition) !== currentWord);
+    vimState.cursorPosition = vimState.globalState.searchState.getNextSearchMatchPosition(vimState.cursorPosition).pos;
 
     // Turn one of the highlighting flags back on (turned off with :nohl)
     Configuration.hl = true;
@@ -1640,12 +1636,11 @@ class CommandSearchCurrentWordExactBackward extends BaseCommand {
     vimState.globalState.searchState = new SearchState(
       SearchDirection.Backward, vimState.cursorPosition, `\\b${currentWord}\\b`, { isRegex: true }
     );
-    do {
-      // use getWordLeft() on position to start at the beginning of the word.
-      // this ensures that any matches happen outside of the word currently selected,
-      // which are the desired semantics for this motion.
-      vimState.cursorPosition = vimState.globalState.searchState.getNextSearchMatchPosition(vimState.cursorPosition.getWordLeft(true)).pos;
-    } while (TextEditor.getWord(vimState.cursorPosition) !== currentWord);
+
+    // use getWordLeft() on position to start at the beginning of the word.
+    // this ensures that any matches happen outside of the word currently selected,
+    // which are the desired semantics for this motion.
+    vimState.cursorPosition = vimState.globalState.searchState.getNextSearchMatchPosition(vimState.cursorPosition.getWordLeft(true)).pos;
 
     // Turn one of the highlighting flags back on (turned off with :nohl)
     Configuration.hl = true;
@@ -1669,12 +1664,10 @@ class CommandSearchCurrentWordBackward extends BaseCommand {
 
     vimState.globalState.searchState = new SearchState(SearchDirection.Backward, vimState.cursorPosition, currentWord);
 
-    do {
-      // use getWordLeft() on position to start at the beginning of the word.
-      // this ensures that any matches happen outside of the word currently selected,
-      // which are the desired semantics for this motion.
-      vimState.cursorPosition = vimState.globalState.searchState.getNextSearchMatchPosition(vimState.cursorPosition.getWordLeft(true)).pos;
-    } while (TextEditor.getWord(vimState.cursorPosition) !== currentWord);
+    // use getWordLeft() on position to start at the beginning of the word.
+    // this ensures that any matches happen outside of the word currently selected,
+    // which are the desired semantics for this motion.
+    vimState.cursorPosition = vimState.globalState.searchState.getNextSearchMatchPosition(vimState.cursorPosition.getWordLeft(true)).pos;
 
     // Turn one of the highlighting flags back on (turned off with :nohl)
     Configuration.hl = true;

--- a/test/mode/normalModeTests/motions.test.ts
+++ b/test/mode/normalModeTests/motions.test.ts
@@ -463,17 +463,25 @@ suite("Motions in Normal Mode", () => {
   });
 
   newTest({
-    title: "Can handle *",
-    start: ['|blah duh blah duh blah'],
-    keysPressed: '*',
-    end: ['blah duh |blah duh blah']
+    title: "Can handle g*",
+    start: ['|blah duh blahblah duh blah'],
+    keysPressed: 'g*',
+    end: ['blah duh |blahblah duh blah']
   });
 
   newTest({
-    title: "Can handle tricky *",
-    start: ['|blah blahblah duh blah'],
+    title: "Can handle g*n",
+    start: ['|blah duh blahblah duh blah'],
+    keysPressed: 'g*n',
+    end: ['blah duh blah|blah duh blah']
+  });
+
+
+  newTest({
+    title: "Can handle *",
+    start: ['|blah blahblah duh blah blah'],
     keysPressed: '*',
-    end: ['blah blahblah duh |blah']
+    end: ['blah blahblah duh |blah blah']
   });
 
   newTest({
@@ -498,10 +506,24 @@ suite("Motions in Normal Mode", () => {
   });
 
   newTest({
+    title: "Can handle g#",
+    start: ['blah duh blahblah duh |blah'],
+    keysPressed: 'g#',
+    end: ['blah duh blah|blah duh blah']
+  });
+
+  newTest({
+    title: "Can handle g#n",
+    start: ['blah duh blahblah duh |blah'],
+    keysPressed: 'g#n',
+    end: ['blah duh |blahblah duh blah']
+  });
+
+  newTest({
     title: "Can handle #",
-    start: ['blah duh |blah duh blah'],
+    start: ['blah blah blahblah duh |blah'],
     keysPressed: '#',
-    end: ['|blah duh blah duh blah']
+    end: ['blah |blah blahblah duh blah']
   });
 
   newTest({


### PR DESCRIPTION
Rename `CommandStar` and `CommandHash` to `CommandSearchCurrentWordExactForward` and `CommandSearchCurrentWorldExactBackward`, which describe their effect. Also include regex word bounds in the search so that they act the same as in Vim.

Add `CommandSearchCurrentWordForward` and `…Backward` (commands `g*` and `g#` respectively), that match without word bounds.

Closes #1266

---

So this is mainly a copy+paste, I wasn't sure if there was an idiomatic approach to sharing behaviour between these two commands. Also I renamed the classes because it felt more sensible to name them after their effect than their keybindings (also it seemed strange to call the new one something like `CommandGStar`.

Let me know if there's anything stylistically or functionally wrong here, I'm happy to iterate on it.

<!--
Yay! We love PRs! 🎊

Please include a description of your change and ensure:

- [ ] Commit message has a short title & issue references
- [ ] Each commit does a logical chunk of work.
- [ ] It builds and tests pass (e.g `gulp`)

More info can be found on our [contribution guide](https://github.com/VSCodeVim/Vim/blob/master/.github/CONTRIBUTING.md).
-->
