### PR TITLE
fix undo points for using arrow keys in insert mode

### DIFF
--- a/src/actions/actions.ts
+++ b/src/actions/actions.ts
@@ -550,6 +550,13 @@ export class CommandInsertInInsertMode extends BaseCommand {
     const char = this.keysPressed[this.keysPressed.length - 1];
     const line = TextEditor.getLineAt(position).text;
 
+    // If we are inserting in a different place than we last inserted (used
+    // arrow keys to get here) then we want to create an undo point
+    if (vimState.recordedState.actionsRun[vimState.recordedState.actionsRun.length - 1].keysPressed.length < 2 &&
+      vimState.recordedState.actionsRun[vimState.recordedState.actionsRun.length - 2] instanceof ArrowsInInsertMode) {
+      vimState.historyTracker.finishCurrentStep();
+    }
+
     if (char === "<BS>") {
       const selection = TextEditor.getSelection();
 

--- a/src/mode/modeHandler.ts
+++ b/src/mode/modeHandler.ts
@@ -931,16 +931,14 @@ export class ModeHandler implements vscode.Disposable {
     let ranRepeatableAction = false;
     let ranAction = false;
 
-    // If arrow keys or mouse was used prior to entering characters while in insert mode, create an undo point
+    // If mouse was used prior to entering characters while in insert mode, create an undo point
     // this needs to happen before any changes are made
-    if (!vimState.isMultiCursor) {
-      let prevPos = vimState.historyTracker.getLastHistoryEndPosition();
-      if (prevPos !== undefined && !vimState.isRunningDotCommand) {
-        if (vimState.cursorPositionJustBeforeAnythingHappened[0].line !== prevPos[0].line ||
-          vimState.cursorPositionJustBeforeAnythingHappened[0].character !== prevPos[0].character) {
-          vimState.globalState.previousFullAction = recordedState;
-          vimState.historyTracker.finishCurrentStep();
-        }
+    const prevPos = vimState.historyTracker.getLastHistoryEndPosition();
+    if (prevPos !== undefined && !vimState.isRunningDotCommand) {
+      if (vimState.cursorPositionJustBeforeAnythingHappened[0].line !== prevPos[0].line ||
+        vimState.cursorPositionJustBeforeAnythingHappened[0].character !== prevPos[0].character) {
+        vimState.globalState.previousFullAction = recordedState;
+        vimState.historyTracker.finishCurrentStep();
       }
     }
 
@@ -1080,8 +1078,7 @@ export class ModeHandler implements vscode.Disposable {
       }
     }
 
-    // Update the current history step to have the latest cursor position
-
+    // Update the current history step to have the latest cursor positions
     vimState.historyTracker.setLastHistoryEndPosition(vimState.allCursors.map(x => x.stop));
 
     if (vimState.getModeObject(this).isVisualMode) {


### PR DESCRIPTION
@johnfn this is really really hacky

that being said it seems to work

Any suggestions on how I can clean it up?

This handles both single and multicursor.

|test
|test
|test  

 Enter insert mode, type something, then use arrowright a few times and type some more. Esc, then undo, and undo. It separates the 2 places you entered stuff

The version in modehandler works the same way, but instead of using<right> click with the mouse somewhere to the right (this does not work in multicursor as well, but isn't too bad)