### PR TITLE
Added new style settings (color, size, etc.) for easymotion markers

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,8 +281,6 @@ Easymotion is based on [easymotion-vim](https://github.com/easymotion/vim-easymo
 To activate easymotion, you need to make sure that `easymotion` is set to `true` in settings.json.
 Now that easymotion is active, you can initiate motions using the following commands. Once you initiate the motion, text decorators will be displayed and you can press the keys displayed to jump to that position. `leader` is configurable and is `\` by default.
 
-If you set `vim.easymotionChangeBackgroundColor = true` you can use the searchHightlightColor as the background color for the text decorations, however you then lose the red/orange indicators on whether it is a one key or two key combination since the font color needs to stay readable.
-
 Motion Command | Description
 ---|--------
 `<leader> <leader> s <char>`|Search character
@@ -295,6 +293,19 @@ Motion Command | Description
 `<leader> <leader> g e`|End of word backwards
 `<leader> <leader> b`|Start of word backwards
 
+You can customize the appearance of your easymotion markers (the boxes with letters) using the following options:
+
+Setting | Description
+---|--------
+`vim.easymotionMarkerBackgroundColor`|The background color of the marker box.
+`vim.easymotionMarkerForegroundColorOneChar`|The font color for one-character markers.
+`vim.easymotionMarkerForegroundColorTwoChar`|The font coor for two-character markers, used to differentiate from one-character markers.
+`vim.easymotionMarkerWidthPerChar`|The width in pixels allotted to each character.
+`vim.easymotionMarkerHeight`|The height of the marker.
+`vim.easymotionMarkerFontFamily`|The font family used for the marker text.
+`vim.easymotionMarkerFontSize`|The font size used for the marker text.
+`vim.easymotionMarkerFontWeight`|The font weight used for the marker text.
+`vim.easymotionMarkerYOffset` The distance between the top of the marker and the text (will typically need some adjusting if height or font size have been changed).
 
 #### How to use surround
 

--- a/README.md
+++ b/README.md
@@ -305,7 +305,7 @@ Setting | Description
 `vim.easymotionMarkerFontFamily`|The font family used for the marker text.
 `vim.easymotionMarkerFontSize`|The font size used for the marker text.
 `vim.easymotionMarkerFontWeight`|The font weight used for the marker text.
-`vim.easymotionMarkerYOffset` The distance between the top of the marker and the text (will typically need some adjusting if height or font size have been changed).
+`vim.easymotionMarkerYOffset`|The distance between the top of the marker and the text (will typically need some adjusting if height or font size have been changed).
 
 #### How to use surround
 

--- a/README.md
+++ b/README.md
@@ -299,7 +299,7 @@ Setting | Description
 ---|--------
 `vim.easymotionMarkerBackgroundColor`|The background color of the marker box.
 `vim.easymotionMarkerForegroundColorOneChar`|The font color for one-character markers.
-`vim.easymotionMarkerForegroundColorTwoChar`|The font coor for two-character markers, used to differentiate from one-character markers.
+`vim.easymotionMarkerForegroundColorTwoChar`|The font color for two-character markers, used to differentiate from one-character markers.
 `vim.easymotionMarkerWidthPerChar`|The width in pixels allotted to each character.
 `vim.easymotionMarkerHeight`|The height of the marker.
 `vim.easymotionMarkerFontFamily`|The font family used for the marker text.

--- a/README.md
+++ b/README.md
@@ -277,9 +277,9 @@ Configure the `useCtrlKeys` option (see [configurations#useCtrlKeys](#usectrlkey
 
 #### How to use easymotion
 
-Easymotion is based on [easymotion-vim](https://github.com/easymotion/vim-easymotion)
-To activate easymotion, you need to make sure that `easymotion` is set to `true` in settings.json.
-Now that easymotion is active, you can initiate motions using the following commands. Once you initiate the motion, text decorators will be displayed and you can press the keys displayed to jump to that position. `leader` is configurable and is `\` by default.
+Easymotion is based on [easymotion-vim](https://github.com/easymotion/vim-easymotion). To activate easymotion, you need to make sure that `easymotion` is set to `true` in settings.json.
+
+Once easymotion is active, you can initiate motions using the following commands. After you initiate the motion, text decorators/markers will be displayed and you can press the keys displayed to jump to that position. `leader` is configurable and is `\` by default.
 
 Motion Command | Description
 ---|--------

--- a/package.json
+++ b/package.json
@@ -352,10 +352,50 @@
                     "description": "Enable the EasyMotion plugin for Vim.",
                     "default": false
                 },
-                "vim.easymotionChangeBackgroundColor": {
-                    "type": "boolean",
-                    "description": "Set to true to use vim.searchHighlightColor as background color",
-                    "default": false
+                "vim.easymotionMarkerBackgroundColor": {
+                    "type": "string",
+                    "description": "Set a custom background color for EasyMotion markers.",
+                    "default": "#000000"
+                },
+                "vim.easymotionMarkerForegroundColorOneChar": {
+                    "type": "string",
+                    "description": "Set a custom color for the text on one character long markers.",
+                    "default": "#ff0000"
+                },
+                "vim.easymotionMarkerForegroundColorTwoChar": {
+                    "type": "string",
+                    "description": "Set a custom color for the text on two character long markers.",
+                    "default": "#ffa500"
+                },
+                "vim.easymotionMarkerWidthPerChar": {
+                    "type": "number",
+                    "description": "Set the width (in pixels) allocated to each character in the match.",
+                    "default": 8
+                },
+                "vim.easymotionMarkerHeight": {
+                    "type": "number",
+                    "description": "Set the height of the marker.",
+                    "default": 14
+                },
+                "vim.easymotionMarkerFontFamily": {
+                    "type": "string",
+                    "description": "Set the font family of the marker text.",
+                    "default": "Consolas"
+                },
+                "vim.easymotionMarkerFontSize": {
+                    "type": "string",
+                    "description": "Set the font size of the marker text.",
+                    "default": "14"
+                },
+                "vim.easymotionMarkerFontWeight": {
+                    "type": "string",
+                    "description": "Set the font weight of the marker text.",
+                    "default": "normal"
+                },
+                "vim.easymotionMarkerYOffset": {
+                    "type": "number",
+                    "description": "Set the Y offset of the marker text (the distance from the top).",
+                    "default": 11
                 },
                 "vim.hlsearch": {
                     "type": "boolean",

--- a/package.json
+++ b/package.json
@@ -448,7 +448,6 @@
         "copy-paste": "^1.3.0",
         "diff-match-patch": "^1.0.0",
         "lodash": "^4.12.0",
-        "color": "^1.0.3",
         "typescript": "^2.2.1"
     },
     "devDependencies": {

--- a/src/configuration/configuration.ts
+++ b/src/configuration/configuration.ts
@@ -173,9 +173,18 @@ class ConfigurationClass {
   easymotion = false;
 
   /**
-   * Use searchHighlightColor for easymotion background
+   * Easymotion marker appearance settings
    */
-  easymotionChangeBackgroundColor = false;
+
+  easymotionMarkerBackgroundColor = "#000000";
+  easymotionMarkerForegroundColorOneChar = "#ff0000";
+  easymotionMarkerForegroundColorTwoChar = "#ffa500";
+  easymotionMarkerWidthPerChar = 8;
+  easymotionMarkerHeight = 14;
+  easymotionMarkerFontFamily = "Consolas";
+  easymotionMarkerFontSize = "14";
+  easymotionMarkerFontWeight = "normal";
+  easymotionMarkerYOffset = 11;
 
   /**
    * Timeout in milliseconds for remapped commands.

--- a/src/easymotion/easymotion.ts
+++ b/src/easymotion/easymotion.ts
@@ -26,7 +26,7 @@ export class EasyMotion {
    * Caches for decorations
    */
   private static decorationTypeCache: vscode.TextEditorDecorationType[] = [];
-  private static svgCache: { [code: string] : vscode.Uri } = {};
+  private static svgCache: { [code: string]: vscode.Uri } = {};
   private static setBackgroundColor: string = "";
 
   /**
@@ -61,41 +61,41 @@ export class EasyMotion {
     var totalSteps = 0;
 
     if (length >= keyTable.length) {
-        var totalRemainder = Math.max(length - keyTable.length, 0);
-        totalSteps = Math.floor(totalRemainder / keyTable.length);
+      var totalRemainder = Math.max(length - keyTable.length, 0);
+      totalSteps = Math.floor(totalRemainder / keyTable.length);
 
-        for (var i = 0; i < totalSteps; i++) {
-            keyDepthTable.push(availableKeyTable.pop()!);
-        }
+      for (var i = 0; i < totalSteps; i++) {
+        keyDepthTable.push(availableKeyTable.pop()!);
+      }
     }
 
     var prefix = "";
     if (index >= availableKeyTable.length) {
-        // Length of available keys before reset and ";"
-        var oldLength = availableKeyTable.length;
-        // The index that remains after taking away the first-level depth markers
-        var remainder = index - availableKeyTable.length;
+      // Length of available keys before reset and ";"
+      var oldLength = availableKeyTable.length;
+      // The index that remains after taking away the first-level depth markers
+      var remainder = index - availableKeyTable.length;
 
-        // ";" can be used as the last marker key, when inside a marker with depth. Reset to available keys and add ";"
-        availableKeyTable = keyTable.slice();
-        availableKeyTable.push(";");
+      // ";" can be used as the last marker key, when inside a marker with depth. Reset to available keys and add ";"
+      availableKeyTable = keyTable.slice();
+      availableKeyTable.push(";");
 
-        // Depth index counts down instead of up
-        var inverted = (length - oldLength - 1 - remainder);
-        var steps = Math.floor((inverted) / availableKeyTable.length);
+      // Depth index counts down instead of up
+      var inverted = (length - oldLength - 1 - remainder);
+      var steps = Math.floor((inverted) / availableKeyTable.length);
 
-        // Add the key to the prefix
-        prefix += keyDepthTable[steps];
+      // Add the key to the prefix
+      prefix += keyDepthTable[steps];
 
-        // Check if we're on the last depth level
-        if (steps >= totalSteps) {
-            // Return the proper key for this index
-            return new EasyMotion.Marker(prefix + availableKeyTable[remainder % availableKeyTable.length], markerPosition);
-        }
+      // Check if we're on the last depth level
+      if (steps >= totalSteps) {
+        // Return the proper key for this index
+        return new EasyMotion.Marker(prefix + availableKeyTable[remainder % availableKeyTable.length], markerPosition);
+      }
 
-        // Return the proper index for depths earlier than the last one, including prefix
-        var num = (availableKeyTable.length - 1 - inverted % availableKeyTable.length) % availableKeyTable.length;
-        return new EasyMotion.Marker(prefix + availableKeyTable[num], markerPosition);
+      // Return the proper index for depths earlier than the last one, including prefix
+      var num = (availableKeyTable.length - 1 - inverted % availableKeyTable.length) % availableKeyTable.length;
+      return new EasyMotion.Marker(prefix + availableKeyTable[num], markerPosition);
     }
 
     // Return the last key in the marker, including prefix
@@ -131,33 +131,35 @@ export class EasyMotion {
   private static getSvgDataUri(code: string, backgroundColor: string, fontFamily: string, fontColor: string,
     fontSize: string, fontWeight: string): vscode.Uri {
 
-      // Clear cache if the backgroundColor has changed
-      if (this.setBackgroundColor !== backgroundColor) {
-        this.svgCache = {};
-        this.setBackgroundColor = backgroundColor;
-      }
+    // Clear cache if the backgroundColor has changed
+    if (this.setBackgroundColor !== backgroundColor) {
+      this.svgCache = {};
+      this.setBackgroundColor = backgroundColor;
+    }
 
-      var cache = this.svgCache[code];
-      if (cache) {
-        return cache;
-      }
+    var cache = this.svgCache[code];
+    if (cache) {
+      return cache;
+    }
 
-      if (fontFamily === undefined) { fontFamily = "Consolas"; }
-      if (fontColor === undefined) { fontColor = "white"; }
-      if (fontSize === undefined) { fontSize = "14"; }
-      if (fontWeight === undefined) { fontWeight = "normal"; }
-      if (backgroundColor === undefined) { backgroundColor = "black"; }
+    if (fontFamily === undefined) { fontFamily = "Consolas"; }
+    if (fontColor === undefined) { fontColor = "white"; }
+    if (fontSize === undefined) { fontSize = "14"; }
+    if (fontWeight === undefined) { fontWeight = "normal"; }
+    if (backgroundColor === undefined) { backgroundColor = "black"; }
 
-      const width = code.length * 8 + 1;
-      var uri = vscode.Uri.parse(
-        `data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 ${width} ` +
-        `13" height="14" width="${width}"><rect width="${width}" height="14" rx="2" ry="2" ` +
-        `style="fill: ${backgroundColor};"></rect><text font-family="${fontFamily}" font-size="${fontSize}" ` +
-        `font-weight="${fontWeight}" fill="${fontColor}" x="1" y="10">${code}</text></svg>`);
+    const width = code.length * Configuration.easymotionMarkerWidthPerChar + 1;
+    const height = Configuration.easymotionMarkerHeight;
 
