### PR TITLE
Visualstar

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,10 @@ These settings are specific to VSCodeVim.
     }
 ```
 
+#### `"vim.visualstar"`
+* When pressing `*` or `#` in visual mode treat it as a new search
+* Type: Boolean (Default: `false`)
+
 ### Key remapping
 
 There's several different settings you can use to define custom remappings. Also related are the [`useCtrlKeys`](#vimusectrlkeys) and [`handleKeys`](#vimhandlekeys) settings.

--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ These settings are specific to VSCodeVim.
 ```
 
 #### `"vim.visualstar"`
-* When pressing `*` or `#` in visual mode treat it as a new search
+* In visual mode, start a search with * or # using the current selection
 * Type: Boolean (Default: `false`)
 
 ### Key remapping

--- a/package.json
+++ b/package.json
@@ -441,6 +441,11 @@
         "vim.statusBarColors": {
           "type": "object",
           "description": "Customize colors per mode when VSCodeVim controls status bar colors"
+        },
+        "vim.visualstar": {
+          "type": "boolean",
+          "description": "When pressing * or # in visual mode treat it as a new search",
+          "default": true
         }
       }
     }

--- a/package.json
+++ b/package.json
@@ -445,7 +445,7 @@
         "vim.visualstar": {
           "type": "boolean",
           "description": "When pressing * or # in visual mode treat it as a new search",
-          "default": true
+          "default": false
         }
       }
     }

--- a/package.json
+++ b/package.json
@@ -444,7 +444,7 @@
         },
         "vim.visualstar": {
           "type": "boolean",
-          "description": "When pressing * or # in visual mode treat it as a new search",
+          "description": "In visual mode, start a search with * or # using the current selection",
           "default": false
         }
       }

