### PR TITLE
Fix #1329 failing build by removing undefined in configuration.ts

### DIFF
--- a/src/configuration/configuration.ts
+++ b/src/configuration/configuration.ts
@@ -145,22 +145,22 @@ class ConfigurationClass {
    * Size of a tab character.
    */
   @overlapSetting({ codeName: "tabSize", default: 8})
-  tabstop: number | undefined = undefined;
+  tabstop: number;
 
   /**
    * Use spaces when the user presses tab?
    */
   @overlapSetting({ codeName: "insertSpaces", default: false})
-  expandtab: boolean | undefined = undefined;
+  expandtab: boolean;
 
   @overlapSetting({ codeName: "lineNumbers", default: true, codeValueMapping: {true: "on", false: "off"}})
-  number: boolean | undefined = undefined;
+  number: boolean;
 
   /**
    * Show relative line numbers?
    */
   @overlapSetting({ codeName: "lineNumbers", default: false, codeValueMapping: {true: "relative", false: "off"}})
-  relativenumber: boolean | undefined = undefined;
+  relativenumber: boolean;
 
   iskeyword: string = "/\\()\"':,.;<>~!@#$%^&*|+=[]{}`?-";
 }


### PR DESCRIPTION
Fix #1329 
The reason behind failing build was due to the changes made in typescript 2.2 as below.
> TypeScript 2.2 improves checking of nullable operands in expressions.
https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-2.html

Hence, I removed union type of undefined in configuration.ts to make the build work.
Builds successfully in typescript 2.1.6 & 2.2.1