### PR TITLE
Override VSCode copy command. #1337, #616.

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,11 @@ Or bind `<leader>w` to save the current file:
   * Have VSCodeVim start in Insert Mode rather than Normal Mode.
   * We would be remiss in our duties as Vim users not to say that you should really be staying in Normal mode as much as you can, but hey, who are we to stop you?
 
+### overrideCopy
+  * Override VSCode's copy command with our own, which works correctly with VSCodeVim.
+  * If cmd-c or ctrl-c is giving you issues, set this to false and complain at https://github.com/Microsoft/vscode/issues/217.
+  * Type: Boolean (Default: `true`)
+
 #### useSystemClipboard
   * Enable yanking to the system clipboard by default
   * Type: Boolean (Default: `false`)

--- a/package.json
+++ b/package.json
@@ -187,6 +187,14 @@
                 "when": "editorTextFocus && vim.useCtrlKeys && !inDebugRepl"
             },
             {
+                "key": "ctrl+c",
+                "win": "ctrl+c",
+                "linux": "ctrl+c",
+                "mac": "cmd+c",
+                "command": "extension.vim_cmd+c",
+                "when": "editorTextFocus && !vim.useCtrlKeys && vim.overrideCopy &&  && !inDebugRepl"
+            },
+            {
                 "key": "ctrl+a",
                 "command": "extension.vim_ctrl+a",
                 "when": "editorTextFocus && vim.useCtrlKeys && !inDebugRepl"
@@ -283,6 +291,11 @@
                     "type": "boolean",
                     "description": "Use system clipboard for unnamed register.",
                     "default": false
+                },
+                "vim.overrideCopy": {
+                    "type": "boolean",
+                    "description": "Override VSCode's copy command with our own copy command, which works better with VSCodeVim. Turn this off if copying is not working.",
+                    "default": true
                 },
                 "vim.insertModeKeyBindings": {
                     "type": "array",

--- a/src/configuration/configuration.ts
+++ b/src/configuration/configuration.ts
@@ -71,6 +71,11 @@ class ConfigurationClass {
   useCtrlKeys = false;
 
   /**
+   * Override default VSCode copy behavior.
+   */
+  overrideCopy = true;
+
+  /**
    * Width in characters to word-wrap to.
    */
   textwidth = 80;

--- a/src/mode/modeHandler.ts
+++ b/src/mode/modeHandler.ts
@@ -1703,6 +1703,7 @@ export class ModeHandler implements vscode.Disposable {
     }
 
     vscode.commands.executeCommand('setContext', 'vim.useCtrlKeys', Configuration.useCtrlKeys);
+    vscode.commands.executeCommand('setContext', 'vim.overrideCopy', Configuration.overrideCopy);
     vscode.commands.executeCommand('setContext', 'vim.platform', process.platform);
   }
 


### PR DESCRIPTION
I just couldn't resist fixing bug #1337. (Not really.) 

This fixes the annoying problem of cmd-c or ctrl-c not copying the final character, which I have heard a lot of people complain about. I would like people on alternate platforms to test this before I release a new version.