### PR TITLE
Fixed Issue #1528

### DIFF
--- a/src/actions/actions.ts
+++ b/src/actions/actions.ts
@@ -5295,7 +5295,6 @@ class SelectWord extends TextObjectMovement {
         stop = position.getCurrentWordEnd();
     } else {
         stop = position.getWordRight().getLeftThroughLineBreaks();
-
         if (stop.isEqual(position.getCurrentWordEnd(true))) {
           start = position.getLastWordEnd().getRight();
         } else {

--- a/src/actions/actions.ts
+++ b/src/actions/actions.ts
@@ -5296,7 +5296,7 @@ class SelectWord extends TextObjectMovement {
     } else {
         stop = position.getWordRight().getLeftThroughLineBreaks();
 
-        if (stop.isEqual(position.getCurrentWordEnd())) {
+        if (stop.isEqual(position.getCurrentWordEnd(true))) {
           start = position.getLastWordEnd().getRight();
         } else {
           start = position.getWordLeft(true);

--- a/src/actions/actions.ts
+++ b/src/actions/actions.ts
@@ -5295,6 +5295,8 @@ class SelectWord extends TextObjectMovement {
         stop = position.getCurrentWordEnd();
     } else {
         stop = position.getWordRight().getLeftThroughLineBreaks();
+        // If we aren't separated from the next word by whitespace(like in "horse ca|t,dog" or at the end of the line)
+        // then we delete the spaces to the left of the current word. Otherwise, we delete to the right.
         if (stop.isEqual(position.getCurrentWordEnd(true))) {
           start = position.getLastWordEnd().getRight();
         } else {

--- a/test/mode/modeNormal.test.ts
+++ b/test/mode/modeNormal.test.ts
@@ -635,7 +635,7 @@ suite("Mode Normal", () => {
       endMode: ModeName.Normal
     });
 
-    newTestOnly({
+    newTest({
       title: "Can handle 'daw' on end of word",
       start: ['one   two   three   fou|r'],
       keysPressed: 'daw',

--- a/test/mode/modeNormal.test.ts
+++ b/test/mode/modeNormal.test.ts
@@ -635,6 +635,14 @@ suite("Mode Normal", () => {
       endMode: ModeName.Normal
     });
 
+    newTestOnly({
+      title: "Can handle 'daw' on end of word",
+      start: ['one   two   three   fou|r'],
+      keysPressed: 'daw',
+      end: ['one   two   thre|e'],
+      endMode: ModeName.Normal
+    });
+
     newTest({
       title: "Can handle 'daW' on big word with cursor inside spaces",
       start: ['one   two |  three,   four  '],
@@ -674,6 +682,8 @@ suite("Mode Normal", () => {
       end: ['one   two   three,   |six'],
       endMode: ModeName.Normal
     });
+
+
 
     newTest({
       title: "Can handle 'diw' on word with cursor inside spaces",


### PR DESCRIPTION
<!--
Yay! We love PRs! 🎊

Please include a description of your change and ensure:

- [ ] Commit message has a short title & issue references
- [ ] Each commit does a logical chunk of work.
- [ ] It builds and tests pass (e.g `gulp`)

More info can be found on our [contribution guide](https://github.com/VSCodeVim/Vim/blob/master/.github/CONTRIBUTING.md).
-->

The issue is that if your cursor starts on the end of a word, getCurrentWordEnd should clearly include the current word.

I plan on adding a couple more unit tests for some edge cases.