### PR TITLE
update clipboardy library with windows utf-8 fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -448,7 +448,7 @@
         "postinstall": "node ./node_modules/vscode/bin/install && gulp init"
     },
     "dependencies": {
-        "clipboardy": "^1.1.0",
+        "clipboardy": "^1.1.1",
         "diff-match-patch": "^1.0.0",
         "lodash": "^4.12.0",
         "typescript": "^2.2.1"


### PR DESCRIPTION
UTF-8 on windows was fixed with this release. He spun his own copy/paste binaries for windows so performance should be fixed now too since there is no sketchy html vbscript stuff. Now macos, linux, and windows should handle utf8 correctly.

fixes #1299 
fixes #1125 
fixes #1284

Thanks to @sindresorhus
https://github.com/sindresorhus/clipboardy/pull/13