### PR TITLE
Change easymotion decoration colors to use searchHighlight colors

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,6 +281,8 @@ Easymotion is based on [easymotion-vim](https://github.com/easymotion/vim-easymo
 To activate easymotion, you need to make sure that `easymotion` is set to `true` in settings.json.
 Now that easymotion is active, you can initiate motions using the following commands. Once you initiate the motion, text decorators will be displayed and you can press the keys displayed to jump to that position. `leader` is configurable and is `\` by default.
 
+If you set `vim.easymotionChangeBackgroundColor = true` you can use the searchHightlightColor as the background color for the text decorations, however you then lose the red/orange indicators on whether it is a one key or two key combination since the font color needs to stay readable.
+
 Motion Command | Description
 ---|--------
 `<leader> <leader> s <char>`|Search character

--- a/package.json
+++ b/package.json
@@ -398,6 +398,7 @@
         "copy-paste": "^1.3.0",
         "diff-match-patch": "^1.0.0",
         "lodash": "^4.12.0",
+        "color": "^1.0.3",
         "typescript": "^2.2.1"
     },
     "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -352,6 +352,11 @@
                     "description": "Enable the EasyMotion plugin for Vim.",
                     "default": false
                 },
+                "vim.easymotionChangeBackgroundColor": {
+                    "type": "boolean",
+                    "description": "Set to true to use vim.searchHighlightColor as background color",
+                    "default": false
+                },
                 "vim.hlsearch": {
                     "type": "boolean",
                     "description": "Show all matches of the most recent search pattern",

--- a/src/configuration/configuration.ts
+++ b/src/configuration/configuration.ts
@@ -173,6 +173,11 @@ class ConfigurationClass {
   easymotion = false;
 
   /**
+   * Use searchHighlightColor for easymotion background
+   */
+  easymotionChangeBackgroundColor = false;
+
+  /**
    * Timeout in milliseconds for remapped commands.
    */
   timeout = 1000;

--- a/src/easymotion/easymotion.ts
+++ b/src/easymotion/easymotion.ts
@@ -127,26 +127,24 @@ export class EasyMotion {
   /**
    * Create and cache the SVG data URI for different marker codes and colors
    */
-  private static getSvgDataUri(code: string, backgroundColor: string, font: string, fontColor: string): vscode.Uri {
-      // var cache = this.svgCache[code];
-      // if (cache) {
-      //   return cache;
-      // }
-
-      if (font === undefined) {
-        font = "Consolas";
+  private static getSvgDataUri(code: string, backgroundColor: string, font: string, fontColor: string,
+    fontSize: string, fontWeight: string): vscode.Uri {
+      var cache = this.svgCache[code];
+      if (cache) {
+        return cache;
       }
 
-      if (fontColor === undefined) {
-        fontColor = "black";
-      }
+      if (font === undefined) { font = "Consolas"; }
+      if (fontColor === undefined) { fontColor = "black"; }
+      if (fontSize === undefined) { fontSize = "14"; }
+      if (fontWeight === undefined) { fontWeight = "normal"; }
 
       const width = code.length * 8 + 1;
       var uri = vscode.Uri.parse(
         `data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 ${width} ` +
         `13" height="14" width="${width}"><rect width="${width}" height="14" rx="2" ry="2" ` +
-        `style="fill: ${backgroundColor};"></rect><text font-family="${font}" font-size="14px" ` +
-        `fill="${fontColor}" x="1" y="10">${code}</text></svg>`);
+        `style="fill: ${backgroundColor};"></rect><text font-family="${font}" font-size="${fontSize}" ` +
+        `font-weight="${fontWeight}" fill="${fontColor}" x="1" y="10">${code}</text></svg>`);
 
       this.svgCache[code] = uri;
 
