### PR TITLE
added cmd_line commands to remapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,16 @@ Below is an example of a [settings.json](https://code.visualstudio.com/Docs/cust
         {
             "before": ["<leader>","d"],
             "after": ["d", "d"]
-        }
+        },
+        {
+           "before":["<C-n>"],
+           "after":[],
+            "commands": [
+                {
+                    "command": ":nohl"
+                }
+            ]
+       }
     ],
     "vim.leader": "<space>",
     "vim.handleKeys":{
@@ -139,10 +148,20 @@ Bind `ZZ` to save and close the current file:
     ]
 ````
 
-Or bind `<leader>w` to save the current file:
+Or bind ctrl+n to turn off search highlighting and `<leader>w` to save the current file:
 
 ```
     "vim.otherModesKeyBindingsNonRecursive": [
+        {
+           "before":["<C-n>"],
+           "after":[],
+            "commands": [
+                {
+                    "command": ":nohl",
+                    "args": []
+                }
+            ]
+        },
         {
             "before": ["leader", "w"],
             "after": [],

--- a/package.json
+++ b/package.json
@@ -407,11 +407,6 @@
                     "description": "Show all matches of the most recent search pattern",
                     "default": false
                 },
-                "vim.hl": {
-                    "type": "boolean",
-                    "description": "Don't worry about this one.",
-                    "default": true
-                },
                 "vim.incsearch": {
                     "type": "boolean",
                     "description": "Show where a / search matches as you type it.",

--- a/package.json
+++ b/package.json
@@ -209,7 +209,7 @@
             {
                 "key": "ctrl+n",
                 "command": "extension.vim_ctrl+n",
-                "when": "suggestWidgetVisible && vim.use<C-n>"
+                "when": "editorTextFocus && vim.use<C-n> && !inDebugRepl"
             },
             {
                 "key": "ctrl+p",

--- a/src/actions/actions.ts
+++ b/src/actions/actions.ts
@@ -1678,7 +1678,7 @@ class CommandNextSearchMatch extends BaseMovement {
     }
 
     // Turn one of the highlighting flags back on (turned off with :nohl)
-    Configuration.hl = true;
+    vimState.globalState.hl = true;
 
     return searchState.getNextSearchMatchPosition(vimState.cursorPosition).pos;
   }
@@ -1724,7 +1724,7 @@ function searchCurrentWord(position: Position, vimState: VimState, direction: Se
     vimState.cursorPosition = vimState.globalState.searchState.getNextSearchMatchPosition(searchStartCursorPosition).pos;
 
     // Turn one of the highlighting flags back on (turned off with :nohl)
-    Configuration.hl = true;
+    vimState.globalState.hl = true;
 
     return vimState;
 }
@@ -1789,7 +1789,7 @@ class CommandPreviousSearchMatch extends BaseMovement {
     }
 
     // Turn one of the highlighting flags back on (turned off with :nohl)
-    Configuration.hl = true;
+    vimState.globalState.hl = true;
 
     return searchState.getNextSearchMatchPosition(vimState.cursorPosition, -1).pos;
   }
@@ -1863,7 +1863,7 @@ export class CommandSearchForwards extends BaseCommand {
     // Reset search history index
     vimState.globalState.searchStateIndex = vimState.globalState.searchStatePrevious.length;
 
-    Configuration.hl = true;
+    vimState.globalState.hl = true;
 
     return vimState;
   }
@@ -1882,7 +1882,7 @@ export class CommandSearchBackwards extends BaseCommand {
     // Reset search history index
     vimState.globalState.searchStateIndex = vimState.globalState.searchStatePrevious.length;
 
-    Configuration.hl = true;
+    vimState.globalState.hl = true;
 
     return vimState;
   }

--- a/src/cmd_line/commands/nohl.ts
+++ b/src/cmd_line/commands/nohl.ts
@@ -1,7 +1,7 @@
 "use strict";
 
 import * as node from "../node";
-import { Configuration } from './../../configuration/configuration';
+import { ModeHandler } from "../../mode/modeHandler";
 
 export class NohlCommand extends node.CommandBase {
   protected _arguments: {};
@@ -17,7 +17,7 @@ export class NohlCommand extends node.CommandBase {
     return this._arguments;
   }
 
-  async execute(): Promise<void> {
-    Configuration.hl = false;
+  async execute(modeHandler : ModeHandler): Promise<void> {
+    modeHandler.vimState.globalState.hl = false;
   }
 }

--- a/src/configuration/configuration.ts
+++ b/src/configuration/configuration.ts
@@ -56,6 +56,11 @@ class ConfigurationClass {
     /* tslint:disable:forin */
     // Disable forin rule here as we make accessors enumerable.`
     for (const option in this) {
+      // Some options are internal states and should not be reinitialized
+      if (option === "hl") {
+        continue;
+      }
+
       const vimOptionValue = vimOptions[option] as any;
       if (vimOptionValue !== null && vimOptionValue !== undefined) {
         this[option] = vimOptionValue;

--- a/src/configuration/configuration.ts
+++ b/src/configuration/configuration.ts
@@ -56,11 +56,6 @@ class ConfigurationClass {
     /* tslint:disable:forin */
     // Disable forin rule here as we make accessors enumerable.`
     for (const option in this) {
-      // Some options are internal states and should not be reinitialized
-      if (option === "hl") {
-        continue;
-      }
-
       const vimOptionValue = vimOptions[option] as any;
       if (vimOptionValue !== null && vimOptionValue !== undefined) {
         this[option] = vimOptionValue;
@@ -150,11 +145,6 @@ class ConfigurationClass {
    * Should we highlight incremental search matches?
    */
   hlsearch = false;
-
-  /**
-   * Used internally for nohl.
-   */
-  hl = true;
 
   /**
    * Ignore case when searching with / or ?.

--- a/src/mode/modeHandler.ts
+++ b/src/mode/modeHandler.ts
@@ -1778,7 +1778,7 @@ export class ModeHandler implements vscode.Disposable {
 
     if (
       (Configuration.incsearch && this.currentMode.name === ModeName.SearchInProgressMode) ||
-      ((Configuration.hlsearch && Configuration.hl) && vimState.globalState.searchState)) {
+      ((Configuration.hlsearch && vimState.globalState.hl) && vimState.globalState.searchState)) {
 
       const searchState = vimState.globalState.searchState!;
 

--- a/src/mode/remapper.ts
+++ b/src/mode/remapper.ts
@@ -3,6 +3,7 @@ import * as _ from 'lodash';
 import { ModeName } from './mode';
 import { ModeHandler, VimState } from './modeHandler';
 import { AngleBracketNotation } from './../notation';
+import { runCmdLine } from '../../src/cmd_line/main';
 
 interface IKeybinding {
   before   : string[];
@@ -129,7 +130,13 @@ class Remapper {
 
       if (remapping.commands) {
         for (const command of remapping.commands) {
-          await vscode.commands.executeCommand(command.command, command.args);
+          // Check if this is a vim command by looking for :
+          if (command.command.slice(0, 1) === ":") {
+            await runCmdLine(command.command.slice(1, command.command.length), modeHandler);
+            await modeHandler.updateView(modeHandler.vimState);
+          } else {
+            await vscode.commands.executeCommand(command.command, command.args);
+          }
         }
       }
 

--- a/src/state/globalState.ts
+++ b/src/state/globalState.ts
@@ -27,6 +27,11 @@ export class GlobalState {
   private static _searchStateIndex: number = 0;
 
   /**
+   * Used internally for nohl.
+   */
+  private static _hl = true;
+
+  /**
    * Getters and setters for changing global state
    */
   public get searchStatePrevious(): SearchState[]{
@@ -59,5 +64,13 @@ export class GlobalState {
 
   public set searchStateIndex(state : number) {
     GlobalState._searchStateIndex = state;
+  }
+
+  public get hl(): boolean {
+    return GlobalState._hl;
+  }
+
+  public set hl(enabled: boolean) {
+    GlobalState._hl = enabled;
   }
 }


### PR DESCRIPTION
This fixes #1166 

example usage:
```
       {
           "before":["<C-n>"],
           "after":[],
            "commands": [
                {
                    "command": ":nohl",
                    "args": []
                }
            ]
       },
       {
           "before":["<C-r>"],
           "after":[],
            "commands": [
                {
                    "command": ":%s/test/123/g",
                    "args": []
                }
            ]
       }
```