--- a/src/actions/actions.ts
+++ b/src/actions/actions.ts
@@ -1744,11 +1744,11 @@ function searchCurrentSelection (vimState: VimState, direction: SearchDirection,
 }
 
 interface IPerformSearchMovementArgs {
-  needle: string | undefined,
-  vimState: VimState,
-  direction: SearchDirection,
-  isExact: boolean,
-  searchStartCursorPosition: Position
+    needle: string | undefined;
+    vimState: VimState;
+    direction: SearchDirection;
+    isExact: boolean;
+    searchStartCursorPosition: Position;
 }
 
 function performSearchMovement(args: IPerformSearchMovementArgs) {

--- a/src/actions/actions.ts
+++ b/src/actions/actions.ts
@@ -1744,11 +1744,11 @@ function searchCurrentSelection (vimState: VimState, direction: SearchDirection,
 }
 
 interface IPerformSearchMovementArgs {
-    needle: string | undefined;
-    vimState: VimState;
-    direction: SearchDirection;
-    isExact: boolean;
-    searchStartCursorPosition: Position;
+  needle: string | undefined,
+  vimState: VimState,
+  direction: SearchDirection,
+  isExact: boolean,
+  searchStartCursorPosition: Position
 }
 
 function performSearchMovement(args: IPerformSearchMovementArgs) {

--- a/src/actions/actions.ts
+++ b/src/actions/actions.ts
@@ -1713,7 +1713,7 @@ function searchCurrentWord(position: Position, vimState: VimState, direction: Se
     return createSearchStateAndMoveToMatch(currentWord, vimState, direction, isExact, searchStartCursorPosition);
 }
 
-function searchCurrentSelection (vimState: VimState, direction: SearchDirection, isExact: boolean) {
+function searchCurrentSelection (vimState: VimState, direction: SearchDirection) {
     const selection = TextEditor.getSelection();
     const end = new Position(selection.end.line, selection.end.character + 1);
     const currentSelection = TextEditor.getText(selection.with(selection.start, end));
@@ -1761,16 +1761,12 @@ function createSearchStateAndMoveToMatch(
 
 @RegisterAction
 class CommandSearchCurrentWordExactForward extends BaseCommand {
-  modes = [ModeName.Normal, ModeName.Visual, ModeName.VisualLine];
+  modes = [ModeName.Normal];
   keys = ["*"];
   isMotion = true;
   runsOnceForEachCountPrefix = true;
 
   public async exec(position: Position, vimState: VimState): Promise<VimState> {
-    if (Configuration.visualstar && vimState.currentMode !== ModeName.Normal) {
-      return searchCurrentSelection(vimState, SearchDirection.Forward, false);
-    }
-
     return searchCurrentWord(position, vimState, SearchDirection.Forward, true);
   }
 }
@@ -1788,17 +1784,25 @@ class CommandSearchCurrentWordForward extends BaseCommand {
 }
 
 @RegisterAction
+class CommandSearchVisualForward extends BaseCommand {
+  modes = [ModeName.Visual, ModeName.VisualLine];
+  keys = ["*"];
+  isMotion = true;
+  runsOnceForEachCountPrefix = true;
+
+  public async exec(position: Position, vimState: VimState): Promise<VimState> {
+    return searchCurrentSelection(vimState, SearchDirection.Forward);
+  }
+}
+
+@RegisterAction
 class CommandSearchCurrentWordExactBackward extends BaseCommand {
-  modes = [ModeName.Normal, ModeName.Visual, ModeName.VisualLine];
+  modes = [ModeName.Normal];
   keys = ["#"];
   isMotion = true;
   runsOnceForEachCountPrefix = true;
 
   public async exec(position: Position, vimState: VimState): Promise<VimState> {
-    if (Configuration.visualstar && vimState.currentMode !== ModeName.Normal) {
-      return searchCurrentSelection(vimState, SearchDirection.Backward, false);
-    }
-
     return searchCurrentWord(position, vimState, SearchDirection.Backward, true);
   }
 }
@@ -1812,6 +1816,18 @@ class CommandSearchCurrentWordBackward extends BaseCommand {
 
   public async exec(position: Position, vimState: VimState): Promise<VimState> {
     return searchCurrentWord(position, vimState, SearchDirection.Backward, false);
+  }
+}
+
+@RegisterAction
+class CommandSearchVisualBackward extends BaseCommand {
+  modes = [ModeName.Visual, ModeName.VisualLine];
+  keys = ["#"];
+  isMotion = true;
+  runsOnceForEachCountPrefix = true;
+
+  public async exec(position: Position, vimState: VimState): Promise<VimState> {
+    return searchCurrentSelection(vimState, SearchDirection.Backward);
   }
 }
 

--- a/src/actions/actions.ts
+++ b/src/actions/actions.ts
@@ -1710,7 +1710,13 @@ function searchCurrentWord(position: Position, vimState: VimState, direction: Se
       ? vimState.cursorPosition.getWordLeft(true)
       : vimState.cursorPosition;
 
-    return performSearchMovement(currentWord, vimState, direction, isExact, searchStartCursorPosition);
+    return performSearchMovement({
+      needle: currentWord,
+      vimState,
+      direction,
+      isExact,
+      searchStartCursorPosition
+    });
 }
 
 function searchCurrentSelection (vimState: VimState, direction: SearchDirection, isExact: boolean) {
@@ -1728,29 +1734,43 @@ function searchCurrentSelection (vimState: VimState, direction: SearchDirection,
       ? vimState.lastVisualSelectionStart.getLeft()
       : vimState.lastVisualSelectionEnd.getRight();
 
-    return performSearchMovement(currentSelection, vimState, direction, isExact, searchStartCursorPosition);
+    return performSearchMovement({
+      needle: currentSelection,
+      vimState,
+      direction,
+      isExact,
+      searchStartCursorPosition
+    });
 }
 
-function performSearchMovement (needle: string | undefined, vimState: VimState, direction: SearchDirection, isExact: boolean, searchStartCursorPosition: Position) {
-    if (needle === undefined || needle === null || needle.length === 0) {
-      return vimState;
+interface IPerformSearchMovementArgs {
+  needle: string | undefined,
+  vimState: VimState,
+  direction: SearchDirection,
+  isExact: boolean,
+  searchStartCursorPosition: Position
+}
+
+function performSearchMovement(args: IPerformSearchMovementArgs) {
+    if (args.needle === undefined || args.needle === null || args.needle.length === 0) {
+      return args.vimState;
     }
 
-    const searchString = isExact
-      ? `\\b${needle}\\b`
-      : needle;
+    const searchString = args.isExact
+      ? `\\b${args.needle}\\b`
+      : args.needle;
 
     // Start a search for the given term.
-    vimState.globalState.searchState = new SearchState(
-      direction, vimState.cursorPosition, searchString, { isRegex: isExact }
+    args.vimState.globalState.searchState = new SearchState(
+      args.direction, args.vimState.cursorPosition, searchString, { isRegex: args.isExact }
     );
 
-    vimState.cursorPosition = vimState.globalState.searchState.getNextSearchMatchPosition(searchStartCursorPosition).pos;
+    args.vimState.cursorPosition = args.vimState.globalState.searchState.getNextSearchMatchPosition(args.searchStartCursorPosition).pos;
 
     // Turn one of the highlighting flags back on (turned off with :nohl)
-    vimState.globalState.hl = true;
+    args.vimState.globalState.hl = true;
 
-    return vimState;
+    return args.vimState;
 }
 
 @RegisterAction

--- a/src/actions/actions.ts
+++ b/src/actions/actions.ts
@@ -1710,7 +1710,13 @@ function searchCurrentWord(position: Position, vimState: VimState, direction: Se
       ? vimState.cursorPosition.getWordLeft(true)
       : vimState.cursorPosition;
 
-    return createSearchStateAndMoveToMatch(currentWord, vimState, direction, isExact, searchStartCursorPosition);
+    return createSearchStateAndMoveToMatch({
+      needle: currentWord,
+      vimState,
+      direction,
+      isExact,
+      searchStartCursorPosition
+    });
 }
 
 function searchCurrentSelection (vimState: VimState, direction: SearchDirection) {
@@ -1728,16 +1734,28 @@ function searchCurrentSelection (vimState: VimState, direction: SearchDirection)
       ? vimState.lastVisualSelectionStart.getLeft()
       : vimState.lastVisualSelectionEnd.getRight();
 
-    return createSearchStateAndMoveToMatch(currentSelection, vimState, direction, false, searchStartCursorPosition);
+    return createSearchStateAndMoveToMatch({
+      needle: currentSelection,
+      vimState,
+      direction,
+      isExact: false,
+      searchStartCursorPosition
+    });
 }
 
-function createSearchStateAndMoveToMatch(
-  needle: string | undefined,
+function createSearchStateAndMoveToMatch(args: {
+  needle?: string | undefined,
   vimState: VimState,
   direction: SearchDirection,
   isExact: boolean,
   searchStartCursorPosition: Position
-) {
+}) {
+    const {
+      needle,
+      vimState,
+      isExact
+    } = args;
+
     if (needle === undefined || needle.length === 0) {
       return vimState;
     }
@@ -1748,10 +1766,10 @@ function createSearchStateAndMoveToMatch(
 
     // Start a search for the given term.
     vimState.globalState.searchState = new SearchState(
-      direction, vimState.cursorPosition, searchString, { isRegex: isExact }
+      args.direction, vimState.cursorPosition, searchString, { isRegex: isExact }
     );
 
-    vimState.cursorPosition = vimState.globalState.searchState.getNextSearchMatchPosition(searchStartCursorPosition).pos;
+    vimState.cursorPosition = vimState.globalState.searchState.getNextSearchMatchPosition(args.searchStartCursorPosition).pos;
 
     // Turn one of the highlighting flags back on (turned off with :nohl)
     vimState.globalState.hl = true;

--- a/src/actions/actions.ts
+++ b/src/actions/actions.ts
@@ -1721,9 +1721,9 @@ function searchCurrentSelection (vimState: VimState, direction: SearchDirection,
     // Go back to Normal mode, otherwise the selection grows to the next match.
     vimState.currentMode = ModeName.Normal;
 
-    // If the search is going left then use `getWordLeft()` on position to start
-    // at the beginning of the word. This ensures that any matches happen
-    // outside of the currently selected word.
+    // If the search is going left then use `getLeft()` on the selection start.
+    // If going right then use `getRight()` on the selection end. This ensures
+    // that any matches happen outside of the currently selected word.
     const searchStartCursorPosition = direction === SearchDirection.Backward
       ? vimState.lastVisualSelectionStart.getLeft()
       : vimState.lastVisualSelectionEnd.getRight();

--- a/src/configuration/configuration.ts
+++ b/src/configuration/configuration.ts
@@ -285,7 +285,7 @@ class ConfigurationClass {
   boundKeyCombinations: string[] = [];
 
   /**
-   * When pressing * or # in visual mode treat it as a new search
+   * In visual mode, start a search with * or # using the current selection
    */
   visualstar = false;
 }

--- a/src/configuration/configuration.ts
+++ b/src/configuration/configuration.ts
@@ -283,6 +283,11 @@ class ConfigurationClass {
    * Array of all key combinations that were registered in angle bracket notation
    */
   boundKeyCombinations: string[] = [];
+
+  /**
+   * When pressing * or # in visual mode treat it as a new search
+   */
+  visualstar = false;
 }
 
 function overlapSetting(args: { codeName: string, default: OptionValue, codeValueMapping?: ValueMapping }) {

--- a/test/mode/modeVisual.test.ts
+++ b/test/mode/modeVisual.test.ts
@@ -6,6 +6,7 @@ import { setupWorkspace, cleanUpWorkspace, assertEqualLines, assertEqual } from 
 import { ModeName } from '../../src/mode/mode';
 import { TextEditor } from '../../src/textEditor';
 import { getTestingFunctions } from '../testSimplifier';
+import { Configuration } from "../../src/configuration/configuration";
 
 suite("Mode Visual", () => {
   let modeHandler: ModeHandler;

--- a/test/mode/modeVisual.test.ts
+++ b/test/mode/modeVisual.test.ts
@@ -741,4 +741,49 @@ suite("Mode Visual", () => {
     });
   });
 
+  suite("visualstar", () => {
+    let originalVisualstarValue = false;
+
+    setup(() => {
+      originalVisualstarValue = Configuration.visualstar;
+      Configuration.visualstar = true;
+    });
+
+    teardown(() => {
+      Configuration.visualstar = originalVisualstarValue;
+    });
+
+    newTest({
+      title: "Works with *",
+      start: [
+          '|public modes = [ModeName.Visual',
+          'public modes = [ModeName.VisualBlock',
+          'public modes = [ModeName.VisualLine',
+      ],
+      keysPressed: "2vfl*n",
+      end: [
+          'public modes = [ModeName.Visual',
+          'public modes = [ModeName.VisualBlock',
+          '|public modes = [ModeName.VisualLine',
+      ],
+      endMode: ModeName.Normal
+    });
+
+    newTest({
+      title: "Works with #",
+      start: [
+          'public modes = [ModeName.Visual',
+          'public modes = [ModeName.VisualBlock',
+          '|public modes = [ModeName.VisualLine',
+      ],
+      keysPressed: "2vfl#n",
+      end: [
+          '|public modes = [ModeName.Visual',
+          'public modes = [ModeName.VisualBlock',
+          'public modes = [ModeName.VisualLine',
+      ],
+      endMode: ModeName.Normal
+    });
+
+  });
 });

--- a/test/mode/modeVisual.test.ts
+++ b/test/mode/modeVisual.test.ts
@@ -761,6 +761,10 @@ suite("Mode Visual", () => {
           'public modes = [ModeName.VisualBlock',
           'public modes = [ModeName.VisualLine',
       ],
+      // This is doing a few things:
+      // - select to the end of "Visual"
+      // - press "*", the cursor will go to the next line since it matches
+      // - press "n", the cursor will go to the last line since it matches
       keysPressed: "2vfl*n",
       end: [
           'public modes = [ModeName.Visual',
@@ -777,6 +781,10 @@ suite("Mode Visual", () => {
           'public modes = [ModeName.VisualBlock',
           '|public modes = [ModeName.VisualLine',
       ],
+      // This is doing a few things:
+      // - select to the end of "Visual"
+      // - press "#", the cursor will go to the previous line since it matches
+      // - press "n", the cursor will go to the first line since it matches
       keysPressed: "2vfl#n",
       end: [
           '|public modes = [ModeName.Visual',

--- a/tslint.json
+++ b/tslint.json
@@ -37,7 +37,6 @@
       "trace"
     ],
     "no-construct": true,
-    "no-parameter-properties": true,
     "no-debugger": true,
     "no-duplicate-variable": true,
     "no-empty": true,

--- a/tslint.json
+++ b/tslint.json
@@ -37,6 +37,7 @@
       "trace"
     ],
     "no-construct": true,
+    "no-parameter-properties": true,
     "no-debugger": true,
     "no-duplicate-variable": true,
     "no-empty": true,


### PR DESCRIPTION
The default behaviour of `*` and `#` isn't really intuitive, and Vim itself has [many plugins to handle this](https://www.google.com/search?q=vim+visual+star).

This PR adds a new option to treat `*` and `#` as a new search when pressed in visual mode.