### PR TITLE
Fixes 1196

### DIFF
--- a/src/motion/position.ts
+++ b/src/motion/position.ts
@@ -572,8 +572,7 @@ export class Position extends vscode.Position {
     while (TextEditor.getLineAt(pos).text !== "" && pos.line < TextEditor.getLineCount() - 1) {
      pos = pos.getDown(0);
     }
-
-    return pos.getLineEnd();
+    return pos.getLeftThroughLineBreaks();
   }
 
   /**

--- a/test/mode/modeNormal.test.ts
+++ b/test/mode/modeNormal.test.ts
@@ -212,6 +212,13 @@ suite("Mode Normal", () => {
     });
 
     newTest({
+      title: "Can handle d}",
+      start: ["|foo", "", "bar"],
+      keysPressed: "d}",
+      end: ["|", "", "bar"],
+    });
+
+    newTest({
       title: "Can handle 'cw'",
       start: ['text text tex|t'],
       keysPressed: '^lllllllcw',


### PR DESCRIPTION
<!--
Yay! We love PRs! 🎊

Please include a description of your change and ensure:

- [ ] Commit message has a short title & issue references
- [ ] Each commit does a logical chunk of work.
- [ ] It builds and tests pass (e.g `gulp`)

More info can be found on our [contribution guide](https://github.com/VSCodeVim/Vim/blob/master/.github/CONTRIBUTING.md).
-->

The getCurrentParagraphEnd() object keeps on going down until the current line is empty. At that point, we should be getting the end of the line above, not the current line. However, going leftthroughlinebreaks works just as well on an empty line.