### PR TITLE
[WIP] Fixed issue #1513

### DIFF
--- a/src/actions/actions.ts
+++ b/src/actions/actions.ts
@@ -564,11 +564,11 @@ export class CommandInsertInInsertMode extends BaseCommand {
           // the next lowest level of indentation.
 
           const tabSize = vimState.editor.options.tabSize as number;
-          const desiredLineLength = Math.floor((line.length - 1) / tabSize) * tabSize;
+          const desiredLineLength = Math.floor((position.character - 1) / tabSize) * tabSize;
 
           vimState.recordedState.transformations.push({
             type: "deleteRange",
-            range: new Range(new Position(position.line, desiredLineLength), position)
+            range: new Range(new Position(position.line, desiredLineLength), new Position(position.line, line.length))
           });
         } else {
           vimState.recordedState.transformations.push({

--- a/test/mode/modeInsert.test.ts
+++ b/test/mode/modeInsert.test.ts
@@ -193,6 +193,20 @@ suite("Mode Insert", () => {
     });
 
     newTest({
+      title: "Backspace works on whitespace only lines",
+      start: ['abcd', '     |    '],
+      keysPressed: 'a<BS><Esc>',
+      end: ['abcd', "   | "],
+    });
+
+    newTest({
+      title: "Backspace works on end of whitespace only lines",
+      start: ['abcd', '     | '],
+      keysPressed: 'a<BS><Esc>',
+      end: ['abcd', "   | "],
+    });
+
+    newTest({
       title: "Can perform <ctrl+o> to exit and perform one command in normal",
       start: ['testtest|'],
       keysPressed: 'a123<C-o>b123',


### PR DESCRIPTION
<!--
Yay! We love PRs! 🎊

Please include a description of your change and ensure:

- [ ] Commit message has a short title & issue references
- [ ] Each commit does a logical chunk of work.
- [ ] It builds and tests pass (e.g `gulp`)

More info can be found on our [contribution guide](https://github.com/VSCodeVim/Vim/blob/master/.github/CONTRIBUTING.md).
-->
So I fixed issue #1513. This issue only occurs when Configuration.expandTab is turned on. 
The main behavioral decision I made is that if you press backspace on a whitespace only line, it deletes both to the next "tab" as well as all the whitespace after it.

I'm unsure about a couple of things

1. I'd like to create tests, but from looking through the repo, I don't see how to set Configuration.expandTab to be true while running these tests.

2. When running the tests locally,  I get 56 tests failing, with or without my change. I don't really know what I'm supposed to do there (I thought I would try running the tests on CI, and cool! They passed.).

Cheers,
Horace