### PR TITLE
Fixes #1251

### DIFF
--- a/src/actions/actions.ts
+++ b/src/actions/actions.ts
@@ -4513,7 +4513,7 @@ class ActionVisualReflowParagraph extends BaseCommand {
           if (lines[lines.length - 1].length + word.length + 1 < maximumLineLength) {
             lines[lines.length - 1] += ` ${ word }`;
           } else {
-            lines.push(` ${ word }`);
+            lines.push(`${ word }`);
           }
         }
       }
@@ -4544,8 +4544,11 @@ class ActionVisualReflowParagraph extends BaseCommand {
       result = result.concat(lines);
     }
 
+    // Remove extra first space if it exists.
+    if (result[0][0] === " ") {
+      result[0] = result[0].slice(1);
+    }
     // Gather up multiple empty lines into single empty lines.
-
     return result.join("\n");
   }
 

--- a/src/actions/actions.ts
+++ b/src/actions/actions.ts
@@ -4513,7 +4513,7 @@ class ActionVisualReflowParagraph extends BaseCommand {
           if (lines[lines.length - 1].length + word.length + 1 < maximumLineLength) {
             lines[lines.length - 1] += ` ${ word }`;
           } else {
-            lines.push(`${ word }`);
+            lines.push(` ${ word }`);
           }
         }
       }


### PR DESCRIPTION
<!--
Yay! We love PRs! 🎊

Please include a description of your change and ensure:

- [ ] Commit message has a short title & issue references
- [ ] Each commit does a logical chunk of work.
- [ ] It builds and tests pass (e.g `gulp`)

More info can be found on our [contribution guide](https://github.com/VSCodeVim/Vim/blob/master/.github/CONTRIBUTING.md).
-->

I think the issue here is that when we go word by word adding it in, we always add " {$word}". However, the first word shouldn't have an extra space in front of it.

This problem should also be fixable here, but I thought my current solution was fine. 
https://github.com/VSCodeVim/Vim/blob/master/src/actions/actions.ts#L4514, 