### PR TITLE
Navigate between view

### DIFF
--- a/extension.ts
+++ b/extension.ts
@@ -219,7 +219,7 @@ export async function activate(context: vscode.ExtensionContext) {
           });
           mh.vimState.cursorPosition = Position.FromVSCodePosition(mh.vimState.editor.selection.start);
           mh.vimState.cursorStartPosition = Position.FromVSCodePosition(mh.vimState.editor.selection.start);
-        }
+      }
       },
       isRunning: false
     });

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "url": "https://github.com/VSCodeVim/Vim/issues"
   },
   "engines": {
-    "vscode": "^1.10.0"
+    "vscode": "^1.11.0"
   },
   "categories": [
     "Other",

--- a/package.json
+++ b/package.json
@@ -195,6 +195,31 @@
         "when": "editorTextFocus && vim.active && vim.use<C-[> && !inDebugRepl"
       },
       {
+        "key": "ctrl+w h",
+        "command": "extension.vim_navigateLeft",
+        "when": "vim.use<C-w> && vim.active && !editorTextFocus"
+      },
+      {
+        "key": "ctrl+w l",
+        "command": "extension.vim_navigateRight",
+        "when": "vim.use<C-w> && vim.active && !editorTextFocus"
+      },
+      {
+        "key": "ctrl+w ctrl+w",
+        "command": "extension.vim_navigateGroups",
+        "when": "vim.use<C-w> && vim.active && !editorTextFocus"
+      },
+      {
+        "key": "ctrl+w j",
+        "command": "extension.vim_navigateDown",
+        "when": "vim.use<C-w> && vim.active && !editorTextFocus"
+      },
+      {
+        "key": "ctrl+w k",
+        "command": "extension.vim_navigateUp",
+        "when": "vim.use<C-w> && vim.active && !editorTextFocus"
+      },
+      {
         "key": "ctrl+w",
         "command": "extension.vim_ctrl+w",
         "when": "editorTextFocus && vim.active && vim.use<C-w> && !inDebugRepl"

--- a/src/actions/actions.ts
+++ b/src/actions/actions.ts
@@ -3438,12 +3438,11 @@ class CommandQuit extends BaseCommand {
 @RegisterAction
 class MoveToRightPane extends BaseCommand {
   modes = [ModeName.Normal, ModeName.Visual, ModeName.VisualLine];
-  keys = [["<C-w>", "l"],
-  ["<C-w>", "<right>"]];
+  keys = [["<C-w>", "l"], ["<C-w>", "<right>"], ["<C-w l>"]];
 
   public async exec(position: Position, vimState: VimState): Promise<VimState> {
     vimState.postponedCodeViewChanges.push({
-      command: "workbench.action.focusNextGroup",
+      command: "workbench.action.navigateRight",
       args: {}
     });
 
@@ -3454,12 +3453,11 @@ class MoveToRightPane extends BaseCommand {
 @RegisterAction
 class MoveToLeftPane  extends BaseCommand {
   modes = [ModeName.Normal, ModeName.Visual, ModeName.VisualLine];
-  keys = [["<C-w>", "h"],
-  ["<C-w>", "<left>"]];
+  keys = [["<C-w>", "h"], ["<C-w>", "<left>"], ["<C-w h>"]];
 
   public async exec(position: Position, vimState: VimState): Promise<VimState> {
     vimState.postponedCodeViewChanges.push({
-      command: "workbench.action.focusPreviousGroup",
+      command: "workbench.action.navigateLeft",
       args: {}
     });
 
@@ -3474,7 +3472,7 @@ class CycleThroughPanes extends BaseCommand {
 
   public async exec(position: Position, vimState: VimState): Promise<VimState> {
     vimState.postponedCodeViewChanges.push({
-      command: "workbench.action.navigateEditorGroups",
+      command: "workbench.action.navigateRight",
       args: {}
     });
 


### PR DESCRIPTION
Ref #1375. Leverage new Code api to navigate between viewlets, panels, editors by <Ctrl>-<hjkl>.

This is contributed by rebornix/Peng's personal account on his personal machine in personal time.