### PR TITLE
Fixes #1532

### DIFF
--- a/src/mode/modeHandler.ts
+++ b/src/mode/modeHandler.ts
@@ -39,6 +39,7 @@ import { PairMatcher } from './../matching/matcher';
 import { Globals } from '../../src/globals';
 import { ReplaceState } from './../state/replaceState';
 import { GlobalState } from './../state/globalState';
+import { waitForCursorUpdatesToHappen } from './../util'
 
 export class ViewChange {
   public command: string;
@@ -515,7 +516,6 @@ export class ModeHandler implements vscode.Disposable {
     ];
     this.vimState.historyTracker = new HistoryTracker(this.vimState);
     this.vimState.easyMotion = new EasyMotion();
-
     if (Configuration.startInInsertMode) {
       this._vimState.currentMode = ModeName.Insert;
     } else {
@@ -534,13 +534,15 @@ export class ModeHandler implements vscode.Disposable {
     // position to the position that VSC set it to.
 
     // This also makes things like gd work.
-    if (this._vimState.editor) {
-      this._vimState.cursorStartPosition = Position.FromVSCodePosition(this._vimState.editor.selection.start);
-      this._vimState.cursorPosition      = Position.FromVSCodePosition(this._vimState.editor.selection.start);
-      this._vimState.desiredColumn       = this._vimState.cursorPosition.character;
+    this.updateView(this.vimState, {drawSelection: false, revealRange: false}).then(() => {
+      if (this._vimState.editor) {
+        this._vimState.cursorStartPosition = Position.FromVSCodePosition(this._vimState.editor.selection.start);
+        this._vimState.cursorPosition      = Position.FromVSCodePosition(this._vimState.editor.selection.start);
+        this._vimState.desiredColumn       = this._vimState.cursorPosition.character;
 
-      this._vimState.whatILastSetTheSelectionTo = this._vimState.editor.selection;
-    }
+        this._vimState.whatILastSetTheSelectionTo = this._vimState.editor.selection;
+      }
+    });
 
     // Handle scenarios where mouse used to change current position.
     const disposer = vscode.window.onDidChangeTextEditorSelection((e: vscode.TextEditorSelectionChangeEvent) => {

--- a/src/mode/modeHandler.ts
+++ b/src/mode/modeHandler.ts
@@ -533,7 +533,7 @@ export class ModeHandler implements vscode.Disposable {
     // position to the position that VSC set it to.
 
     // This also makes things like gd work.
-    this.updateView(this.vimState, {drawSelection: false, revealRange: false}).then(() => {
+    setTimeout(() => {
       if (this._vimState.editor) {
         this._vimState.cursorStartPosition = Position.FromVSCodePosition(this._vimState.editor.selection.start);
         this._vimState.cursorPosition      = Position.FromVSCodePosition(this._vimState.editor.selection.start);
@@ -541,7 +541,7 @@ export class ModeHandler implements vscode.Disposable {
 
         this._vimState.whatILastSetTheSelectionTo = this._vimState.editor.selection;
       }
-    });
+    }, 0);
 
     // Handle scenarios where mouse used to change current position.
     const disposer = vscode.window.onDidChangeTextEditorSelection((e: vscode.TextEditorSelectionChangeEvent) => {

--- a/src/mode/modeHandler.ts
+++ b/src/mode/modeHandler.ts
@@ -39,7 +39,6 @@ import { PairMatcher } from './../matching/matcher';
 import { Globals } from '../../src/globals';
 import { ReplaceState } from './../state/replaceState';
 import { GlobalState } from './../state/globalState';
-import { waitForCursorUpdatesToHappen } from './../util'
 
 export class ViewChange {
   public command: string;

--- a/src/mode/modeHandler.ts
+++ b/src/mode/modeHandler.ts
@@ -533,6 +533,8 @@ export class ModeHandler implements vscode.Disposable {
     // position to the position that VSC set it to.
 
     // This also makes things like gd work.
+    // For whatever reason, the editor positions aren't updated until after the
+    // stack clears, which is why this setTimeout is necessary
     setTimeout(() => {
       if (this._vimState.editor) {
         this._vimState.cursorStartPosition = Position.FromVSCodePosition(this._vimState.editor.selection.start);


### PR DESCRIPTION
<!--
Yay! We love PRs! 🎊

Please include a description of your change and ensure:

- [ ] Commit message has a short title & issue references
- [ ] Each commit does a logical chunk of work.
- [ ] It builds and tests pass (e.g `gulp`)

More info can be found on our [contribution guide](https://github.com/VSCodeVim/Vim/blob/master/.github/CONTRIBUTING.md).
-->

this._vimState.editor.selection.start doesn't get updated until we call updateView. 

Why, you ask?

No clue. But it works!

(Well, we know that updateView updates the vscode object a bunch of times, so that probably has something to do with it.)