### PR TITLE
D in visual mode behaves like d

### DIFF
--- a/src/actions/actions.ts
+++ b/src/actions/actions.ts
@@ -1869,6 +1869,10 @@ export class DeleteOperatorVisual extends BaseOperator {
     public modes = [ModeName.Visual, ModeName.VisualLine];
 
     public async run(vimState: VimState, start: Position, end: Position): Promise<VimState> {
+      // ensures linewise deletion when in visual mode
+      // see special case in DeleteOperator.delete()
+      vimState.currentRegisterMode = RegisterMode.LineWise;
+
       return await new DeleteOperator(this.multicursorIndex).run(vimState, start, end);
     }
 }

--- a/src/actions/actions.ts
+++ b/src/actions/actions.ts
@@ -696,7 +696,7 @@ export class CommandOneNormalCommandInInsertMode extends BaseCommand {
 
   public async exec(position: Position, vimState: VimState): Promise<VimState> {
     vimState.returnToInsertAfterCommand = true;
-    return await new CommandEscInsertMode().exec(position, vimState);
+    return await new CommandEscInsertMode().exec(position.add(new PositionDiff(0, 1)), vimState);
   }
 }
 

--- a/src/actions/actions.ts
+++ b/src/actions/actions.ts
@@ -696,7 +696,9 @@ export class CommandOneNormalCommandInInsertMode extends BaseCommand {
 
   public async exec(position: Position, vimState: VimState): Promise<VimState> {
     vimState.returnToInsertAfterCommand = true;
-    return await new CommandEscInsertMode().exec(position.getRight(), vimState);
+    return await new CommandEscInsertMode().exec(
+                      position.character === 0 ? position : position.getRight(),
+                      vimState);
   }
 }
 

--- a/src/actions/actions.ts
+++ b/src/actions/actions.ts
@@ -696,7 +696,7 @@ export class CommandOneNormalCommandInInsertMode extends BaseCommand {
 
   public async exec(position: Position, vimState: VimState): Promise<VimState> {
     vimState.returnToInsertAfterCommand = true;
-    return await new CommandEscInsertMode().exec(position.add(new PositionDiff(0, 1)), vimState);
+    return await new CommandEscInsertMode().exec(position.getRight(), vimState);
   }
 }
 

--- a/test/mode/modeVisual.test.ts
+++ b/test/mode/modeVisual.test.ts
@@ -128,11 +128,11 @@ suite("Mode Visual", () => {
   });
 
   newTest({
-      title: "Can handle H key",
-      start: ['1', '2', '|3', '4', '5'],
-      keysPressed: 'vH',
-      end: ['|1', '2', '3', '4', '5']
-    });
+    title: "Can handle H key",
+    start: ['1', '2', '|3', '4', '5'],
+    keysPressed: 'vH',
+    end: ['|1', '2', '3', '4', '5']
+  });
 
   test("handles case where we delete over a newline", async () => {
     await modeHandler.handleMultipleKeyEvents("ione two\n\nthree four".split(""));
@@ -472,7 +472,7 @@ suite("Mode Visual", () => {
     });
 
     newTest({
-      title: "Can handle 'Y' in visual mode" ,
+      title: "Can handle 'Y' in visual mode",
       start: ['one', '|two'],
       keysPressed: 'vwYP',
       end: ['one', '|two', 'two'],
@@ -638,5 +638,24 @@ suite("Mode Visual", () => {
     keysPressed: "vl<Esc>llgvd",
     end: ["tes|est"],
     endMode: ModeName.Normal
+  });
+
+  suite("D command will remove all selected lines", () => {
+    newTest({
+      title: "D deletes all selected lines",
+      start: ["first line", "test| line1", "test line2", "second line"],
+      keysPressed: "vjD",
+      end: ["first line", "|second line"],
+      endMode: ModeName.Normal
+    });
+
+    newTest({
+      title: "D deletes the current line",
+      start: ["first line", "test| line1", "second line"],
+      keysPressed: "vlllD",
+      end: ["first line", "|second line"],
+      endMode: ModeName.Normal
+    });
+
   });
 });


### PR DESCRIPTION
The delete function of the DeleteOperation Class already account for this case, if the Register Mode is set to LineWise.