### PR TITLE
Fix #1329 failing build by changing typescript dependency version

### DIFF
--- a/package.json
+++ b/package.json
@@ -380,7 +380,7 @@
         "copy-paste": "^1.3.0",
         "diff-match-patch": "^1.0.0",
         "lodash": "^4.12.0",
-        "typescript": "^2.0.10",
+        "typescript": "2.0.10",
         "vscode": "^0.11.16"
     },
     "devDependencies": {


### PR DESCRIPTION
Fix #1329 
Typescript dependency version in package.json has been changed to "2.0.10"(fixed)
since typescript is currently at 2.2.1 and newcomers to this project will get that(2.2.1)
when installing via ```npm install```
It seems like the build fails due to the version difference of typescript.
Master branch build shows no problem with typescript version 2.0.10