### PR TITLE
Use block cursor in visual & underline in replace

### DIFF
--- a/src/mode/mode.ts
+++ b/src/mode/mode.ts
@@ -14,7 +14,9 @@ export enum ModeName {
 }
 
 export enum VSCodeVimCursorType {
-  Native,
+  Block,
+  Line,
+  Underline,
   TextDecoration
 }
 

--- a/src/mode/modeEasyMotion.ts
+++ b/src/mode/modeEasyMotion.ts
@@ -5,7 +5,7 @@ import { VSCodeVimCursorType } from './mode';
 
 export class EasyMotionMode extends Mode {
   public text = "EasyMotion Mode";
-  public cursorType = VSCodeVimCursorType.Native;
+  public cursorType = VSCodeVimCursorType.Block;
 
    constructor() {
     super(ModeName.EasyMotionMode);

--- a/src/mode/modeHandler.ts
+++ b/src/mode/modeHandler.ts
@@ -1694,11 +1694,17 @@ export class ModeHandler implements vscode.Disposable {
         .update("cursorBlinking", this.currentMode.name !== ModeName.Insert ? "solid" : "blink", true);
     }
 
-    // Use native block cursor if possible.
-    let cursorStyle = this.currentMode.cursorType === VSCodeVimCursorType.Native &&
-      this.currentMode.name !== ModeName.VisualBlockInsertMode &&
-      this.currentMode.name !== ModeName.Insert ?
-      vscode.TextEditorCursorStyle.Block : vscode.TextEditorCursorStyle.Line;
+    // Use native cursor if possible. Default to Block.
+    let cursorStyle = vscode.TextEditorCursorStyle.Block;
+    switch (this.currentMode.cursorType) {
+      case VSCodeVimCursorType.TextDecoration:
+      case VSCodeVimCursorType.Line:
+        cursorStyle = vscode.TextEditorCursorStyle.Line;
+        break;
+      case VSCodeVimCursorType.Underline:
+        cursorStyle = vscode.TextEditorCursorStyle.Underline;
+        break;
+    }
 
     let options = vscode.window.activeTextEditor.options;
     options.cursorStyle = cursorStyle;

--- a/src/mode/modeHandler.ts
+++ b/src/mode/modeHandler.ts
@@ -1713,12 +1713,19 @@ export class ModeHandler implements vscode.Disposable {
     // TODO xconverge: temporary workaround for vscode bug not changing cursor style properly
     // https://github.com/Microsoft/vscode/issues/17472
     // https://github.com/Microsoft/vscode/issues/17513
-    if (options.cursorStyle === vscode.TextEditorCursorStyle.Block) {
-      vscode.window.activeTextEditor.options.cursorStyle = vscode.TextEditorCursorStyle.Line;
-      vscode.window.activeTextEditor.options.cursorStyle = vscode.TextEditorCursorStyle.Block;
-    } else if (options.cursorStyle === vscode.TextEditorCursorStyle.Line) {
-      vscode.window.activeTextEditor.options.cursorStyle = vscode.TextEditorCursorStyle.Block;
-      vscode.window.activeTextEditor.options.cursorStyle = vscode.TextEditorCursorStyle.Line;
+    switch (options.cursorStyle) {
+      case vscode.TextEditorCursorStyle.Block:
+        vscode.window.activeTextEditor.options.cursorStyle = vscode.TextEditorCursorStyle.Line;
+        vscode.window.activeTextEditor.options.cursorStyle = vscode.TextEditorCursorStyle.Block;
+        break;
+      case vscode.TextEditorCursorStyle.Line:
+        vscode.window.activeTextEditor.options.cursorStyle = vscode.TextEditorCursorStyle.Block;
+        vscode.window.activeTextEditor.options.cursorStyle = vscode.TextEditorCursorStyle.Line;
+        break;
+      case vscode.TextEditorCursorStyle.Underline:
+        vscode.window.activeTextEditor.options.cursorStyle = vscode.TextEditorCursorStyle.Block;
+        vscode.window.activeTextEditor.options.cursorStyle = vscode.TextEditorCursorStyle.Underline;
+        break;
     }
 
     if (this.currentMode.cursorType === VSCodeVimCursorType.TextDecoration &&

--- a/src/mode/modeInsert.ts
+++ b/src/mode/modeInsert.ts
@@ -5,7 +5,7 @@ import { VSCodeVimCursorType } from './mode';
 
 export class InsertMode extends Mode {
   public text = "Insert Mode";
-  public cursorType = VSCodeVimCursorType.Native;
+  public cursorType = VSCodeVimCursorType.Line;
 
    constructor() {
     super(ModeName.Insert);

--- a/src/mode/modeInsertVisualBlock.ts
+++ b/src/mode/modeInsertVisualBlock.ts
@@ -5,7 +5,7 @@ import { VSCodeVimCursorType } from './mode';
 
 export class InsertVisualBlockMode extends Mode {
   public text = "Visual Block Insert Mode";
-  public cursorType = VSCodeVimCursorType.Native;
+  public cursorType = VSCodeVimCursorType.Line;
   public isVisualMode = true;
 
   constructor() {

--- a/src/mode/modeNormal.ts
+++ b/src/mode/modeNormal.ts
@@ -8,7 +8,7 @@ export class NormalMode extends Mode {
   private _modeHandler: ModeHandler;
 
   public text = "Normal Mode";
-  public cursorType = VSCodeVimCursorType.Native;
+  public cursorType = VSCodeVimCursorType.Block;
 
   constructor(modeHandler: ModeHandler) {
     super(ModeName.Normal);

--- a/src/mode/modeReplace.ts
+++ b/src/mode/modeReplace.ts
@@ -5,7 +5,7 @@ import { VSCodeVimCursorType } from './mode';
 
 export class ReplaceMode extends Mode {
   public text = "Replace";
-  public cursorType = VSCodeVimCursorType.TextDecoration;
+  public cursorType = VSCodeVimCursorType.Underline;
 
   constructor() {
     super(ModeName.Replace);

--- a/src/mode/modeSearchInProgress.ts
+++ b/src/mode/modeSearchInProgress.ts
@@ -5,7 +5,7 @@ import { VSCodeVimCursorType } from './mode';
 
 export class SearchInProgressMode extends Mode {
   public text = "Search In Progress";
-  public cursorType = VSCodeVimCursorType.Native;
+  public cursorType = VSCodeVimCursorType.Block;
 
    constructor() {
     super(ModeName.SearchInProgressMode);

--- a/src/mode/modeVisual.ts
+++ b/src/mode/modeVisual.ts
@@ -5,7 +5,7 @@ import { VSCodeVimCursorType } from './mode';
 
 export class VisualMode extends Mode {
   public text = "Visual Mode";
-  public cursorType = VSCodeVimCursorType.TextDecoration;
+  public cursorType = VSCodeVimCursorType.Block;
   public isVisualMode = true;
 
   constructor() {

--- a/src/mode/modeVisualLine.ts
+++ b/src/mode/modeVisualLine.ts
@@ -5,7 +5,7 @@ import { VSCodeVimCursorType } from './mode';
 
 export class VisualLineMode extends Mode {
   public text = "Visual Line Mode";
-  public cursorType = VSCodeVimCursorType.TextDecoration;
+  public cursorType = VSCodeVimCursorType.Block;
   public isVisualMode = true;
 
   constructor() {

--- a/src/mode/surroundInputMode.ts
+++ b/src/mode/surroundInputMode.ts
@@ -5,7 +5,7 @@ import { VSCodeVimCursorType } from './mode';
 
 export class SurroundInputMode extends Mode {
   public text = "Surround Input Mode";
-  public cursorType = VSCodeVimCursorType.Native;
+  public cursorType = VSCodeVimCursorType.Block;
 
    constructor() {
     super(ModeName.SurroundInputMode);


### PR DESCRIPTION
This PR changes the visual mode cursor to the standard block cursor, and the replace mode cursor to an underline. These two changes result in a cleaner look, and more closely match Vim's aesthetic. The block cursor unfortunately not possible in visual block mode.

_Cursors Before_

<img width="64" alt="screen shot 2017-03-12 at 7 37 02 pm" src="https://cloud.githubusercontent.com/assets/6983821/23841720/b350659e-0785-11e7-9008-af6fa2f47138.png"> <img width="129" alt="screen shot 2017-03-13 at 12 37 44 am" src="https://cloud.githubusercontent.com/assets/6983821/23841737/ce1f202c-0785-11e7-9837-aa1e8d15e45f.png">

_Cursors After_

<img width="68" alt="screen shot 2017-03-12 at 7 46 00 pm" src="https://cloud.githubusercontent.com/assets/6983821/23841734/c89e8e08-0785-11e7-8b3b-1b9c07dee148.png"> <img width="125" alt="screen shot 2017-03-13 at 12 37 55 am" src="https://cloud.githubusercontent.com/assets/6983821/23841739/d1d2a7f2-0785-11e7-98f7-28620a61cb4d.png">

