### PR TITLE
Fix logo src so logo displays inside VSCode

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <h1 align="center">
-    <img src="https://cdn.rawgit.com/VSCodeVim/Vim/master/images/icon.png" height="128">
+    <img src="https://raw.githubusercontent.com/VSCodeVim/Vim/master/images/icon.png" height="128">
     <br>
     VSCodeVim
 </h1>

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <h1 align="center">
-    <img src="./images/icon.png" height="128">
+    <img src="https://cdn.rawgit.com/VSCodeVim/Vim/master/images/icon.png" height="128">
     <br>
     VSCodeVim
 </h1>


### PR DESCRIPTION
The relative URL that was being used only works when viewing the README
from GitHub, and leaves a big blank space if you open VSCodeVim's page
inside VSCodeVim.

This uses a full URL, which should fix the issue. This is how the Chrome
Debugger plugin loads their logo.
