### PR TITLE
use editor from event fixes #1607

### DIFF
--- a/src/mode/modeHandler.ts
+++ b/src/mode/modeHandler.ts
@@ -611,7 +611,7 @@ export class ModeHandler implements vscode.Disposable {
     if ((e.selections.length !== this.vimState.allCursors.length || this.vimState.isMultiCursor) &&
       this.vimState.currentMode !== ModeName.VisualBlock) {
       // Number of selections changed, make sure we know about all of them still
-      this.vimState.allCursors = vscode.window.activeTextEditor!.selections.map(x =>
+      this.vimState.allCursors = e.textEditor.selections.map(x =>
         new Range(Position.FromVSCodePosition(x.start), Position.FromVSCodePosition(x.end)));
 
       await this.updateView(this.vimState);


### PR DESCRIPTION
<!--
Yay! We love PRs! 🎊

Please include a description of your change and ensure:

- [x] Commit message has a short title & issue references
- [x] Each commit does a logical chunk of work.
- [x] It builds and tests pass (e.g `gulp`)

More info can be found on our [contribution guide](https://github.com/VSCodeVim/Vim/blob/master/.github/CONTRIBUTING.md).
-->

When there is no active editor, `handleSelectionChange` throws an error:

```
TypeError: Cannot read property 'selections' of undefined
    at ModeHandler.<anonymous> (/Users/brandoncc/.vscode/extensions/vscodevim.vim-0.6.20/out/src/mode/modeHandler.js:451:74)
    at next (<anonymous>)
    at __awaiter (/Users/brandoncc/.vscode/extensions/vscodevim.vim-0.6.20/out/src/mode/modeHandler.js:7:71)
    at __awaiter (/Users/brandoncc/.vscode/extensions/vscodevim.vim-0.6.20/out/src/mode/modeHandler.js:3:12)
```

This PR updates that function to use the editor that is attached to the event argument instead.

I did the manual testing located at https://gist.github.com/rebornix/d21d1cc060c009d4430d3904030bd4c1