### PR TITLE
avoid using user remapping in test mode

### DIFF
--- a/src/mode/modeHandler.ts
+++ b/src/mode/modeHandler.ts
@@ -744,10 +744,14 @@ export class ModeHandler implements vscode.Disposable {
           (withinTimeout || keys.length === 1)) {
 
 
-        handled = handled || await this._insertModeRemapper.sendKey(keys, this, this.vimState);
-        handled = handled || await this._otherModesRemapper.sendKey(keys, this, this.vimState);
-        handled = handled || await this._insertModeNonRecursive.sendKey(keys, this, this.vimState);
-        handled = handled || await this._otherModesNonRecursive.sendKey(keys, this, this.vimState);
+        // User remappings bork the tests. If the the remappings start getting tested
+        // at some point, will probably need a new solution.
+        if (!ModeHandler.IsTesting) {
+          handled = handled || await this._insertModeRemapper.sendKey(keys, this, this.vimState);
+          handled = handled || await this._otherModesRemapper.sendKey(keys, this, this.vimState);
+          handled = handled || await this._insertModeNonRecursive.sendKey(keys, this, this.vimState);
+          handled = handled || await this._otherModesNonRecursive.sendKey(keys, this, this.vimState);
+        }
       }
 
       if (!handled) {


### PR DESCRIPTION
User remapping affect tests, resulting in unpredictable test breakage on local. If the remapping functionality starts to receive testing later, a new solution will probably need to be found.