### PR TITLE
Add line comment operator

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ VSCodeVim is a [Visual Studio Code](https://code.visualstudio.com/) extension th
 * Multi-cursor support. Allows multiple simultaneous cursors to receive Vim commands (e.g. allows `/` search, each cursor has independent clipboards, etc.).
 * The [EasyMotion plugin](#how-to-use-easymotion)!
 * The [Surround.vim plugin](#how-to-use-surround)!
+* The [Commentary plugin](#how-to-use-commentary).
 * And much more! Refer to the [roadmap](ROADMAP.md) or everything we support.
 
 Please [report missing features/bugs on GitHub](https://github.com/VSCodeVim/Vim/issues), which will help us get to them faster.
@@ -328,6 +329,31 @@ Some examples:
 * `"test"` with cursor inside quotes type ds" to end up with `test`
 * `"test"` with cursor inside quotes type cs"t and enter 123> to end up with `<123>test</123>`
 * `test` with cursor on word test type ysaw) to end up with `(test)`
+
+#### How to use commentary
+
+Commentary in VSCodeVim works similarly to tpope's [vim-commentary] (https://github.com/tpope/vim-commentary) but uses the VSCode native "Toggle Line Comment" and "Toggle Block Comment" features.
+
+Because `gc` is already used in VSCodeVim the commentary operators are bound to `gb` for line comments and `gB` for block comments.
+
+Usage examples:
+* `gb` - toggles line comment. For example `gbb` to toggle line comment for current line and `gb2j` to toggle line comments for the current line and the next line.
+* `gB` - toggles block comment. For example `gBi)` to comment out everything within parenthesis.
+
+If you are use to using vim-commentary you are probably use to using `gc` instead of `gb`. This can be achieved by adding the following remapping to your VSCode settings:
+
+```
+"vim.otherModesKeyBindings": [
+    {
+        "before": ["g", "c"],
+        "after": ["g", "b"]
+    },
+    {
+        "before": ["g", "C"],
+        "after": ["g", "B"]
+    }
+],
+```
 
 ## Contributing
 

--- a/src/actions/actions.ts
+++ b/src/actions/actions.ts
@@ -7050,3 +7050,19 @@ class CommandSurroundAddToReplacement extends BaseCommand {
     return false;
   }
 }
+
+@RegisterAction
+export class CommentOperator extends BaseOperator {
+  public keys = ["g", "b"];
+  public modes = [ModeName.Normal, ModeName.Visual, ModeName.VisualLine];
+
+  public async run(vimState: VimState, start: Position, end: Position): Promise<VimState> {
+    vimState.editor.selection = new vscode.Selection(start.getLineBegin(), end.getLineEnd());
+    await vscode.commands.executeCommand("editor.action.commentLine");
+
+    vimState.cursorPosition = new Position(start.line, 0);
+    vimState.currentMode = ModeName.Normal;
+
+    return vimState;
+  }
+}

--- a/src/actions/actions.ts
+++ b/src/actions/actions.ts
@@ -7066,3 +7066,21 @@ export class CommentOperator extends BaseOperator {
     return vimState;
   }
 }
+
+@RegisterAction
+export class CommentBlockOperator extends BaseOperator {
+  public keys = ["g", "B"];
+  public modes = [ModeName.Normal, ModeName.Visual, ModeName.VisualLine];
+
+  public async run(vimState: VimState, start: Position, end: Position): Promise<VimState> {
+    const endPosition = vimState.currentMode === ModeName.Normal ? end.getRight() : end;
+    vimState.editor.selection = new vscode.Selection(start, endPosition);
+    await vscode.commands.executeCommand("editor.action.blockComment");
+
+    vimState.cursorPosition = start;
+    vimState.currentMode = ModeName.Normal;
+
+    return vimState;
+  }
+
+}

--- a/test/mode/modeHandler.test.ts
+++ b/test/mode/modeHandler.test.ts
@@ -7,7 +7,9 @@ import { ModeHandler } from '../../src/mode/modeHandler';
 
 suite("Mode Handler", () => {
 
-  setup(setupWorkspace);
+  setup(async () => {
+    await setupWorkspace();
+  });
 
   teardown(cleanUpWorkspace);
 

--- a/test/operator/comment.test.ts
+++ b/test/operator/comment.test.ts
@@ -1,0 +1,50 @@
+"use strict";
+
+import { setupWorkspace, setTextEditorOptions, cleanUpWorkspace } from './../testUtils';
+import { ModeName } from '../../src/mode/mode';
+import { ModeHandler } from '../../src/mode/modeHandler';
+import { getTestingFunctions } from '../testSimplifier';
+
+suite("comment operator", () => {
+    let modeHandler: ModeHandler;
+    let {
+        newTest,
+        newTestOnly,
+    } = getTestingFunctions();
+
+    setup(async () => {
+        await setupWorkspace(".js");
+        setTextEditorOptions(4, false);
+        modeHandler = new ModeHandler();
+    });
+
+    teardown(cleanUpWorkspace);
+
+    newTest({
+      title: "gbb comments out current line",
+      start: [
+        "first| line",
+        "second line"
+      ],
+      keysPressed: 'gbb',
+      end: [
+        "|// first line",
+        "second line",
+      ],
+    });
+
+    newTest({
+      title: "gbj comments in current and next line",
+      start: [
+        "// first| line",
+        "// second line",
+        "third line"
+      ],
+      keysPressed: 'gbj',
+      end: [
+        "|first line",
+        "second line",
+        "third line"
+      ],
+    });
+});

--- a/test/operator/comment.test.ts
+++ b/test/operator/comment.test.ts
@@ -47,4 +47,28 @@ suite("comment operator", () => {
         "third line"
       ],
     });
+
+    newTest({
+      title: "block comment with motion",
+      start: [
+        "function myTestFunction(arg|1, arg2, arg3) {"
+      ],
+      keysPressed: 'gBi)',
+      end: [
+        "function myTestFunction(|/*arg1, arg2, arg3*/) {"
+      ]
+    });
+
+    newTest({
+      title: "block comment in Visual Mode",
+      start: [
+        "blah |blah blah"
+      ],
+      keysPressed: 'vllllgB',
+      end: [
+        "blah |/*blah*/ blah"
+      ],
+      endMode: ModeName.Normal
+    });
+
 });

--- a/test/testUtils.ts
+++ b/test/testUtils.ts
@@ -12,8 +12,8 @@ function rndName() {
   return Math.random().toString(36).replace(/[^a-z]+/g, '').substr(0, 10);
 }
 
-async function createRandomFile(contents: string): Promise<vscode.Uri> {
-  const tmpFile = join(os.tmpdir(), rndName());
+async function createRandomFile(contents: string, fileExtension: string): Promise<vscode.Uri> {
+  const tmpFile = join(os.tmpdir(), rndName() + fileExtension);
 
   try {
     fs.writeFileSync(tmpFile, contents);
@@ -41,8 +41,8 @@ export function assertEqual<T>(one: T, two: T, message: string = ""): void {
   assert.equal(one, two, message);
 }
 
-export async function setupWorkspace(): Promise<any> {
-  const file   = await createRandomFile("");
+export async function setupWorkspace(fileExtension: string = ""): Promise<any> {
+  const file   = await createRandomFile("", fileExtension);
   const doc  = await vscode.workspace.openTextDocument(file);
 
   await vscode.window.showTextDocument(doc);

--- a/test/textEditor.test.ts
+++ b/test/textEditor.test.ts
@@ -6,7 +6,9 @@ import { TextEditor } from './../src/textEditor';
 import { setupWorkspace, cleanUpWorkspace } from './testUtils';
 
 suite("text editor", () => {
-  suiteSetup(setupWorkspace);
+  suiteSetup(async () => {
+    await setupWorkspace();
+  });
 
   suiteTeardown(cleanUpWorkspace);
 


### PR DESCRIPTION
This PR adds functionality similar to tpope's [vim-commentary](https://github.com/tpope/vim-commentary). As it didn't require a lot of work I thought I would just create a PR instead of opening an issue / feature request.

It can toggle line comment the current line using `gbb` or toggle comments on the target of a motion i.e. `gb5j` to toggle line comments on current line and the following next four lines or `gbap` to toggle line comments in a paragraph etc.

It uses the built-in _Toggle Line Comment_ functionality of VSCode to determine how to apply/unapply comments.

A few questions:
- I would have liked to use `gc` as the original Vim plugin but since this is already used in this extension I settled for `gb`. Thought on this?
- Since VSCode's _Toggle Line Comment_ relies on the current editors language mode to determine how to apply comments I could not find an good way to add tests for this as it does nothing in Plain Text mode. Any advice on the best way to add a test case that runs under another language mode (for example JavaScript)?

Let me know what you think. Thanks!