### PR TITLE
Fix for #1293

### DIFF
--- a/src/actions/actions.ts
+++ b/src/actions/actions.ts
@@ -696,7 +696,7 @@ export class CommandOneNormalCommandInInsertMode extends BaseCommand {
 
   public async exec(position: Position, vimState: VimState): Promise<VimState> {
     vimState.returnToInsertAfterCommand = true;
-    return await new CommandEscInsertMode().exec(position, vimState);
+    return await new CommandEscInsertMode().exec(position.add(new PositionDiff(0, 1)), vimState);
   }
 }
 

--- a/src/actions/actions.ts
+++ b/src/actions/actions.ts
@@ -696,7 +696,9 @@ export class CommandOneNormalCommandInInsertMode extends BaseCommand {
 
   public async exec(position: Position, vimState: VimState): Promise<VimState> {
     vimState.returnToInsertAfterCommand = true;
-    return await new CommandEscInsertMode().exec(position.getRight(), vimState);
+    return await new CommandEscInsertMode().exec(
+                      position.character === 0 ? position : position.getRight(),
+                      vimState);
   }
 }
 

--- a/src/actions/actions.ts
+++ b/src/actions/actions.ts
@@ -696,7 +696,7 @@ export class CommandOneNormalCommandInInsertMode extends BaseCommand {
 
   public async exec(position: Position, vimState: VimState): Promise<VimState> {
     vimState.returnToInsertAfterCommand = true;
-    return await new CommandEscInsertMode().exec(position.add(new PositionDiff(0, 1)), vimState);
+    return await new CommandEscInsertMode().exec(position.getRight(), vimState);
   }
 }
 


### PR DESCRIPTION
When using `C-o` in Insert Mode to execute a single Normal Mode command, the cursor will be of by one after the change.

Changing the argument input for the specific action fixes this bug, while not changing the behavior of other code