### PR TITLE
WIP Fixes #1017

### DIFF
--- a/src/actions/actions.ts
+++ b/src/actions/actions.ts
@@ -2929,9 +2929,21 @@ class CommandClearLine extends BaseCommand {
   runsOnceForEachCountPrefix = false;
 
   public async exec(position: Position, vimState: VimState): Promise<VimState> {
-    let count = vimState.recordedState.count || 1;
-    let end = position.getDownByCount(Math.max(0, count - 1)).getLineEnd().getLeft();
-    return new ChangeOperator().run(vimState, position.getLineBeginRespectingIndent(), end);
+    let indentLine = position;
+    do {
+      indentLine = indentLine.getUp(1);
+    } while (indentLine.getLineEnd().character === 0 && indentLine.getDocumentBegin().line !== indentLine.line);
+    let indentLevel = TextEditor.getIndentationLevel(TextEditor.getLineAt(indentLine).text);
+    vimState.recordedState.transformations.push({
+      type: "replaceText",
+      text: TextEditor.setIndentationLevel("", indentLevel),
+      start: position.getLineBegin(),
+      end: position.getLineEnd(),
+      manuallySetCursorPositions: true
+    });
+    vimState.currentMode = ModeName.Insert;
+    vimState.cursorPosition = new Position(position.line, indentLevel);
+    return vimState;
   }
 }
 


### PR DESCRIPTION
<!--
Yay! We love PRs! 🎊

Please include a description of your change and ensure:

- [ ] Commit message has a short title & issue references
- [ ] Each commit does a logical chunk of work.
- [ ] It builds and tests pass (e.g `gulp`)

More info can be found on our [contribution guide](https://github.com/VSCodeVim/Vim/blob/master/.github/CONTRIBUTING.md).
-->

I'm not actually completely sure what the "vim" rule for autoindenting something like this is. I thought it was what I had implemented, but upon further testing, that doesn't seem to be right.

I also have tests, but due to what I think is a bug in the testing framework, they aren't working out so well. Namely, tests like these 
```
    newTestOnly({
      title: "Can handle 'S' on empty line",
      start: ['one', 'tw|o'],
      keysPressed: 'Aabc',
      end: ['one', 'abc|']
    });
```
end up inserting
```
one
two
two
```

If I could get a suggestion on how to get indentation level properly (I couldn't find a good example elsewhere in the code), or advice on fixing the tests, that'd be nice.