-      this.svgCache[code] = uri;
+    var uri = vscode.Uri.parse(
+      `data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 ${width} ` +
+      `${height}" height="${height}" width="${width}"><rect width="${width}" height="${height}" rx="2" ry="2" ` +
+      `style="fill: ${backgroundColor}"></rect><text font-family="${fontFamily}" font-size="${fontSize}" ` +
+      `font-weight="${fontWeight}" fill="${fontColor}" x="1" y="${Configuration.easymotionMarkerYOffset}">${code}</text></svg>`);
 
-      return uri;
+    this.svgCache[code] = uri;
+
+    return uri;
   }
 
   /**
@@ -240,8 +242,8 @@ export class EasyMotion {
 
         // Check if match is within bounds
         if ((options.min && pos.isBefore(options.min)) ||
-            (options.max && pos.isAfter(options.max)) ||
-            Math.abs(pos.line - position.line) > 100) { // Stop searching after 100 lines in both directions
+          (options.max && pos.isAfter(options.max)) ||
+          Math.abs(pos.line - position.line) > 100) { // Stop searching after 100 lines in both directions
 
           result = regex.exec(line);
           continue;
@@ -299,18 +301,12 @@ export class EasyMotion {
     this.visibleMarkers = [];
     this.decorations = [];
 
-    const fontFamily = vscode.workspace.getConfiguration().get("editor.fontFamily") as string;
-    const fontSize = vscode.workspace.getConfiguration().get("editor.fontSize") as string;
-    const fontWeight = vscode.workspace.getConfiguration().get("editor.fontWeight") as string;
+    const fontFamily = Configuration.easymotionMarkerFontFamily;
+    const fontSize = Configuration.easymotionMarkerFontSize;
+    const fontWeight = Configuration.easymotionMarkerFontWeight;
 
     // Compute font color based on background (remove opacity)
-    var Color = require('color');
-    let backgroundColor = Color.rgb(Configuration.searchHighlightColor).alpha(1.0);
-
-    let fontColor = "white";
-    if (backgroundColor.light()) {
-      fontColor = "black";
-    }
+    // var Color = require('color');
 
     for (var i = 0; i < this.markers.length; i++) {
       var marker = this.getMarker(i);
@@ -328,10 +324,10 @@ export class EasyMotion {
         this.decorations[keystroke.length] = [];
       }
 
-      if (!Configuration.easymotionChangeBackgroundColor) {
-        fontColor = keystroke.length > 1 ? "orange" : "red";
-        backgroundColor = Color('black');
-      }
+      let fontColor = keystroke.length > 1 ?
+        Configuration.easymotionMarkerForegroundColorTwoChar
+        : Configuration.easymotionMarkerForegroundColorOneChar;
+      let backgroundColor = Configuration.easymotionMarkerBackgroundColor;
 
       // Position should be offsetted by the length of the keystroke to prevent hiding behind the gutter
       var charPos = pos.character + 1 + (keystroke.length - 1);
@@ -341,13 +337,13 @@ export class EasyMotion {
           dark: {
             after: {
               contentIconPath: EasyMotion.getSvgDataUri(
-                keystroke, backgroundColor.string(), fontFamily, fontColor, fontSize, fontWeight)
+                keystroke, backgroundColor, fontFamily, fontColor, fontSize, fontWeight)
             }
           },
           light: {
             after: {
               contentIconPath: EasyMotion.getSvgDataUri(
-                keystroke, backgroundColor.string(), fontFamily, fontColor, fontSize, fontWeight)
+                keystroke, backgroundColor, fontFamily, fontColor, fontSize, fontWeight)
             }
           }
         }


### PR DESCRIPTION
<!--
Yay! We love PRs! 🎊

Please include a description of your change and ensure:

- [ ] Commit message has a short title & issue references
- [ ] Each commit does a logical chunk of work.
- [ ] It builds and tests pass (e.g `gulp`)

More info can be found on our [contribution guide](https://github.com/VSCodeVim/Vim/blob/master/.github/CONTRIBUTING.md).
-->

Made this for my own issue :P #1481 

Here's an example of the settings in use:

```
    "vim.easymotionMarkerBackgroundColor": "#3C6478",
    "vim.easymotionMarkerForegroundColorOneChar": "white",
    "vim.easymotionMarkerForegroundColorTwoChar": "white",
    "vim.easymotionMarkerHeight": 20,
    "vim.easymotionMarkerYOffset": 12,
    "vim.easymotionMarkerWidthPerChar": 10,
```
**I removed the existing easymotion background color option since I feel this encompasses that, but feel free to add it back if you think it's better to keep it!**

Here are some examples of what the styling can look like: (p.s. I happened to use white and black for the font colors but they can be anything, like yellow text on dark blue bg or something)

![](http://i.imgur.com/RSrBQOy.png)
![](http://i.imgur.com/7xbp6PJ.png)