### PR TITLE
Fix c on line beginning#1302

### DIFF
--- a/src/actions/actions.ts
+++ b/src/actions/actions.ts
@@ -2082,7 +2082,7 @@ export class ChangeOperator extends BaseOperator {
         const isEndOfLine = end.character === end.getLineEnd().character;
         const isBeginning =
                 end.isLineBeginning() &&
-                start.isLineBeginning() // to ensure this is a selection and not e.g. and s command
+                start.isLineBeginning(); // to ensure this is a selection and not e.g. and s command
         let state = vimState;
 
         // If we delete to EOL, the block cursor would end on the final character,

--- a/src/actions/actions.ts
+++ b/src/actions/actions.ts
@@ -2080,13 +2080,16 @@ export class ChangeOperator extends BaseOperator {
 
     public async run(vimState: VimState, start: Position, end: Position): Promise<VimState> {
         const isEndOfLine = end.character === end.getLineEnd().character;
+        const isBeginning =
+                end.character === end.getLineBegin().character &&
+                start.character !== start.getLineBegin().character; // to ensure this is a selection and not e.g. and s command
         let state = vimState;
 
         // If we delete to EOL, the block cursor would end on the final character,
         // which means the insert cursor would be one to the left of the end of
         // the line. We do want to run delete if it is a multiline change though ex. c}
         if (Position.getLineLength(TextEditor.getLineAt(start).lineNumber) !== 0 || (end.line !== start.line)) {
-          if (isEndOfLine) {
+          if (isEndOfLine || isBeginning) {
             state = await new DeleteOperator(this.multicursorIndex).run(vimState, start, end.getLeftThroughLineBreaks());
           } else {
             state = await new DeleteOperator(this.multicursorIndex).run(vimState, start, end);

--- a/src/actions/actions.ts
+++ b/src/actions/actions.ts
@@ -2082,7 +2082,7 @@ export class ChangeOperator extends BaseOperator {
         const isEndOfLine = end.character === end.getLineEnd().character;
         const isBeginning =
                 end.isLineBeginning() &&
-                start.isLineBeginning(); // to ensure this is a selection and not e.g. and s command
+                !start.isLineBeginning(); // to ensure this is a selection and not e.g. and s command
         let state = vimState;
 
         // If we delete to EOL, the block cursor would end on the final character,

--- a/src/actions/actions.ts
+++ b/src/actions/actions.ts
@@ -2081,8 +2081,8 @@ export class ChangeOperator extends BaseOperator {
     public async run(vimState: VimState, start: Position, end: Position): Promise<VimState> {
         const isEndOfLine = end.character === end.getLineEnd().character;
         const isBeginning =
-                end.character === end.getLineBegin().character &&
-                start.character !== start.getLineBegin().character; // to ensure this is a selection and not e.g. and s command
+                end.isLineBeginning() &&
+                start.isLineBeginning() // to ensure this is a selection and not e.g. and s command
         let state = vimState;
 
         // If we delete to EOL, the block cursor would end on the final character,

--- a/test/mode/modeVisual.test.ts
+++ b/test/mode/modeVisual.test.ts
@@ -639,4 +639,12 @@ suite("Mode Visual", () => {
     end: ["tes|est"],
     endMode: ModeName.Normal
   });
+
+  newTest({
+    title: "Changes on a firstline selection will not delete first character",
+    start: ["test|jojo", "haha"],
+    keysPressed: "vj0c",
+    end: ["test|haha"],
+    endMode: ModeName.Insert
+  });
 });


### PR DESCRIPTION
Changed the c Action to encounter for cases where the selection ends at the beginning of a line.
The tests revealed, that s is implemented using c(0,0).

Therefore i check, if this is a real selection before calling the getLeftThroughLineBreaks() function
