### PR TITLE
Allow user to change status bar color based on mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ VSCodeVim is a [Visual Studio Code](https://code.visualstudio.com/) extension th
 * The [EasyMotion plugin](#how-to-use-easymotion)
 * The [Surround.vim plugin](#how-to-use-surround)
 * The [Commentary plugin](#how-to-use-commentary)
+* The [Vim-airline plugin](#statusBarColorControl)
 * And much more! Refer to the [roadmap](ROADMAP.md) or everything we support.
 
 Please [report missing features/bugs on GitHub](https://github.com/VSCodeVim/Vim/issues), which will help us get to them faster.
@@ -212,6 +213,25 @@ Or bind ctrl+n to turn off search highlighting and `<leader>w` to save the curre
 #### useSolidBlockCursor
   * Use a non-blinking block cursor
   * Type: Boolean (Default: `false`)
+
+
+#### statusBarColorControl
+  * Control status bar color based on current mode
+  * Type: Boolean (Default: `false`)
+
+  Once this is set, you need to set statusBarColors as well with these exact strings for modenames. The colors can be adjusted to suit the user.
+
+```
+    "vim.statusBarColorControl": true,
+    "vim.statusBarColors" : {
+        "normal": "#005f5f",
+        "insert": "#5f0000",
+        "visual": "#5f00af",
+        "visualline": "#005f87",
+        "visualblock": "#86592d",
+        "replace": "#000000"
+    }
+```
 
 ### Vim settings we support
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ VSCodeVim is a [Visual Studio Code](https://code.visualstudio.com/) extension th
 * The [EasyMotion plugin](#how-to-use-easymotion)
 * The [Surround.vim plugin](#how-to-use-surround)
 * The [Commentary plugin](#how-to-use-commentary)
-* The [Vim-airline plugin](#statusBarColorControl)
+* The [Vim-airline plugin](#statusbarcolorcontrol)
 * And much more! Refer to the [roadmap](ROADMAP.md) or everything we support.
 
 Please [report missing features/bugs on GitHub](https://github.com/VSCodeVim/Vim/issues), which will help us get to them faster.

--- a/package.json
+++ b/package.json
@@ -429,6 +429,14 @@
                 "vim.handleKeys": {
                     "type": "object",
                     "description": "Option to delegate certain key combinations back to VSCode to be handled natively"
+                },
+                "vim.statusBarColorControl":{
+                    "type": "boolean",
+                    "description": "Allow VSCodeVim to change status bar color based on mode"
+                },
+                "vim.statusBarColors": {
+                    "type": "object",
+                    "description": "Customize colors per mode when VSCodeVim controls status bar colors"
                 }
             }
         }

--- a/src/configuration/configuration.ts
+++ b/src/configuration/configuration.ts
@@ -14,6 +14,10 @@ export interface IHandleKeys {
   [key: string]: boolean;
 }
 
+export interface IStatusBarColors {
+  [key: string]: string;
+}
+
 /**
  * Every Vim option we support should
  * 1. Be added to contribution section of `package.json`.
@@ -214,6 +218,16 @@ class ConfigurationClass {
    * Start in insert mode?
    */
   startInInsertMode = false;
+
+  /**
+   * Start in insert mode?
+   */
+  statusBarColorControl = false;
+
+  /**
+   * Status bar colors to change to based on mode
+   */
+  statusBarColors: IStatusBarColors = {};
 
   /**
    * Color of search highlights.

--- a/src/mode/modeHandler.ts
+++ b/src/mode/modeHandler.ts
@@ -1795,10 +1795,17 @@ export class ModeHandler implements vscode.Disposable {
 
     this._vimState.editor.setDecorations(this._searchHighlightDecoration, searchRanges);
 
-
     for (let i = 0; i < this.vimState.postponedCodeViewChanges.length; i++) {
       let viewChange = this.vimState.postponedCodeViewChanges[i];
       await vscode.commands.executeCommand(viewChange.command, viewChange.args);
+    }
+
+    // If user wants to change status bar color based on mode
+    if (Configuration.statusBarColorControl) {
+      let colorToSet = Configuration.statusBarColors[this._vimState.currentModeName().toLowerCase()];
+      if (colorToSet !== undefined) {
+        this.setStatusBarColor(colorToSet);
+      }
     }
 
     this.vimState.postponedCodeViewChanges = [];
@@ -1861,6 +1868,15 @@ export class ModeHandler implements vscode.Disposable {
 
     ModeHandler._statusBarItem.text = text || '';
     ModeHandler._statusBarItem.show();
+  }
+
+  setStatusBarColor(color: string): void {
+    vscode.workspace.getConfiguration("workbench.experimental").update("colorCustomizations",
+      {
+        "statusBarBackground": `${color}`,
+        "statusBarNoFolderBackground": `${color}`,
+        "statusBarDebuggingBackground": `${color}`
+      });
   }
 
   // Return true if a new undo point should be created based on brackets and parenthesis


### PR DESCRIPTION
I am ok opening this now since it is off by default and behind a config flag. We can either wait on it or just release it now and change that single function in the future when vscode changes the way this is done...

fixes #1056 

![apr-18-2017 19-41-59](https://cloud.githubusercontent.com/assets/4219348/25161240/9f490aae-246f-11e7-94ce-d73f0fe6e827.gif)