@@ -293,6 +291,8 @@ export class EasyMotion {
     this.decorations = [];
 
     const font = vscode.workspace.getConfiguration().get("editor.fontFamily") as string;
+    const fontSize = vscode.workspace.getConfiguration().get("editor.fontSize") as string;
+    const fontWeight = vscode.workspace.getConfiguration().get("editor.fontWeight") as string;
 
     // Compute font color based on background (remove opacity)
     var Color = require('color');
@@ -326,12 +326,12 @@ export class EasyMotion {
         renderOptions: {
           dark: {
             after: {
-              contentIconPath: EasyMotion.getSvgDataUri(keystroke, backgroundColor, font, fontColor)
+              contentIconPath: EasyMotion.getSvgDataUri(keystroke, backgroundColor, font, fontColor, fontSize, fontWeight)
             }
           },
           light: {
             after: {
-              contentIconPath: EasyMotion.getSvgDataUri(keystroke, backgroundColor, font, fontColor)
+              contentIconPath: EasyMotion.getSvgDataUri(keystroke, backgroundColor, font, fontColor, fontSize, fontWeight)
             }
           }
         }

--- a/src/easymotion/easymotion.ts
+++ b/src/easymotion/easymotion.ts
@@ -305,7 +305,7 @@ export class EasyMotion {
 
     // Compute font color based on background (remove opacity)
     var Color = require('color');
-    const backgroundColor = Color.rgb(Configuration.searchHighlightColor).alpha(1.0);
+    let backgroundColor = Color.rgb(Configuration.searchHighlightColor).alpha(1.0);
 
     let fontColor = "white";
     if (backgroundColor.light()) {
@@ -326,6 +326,11 @@ export class EasyMotion {
 
       if (!this.decorations[keystroke.length]) {
         this.decorations[keystroke.length] = [];
+      }
+
+      if (!Configuration.easymotionChangeBackgroundColor) {
+        fontColor = keystroke.length > 1 ? "orange" : "red";
+        backgroundColor = Color('black');
       }
 
       // Position should be offsetted by the length of the keystroke to prevent hiding behind the gutter

--- a/src/easymotion/easymotion.ts
+++ b/src/easymotion/easymotion.ts
@@ -143,9 +143,10 @@ export class EasyMotion {
       }
 
       if (font === undefined) { font = "Consolas"; }
-      if (fontColor === undefined) { fontColor = "black"; }
+      if (fontColor === undefined) { fontColor = "white"; }
       if (fontSize === undefined) { fontSize = "14"; }
       if (fontWeight === undefined) { fontWeight = "normal"; }
+      if (backgroundColor === undefined) { backgroundColor = "black"; }
 
       const width = code.length * 8 + 1;
       var uri = vscode.Uri.parse(

--- a/src/easymotion/easymotion.ts
+++ b/src/easymotion/easymotion.ts
@@ -27,6 +27,7 @@ export class EasyMotion {
    */
   private static decorationTypeCache: vscode.TextEditorDecorationType[] = [];
   private static svgCache: { [code: string] : vscode.Uri } = {};
+  private static setBackgroundColor: string = "";
 
   /**
    * The key sequence for marker name generation
@@ -129,6 +130,13 @@ export class EasyMotion {
    */
   private static getSvgDataUri(code: string, backgroundColor: string, font: string, fontColor: string,
     fontSize: string, fontWeight: string): vscode.Uri {
+
+      // Clear cache if the backgroundColor has changed
+      if (this.setBackgroundColor !== backgroundColor) {
+        this.svgCache = {};
+        this.setBackgroundColor = backgroundColor;
+      }
+
       var cache = this.svgCache[code];
       if (cache) {
         return cache;
@@ -326,12 +334,12 @@ export class EasyMotion {
         renderOptions: {
           dark: {
             after: {
-              contentIconPath: EasyMotion.getSvgDataUri(keystroke, backgroundColor, font, fontColor, fontSize, fontWeight)
+              contentIconPath: EasyMotion.getSvgDataUri(keystroke, backgroundColor.string(), font, fontColor, fontSize, fontWeight)
             }
           },
           light: {
             after: {
-              contentIconPath: EasyMotion.getSvgDataUri(keystroke, backgroundColor, font, fontColor, fontSize, fontWeight)
+              contentIconPath: EasyMotion.getSvgDataUri(keystroke, backgroundColor.string(), font, fontColor, fontSize, fontWeight)
             }
           }
         }

--- a/src/easymotion/easymotion.ts
+++ b/src/easymotion/easymotion.ts
@@ -128,7 +128,7 @@ export class EasyMotion {
   /**
    * Create and cache the SVG data URI for different marker codes and colors
    */
-  private static getSvgDataUri(code: string, backgroundColor: string, font: string, fontColor: string,
+  private static getSvgDataUri(code: string, backgroundColor: string, fontFamily: string, fontColor: string,
     fontSize: string, fontWeight: string): vscode.Uri {
 
       // Clear cache if the backgroundColor has changed
@@ -142,7 +142,7 @@ export class EasyMotion {
         return cache;
       }
 
-      if (font === undefined) { font = "Consolas"; }
+      if (fontFamily === undefined) { fontFamily = "Consolas"; }
       if (fontColor === undefined) { fontColor = "white"; }
       if (fontSize === undefined) { fontSize = "14"; }
       if (fontWeight === undefined) { fontWeight = "normal"; }
@@ -152,7 +152,7 @@ export class EasyMotion {
       var uri = vscode.Uri.parse(
         `data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 ${width} ` +
         `13" height="14" width="${width}"><rect width="${width}" height="14" rx="2" ry="2" ` +
-        `style="fill: ${backgroundColor};"></rect><text font-family="${font}" font-size="${fontSize}" ` +
+        `style="fill: ${backgroundColor};"></rect><text font-family="${fontFamily}" font-size="${fontSize}" ` +
         `font-weight="${fontWeight}" fill="${fontColor}" x="1" y="10">${code}</text></svg>`);
 
       this.svgCache[code] = uri;
@@ -299,7 +299,7 @@ export class EasyMotion {
     this.visibleMarkers = [];
     this.decorations = [];
 
-    const font = vscode.workspace.getConfiguration().get("editor.fontFamily") as string;
+    const fontFamily = vscode.workspace.getConfiguration().get("editor.fontFamily") as string;
     const fontSize = vscode.workspace.getConfiguration().get("editor.fontSize") as string;
     const fontWeight = vscode.workspace.getConfiguration().get("editor.fontWeight") as string;
 
@@ -335,12 +335,14 @@ export class EasyMotion {
         renderOptions: {
           dark: {
             after: {
-              contentIconPath: EasyMotion.getSvgDataUri(keystroke, backgroundColor.string(), font, fontColor, fontSize, fontWeight)
+              contentIconPath: EasyMotion.getSvgDataUri(
+                keystroke, backgroundColor.string(), fontFamily, fontColor, fontSize, fontWeight)
             }
           },
           light: {
             after: {
-              contentIconPath: EasyMotion.getSvgDataUri(keystroke, backgroundColor.string(), font, fontColor, fontSize, fontWeight)
+              contentIconPath: EasyMotion.getSvgDataUri(
+                keystroke, backgroundColor.string(), fontFamily, fontColor, fontSize, fontWeight)
             }
           }
         }


### PR DESCRIPTION
I can get the same result without the library if we want, but it definitely cleans up the code

Also, I spent a while using different functions of it to manipulate the color wheel to try out different things for readability. Complementary font color, etc don't look good.

Black and white and using the light()/dark() luminosity formula seemed to give the best results.