### PR TITLE
fix multi line in 'at' and 'it' commands

### DIFF
--- a/src/actions/actions.ts
+++ b/src/actions/actions.ts
@@ -6156,8 +6156,9 @@ abstract class MoveTagMatch extends BaseMovement {
   protected includeTag = false;
 
   public async execAction(position: Position, vimState: VimState): Promise<IMovement> {
-    const text = TextEditor.getLineAt(position).text;
-    const tagMatcher = new TagMatcher(text, position.character);
+    const editorText = TextEditor.getText();
+    const offset = TextEditor.getOffsetAt(position);
+    const tagMatcher = new TagMatcher(editorText, offset);
     const start = tagMatcher.findOpening(this.includeTag);
     const end = tagMatcher.findClosing(this.includeTag);
 
@@ -6169,24 +6170,24 @@ abstract class MoveTagMatch extends BaseMovement {
       };
     }
 
-    if (end === start) {
+    if (start === end) {
       return {
-        start:  new Position(position.line, start),
-        stop:   new Position(position.line, start),
+        start: new Position(position.line, start),
+        stop: new Position(position.line, start),
         failed: true,
       };
     }
 
-    let startPos = new Position(position.line, start);
-    let endPos = new Position(position.line, end - 1);
+    let startPosition = start ? TextEditor.getPositionAt(start) : position;
+    let endPosition = end ? TextEditor.getPositionAt(end) : position;
 
-    if (position.isBefore(startPos)) {
-      vimState.recordedState.operatorPositionDiff = startPos.subtract(position);
+    if (position.isBefore(startPosition)) {
+      vimState.recordedState.operatorPositionDiff = startPosition.subtract(position);
     }
 
     return {
-      start: startPos,
-      stop: endPos
+      start: startPosition,
+      stop: new Position(endPosition.line, endPosition.character - 1)
     };
   }
 

--- a/src/matching/tagMatcher.ts
+++ b/src/matching/tagMatcher.ts
@@ -1,8 +1,8 @@
 export class TagMatcher {
-  static openTag = "<";
-  static closeTag = ">";
-  static closeSlash = "/";
-  static tagNameRegex = /[^\s>]+/;
+  static TAG_REGEX = /\<(\/)?([^\>\<\s]+)\s*(\/?)\s*\>/g;
+  static OPEN_FORWARD_SLASH = 1;
+  static TAG_NAME = 2;
+  static CLOSE_FORWARD_SLASH = 3;
 
   openStart: number|undefined;
   openEnd: number|undefined;
@@ -10,41 +10,79 @@ export class TagMatcher {
   closeEnd: number|undefined;
 
   constructor(corpus: string, position: number) {
-    let opening = corpus.lastIndexOf(TagMatcher.openTag, position);
-    if (opening === -1) {
-      return;
-    }
+    let match = TagMatcher.TAG_REGEX.exec(corpus);
+    const tags = [];
 
-    // If we found the closing tag, keep searching back for the opening tag
-    if (corpus[opening + 1] === TagMatcher.closeSlash) {
-      position = opening;
-
-      opening = corpus.lastIndexOf(TagMatcher.openTag, opening - 1);
-      if (opening === -1) {
-        return;
+    // Gather all the existing tags.
+    while (match) {
+      // Node is a self closing tag, skip.
+      if (match[TagMatcher.CLOSE_FORWARD_SLASH]) {
+        continue;
       }
+
+      tags.push({
+        name: match[TagMatcher.TAG_NAME],
+        type: match[TagMatcher.OPEN_FORWARD_SLASH] ? 'close' : 'open',
+        startPos: match.index,
+        endPos: TagMatcher.TAG_REGEX.lastIndex,
+      });
+
+      match = TagMatcher.TAG_REGEX.exec(corpus);
     }
 
-    const tagNameMatch = TagMatcher.tagNameRegex.exec(corpus.substring(opening + 1));
-    if (tagNameMatch === null) {
+    const stack : any = [];
+    const matchedTags : any = [];
+
+    tags.forEach((tag) => {
+      // We have to push on the stack
+      // if it is an open tag.
+      if (tag.type === 'open') {
+        stack.push(tag);
+      } else {
+        // We have an unmatched closing tag,
+        // so try and match it with any existing tag.
+        let i = stack.length - 1;
+        let isDone = false;
+        while (!isDone && i >= 0) {
+          const openNode = stack[i];
+
+          if (openNode.type === 'open'
+              && openNode.name === tag.name) {
+            // A matching tag was found, ignore
+            // any tags that were in between.
+            matchedTags.push({
+              tag: openNode.name,
+              openingTagStart: openNode.startPos,
+              openingTagEnd: openNode.endPos,
+              closingTagStart: tag.startPos,
+              closingTagEnd: tag.endPos,
+            });
+
+            stack.splice(i);
+
+            isDone = false;
+          }
+
+          i--;
+        }
+      }
+    });
+
+    const tagsSurrounding = matchedTags.filter((n : any) => {
+      return position >= n.openingTagStart && position <= n.closingTagEnd;
+    });
+
+    if (!tagsSurrounding.length) {
       return;
     }
-    const close = corpus.indexOf(TagMatcher.closeTag, opening + 1);
-    const tagName = tagNameMatch[0];
 
-    // We now know where the opening tag is
-    this.openStart = opening;
-    this.openEnd = close + 1;
+    // The first one should be the most relevant tag.
+    const nodeSurrounding = tagsSurrounding[0];
 
-    // Search for the closing tag
-    const toFind = `</${tagName}>`;
-    const closeTag = corpus.indexOf(toFind, position);
-    if (closeTag === -1) {
-      return;
-    }
-
-    this.closeStart = closeTag;
-    this.closeEnd = closeTag + toFind.length;
+    this.openStart = nodeSurrounding.openingTagStart;
+    this.openEnd = nodeSurrounding.openingTagEnd;
+    this.closeStart = nodeSurrounding.closingTagStart;
+    this.closeEnd = nodeSurrounding.closingTagEnd;
   }
 
   findOpening(inclusive: boolean): number|undefined {

--- a/src/matching/tagMatcher.ts
+++ b/src/matching/tagMatcher.ts
@@ -1,5 +1,5 @@
 export class TagMatcher {
-  static TAG_REGEX = /\<(\/)?([^\>\<\s]+)\s*(\/?)\s*\>/g;
+  static TAG_REGEX = /\<(\/)?([^\>\<\s]+)[^\>\<]*(\/?)\>/g;
   static OPEN_FORWARD_SLASH = 1;
   static TAG_NAME = 2;
   static CLOSE_FORWARD_SLASH = 3;

--- a/src/textEditor.ts
+++ b/src/textEditor.ts
@@ -148,7 +148,7 @@ export class TextEditor {
     return vscode.window.activeTextEditor!.selection;
   }
 
-  static getText(selection: vscode.Range): string {
+  static getText(selection?: vscode.Range): string {
     return vscode.window.activeTextEditor!.document.getText(selection);
   }
 
@@ -243,6 +243,16 @@ export class TextEditor {
     }
 
     return indentString + line.substring(firstNonWhiteSpace, line.length);
+  }
+
+  static getPositionAt(offset: number) : Position {
+    const pos = vscode.window.activeTextEditor!.document.positionAt(offset);
+
+    return new Position(pos.line, pos.character);
+  }
+
+  static getOffsetAt(position: Position) : number {
+    return vscode.window.activeTextEditor!.document.offsetAt(position);
   }
 }
 

--- a/test/mode/modeNormal.test.ts
+++ b/test/mode/modeNormal.test.ts
@@ -1357,7 +1357,15 @@ suite("Mode Normal", () => {
 
     newTest({
       title: "Can do cit on a multiline tag",
-      start: [" <blink>\nhe|llo\n</blink>"],
+      start: [" <blink>\nhe|llo\ntext</blink>"],
+      keysPressed: "cit",
+      end: [" <blink>|</blink>"],
+      endMode: ModeName.Insert
+    });
+
+    newTest({
+      title: "Can do cit on a multiline tag with nested tags",
+      start: [" <blink>\n<h1>hello</h1>\nh<br>e|llo\nte</h1>xt</blink>"],
       keysPressed: "cit",
       end: [" <blink>|</blink>"],
       endMode: ModeName.Insert

--- a/test/mode/modeNormal.test.ts
+++ b/test/mode/modeNormal.test.ts
@@ -1356,6 +1356,38 @@ suite("Mode Normal", () => {
     });
 
     newTest({
+      title: "Can do cit on a multiline tag",
+      start: [" <blink>\nhe|llo\n </blink>"],
+      keysPressed: "cit",
+      end: [" <blink>|</blink>"],
+      endMode: ModeName.Insert
+    });
+
+    newTest({
+      title: "Can do cit inside of a tag with another non closing tag inside tags",
+      start: ["<blink>hello<br>wo|rld</blink>"],
+      keysPressed: "cit",
+      end: ["<blink>|</blink>"],
+      endMode: ModeName.Insert
+    });
+
+    newTest({
+      title: "Can do cit inside of a tag with another empty closing tag inside tags",
+      start: ["<blink>hel|lo</h1>world</blink>"],
+      keysPressed: "cit",
+      end: ["<blink>|</blink>"],
+      endMode: ModeName.Insert
+    });
+
+    newTest({
+      title: "Can do cit on empty tag block, cursor moves to inside",
+      start: ["<bli|nk></blink>"],
+      keysPressed: "dit",
+      end: ["<blink>|</blink>"],
+      endMode: ModeName.Normal
+    });
+
+    newTest({
       title: "Respects indentation with cc",
       start: ["{", "  int| a;"],
       keysPressed: "cc",

--- a/test/mode/modeNormal.test.ts
+++ b/test/mode/modeNormal.test.ts
@@ -1357,7 +1357,7 @@ suite("Mode Normal", () => {
 
     newTest({
       title: "Can do cit on a multiline tag",
-      start: [" <blink>\nhe|llo\n </blink>"],
+      start: [" <blink>\nhe|llo\n</blink>"],
       keysPressed: "cit",
       end: [" <blink>|</blink>"],
       endMode: ModeName.Insert


### PR DESCRIPTION
Fixes #971, #1108, #1232, and #1300.

Remaining existing issues: `cit` does not enter insert mode when tag is empty, and it also doesn't return to the correct position when you run `cit` in the closing tag.
