### PR TITLE
Fixes #1554, #1553

### DIFF
--- a/src/actions/actions.ts
+++ b/src/actions/actions.ts
@@ -5348,6 +5348,7 @@ class SelectABigWord extends TextObjectMovement {
         start = position.getLastBigWordEnd().getRight();
         stop = position.getCurrentBigWordEnd();
     } else {
+        // Check 'aw' code for much of the reasoning behind this logic.
         let nextWord = position.getBigWordRight();
         if ((nextWord.isEqual(nextWord.getFirstLineNonBlankChar()) || nextWord.isLineEnd()) &&
               vimState.recordedState.count === 0) {

--- a/src/actions/actions.ts
+++ b/src/actions/actions.ts
@@ -5295,6 +5295,10 @@ class SelectWord extends TextObjectMovement {
         stop = position.getCurrentWordEnd();
     } else {
         stop = position.getWordRight();
+        // If the next word is not at the beginning of the next line, we want to pretend it is.
+        // This is because 'aw' has two fundamentally different behaviors distinguished by whether
+        // the next word is directly after the current word, as described in the following comment.
+        // The only case that's not true is in cases like #1350.
         if (stop.isEqual(stop.getFirstLineNonBlankChar())) {
           stop = stop.getLineBegin();
         }
@@ -5344,10 +5348,15 @@ class SelectABigWord extends TextObjectMovement {
         start = position.getLastBigWordEnd().getRight();
         stop = position.getCurrentBigWordEnd();
     } else {
-        start = position.getBigWordLeft();
-        stop = position.getBigWordRight().getLeft();
+        let nextWord = position.getBigWordRight();
+        if (nextWord.isEqual(nextWord.getFirstLineNonBlankChar()) || nextWord.isLineEnd()) {
+          start = position.getLastWordEnd().getRight();
+          stop = position.getLineEnd();
+        } else {
+          start = position.getBigWordLeft(true);
+          stop = position.getBigWordRight().getLeft();
+        }
     }
-
     if (vimState.currentMode === ModeName.Visual && !vimState.cursorPosition.isEqual(vimState.cursorStartPosition)) {
         start = vimState.cursorStartPosition;
 

--- a/src/actions/actions.ts
+++ b/src/actions/actions.ts
@@ -5287,7 +5287,6 @@ class SelectWord extends TextObjectMovement {
   public async execAction(position: Position, vimState: VimState): Promise<IMovement> {
     let start: Position;
     let stop: Position;
-
     const currentChar = TextEditor.getLineAt(position).text[position.character];
 
     if (/\s/.test(currentChar)) {
@@ -5307,7 +5306,8 @@ class SelectWord extends TextObjectMovement {
         // then we delete the spaces to the left of the current word. Otherwise, we delete to the right.
         // Also, if the current word is the leftmost word, we only delete from the start of the word to the end.
         if (stop.isEqual(position.getCurrentWordEnd(true)) &&
-            !position.getWordLeft(true).isEqual(position.getFirstLineNonBlankChar())) {
+            !position.getWordLeft(true).isEqual(position.getFirstLineNonBlankChar())
+            && vimState.recordedState.count === 0) {
           start = position.getLastWordEnd().getRight();
         } else {
           start = position.getWordLeft(true);
@@ -5349,7 +5349,8 @@ class SelectABigWord extends TextObjectMovement {
         stop = position.getCurrentBigWordEnd();
     } else {
         let nextWord = position.getBigWordRight();
-        if (nextWord.isEqual(nextWord.getFirstLineNonBlankChar()) || nextWord.isLineEnd()) {
+        if ((nextWord.isEqual(nextWord.getFirstLineNonBlankChar()) || nextWord.isLineEnd()) &&
+              vimState.recordedState.count === 0) {
           start = position.getLastWordEnd().getRight();
           stop = position.getLineEnd();
         } else {

--- a/src/motion/position.ts
+++ b/src/motion/position.ts
@@ -480,8 +480,8 @@ export class Position extends vscode.Position {
     return this.getWordLeftWithRegex(this._nonWordCharRegex, inclusive);
   }
 
-  public getBigWordLeft(): Position {
-    return this.getWordLeftWithRegex(this._nonBigWordCharRegex);
+  public getBigWordLeft(inclusive: boolean = false): Position {
+    return this.getWordLeftWithRegex(this._nonBigWordCharRegex, inclusive);
   }
 
   public getFilePathLeft(inclusive: boolean = false): Position {
@@ -495,7 +495,7 @@ export class Position extends vscode.Position {
     return this.getWordRightWithRegex(this._nonWordCharRegex, inclusive);
   }
 
-  public getBigWordRight() : Position {
+  public getBigWordRight(inclusive: boolean = false) : Position {
     return this.getWordRightWithRegex(this._nonBigWordCharRegex);
   }
 

--- a/test/mode/modeNormal.test.ts
+++ b/test/mode/modeNormal.test.ts
@@ -628,6 +628,14 @@ suite("Mode Normal", () => {
     });
 
     newTest({
+    title: "Can handle 'daw' on word with numeric prefix and across lines",
+      start: ['one two fo|ur', 'five  six'],
+      keysPressed: 'd2aw',
+      end: ['one two |six'],
+      endMode: ModeName.Normal
+    });
+
+    newTest({
       title: "Can handle 'daw' on word with numeric prefix and across lines, containing words end with `.`",
       start: ['one   two   three,   fo|ur  ', 'five.  six'],
       keysPressed: 'd2aw',
@@ -732,6 +740,30 @@ suite("Mode Normal", () => {
       keysPressed: 'd2aW',
       end: ['one   two   three,   |six'],
       endMode: ModeName.Normal
+    });
+
+    newTest({
+      title: "Can handle 'daW' on beginning of word",
+      start: ['one |two three'],
+      keysPressed: 'daW',
+      end: ['one |three'],
+      endMode: ModeName.Normal
+    });
+
+    newTest({
+      title: "Can handle 'daW' on end of one line",
+      start: ['one |two'],
+      keysPressed: 'daW',
+      end: ['on|e'],
+      endMode: ModeName.Normal
+    });
+    newTest({
+      title: "Can handle 'daW' around word at end of line",
+      start: ['one t|wo',
+              ' three'],
+      keysPressed: 'daW',
+      end: ['on|e',
+            ' three']
     });
 
     newTest({


### PR DESCRIPTION
<!--
Yay! We love PRs! 🎊

Please include a description of your change and ensure:

- [ ] Commit message has a short title & issue references
- [ ] Each commit does a logical chunk of work.
- [ ] It builds and tests pass (e.g `gulp`)

More info can be found on our [contribution guide](https://github.com/VSCodeVim/Vim/blob/master/.github/CONTRIBUTING.md).
-->

Fixes those two issues. One potentially bad practice is that I'm accessing vimState.recordedState.count. I don't know how that might play with things like undo.

This commit also fixes a regression I introduced in PR #1549 . In my defense, the reason the regression happened was that buggy behavior was hiding another bug.

I also added a comment explaining code added in PR #1549 .
