### PR TITLE
Fixes #1575 (and also adds general newline support for searches)

### DIFF
--- a/src/actions/actions.ts
+++ b/src/actions/actions.ts
@@ -1676,7 +1676,7 @@ class CommandNextSearchMatch extends BaseMovement {
 
     vimState.globalState.hl = true;
 
-    if (vimState.cursorPosition.getRight().isEqual(vimState.cursorPosition.getLineEnd())){
+    if (vimState.cursorPosition.getRight().isEqual(vimState.cursorPosition.getLineEnd())) {
       return searchState.getNextSearchMatchPosition(vimState.cursorPosition.getRight()).pos;
     }
 

--- a/src/actions/actions.ts
+++ b/src/actions/actions.ts
@@ -1673,7 +1673,7 @@ class CommandNextSearchMatch extends BaseMovement {
     if (!searchState || searchState.searchString === "") {
       return position;
     }
-
+    // Turn one of the highlighting flags back on (turned off with :nohl)
     vimState.globalState.hl = true;
 
     if (vimState.cursorPosition.getRight().isEqual(vimState.cursorPosition.getLineEnd())) {

--- a/src/actions/actions.ts
+++ b/src/actions/actions.ts
@@ -1674,8 +1674,13 @@ class CommandNextSearchMatch extends BaseMovement {
       return position;
     }
 
-    // Turn one of the highlighting flags back on (turned off with :nohl)
     vimState.globalState.hl = true;
+
+    if (vimState.cursorPosition.getRight().isEqual(vimState.cursorPosition.getLineEnd())){
+      return searchState.getNextSearchMatchPosition(vimState.cursorPosition.getRight()).pos;
+    }
+
+    // Turn one of the highlighting flags back on (turned off with :nohl)
 
     return searchState.getNextSearchMatchPosition(vimState.cursorPosition).pos;
   }

--- a/src/cmd_line/main.ts
+++ b/src/cmd_line/main.ts
@@ -13,8 +13,7 @@ export async function showCmdLine(initialText: string, modeHandler : ModeHandler
 
   const options : vscode.InputBoxOptions = {
     prompt: "Vim command line",
-    value: initialText,
-    ignoreFocusOut: true
+    value: initialText
   };
 
   try {

--- a/src/cmd_line/main.ts
+++ b/src/cmd_line/main.ts
@@ -13,7 +13,8 @@ export async function showCmdLine(initialText: string, modeHandler : ModeHandler
 
   const options : vscode.InputBoxOptions = {
     prompt: "Vim command line",
-    value: initialText
+    value: initialText,
+    ignoreFocusOut: true
   };
 
   try {

--- a/src/state/searchState.ts
+++ b/src/state/searchState.ts
@@ -48,14 +48,12 @@ export class SearchState {
 
   private _recalculateSearchRanges({ forceRecalc }: { forceRecalc?: boolean } = {}): void {
     const search = this.searchString;
-    const selection = vscode.window.activeTextEditor!.selection;
-    const lineToStartAt = Math.min(selection.start.line, selection.end.line);
-
     if (search === "") { return; }
 
     // checking if the tab that is worked on has changed, or the file version has changed
     const shouldRecalculate = (this._cachedDocumentName !== TextEditor.getDocumentName()) ||
       (this._cachedDocumentVersion !== TextEditor.getDocumentVersion()) || forceRecalc;
+
     if (shouldRecalculate) {
       // Calculate and store all matching ranges
       this._cachedDocumentVersion = TextEditor.getDocumentVersion();
@@ -90,55 +88,57 @@ export class SearchState {
         regex = new RegExp(searchRE, regexFlags);
       }
 
-      let lineIdx = lineToStartAt;
-
-      let numNewLines = (searchRE.match(/\\n/g) || []).length;
+      let text = TextEditor.getText(new vscode.Range(new Position(0 , 0),
+          new Position(TextEditor.getLineCount() - 1, TextEditor.getLineMaxColumn(TextEditor.getLineCount() - 1))));
       // Start at the current line and wrap the document if we hit the end.
+      const lineLengths = text.split("\n").map(x => x.length + 1);
+      let sumLineLengths = [];
+      let curLength = 0;
+      for (const length of lineLengths){
+        sumLineLengths.push(curLength);
+        curLength += length;
+      }
+      let binSearch = function(val: number, l: number, r: number, arr: Array<number>): Position {
+        const mid = Math.floor((l + r) / 2);
+        if (l === r - 1) {
+          return new Position(l, val - arr[mid]);
+        }
+        if (arr[mid] >= val) {
+          return binSearch(val, l, mid, arr);
+        } else {
+          return binSearch(val, mid, r, arr);
+        }
+      };
+      let startPos = sumLineLengths[this.searchCursorStartPosition.line] + this.searchCursorStartPosition.character;
+      regex.lastIndex = startPos;
+      let result = regex.exec(text);
+      let wrappedOver = false;
+
       outer:
-      do {
-        let rangeStart = new Position(lineIdx, 0);
-        let rangeEnd = rangeStart.getLineEnd();
-        let lineLengths = [];
-        for (var i = 0; i < numNewLines; i++) {
-          lineLengths.push(rangeEnd.getLineEndIncludingEOL().character);
-          rangeEnd = rangeEnd.getDown(1).getLineEndIncludingEOL();
-        }
-        const line = TextEditor.getText(new vscode.Range(rangeStart, rangeEnd));
-        let result = regex.exec(line);
-
-        while (result) {
-          if (this._matchRanges.length >= SearchState.MAX_SEARCH_RANGES) {
-            break outer;
-          }
-          let resultToPosition = function(resultIdx: number, lineIdx: number, lineLengths: Array<number>, result: RegExpExecArray){
-            let cur = resultIdx;
-            for (var idx = 0; idx < lineLengths.length; idx++) {
-              if (cur <= lineLengths[idx]) {
-                return new Position(idx + lineIdx, cur);
-              }
-              cur -= lineLengths[idx];
-            }
-            return new Position(lineLengths.length + lineIdx, cur);
-          };
-
-          this.matchRanges.push(new vscode.Range(
-            resultToPosition(result.index, lineIdx, lineLengths, result),
-            resultToPosition(result.index + result[0].length, lineIdx, lineLengths, result)
-          ));
-
-          if (result.index === regex.lastIndex) {
-            regex.lastIndex++;
-          }
-
-          result = regex.exec(line);
+      while (result && !(wrappedOver && result!.index > startPos)) {
+        if (this._matchRanges.length >= SearchState.MAX_SEARCH_RANGES) {
+          break outer;
         }
 
-        lineIdx === TextEditor.getLineCount() - 1 ? lineIdx = 0 : lineIdx++;
-      } while (lineIdx !== lineToStartAt);
+        this.matchRanges.push(new vscode.Range(
+          binSearch(result.index, 0, sumLineLengths.length, sumLineLengths),
+          binSearch(result.index + result[0].length, 0, sumLineLengths.length, sumLineLengths)
+        ));
+
+        if (result.index === regex.lastIndex) {
+          regex.lastIndex++;
+        }
+        result = regex.exec(text);
+        if (!result && !wrappedOver) {
+          regex.lastIndex = 0;
+          wrappedOver = true;
+          result = regex.exec(text);
+        }
+      }
 
       this._matchRanges.sort((x, y) =>
-        x.start.line < y.start.line ||
-        x.start.line === y.start.line && x.start.character < y.start.character ? -1 : 1);
+        (x.start.line < y.start.line) ||
+        (x.start.line === y.start.line && x.start.character < y.start.character) ? -1 : 1);
     }
   }
 

--- a/src/state/searchState.ts
+++ b/src/state/searchState.ts
@@ -87,7 +87,7 @@ export class SearchState {
         searchRE = search.replace(SearchState.specialCharactersRegex, "\\$&");
         regex = new RegExp(searchRE, regexFlags);
       }
-      let finalPos = new Position(TextEditor.getLineCount()-1, 0).getLineEndIncludingEOL();
+      const finalPos = new Position(TextEditor.getLineCount() - 1, 0).getLineEndIncludingEOL();
       const text = TextEditor.getText(new vscode.Range(new Position(0 , 0), finalPos));
       // Start at the current line and wrap the document if we hit the end.
       const lineLengths = text.split("\n").map(x => x.length + 1);
@@ -97,7 +97,7 @@ export class SearchState {
         sumLineLengths.push(curLength);
         curLength += length;
       }
-      let binSearch = (val: number, l: number, r: number, arr: Array<number>): Position => {
+      const binSearch = (val: number, l: number, r: number, arr: Array<number>): Position => {
         const mid = Math.floor((l + r) / 2);
         if (l === r - 1) {
           return new Position(l, val - arr[mid]);
@@ -115,15 +115,17 @@ export class SearchState {
       let result = regex.exec(text);
       let wrappedOver = false;
 
-      if (!result && !wrappedOver) {
-        regex.lastIndex = 0;
-        wrappedOver = true;
-        result = regex.exec(text);
-      }
-      outer:
-      while (result && !(wrappedOver && result!.index > startPos)) {
+      do {
+        if (!result && !wrappedOver) {
+          regex.lastIndex = 0;
+          wrappedOver = true;
+          result = regex.exec(text);
+        }
+        if (!result) {
+          break;
+        }
         if (this._matchRanges.length >= SearchState.MAX_SEARCH_RANGES) {
-          break outer;
+          break;
         }
 
         this.matchRanges.push(new vscode.Range(
@@ -140,7 +142,7 @@ export class SearchState {
           wrappedOver = true;
           result = regex.exec(text);
         }
-      }
+      } while (result && !(wrappedOver && result!.index > startPos));
 
       this._matchRanges.sort((x, y) =>
         (x.start.line < y.start.line) ||

--- a/test/mode/modeNormal.test.ts
+++ b/test/mode/modeNormal.test.ts
@@ -1398,7 +1398,7 @@ suite("Mode Normal", () => {
       end: ["", "one tw|o2o"]
     });
 
-    newTestOnly({
+    newTest({
       title: "/ can search with newline",
       start: ["|asdf", "__asdf", "asdf"],
       keysPressed: "/\\nasdf\n",

--- a/test/mode/modeNormal.test.ts
+++ b/test/mode/modeNormal.test.ts
@@ -1406,6 +1406,13 @@ suite("Mode Normal", () => {
     });
 
     newTest({
+      title: "/ can search through multiple newlines",
+      start: ["|asdf", "__asdf", "asdf", "abc", "   abc"],
+      keysPressed: "/\asdf\\nasdf\\nabc\n",
+      end: ["asdf", "__|asdf", "asdf", "abc", "   abc"],
+    });
+
+    newTest({
       title: "Can do C",
       start: ["export const options = {", "|", "};"],
       keysPressed: "C",

--- a/test/mode/modeNormal.test.ts
+++ b/test/mode/modeNormal.test.ts
@@ -1398,6 +1398,13 @@ suite("Mode Normal", () => {
       end: ["", "one tw|o2o"]
     });
 
+    newTestOnly({
+      title: "/ can search with newline",
+      start: ["|asdf", "__asdf", "asdf"],
+      keysPressed: "/\\nasdf\n",
+      end: ["asdf", "__asd|f", "asdf"],
+    });
+
     newTest({
       title: "Can do C",
       start: ["export const options = {", "|", "};"],


### PR DESCRIPTION
<!--
Yay! We love PRs! 🎊

Please include a description of your change and ensure:

- [ ] Commit message has a short title & issue references
- [ ] Each commit does a logical chunk of work.
- [ ] It builds and tests pass (e.g `gulp`)

More info can be found on our [contribution guide](https://github.com/VSCodeVim/Vim/blob/master/.github/CONTRIBUTING.md).
-->

Basically, the general approach is that we count how many newlines there are in their search string, and expand our search beyond line by line accordingly.

Thus, if their string contains two newline characters, then we check two lines at a time, and so on.

Accordingly, if there are no newline characters, this shouldn't affect performance at all, and performance should then degrade linearly with the amount of newlines (which makes sense).

One thing that it's missing is that Vscode doesn't seem to support highlighting the "newline" character. That makes newlines pretty invisible.

I've also added a test.

![](http://i.imgur.com/IZr9iTk.jpg)

PS: You'll notice the commit that made the command line persistent, PR #1601. I accidentally checked it out and don't know how to delete a commit in the past, so I simply reverted it and then squashed the commit. I hope that's not an issue if both PR's are merged...