### PR TITLE
Fixes #1539 

### DIFF
--- a/src/cmd_line/commands/register.ts
+++ b/src/cmd_line/commands/register.ts
@@ -26,7 +26,8 @@ export class RegisterCommand extends node.CommandBase {
     if (result instanceof Array) {
       result = result.join("\n").substr(0, 100);
     } else if (result instanceof RecordedState) {
-      result = result.actionsRun.map(x => x.keysPressed.join("")).join("");
+      result = result.actionsRun.map(x => x.keysPressed.join(""));
+      result = result.join("");
     }
 
     return result;
@@ -34,7 +35,7 @@ export class RegisterCommand extends node.CommandBase {
 
   async displayRegisterValue(register: string): Promise<void> {
     let result = await this.getRegisterDisplayValue(register);
-
+    result = result.replace(/\n/g, "\\n");
     vscode.window.showInformationMessage(`${register} ${result}`);
   }
 

--- a/src/cmd_line/commands/register.ts
+++ b/src/cmd_line/commands/register.ts
@@ -26,8 +26,7 @@ export class RegisterCommand extends node.CommandBase {
     if (result instanceof Array) {
       result = result.join("\n").substr(0, 100);
     } else if (result instanceof RecordedState) {
-      result = result.actionsRun.map(x => x.keysPressed.join(""));
-      result = result.join("");
+      result = result.actionsRun.map(x => x.keysPressed.join("")).join("");
     }
 
     return result;


### PR DESCRIPTION
<!--
Yay! We love PRs! 🎊

Please include a description of your change and ensure:

- [ ] Commit message has a short title & issue references
- [ ] Each commit does a logical chunk of work.
- [ ] It builds and tests pass (e.g `gulp`)

More info can be found on our [contribution guide](https://github.com/VSCodeVim/Vim/blob/master/.github/CONTRIBUTING.md).
-->
This time for real.

The showInformationMessage function just straight up drops the rest of the string after a newline, which seems like unintuitive behavior to me.

There's also the possibility that some other kind of character needs to be escaped. If any of you guys know a better way to escape strings in typescript, I'd love to hear it.