### PR TITLE
Fixes #1193, #1350

### DIFF
--- a/src/actions/actions.ts
+++ b/src/actions/actions.ts
@@ -5297,7 +5297,9 @@ class SelectWord extends TextObjectMovement {
         stop = position.getWordRight().getLeftThroughLineBreaks();
         // If we aren't separated from the next word by whitespace(like in "horse ca|t,dog" or at the end of the line)
         // then we delete the spaces to the left of the current word. Otherwise, we delete to the right.
-        if (stop.isEqual(position.getCurrentWordEnd(true))) {
+        if (stop.isEqual(position.getCurrentWordEnd(true)) && !position.getWordLeft(true).isEqual(position.getFirstLineNonBlankChar())) {
+          start = position.getWordLeft(true);
+          start = position.getFirstLineNonBlankChar();
           start = position.getLastWordEnd().getRight();
         } else {
           start = position.getWordLeft(true);

--- a/src/actions/actions.ts
+++ b/src/actions/actions.ts
@@ -5302,7 +5302,6 @@ class SelectWord extends TextObjectMovement {
         // If we aren't separated from the next word by whitespace(like in "horse ca|t,dog" or at the end of the line)
         // then we delete the spaces to the left of the current word. Otherwise, we delete to the right.
         // Also, if the current word is the leftmost word, we only delete from the start of the word to the end.
-        let t = position.getCurrentWordEnd(true)
         if (stop.isEqual(position.getCurrentWordEnd(true)) &&
             !position.getWordLeft(true).isEqual(position.getFirstLineNonBlankChar())) {
           start = position.getLastWordEnd().getRight();

--- a/src/actions/actions.ts
+++ b/src/actions/actions.ts
@@ -5297,9 +5297,8 @@ class SelectWord extends TextObjectMovement {
         stop = position.getWordRight().getLeftThroughLineBreaks();
         // If we aren't separated from the next word by whitespace(like in "horse ca|t,dog" or at the end of the line)
         // then we delete the spaces to the left of the current word. Otherwise, we delete to the right.
-        if (stop.isEqual(position.getCurrentWordEnd(true)) && !position.getWordLeft(true).isEqual(position.getFirstLineNonBlankChar())) {
-          start = position.getWordLeft(true);
-          start = position.getFirstLineNonBlankChar();
+        if (stop.isEqual(position.getCurrentWordEnd(true)) &&
+            !position.getWordLeft(true).isEqual(position.getFirstLineNonBlankChar())) {
           start = position.getLastWordEnd().getRight();
         } else {
           start = position.getWordLeft(true);

--- a/src/actions/actions.ts
+++ b/src/actions/actions.ts
@@ -5294,11 +5294,15 @@ class SelectWord extends TextObjectMovement {
         start = position.getLastWordEnd().getRight();
         stop = position.getCurrentWordEnd();
     } else {
-        stop = position.getWordRight().getLeftThroughLineBreaks();
+        stop = position.getWordRight();
+        if (stop.isEqual(stop.getFirstLineNonBlankChar())) {
+          stop = stop.getLineBegin();
+        }
+        stop = stop.getLeftThroughLineBreaks().getLeftIfEOL();
         // If we aren't separated from the next word by whitespace(like in "horse ca|t,dog" or at the end of the line)
         // then we delete the spaces to the left of the current word. Otherwise, we delete to the right.
         // Also, if the current word is the leftmost word, we only delete from the start of the word to the end.
-
+        let t = position.getCurrentWordEnd(true)
         if (stop.isEqual(position.getCurrentWordEnd(true)) &&
             !position.getWordLeft(true).isEqual(position.getFirstLineNonBlankChar())) {
           start = position.getLastWordEnd().getRight();

--- a/src/actions/actions.ts
+++ b/src/actions/actions.ts
@@ -5297,6 +5297,8 @@ class SelectWord extends TextObjectMovement {
         stop = position.getWordRight().getLeftThroughLineBreaks();
         // If we aren't separated from the next word by whitespace(like in "horse ca|t,dog" or at the end of the line)
         // then we delete the spaces to the left of the current word. Otherwise, we delete to the right.
+        // Also, if the current word is the leftmost word, we only delete from the start of the word to the end.
+
         if (stop.isEqual(position.getCurrentWordEnd(true)) &&
             !position.getWordLeft(true).isEqual(position.getFirstLineNonBlankChar())) {
           start = position.getLastWordEnd().getRight();

--- a/test/mode/modeNormal.test.ts
+++ b/test/mode/modeNormal.test.ts
@@ -579,7 +579,7 @@ suite("Mode Normal", () => {
       endMode: ModeName.Normal
     });
 
-    newTestOnly({
+    newTest({
       title: "Can handle 'ca`' inside word",
       start: ['one `t|wo`'],
       keysPressed: 'ca`',
@@ -587,7 +587,7 @@ suite("Mode Normal", () => {
       endMode: ModeName.Insert
     });
 
-    newTestOnly({
+    newTest({
       title: "Can handle 'daw' on word with cursor inside spaces",
       start: ['one   two |  three,   four  '],
       keysPressed: 'daw',
@@ -595,7 +595,7 @@ suite("Mode Normal", () => {
       endMode: ModeName.Normal
     });
 
-    newTestOnly({
+    newTest({
       title: "Can handle 'daw' on word with trailing spaces",
       start: ['one   tw|o   three,   four  '],
       keysPressed: 'daw',
@@ -603,7 +603,7 @@ suite("Mode Normal", () => {
       endMode: ModeName.Normal
     });
 
-    newTestOnly({
+    newTest({
       title: "Can handle 'daw' on word with leading spaces",
       start: ['one   two   th|ree,   four  '],
       keysPressed: 'daw',
@@ -611,7 +611,7 @@ suite("Mode Normal", () => {
       endMode: ModeName.Normal
     });
 
-    newTestOnly({
+    newTest({
       title: "Can handle 'daw' on word with numeric prefix",
       start: ['on|e   two   three,   four  '],
       keysPressed: 'd3aw',
@@ -619,7 +619,7 @@ suite("Mode Normal", () => {
       endMode: ModeName.Normal
     });
 
-    newTestOnly({
+    newTest({
       title: "Can handle 'daw' on word with numeric prefix and across lines",
       start: ['one   two   three,   fo|ur  ', 'five  six'],
       keysPressed: 'd2aw',
@@ -627,7 +627,7 @@ suite("Mode Normal", () => {
       endMode: ModeName.Normal
     });
 
-    newTestOnly({
+    newTest({
       title: "Can handle 'daw' on word with numeric prefix and across lines, containing words end with `.`",
       start: ['one   two   three,   fo|ur  ', 'five.  six'],
       keysPressed: 'd2aw',
@@ -635,7 +635,7 @@ suite("Mode Normal", () => {
       endMode: ModeName.Normal
     });
 
-    newTestOnly({
+    newTest({
       title: "Can handle 'daw' on end of word",
       start: ['one   two   three   fou|r'],
       keysPressed: 'daw',
@@ -643,7 +643,7 @@ suite("Mode Normal", () => {
       endMode: ModeName.Normal
     });
 
-    newTestOnly({
+    newTest({
       title: "Can handle 'daw' on words at beginning of line with leading whitespace",
       start: ['if (something){',
               '  |this.method();'],
@@ -652,7 +652,7 @@ suite("Mode Normal", () => {
             '  |.method();']
     });
 
-    newTestOnly({
+    newTest({
       title: "Can handle 'daw' on words at ends of lines in the middle of whitespace",
       start: ['one two | ',
              'four'],
@@ -660,14 +660,14 @@ suite("Mode Normal", () => {
       end: ['one tw|o']
     });
 
-    newTestOnly({
+    newTest({
       title: "Can handle 'daw' on word at beginning of file",
       start: ['o|ne'],
       keysPressed: 'daw',
       end: ['|']
     });
 
-    newTestOnly({
+    newTest({
       title: "Can handle 'daw' on word at beginning of line",
       start: ['one two',
               'th|ree'],
@@ -676,7 +676,7 @@ suite("Mode Normal", () => {
             '|']
     });
 
-    newTestOnly({
+    newTest({
       title: "Can handle 'daw' on word at end of line with trailing whitespace",
       start: ['one tw|o  ',
               'three four'],
@@ -685,7 +685,7 @@ suite("Mode Normal", () => {
             'three four']
     });
 
-    newTestOnly({
+    newTest({
       title: "Can handle 'daw' around word at end of line",
       start: ['one t|wo',
               ' three'],

--- a/test/mode/modeNormal.test.ts
+++ b/test/mode/modeNormal.test.ts
@@ -693,14 +693,6 @@ suite("Mode Normal", () => {
       end: ['on|e',
             ' three']
     })
-    // newTestOnly({
-    //   title: "Can handle 'daw' on newline with words after",
-    //   start: ['one two',
-    //           '|',
-    //           'asdf'],
-    //   keysPressed: 'daw',
-    //   end: ['one tw|o']
-    // })
     newTest({
       title: "Can handle 'daW' on big word with cursor inside spaces",
       start: ['one   two |  three,   four  '],

--- a/test/mode/modeNormal.test.ts
+++ b/test/mode/modeNormal.test.ts
@@ -683,7 +683,14 @@ suite("Mode Normal", () => {
       endMode: ModeName.Normal
     });
 
-
+    newTestOnly({
+      title: "Can handle daw on words at beginning of line with leading whitespace",
+      start: ['if (something){',
+              '  |this.method();'],
+      keysPressed: 'daw',
+      end: ['if (something){',
+            '  |.method();']
+    });
 
     newTest({
       title: "Can handle 'diw' on word with cursor inside spaces",

--- a/test/mode/modeNormal.test.ts
+++ b/test/mode/modeNormal.test.ts
@@ -579,7 +579,7 @@ suite("Mode Normal", () => {
       endMode: ModeName.Normal
     });
 
-    newTest({
+    newTestOnly({
       title: "Can handle 'ca`' inside word",
       start: ['one `t|wo`'],
       keysPressed: 'ca`',
@@ -587,7 +587,7 @@ suite("Mode Normal", () => {
       endMode: ModeName.Insert
     });
 
-    newTest({
+    newTestOnly({
       title: "Can handle 'daw' on word with cursor inside spaces",
       start: ['one   two |  three,   four  '],
       keysPressed: 'daw',
@@ -595,7 +595,7 @@ suite("Mode Normal", () => {
       endMode: ModeName.Normal
     });
 
-    newTest({
+    newTestOnly({
       title: "Can handle 'daw' on word with trailing spaces",
       start: ['one   tw|o   three,   four  '],
       keysPressed: 'daw',
@@ -603,7 +603,7 @@ suite("Mode Normal", () => {
       endMode: ModeName.Normal
     });
 
-    newTest({
+    newTestOnly({
       title: "Can handle 'daw' on word with leading spaces",
       start: ['one   two   th|ree,   four  '],
       keysPressed: 'daw',
@@ -611,7 +611,7 @@ suite("Mode Normal", () => {
       endMode: ModeName.Normal
     });
 
-    newTest({
+    newTestOnly({
       title: "Can handle 'daw' on word with numeric prefix",
       start: ['on|e   two   three,   four  '],
       keysPressed: 'd3aw',
@@ -619,7 +619,7 @@ suite("Mode Normal", () => {
       endMode: ModeName.Normal
     });
 
-    newTest({
+    newTestOnly({
       title: "Can handle 'daw' on word with numeric prefix and across lines",
       start: ['one   two   three,   fo|ur  ', 'five  six'],
       keysPressed: 'd2aw',
@@ -627,7 +627,7 @@ suite("Mode Normal", () => {
       endMode: ModeName.Normal
     });
 
-    newTest({
+    newTestOnly({
       title: "Can handle 'daw' on word with numeric prefix and across lines, containing words end with `.`",
       start: ['one   two   three,   fo|ur  ', 'five.  six'],
       keysPressed: 'd2aw',
@@ -635,7 +635,7 @@ suite("Mode Normal", () => {
       endMode: ModeName.Normal
     });
 
-    newTest({
+    newTestOnly({
       title: "Can handle 'daw' on end of word",
       start: ['one   two   three   fou|r'],
       keysPressed: 'daw',
@@ -643,8 +643,8 @@ suite("Mode Normal", () => {
       endMode: ModeName.Normal
     });
 
-    newTest({
-      title: "Can handle daw on words at beginning of line with leading whitespace",
+    newTestOnly({
+      title: "Can handle 'daw' on words at beginning of line with leading whitespace",
       start: ['if (something){',
               '  |this.method();'],
       keysPressed: 'daw',
@@ -652,6 +652,55 @@ suite("Mode Normal", () => {
             '  |.method();']
     });
 
+    newTestOnly({
+      title: "Can handle 'daw' on words at ends of lines in the middle of whitespace",
+      start: ['one two | ',
+             'four'],
+      keysPressed: 'daw',
+      end: ['one tw|o']
+    });
+
+    newTestOnly({
+      title: "Can handle 'daw' on word at beginning of file",
+      start: ['o|ne'],
+      keysPressed: 'daw',
+      end: ['|']
+    })
+
+    newTestOnly({
+      title: "Can handle 'daw' on word at beginning of line",
+      start: ['one two',
+              'th|ree'],
+      keysPressed: 'daw',
+      end: ['one two',
+            '|']
+    });
+
+    newTestOnly({
+      title: "Can handle 'daw' on word at end of line with trailing whitespace",
+      start: ['one tw|o  ',
+              'three four'],
+      keysPressed: 'daw',
+      end: ['one| ',
+            'three four']
+    })
+
+    newTestOnly({
+      title: "Can handle 'daw' around word at end of line",
+      start: ['one t|wo',
+              ' three'],
+      keysPressed: 'daw',
+      end: ['on|e',
+            ' three']
+    })
+    // newTestOnly({
+    //   title: "Can handle 'daw' on newline with words after",
+    //   start: ['one two',
+    //           '|',
+    //           'asdf'],
+    //   keysPressed: 'daw',
+    //   end: ['one tw|o']
+    // })
     newTest({
       title: "Can handle 'daW' on big word with cursor inside spaces",
       start: ['one   two |  three,   four  '],
@@ -659,6 +708,7 @@ suite("Mode Normal", () => {
       end: ['one   two|   four  '],
       endMode: ModeName.Normal
     });
+
 
     newTest({
       title: "Can handle 'daW' on word with trailing spaces",

--- a/test/mode/modeNormal.test.ts
+++ b/test/mode/modeNormal.test.ts
@@ -644,6 +644,15 @@ suite("Mode Normal", () => {
     });
 
     newTest({
+      title: "Can handle daw on words at beginning of line with leading whitespace",
+      start: ['if (something){',
+              '  |this.method();'],
+      keysPressed: 'daw',
+      end: ['if (something){',
+            '  |.method();']
+    });
+
+    newTest({
       title: "Can handle 'daW' on big word with cursor inside spaces",
       start: ['one   two |  three,   four  '],
       keysPressed: 'daW',
@@ -681,15 +690,6 @@ suite("Mode Normal", () => {
       keysPressed: 'd2aW',
       end: ['one   two   three,   |six'],
       endMode: ModeName.Normal
-    });
-
-    newTestOnly({
-      title: "Can handle daw on words at beginning of line with leading whitespace",
-      start: ['if (something){',
-              '  |this.method();'],
-      keysPressed: 'daw',
-      end: ['if (something){',
-            '  |.method();']
     });
 
     newTest({

--- a/test/mode/modeNormal.test.ts
+++ b/test/mode/modeNormal.test.ts
@@ -665,7 +665,7 @@ suite("Mode Normal", () => {
       start: ['o|ne'],
       keysPressed: 'daw',
       end: ['|']
-    })
+    });
 
     newTestOnly({
       title: "Can handle 'daw' on word at beginning of line",
@@ -683,7 +683,7 @@ suite("Mode Normal", () => {
       keysPressed: 'daw',
       end: ['one| ',
             'three four']
-    })
+    });
 
     newTestOnly({
       title: "Can handle 'daw' around word at end of line",
@@ -692,7 +692,8 @@ suite("Mode Normal", () => {
       keysPressed: 'daw',
       end: ['on|e',
             ' three']
-    })
+    });
+
     newTest({
       title: "Can handle 'daW' on big word with cursor inside spaces",
       start: ['one   two |  three,   four  '],
@@ -700,7 +701,6 @@ suite("Mode Normal", () => {
       end: ['one   two|   four  '],
       endMode: ModeName.Normal
     });
-
 
     newTest({
       title: "Can handle 'daW' on word with trailing spaces",


### PR DESCRIPTION
<!--
Yay! We love PRs! 🎊

Please include a description of your change and ensure:

- [ ] Commit message has a short title & issue references
- [ ] Each commit does a logical chunk of work.
- [ ] It builds and tests pass (e.g `gulp`)

More info can be found on our [contribution guide](https://github.com/VSCodeVim/Vim/blob/master/.github/CONTRIBUTING.md).
-->

As I was working on the "aw" object, I thought I would fix the other related bugs.

It'd be ideal if I didn't need to special case this, but from thinking about it, it does seem like it's a special case. Normally, when you daw with a "." right at the end, you also want to delete all the whitespace on the left of the word until you reach another word. In this scenario, however, you want it to stay in the same place.

I was working on a complete rewrite of the 'aw' object based off "boundaries", but decided that it was overengineering. However, while writing it, I came some more cases where our behavior doesn't align with vim. I'd like some feedback on whether those cases are worth fixing (imo, vim does some very bizarre things in some of these cases).

```
one  
|  
three
```
becomes
`|one`