### PR TITLE
Allowing user to selectively disable some key combos

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ The following is a subset of the supported configurations; the full list is desc
 
 #### handleKeys
   * Allows user to select certain modifier keybindings and delegate them back to VSCode so that VSCodeVim does not process them.
+  * Complete list of keys that can be delegated back to VSCode can be found in our [package.json](https://github.com/VSCodeVim/Vim/blob/master/package.json#L44). Each key that has a vim.use<C-...> in the when argument can be delegated back to vscode by doing "<C-...>":false.
   * An example would be if a user wanted to continue to use ctrl + f for find, but wants to have useCtrlKeys set to true so that other vim bindings work.
 
     ```

--- a/README.md
+++ b/README.md
@@ -49,7 +49,11 @@ Below is an example of a [settings.json](https://code.visualstudio.com/Docs/cust
             "after": ["d", "d"]
         }
     ],
-    "vim.leader": "<space>"
+    "vim.leader": "<space>",
+    "vim.handleKeys":{
+        "<C-a>": false,
+        "<C-f>": false
+    }
 }
 ```
 
@@ -70,6 +74,17 @@ The following is a subset of the supported configurations; the full list is desc
 
     ```
     "vim.useCtrlKeys": true
+    ```
+
+#### handleKeys
+  * Allows user to select certain modifier keybindings and delegate them back to VSCode so that VSCodeVim does not process them.
+  * An example would be if a user wanted to continue to use ctrl + f for find, but wants to have useCtrlKeys set to true so that other vim bindings work.
+
+    ```
+    "vim.handleKeys":{
+        "<C-a>": false,
+        "<C-f>": false
+    }
     ```
 
 #### insertModeKeyBindings/otherModesKeyBindings

--- a/extension.ts
+++ b/extension.ts
@@ -261,9 +261,14 @@ export async function activate(context: vscode.ExtensionContext) {
 
     let bracketedKey = AngleBracketNotation.Normalize(keyToBeBound);
 
-    // Register the keybinding
+    // Store registered key bindings in bracket notation form
+    Configuration.boundKeyCombinations.push(bracketedKey);
+
     registerCommand(context, keybinding.command, () => handleKeyEvent(`${ bracketedKey }`));
   }
+
+  // Update configuration now that bound keys array is populated
+  Configuration.updateConfiguration();
 
   // Initialize mode handler for current active Text Editor at startup.
   if (vscode.window.activeTextEditor) {

--- a/extension.ts
+++ b/extension.ts
@@ -15,7 +15,7 @@ import { Position } from './src/motion/position';
 import { Globals } from './src/globals';
 import { AngleBracketNotation } from './src/notation';
 import { ModeName } from './src/mode/mode';
-import { Configuration, IHandleKeys } from './src/configuration/configuration'
+import { Configuration } from './src/configuration/configuration'
 
 interface VSCodeKeybinding {
   key: string;
@@ -245,11 +245,6 @@ export async function activate(context: vscode.ExtensionContext) {
     showCmdLine("", modeHandlerToEditorIdentity[new EditorIdentity(vscode.window.activeTextEditor).toString()]);
   });
 
-  // Get configuration setting for handled keys, this allows user to disable
-  // certain key comboinations
-  const handleKeys = vscode.workspace.getConfiguration('vim')
-    .get<IHandleKeys[]>("handleKeys", []);
-
   for (let keybinding of packagejson.contributes.keybindings) {
     let keyToBeBound = "";
 
@@ -265,25 +260,6 @@ export async function activate(context: vscode.ExtensionContext) {
     }
 
     let bracketedKey = AngleBracketNotation.Normalize(keyToBeBound);
-
-    // Set context for key that is not used
-    // This either happens when user sets useCtrlKeys to false (ctrl keys are not used then)
-    // Or if user usese vim.handleKeys configuration option to set certain combinations to false
-    // By default, all key combinations are used so start with true
-    let useKey = true;
-
-    //Check for configuration setting disabling combo
-    if (handleKeys[bracketedKey] !== undefined) {
-      if (handleKeys[bracketedKey] === false) {
-        useKey = false;
-      }
-    } else if (!Configuration.useCtrlKeys && (bracketedKey.slice(1, 3) === "C-")) {
-      // Check for useCtrlKeys and if it is a <C- ctrl based keybinding
-      useKey = false;
-    }
-
-    // Set the context of whether or not this key will be used based on criteria from above
-    vscode.commands.executeCommand('setContext', 'vim.use' + bracketedKey, useKey);
 
     // Register the keybinding
     registerCommand(context, keybinding.command, () => handleKeyEvent(`${ bracketedKey }`));

--- a/extension.ts
+++ b/extension.ts
@@ -245,6 +245,10 @@ export async function activate(context: vscode.ExtensionContext) {
     showCmdLine("", modeHandlerToEditorIdentity[new EditorIdentity(vscode.window.activeTextEditor).toString()]);
   });
 
+  // Clear boundKeyCombinations array incase there are any entries in it so
+  // that we have a clean list of keys with no duplicates
+  Configuration.boundKeyCombinations = [];
+
   for (let keybinding of packagejson.contributes.keybindings) {
     let keyToBeBound = "";
 
@@ -259,7 +263,7 @@ export async function activate(context: vscode.ExtensionContext) {
       keyToBeBound = keybinding.key;
     }
 
-    let bracketedKey = AngleBracketNotation.Normalize(keyToBeBound);
+    const bracketedKey = AngleBracketNotation.Normalize(keyToBeBound);
 
     // Store registered key bindings in bracket notation form
     Configuration.boundKeyCombinations.push(bracketedKey);

--- a/extension.ts
+++ b/extension.ts
@@ -15,7 +15,7 @@ import { Position } from './src/motion/position';
 import { Globals } from './src/globals';
 import { AngleBracketNotation } from './src/notation';
 import { ModeName } from './src/mode/mode';
-import { Configuration } from './src/configuration/configuration'
+import { Configuration, IHandleKeys } from './src/configuration/configuration'
 
 interface VSCodeKeybinding {
   key: string;
@@ -245,6 +245,11 @@ export async function activate(context: vscode.ExtensionContext) {
     showCmdLine("", modeHandlerToEditorIdentity[new EditorIdentity(vscode.window.activeTextEditor).toString()]);
   });
 
+  // Get configuration setting for handled keys, this allows user to disable
+  // certain key comboinations
+  const handleKeys = vscode.workspace.getConfiguration('vim')
+    .get<IHandleKeys[]>("handleKeys", []);
+
   for (let keybinding of packagejson.contributes.keybindings) {
     let keyToBeBound = "";
 
@@ -261,6 +266,26 @@ export async function activate(context: vscode.ExtensionContext) {
 
     let bracketedKey = AngleBracketNotation.Normalize(keyToBeBound);
 
+    // Set context for key that is not used
+    // This either happens when user sets useCtrlKeys to false (ctrl keys are not used then)
+    // Or if user usese vim.handleKeys configuration option to set certain combinations to false
+    // By default, all key combinations are used so start with true
+    let useKey = true;
+
+    //Check for configuration setting disabling combo
+    if (handleKeys[bracketedKey] !== undefined) {
+      if (handleKeys[bracketedKey] === false) {
+        useKey = false;
+      }
+    } else if (!Configuration.useCtrlKeys && (bracketedKey.slice(1, 3) === "C-")) {
+      // Check for useCtrlKeys and if it is a <C- ctrl based keybinding
+      useKey = false;
+    }
+
+    // Set the context of whether or not this key will be used based on criteria from above
+    vscode.commands.executeCommand('setContext', 'vim.use' + bracketedKey, useKey);
+
+    // Register the keybinding
     registerCommand(context, keybinding.command, () => handleKeyEvent(`${ bracketedKey }`));
   }
 

--- a/package.json
+++ b/package.json
@@ -60,22 +60,22 @@
             {
                 "key": "cmd+left",
                 "command": "extension.vim_cmd+left",
-                "when": "editorTextFocus && !inDebugRepl && vim.mode != 'Insert'"
+                "when": "editorTextFocus && vim.use<D-left> && !inDebugRepl && vim.mode != 'Insert'"
             },
             {
                 "key": "cmd+right",
                 "command": "extension.vim_cmd+right",
-                "when": "editorTextFocus && !inDebugRepl && vim.mode != 'Insert'"
+                "when": "editorTextFocus && vim.use<D-right> &&  !inDebugRepl && vim.mode != 'Insert'"
             },
             {
                 "key": "cmd+d",
                 "command": "extension.vim_cmd+d",
-                "when": "editorTextFocus && vim.use<D-d> !inDebugRepl"
+                "when": "editorTextFocus && vim.use<D-d> && !inDebugRepl"
             },
             {
                 "key": "cmd+a",
                 "command": "extension.vim_cmd+a",
-                "when": "editorTextFocus && vim.use<D-a> !inDebugRepl && vim.mode != 'Insert'"
+                "when": "editorTextFocus && vim.use<D-a> && !inDebugRepl && vim.mode != 'Insert'"
             },
             {
                 "key": "ctrl+d",
@@ -104,7 +104,7 @@
             {
                 "key": "shift+backspace",
                 "command": "extension.vim_shift+backspace",
-                "when": "editorTextFocus && vim.mode == 'SearchInProgressMode' && !inDebugRepl"
+                "when": "editorTextFocus && vim.use<shift+BS> && vim.mode == 'SearchInProgressMode' && !inDebugRepl"
             },
             {
                 "key": "Delete",
@@ -184,62 +184,62 @@
             {
                 "key": "ctrl+[",
                 "command": "extension.vim_ctrl+[",
-                "when": "editorTextFocus && vim.use<C-[> !inDebugRepl"
+                "when": "editorTextFocus && vim.use<C-[> && !inDebugRepl"
             },
             {
                 "key": "ctrl+w",
                 "command": "extension.vim_ctrl+w",
-                "when": "editorTextFocus && vim.use<C-w> !inDebugRepl"
+                "when": "editorTextFocus && vim.use<C-w> && !inDebugRepl"
             },
             {
                 "key": "ctrl+c",
                 "command": "extension.vim_ctrl+c",
-                "when": "editorTextFocus && vim.use<C-c> !inDebugRepl && vim.overrideCtrlC"
+                "when": "editorTextFocus && vim.use<C-c> && !inDebugRepl && vim.overrideCtrlC"
             },
             {
                 "key": "cmd+c",
                 "command": "extension.vim_cmd+c",
-                "when": "editorTextFocus && vim.use<D-c> vim.overrideCopy && !inDebugRepl"
+                "when": "editorTextFocus && vim.use<D-c> && vim.overrideCopy && !inDebugRepl"
             },
             {
                 "key": "ctrl+a",
                 "command": "extension.vim_ctrl+a",
-                "when": "editorTextFocus && vim.use<C-a> !inDebugRepl"
+                "when": "editorTextFocus && vim.use<C-a> && !inDebugRepl"
             },
             {
                 "key": "ctrl+n",
                 "command": "extension.vim_ctrl+n",
-                "when": "suggestWidgetVisible && vim.use<C-n> vim.useCtrlKeys"
+                "when": "suggestWidgetVisible && vim.use<C-n>"
             },
             {
                 "key": "ctrl+p",
                 "command": "extension.vim_ctrl+p",
-                "when": "suggestWidgetVisible && vim.use<C-p> vim.useCtrlKeys"
+                "when": "suggestWidgetVisible && vim.use<C-p>"
             },
             {
                 "key": "ctrl+x",
                 "command": "extension.vim_ctrl+x",
-                "when": "editorTextFocus && vim.use<C-x> !inDebugRepl"
+                "when": "editorTextFocus && vim.use<C-x> && !inDebugRepl"
             },
             {
                 "key": "ctrl+shift+2",
                 "command": "extension.vim_ctrl+shift+2",
-                "when": "editorTextFocus && vim.useCtrlKeys"
+                "when": "editorTextFocus && vim.use<C-shift+2>"
             },
             {
                 "key": "ctrl+t",
                 "command": "extension.vim_ctrl+t",
-                "when": "editorTextFocus && vim.use<C-t> !inDebugRepl"
+                "when": "editorTextFocus && vim.use<C-t> && !inDebugRepl"
             },
             {
                 "key": "ctrl+pagedown",
                 "command": "extension.vim_ctrl+pagedown",
-                "when": "editorTextFocus && vim.useCtrlKeys && !inDebugRepl"
+                "when": "editorTextFocus && vim.use<C-pagedown> && !inDebugRepl"
             },
             {
                 "key": "ctrl+pageup",
                 "command": "extension.vim_ctrl+pageup",
-                "when": "editorTextFocus && vim.useCtrlKeys && !inDebugRepl"
+                "when": "editorTextFocus && vim.use<C-pageup> && !inDebugRepl"
             },
             {
                 "key": "left",

--- a/package.json
+++ b/package.json
@@ -70,17 +70,17 @@
             {
                 "key": "cmd+d",
                 "command": "extension.vim_cmd+d",
-                "when": "editorTextFocus && !inDebugRepl"
+                "when": "editorTextFocus && vim.use<D-d> !inDebugRepl"
             },
             {
                 "key": "cmd+a",
                 "command": "extension.vim_cmd+a",
-                "when": "editorTextFocus && !inDebugRepl && vim.mode != 'Insert'"
+                "when": "editorTextFocus && vim.use<D-a> !inDebugRepl && vim.mode != 'Insert'"
             },
             {
                 "key": "ctrl+d",
                 "command": "extension.vim_ctrl+d",
-                "when": "editorTextFocus && vim.useCtrlKeys && !inDebugRepl"
+                "when": "editorTextFocus && vim.use<C-d> && !inDebugRepl"
             },
             {
                 "key": "ctrl+alt+down",
@@ -119,107 +119,107 @@
             {
                 "key": "ctrl+r",
                 "command": "extension.vim_ctrl+r",
-                "when": "editorTextFocus && vim.useCtrlKeys && !inDebugRepl"
+                "when": "editorTextFocus && vim.use<C-r> && !inDebugRepl"
             },
             {
                 "key": "ctrl+f",
                 "command": "extension.vim_ctrl+f",
-                "when": "editorTextFocus && vim.useCtrlKeys && !inDebugRepl"
+                "when": "editorTextFocus && vim.use<C-f> && !inDebugRepl"
             },
             {
                 "key": "ctrl+b",
                 "command": "extension.vim_ctrl+b",
-                "when": "editorTextFocus && vim.useCtrlKeys && vim.mode != 'Insert' && !inDebugRepl"
+                "when": "editorTextFocus && vim.use<C-b> && vim.mode != 'Insert' && !inDebugRepl"
             },
             {
                 "key": "ctrl+j",
                 "command": "extension.vim_ctrl+j",
-                "when": "editorTextFocus && vim.useCtrlKeys && vim.mode != 'Insert' && !inDebugRepl"
+                "when": "editorTextFocus && vim.use<C-j> && vim.mode != 'Insert' && !inDebugRepl"
             },
             {
                 "key": "ctrl+k",
                 "command": "extension.vim_ctrl+k",
-                "when": "editorTextFocus && vim.useCtrlKeys && vim.mode != 'Insert' && !inDebugRepl"
+                "when": "editorTextFocus && vim.use<C-k> && vim.mode != 'Insert' && !inDebugRepl"
             },
             {
                 "key": "ctrl+h",
                 "command": "extension.vim_ctrl+h",
-                "when": "editorTextFocus && vim.useCtrlKeys && vim.mode == 'Insert' && !inDebugRepl"
+                "when": "editorTextFocus && vim.use<C-h> && vim.mode == 'Insert' && !inDebugRepl"
             },
             {
                 "key": "ctrl+e",
                 "command": "extension.vim_ctrl+e",
-                "when": "editorTextFocus && vim.useCtrlKeys && !inDebugRepl"
+                "when": "editorTextFocus && vim.use<C-e> && !inDebugRepl"
             },
             {
                 "key": "ctrl+y",
                 "command": "extension.vim_ctrl+y",
-                "when": "editorTextFocus && vim.useCtrlKeys && !inDebugRepl"
+                "when": "editorTextFocus && vim.use<C-y> && !inDebugRepl"
             },
             {
                 "key": "ctrl+u",
                 "command": "extension.vim_ctrl+u",
-                "when": "editorTextFocus && vim.useCtrlKeys && !inDebugRepl"
+                "when": "editorTextFocus && vim.use<C-u> && !inDebugRepl"
             },
             {
                 "key": "ctrl+o",
                 "command": "extension.vim_ctrl+o",
-                "when": "editorTextFocus && vim.useCtrlKeys && !inDebugRepl"
+                "when": "editorTextFocus && vim.use<C-o> && !inDebugRepl"
             },
             {
                 "key": "ctrl+i",
                 "command": "extension.vim_ctrl+i",
-                "when": "editorTextFocus && vim.useCtrlKeys && !inDebugRepl"
+                "when": "editorTextFocus && vim.use<C-i> && !inDebugRepl"
             },
             {
                 "key": "ctrl+v",
                 "command": "extension.vim_ctrl+v",
-                "when": "editorTextFocus && vim.mode != 'Insert' && vim.useCtrlKeys && !inDebugRepl"
+                "when": "editorTextFocus && vim.use<C-v> && vim.mode != 'Insert' && !inDebugRepl"
             },
             {
                 "key": "cmd+v",
                 "command": "extension.vim_cmd+v",
-                "when": "editorTextFocus && vim.mode == 'SearchInProgressMode' && !inDebugRepl"
+                "when": "editorTextFocus && vim.use<D-v> && vim.mode == 'SearchInProgressMode' && !inDebugRepl"
             },
             {
                 "key": "ctrl+[",
                 "command": "extension.vim_ctrl+[",
-                "when": "editorTextFocus && vim.useCtrlKeys && !inDebugRepl"
+                "when": "editorTextFocus && vim.use<C-[> !inDebugRepl"
             },
             {
                 "key": "ctrl+w",
                 "command": "extension.vim_ctrl+w",
-                "when": "editorTextFocus && vim.useCtrlKeys && !inDebugRepl"
+                "when": "editorTextFocus && vim.use<C-w> !inDebugRepl"
             },
             {
                 "key": "ctrl+c",
                 "command": "extension.vim_ctrl+c",
-                "when": "editorTextFocus && !inDebugRepl && vim.overrideCtrlC"
+                "when": "editorTextFocus && vim.use<C-c> !inDebugRepl && vim.overrideCtrlC"
             },
             {
                 "key": "cmd+c",
                 "command": "extension.vim_cmd+c",
-                "when": "editorTextFocus && vim.overrideCopy && !inDebugRepl"
+                "when": "editorTextFocus && vim.use<D-c> vim.overrideCopy && !inDebugRepl"
             },
             {
                 "key": "ctrl+a",
                 "command": "extension.vim_ctrl+a",
-                "when": "editorTextFocus && vim.useCtrlKeys && !inDebugRepl"
+                "when": "editorTextFocus && vim.use<C-a> !inDebugRepl"
             },
             {
                 "key": "ctrl+n",
                 "command": "extension.vim_ctrl+n",
-                "when": "suggestWidgetVisible && vim.useCtrlKeys"
+                "when": "suggestWidgetVisible && vim.use<C-n> vim.useCtrlKeys"
             },
             {
                 "key": "ctrl+p",
                 "command": "extension.vim_ctrl+p",
-                "when": "suggestWidgetVisible && vim.useCtrlKeys"
+                "when": "suggestWidgetVisible && vim.use<C-p> vim.useCtrlKeys"
             },
             {
                 "key": "ctrl+x",
                 "command": "extension.vim_ctrl+x",
-                "when": "editorTextFocus && vim.useCtrlKeys && !inDebugRepl"
+                "when": "editorTextFocus && vim.use<C-x> !inDebugRepl"
             },
             {
                 "key": "ctrl+shift+2",
@@ -229,7 +229,7 @@
             {
                 "key": "ctrl+t",
                 "command": "extension.vim_ctrl+t",
-                "when": "editorTextFocus && vim.useCtrlKeys && !inDebugRepl"
+                "when": "editorTextFocus && vim.use<C-t> !inDebugRepl"
             },
             {
                 "key": "ctrl+pagedown",
@@ -380,6 +380,10 @@
                 "vim.startInInsertMode": {
                     "type": "boolean",
                     "description": "Start in Insert Mode."
+                },
+                "vim.handleKeys": {
+                    "type": "array",
+                    "description": "Allow to delegate certain key combinations back to VSCode"
                 }
             }
         }

--- a/package.json
+++ b/package.json
@@ -383,7 +383,7 @@
                 },
                 "vim.handleKeys": {
                     "type": "array",
-                    "description": "Allow to delegate certain key combinations back to VSCode"
+                    "description": "Option to delegate certain key combinations back to VSCode to be handled natively"
                 }
             }
         }

--- a/src/configuration/configuration.ts
+++ b/src/configuration/configuration.ts
@@ -67,7 +67,7 @@ class ConfigurationClass {
     const handleKeys = vscode.workspace.getConfiguration('vim')
       .get<IHandleKeys[]>("handleKeys", []);
 
-    for (let bracketedKey of this.boundKeyCombinations) {
+    for (const bracketedKey of this.boundKeyCombinations) {
       // Set context for key that is not used
       // This either happens when user sets useCtrlKeys to false (ctrl keys are not used then)
       // Or if user usese vim.handleKeys configuration option to set certain combinations to false

--- a/src/configuration/configuration.ts
+++ b/src/configuration/configuration.ts
@@ -10,6 +10,10 @@ export type ValueMapping = {
   [key: string]: OptionValue
 }
 
+export interface IHandleKeys {
+  [key: string]: boolean;
+}
+
 /**
  * Every Vim option we support should
  * 1. Be added to contribution section of `package.json`.

--- a/src/configuration/configuration.ts
+++ b/src/configuration/configuration.ts
@@ -3,7 +3,6 @@
 import * as vscode from 'vscode';
 import { taskQueue } from '../../src/taskQueue';
 import { Globals } from '../../src/globals';
-import { AngleBracketNotation } from '../../src/notation';
 
 export type OptionValue = number | string | boolean;
 export type ValueMapping = {
@@ -68,23 +67,7 @@ class ConfigurationClass {
     const handleKeys = vscode.workspace.getConfiguration('vim')
       .get<IHandleKeys[]>("handleKeys", []);
 
-    let pkg = require(__dirname + '/../../../package.json');
-
-    for (let keybinding of pkg.contributes.keybindings) {
-      let keyToBeBound = "";
-
-      /**
-       * On OSX, handle mac keybindings if we specified one.
-       */
-      if (process.platform === "darwin") {
-        keyToBeBound = keybinding.mac || keybinding.key;
-      } else if (process.platform === "linux") {
-        keyToBeBound = keybinding.linux || keybinding.key;
-      } else {
-        keyToBeBound = keybinding.key;
-      }
-
-      let bracketedKey = AngleBracketNotation.Normalize(keyToBeBound);
+    for (let bracketedKey of this.boundKeyCombinations) {
       // Set context for key that is not used
       // This either happens when user sets useCtrlKeys to false (ctrl keys are not used then)
       // Or if user usese vim.handleKeys configuration option to set certain combinations to false
@@ -219,6 +202,11 @@ class ConfigurationClass {
   relativenumber: boolean;
 
   iskeyword: string = "/\\()\"':,.;<>~!@#$%^&*|+=[]{}`?-";
+
+  /**
+   * Array of all key combinations that were registered in angle bracket notation
+   */
+  boundKeyCombinations: string[] = [];
 }
 
 function overlapSetting(args: { codeName: string, default: OptionValue, codeValueMapping?: ValueMapping }) {


### PR DESCRIPTION
I like this. PR for #1424

example config option that may be handy on windows for some

```
 "vim.handleKeys":{
        "<C-a>": false,
        "<C-f>": false
    },
```

I would like to have it all in configuration.ts so that it can happen without a vscode restart so that will be next. Then trying to clean it up some more and make sure all of our keys in package.json are handled (only modifier key combos I think will be part of this)
