### PR TITLE
More surround fixes

### DIFF
--- a/src/actions/actions.ts
+++ b/src/actions/actions.ts
@@ -6314,6 +6314,7 @@ class CommandSurroundModeStart extends BaseCommand {
       operator   : operatorString,
       replacement: undefined,
       range      : undefined,
+      isVisual   : false
     };
 
     if (operatorString !== "yank") {
@@ -6352,6 +6353,7 @@ class CommandSurroundModeStartVisual extends BaseCommand {
       operator: "yank",
       replacement: undefined,
       range: new Range(vimState.cursorStartPosition, vimState.cursorPosition),
+      isVisual : true
     };
 
     vimState.currentMode = ModeName.SurroundInputMode;
@@ -6419,7 +6421,14 @@ class CommandSurroundAddToReplacement extends BaseCommand {
       vimState.surround.replacement = "";
     }
 
-    vimState.surround.replacement += this.keysPressed[this.keysPressed.length - 1];
+    let stringToAdd = this.keysPressed[this.keysPressed.length - 1];
+
+    // t should start creation of a tag
+    if (this.keysPressed[0] === "t" && vimState.surround.replacement.length === 0) {
+      stringToAdd = "<";
+    }
+
+    vimState.surround.replacement += stringToAdd;
 
     await CommandSurroundAddToReplacement.TryToExecuteSurround(vimState, position);
 
@@ -6518,6 +6527,11 @@ class CommandSurroundAddToReplacement extends BaseCommand {
       let stop  = vimState.surround.range.stop;
 
       stop = stop.getRight();
+
+      if (vimState.surround.isVisual) {
+        startReplace = startReplace + "\n";
+        endReplace = "\n" + endReplace;
+      }
 
       vimState.recordedState.transformations.push({ type: "insertText", text: startReplace, position: start });
       vimState.recordedState.transformations.push({ type: "insertText", text: endReplace,   position: stop });

--- a/src/matching/matcher.ts
+++ b/src/matching/matcher.ts
@@ -19,9 +19,9 @@ export class PairMatcher {
     ">" : { match: "<",  nextMatchIsForward: false },
     // These are useful for deleting closing and opening quotes, but don't seem to negatively
     // affect how text objects such as `ci"` work, which was my worry.
-    '"' : { match: '"',  nextMatchIsForward: true  },
-    "'" : { match: "'",  nextMatchIsForward: true  },
-    "`" : { match: "`",  nextMatchIsForward: true  },
+    '"' : { match: '"',  nextMatchIsForward: false  },
+    "'" : { match: "'",  nextMatchIsForward: false  },
+    "`" : { match: "`",  nextMatchIsForward: false  },
   };
 
   static nextPairedChar(position: Position, charToMatch: string, closed: boolean = true): Position | undefined {

--- a/src/mode/modeHandler.ts
+++ b/src/mode/modeHandler.ts
@@ -101,6 +101,7 @@ export class VimState {
     target: string | undefined;
     replacement: string | undefined;
     range: Range | undefined;
+    isVisual: boolean;
   } = undefined;
 
   /**

--- a/src/mode/modeHandler.ts
+++ b/src/mode/modeHandler.ts
@@ -101,7 +101,7 @@ export class VimState {
     target: string | undefined;
     replacement: string | undefined;
     range: Range | undefined;
-    isVisual: boolean;
+    isVisualLine: boolean;
   } = undefined;
 
   /**


### PR DESCRIPTION
Fixes the important ones from #1255, the only ones left have nothing to do with surround but more so how sentence objects and word objects work

- backspace when entering tags
- visual line then surround creates newlines before/after and puts cursor in right place
- surround t triggers tag input correctly
- added some shortcuts from the original surround plugin b = (, B = {, and r = [