### PR TITLE
Allow users to use VSCode keybinding for remapping

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,10 @@
             {
                 "command": "extension.showCmdLine",
                 "title": "Vim: Show Command Line"
+            },
+            {
+                "command": "vim.remap",
+                "title": "Vim: Remap any key combination that VS Code supports to Vim motions/operators/ExCommands/macro."
             }
         ],
         "keybindings": [

--- a/src/mode/remapper.ts
+++ b/src/mode/remapper.ts
@@ -5,6 +5,11 @@ import { ModeHandler, VimState } from './modeHandler';
 import { AngleBracketNotation } from './../notation';
 import { runCmdLine } from '../../src/cmd_line/main';
 
+export interface ICodeKeybinding {
+  after?: string[];
+  commands?: { command: string; args: any[] }[];
+}
+
 interface IKeybinding {
   before   : string[];
   after?   : string[];


### PR DESCRIPTION
Ref https://github.com/VSCodeVim/Vim/issues/1543

```
    {
        "key": "F3",
        "command": "vim.remap",
        "when": "editorTextFocus",
        "args": {
            "value": ["a", "b", "c", "<Esc>"]
        }
    }
```

Fixes #1505, #1452