### PR TITLE
fixes #1327

### DIFF
--- a/src/matching/matcher.ts
+++ b/src/matching/matcher.ts
@@ -17,11 +17,6 @@ export class PairMatcher {
     // useful for text objects.
     "<" : { match: ">",  nextMatchIsForward: true  },
     ">" : { match: "<",  nextMatchIsForward: false },
-    // These are useful for deleting closing and opening quotes, but don't seem to negatively
-    // affect how text objects such as `ci"` work, which was my worry.
-    '"' : { match: '"',  nextMatchIsForward: false  },
-    "'" : { match: "'",  nextMatchIsForward: false  },
-    "`" : { match: "`",  nextMatchIsForward: false  },
   };
 
   static nextPairedChar(position: Position, charToMatch: string, closed: boolean = true): Position | undefined {
@@ -85,7 +80,13 @@ export class PairMatcher {
     if ("{[(\"'`".indexOf(deleteText) > -1) {
       const matchPosition = currentPosition.add(new PositionDiff(0, 1));
       matchRange = new vscode.Range(matchPosition, matchPosition.getLeftThroughLineBreaks());
-      isNextMatch = vscode.window.activeTextEditor.document.getText(matchRange) === PairMatcher.pairings[deleteText].match;
+
+      // Quotes are in pairings so treat them separately since they do not have an open/close direction
+      if ("\"'`".indexOf(deleteText) > -1) {
+        isNextMatch = vscode.window.activeTextEditor.document.getText(matchRange) === deleteText;
+      } else {
+        isNextMatch = vscode.window.activeTextEditor.document.getText(matchRange) === PairMatcher.pairings[deleteText].match;
+      }
     }
 
     if (isNextMatch && matchRange) {

--- a/src/matching/matcher.ts
+++ b/src/matching/matcher.ts
@@ -6,7 +6,10 @@ import * as vscode from 'vscode';
  * instances of the pair.
  */
 export class PairMatcher {
-  static pairings: { [key: string]: { match: string, nextMatchIsForward: boolean, matchesWithPercentageMotion?: boolean }} = {
+  static pairings: {
+    [key: string]:
+    { match: string, nextMatchIsForward: boolean, directionLess?: boolean, matchesWithPercentageMotion?: boolean }
+  } = {
     "(" : { match: ")",  nextMatchIsForward: true,  matchesWithPercentageMotion: true },
     "{" : { match: "}",  nextMatchIsForward: true,  matchesWithPercentageMotion: true },
     "[" : { match: "]",  nextMatchIsForward: true,  matchesWithPercentageMotion: true },
@@ -19,9 +22,9 @@ export class PairMatcher {
     ">" : { match: "<",  nextMatchIsForward: false },
     // These are useful for deleting closing and opening quotes, but don't seem to negatively
     // affect how text objects such as `ci"` work, which was my worry.
-    '"' : { match: '"',  nextMatchIsForward: false  },
-    "'" : { match: "'",  nextMatchIsForward: false  },
-    "`" : { match: "`",  nextMatchIsForward: false  },
+    '"': { match: '"', nextMatchIsForward: false, directionLess: true },
+    "'": { match: "'", nextMatchIsForward: false, directionLess: true },
+    "`": { match: "`", nextMatchIsForward: false, directionLess: true },
   };
 
   static nextPairedChar(position: Position, charToMatch: string, closed: boolean = true): Position | undefined {
@@ -38,7 +41,7 @@ export class PairMatcher {
      */
     const toFind = this.pairings[charToMatch];
 
-    if (toFind === undefined) {
+    if (toFind === undefined || toFind.directionLess) {
       return undefined;
     }
 

--- a/src/matching/matcher.ts
+++ b/src/matching/matcher.ts
@@ -17,6 +17,11 @@ export class PairMatcher {
     // useful for text objects.
     "<" : { match: ">",  nextMatchIsForward: true  },
     ">" : { match: "<",  nextMatchIsForward: false },
+    // These are useful for deleting closing and opening quotes, but don't seem to negatively
+    // affect how text objects such as `ci"` work, which was my worry.
+    '"' : { match: '"',  nextMatchIsForward: false  },
+    "'" : { match: "'",  nextMatchIsForward: false  },
+    "`" : { match: "`",  nextMatchIsForward: false  },
   };
 
   static nextPairedChar(position: Position, charToMatch: string, closed: boolean = true): Position | undefined {
@@ -80,13 +85,7 @@ export class PairMatcher {
     if ("{[(\"'`".indexOf(deleteText) > -1) {
       const matchPosition = currentPosition.add(new PositionDiff(0, 1));
       matchRange = new vscode.Range(matchPosition, matchPosition.getLeftThroughLineBreaks());
-
-      // Quotes are in pairings so treat them separately since they do not have an open/close direction
-      if ("\"'`".indexOf(deleteText) > -1) {
-        isNextMatch = vscode.window.activeTextEditor.document.getText(matchRange) === deleteText;
-      } else {
-        isNextMatch = vscode.window.activeTextEditor.document.getText(matchRange) === PairMatcher.pairings[deleteText].match;
-      }
+      isNextMatch = vscode.window.activeTextEditor.document.getText(matchRange) === PairMatcher.pairings[deleteText].match;
     }
 
     if (isNextMatch && matchRange) {


### PR DESCRIPTION
@rufusroflpunch this isn't the cleanest way to fix the problem but I think it is fine, what do you think?

The problem is we use nextPairedCharacter in the matcher in a few other places, and if it is not in the pairings, then it returns instantly. However, when we added quotes, this meant nextPairedCharacter would now iterate the document looking for a forward or backward matching char, this could probably be made to work correctly since in these cases quotes are typically pairs, but this solution seemed easier to me for now...