### PR TITLE
Fixes #1588

### DIFF
--- a/src/motion/position.ts
+++ b/src/motion/position.ts
@@ -264,6 +264,7 @@ export class Position extends vscode.Position {
     }
   }
 
+  // Iterates through words on the same line, starting from the current position.
   public static *IterateWords(start: Position): Iterable<{ start: Position, end: Position, word: string }> {
     const text = TextEditor.getLineAt(start).text;
     let wordEnd = start.getCurrentWordEnd(true);
@@ -279,7 +280,7 @@ export class Position extends vscode.Position {
         return;
       }
       start = start.getWordRight();
-      wordEnd = start.getCurrentWordEnd();
+      wordEnd = start.getCurrentWordEnd(true);
     } while (true);
   }
 

--- a/src/motion/position.ts
+++ b/src/motion/position.ts
@@ -275,7 +275,7 @@ export class Position extends vscode.Position {
         word: word,
       };
 
-      if (wordEnd.isLineEnd()) {
+      if (wordEnd.getRight().isLineEnd()) {
         return;
       }
       start = start.getWordRight();

--- a/test/mode/modeNormal.test.ts
+++ b/test/mode/modeNormal.test.ts
@@ -1379,6 +1379,13 @@ suite("Mode Normal", () => {
     });
 
     newTest({
+      title: "can ctrl-a properly on multiple lines",
+      start: ["id: 1|,", "someOtherId: 1"],
+      keysPressed: "<C-a>",
+      end: ["id: 1|,",  "someOtherId: 1"]
+    });
+
+    newTest({
       title: "can do Y",
       start: ["|blah blah"],
       keysPressed: "Yp",


### PR DESCRIPTION
<!--
Yay! We love PRs! 🎊

Please include a description of your change and ensure:

- [ ] Commit message has a short title & issue references
- [ ] Each commit does a logical chunk of work.
- [ ] It builds and tests pass (e.g `gulp`)

More info can be found on our [contribution guide](https://github.com/VSCodeVim/Vim/blob/master/.github/CONTRIBUTING.md).
-->

Comes from a bug in the IterateWords helper function used. The function should stop at the end of the line, but since wordEnd() isn't at lineEnd(), it continues onto the next line and takes characters from there.

Fixes another small bug as well. Namely, 
```
|-5
abcd
```
does not do right things.