### PR TITLE
Add ability to turn surround plugin off

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,6 +302,8 @@ Surround plugin based on tpope's [surround.vim](https://github.com/tpope/vim-sur
 
 t or < as <desired char> or <existing char> will do tags and enter tag entry mode.
 
+Surround can be disabled by setting vim.surround : false
+
 Surround Command | Description
 ---|--------
 `d s <existing char>`|Delete existing surround

--- a/package.json
+++ b/package.json
@@ -357,6 +357,11 @@
                     "description": "Set to true to use vim.searchHighlightColor as background color",
                     "default": false
                 },
+                "vim.surround": {
+                    "type": "boolean",
+                    "description": "Enable the Surround plugin for Vim.",
+                    "default": true
+                },
                 "vim.hlsearch": {
                     "type": "boolean",
                     "description": "Show all matches of the most recent search pattern",

--- a/src/actions/actions.ts
+++ b/src/actions/actions.ts
@@ -6640,6 +6640,11 @@ class CommandSurroundModeStart extends BaseCommand {
   runsOnceForEveryCursor() { return false; }
 
   public async exec(position: Position, vimState: VimState): Promise<VimState> {
+    // Only execute the action if the configuration is set
+    if (!Configuration.surround) {
+      return vimState;
+    }
+
     const operator = vimState.recordedState.operator;
     let operatorString: "change" | "delete" | "yank" | undefined;
 
@@ -6688,6 +6693,11 @@ class CommandSurroundModeStartVisual extends BaseCommand {
   runsOnceForEveryCursor() { return false; }
 
   public async exec(position: Position, vimState: VimState): Promise<VimState> {
+    // Only execute the action if the configuration is set
+    if (!Configuration.surround) {
+      return vimState;
+    }
+
     // Make sure cursor positions are ordered correctly for top->down or down->top selection
     if (vimState.cursorStartPosition.line > vimState.cursorPosition.line) {
       [vimState.cursorPosition, vimState.cursorStartPosition] =

--- a/src/configuration/configuration.ts
+++ b/src/configuration/configuration.ts
@@ -173,6 +173,11 @@ class ConfigurationClass {
   easymotion = false;
 
   /**
+   * Use surround plugin?
+   */
+  surround = true;
+
+  /**
    * Use searchHighlightColor for easymotion background
    */
   easymotionChangeBackgroundColor = false;


### PR DESCRIPTION
Someone asked on slack, not sure why but seems to make sense to at least have the option since easymotion does as well.