### PR TITLE
Fixes #1196, #1197: d}/y} not working correctly

### DIFF
--- a/src/actions/motion.ts
+++ b/src/actions/motion.ts
@@ -133,6 +133,8 @@ export abstract class BaseMovement extends BaseAction {
         } else {
           position = temporaryResult.stop.getRightThroughLineBreaks();
         }
+
+        result.registerMode = temporaryResult.registerMode;
       }
     }
 
@@ -1000,8 +1002,14 @@ class MoveNextSentenceBegin extends BaseMovement {
 class MoveParagraphEnd extends BaseMovement {
   keys = ["}"];
 
-  public async execAction(position: Position, vimState: VimState): Promise<Position> {
-    return position.getCurrentParagraphEnd();
+  public async execAction(position: Position, vimState: VimState): Promise<IMovement> {
+    const isLineWise = position.isLineBeginning() && vimState.currentMode === ModeName.Normal && vimState.recordedState.operator;
+    let paragraphEnd = position.getCurrentParagraphEnd();
+    return {
+      start: position,
+      stop: (isLineWise ? paragraphEnd.getLeftThroughLineBreaks(true) : paragraphEnd),
+      registerMode: isLineWise ? RegisterMode.LineWise : RegisterMode.FigureItOutFromCurrentMode
+    };
   }
 }
 
@@ -1302,10 +1310,8 @@ export abstract class MoveInsideCharacter extends BaseMovement {
 
     // If the closing character is the first on the line, don't swallow it.
     if (!this.includeSurrounding) {
-      if (endPos.character === 0 && vimState.currentMode !== ModeName.Visual) {
-        endPos = endPos.getLeftThroughLineBreaks();
-      } else if (endPos.getLeft().isInLeadingWhitespace()) {
-        endPos = endPos.getPreviousLineBegin().getLineEnd();
+      if (endPos.getLeft().isInLeadingWhitespace()) {
+        endPos = endPos.getLineBegin();
       }
     }
 

--- a/src/actions/operator.ts
+++ b/src/actions/operator.ts
@@ -428,7 +428,7 @@ export class ChangeOperator extends BaseOperator {
     state.currentMode = ModeName.Insert;
 
     if (isEndOfLine) {
-      state.cursorPosition = state.cursorPosition.getRight();
+      state.cursorPosition = state.getRight();
     }
 
     return state;

--- a/src/actions/textobject.ts
+++ b/src/actions/textobject.ts
@@ -454,12 +454,21 @@ abstract class IndentObjectMatch extends TextObjectMovement {
     // TextEditor.getLineMaxColumn throws when given line 0, which we don't
     // care about here since it just means this text object wouldn't work on a
     // single-line document.
-    const endCharacter = TextEditor.readLineAt(endLineNumber).length;
-
+    let endCharacter;
+    if (endLineNumber === TextEditor.getLineCount() - 1 || vimState.currentMode === ModeName.Visual) {
+      endCharacter = TextEditor.getLineMaxColumn(endLineNumber);
+    } else {
+      endCharacter = 0;
+      endLineNumber++;
+    }
     return {
       start: new Position(startLineNumber, startCharacter),
       stop: new Position(endLineNumber, endCharacter),
     };
+  }
+
+  public async execActionForOperator(position: Position, vimState: VimState): Promise<IMovement> {
+    return await this.execAction(position, vimState);
   }
 
   /**

--- a/src/mode/modeHandler.ts
+++ b/src/mode/modeHandler.ts
@@ -1209,16 +1209,7 @@ export class ModeHandler implements vscode.Disposable {
     vimState.recordedState.count = 0;
 
     // Keep the cursor within bounds
-
-    if (vimState.currentMode === ModeName.Normal && !recordedState.operator) {
-      for (const { stop, i } of Range.IterateRanges(vimState.allCursors)) {
-        if (stop.character >= Position.getLineLength(stop.line)) {
-          vimState.allCursors[i].withNewStop(
-            stop.getLineEnd().getLeft()
-          );
-        }
-      }
-    } else {
+    if (vimState.currentMode !== ModeName.Normal || recordedState.operator) {
       let stop = vimState.cursorPosition;
 
       // Vim does this weird thing where it allows you to select and delete
@@ -1258,12 +1249,8 @@ export class ModeHandler implements vscode.Disposable {
       }
 
       if (!cachedMode.isVisualMode && cachedRegister !== RegisterMode.LineWise) {
-        if (Position.EarlierOf(start, stop) === start) {
-          stop = stop.getLeft();
-        } else {
-          stop = stop.getRight();
-        }
-      }
+        stop = stop.getLeftThroughLineBreaks(true);
+     }
 
       if (this.currentModeName === ModeName.VisualLine) {
         start = start.getLineBegin();

--- a/test/mode/modeNormal.test.ts
+++ b/test/mode/modeNormal.test.ts
@@ -863,6 +863,22 @@ suite("Mode Normal", () => {
     });
 
     newTest({
+      title: "Can handle d}",
+      start: ['|foo', 'bar', '', 'fun'],
+      keysPressed: 'd}',
+      end: ['|', 'fun'],
+      endMode: ModeName.Normal
+    });
+
+    newTest({
+      title: "Can handle y} at beginning of line",
+      start: ['|foo', 'bar', '', 'fun'],
+      keysPressed: 'y}p',
+      end: ['foo', '|foo', 'bar', 'bar', '', 'fun'],
+      endMode: ModeName.Normal
+    });
+
+    newTest({
       title: "Select sentence with trailing spaces",
       start: ["That's my sec|ret, Captain. I'm always angry."],
       keysPressed: 'das',

--- a/test/mode/modeNormal.test.ts
+++ b/test/mode/modeNormal.test.ts
@@ -1654,8 +1654,7 @@ suite("Mode Normal", () => {
       ],
       keysPressed: "dai",
       end: [
-          '|',
-          'do_something_else()',
+          '|do_something_else()',
       ],
       endMode: ModeName.Normal
     });


### PR DESCRIPTION
<!--
Yay! We love PRs! 🎊

Please include a description of your change and ensure:

- [ ] Commit message has a short title & issue references
- [ ] Each commit does a logical chunk of work.
- [ ] It builds and tests pass (e.g `gulp`)

More info can be found on our [contribution guide](https://github.com/VSCodeVim/Vim/blob/master/.github/CONTRIBUTING.md).
-->

This fixes #1196, which was a lot harder than it seemed. I also refactored a tiny part of modeHandler that made it very difficult/impossible to fix this.

I also fixed #1197 

However, the fix also actually broke a test, but I think it actually broke the test so it actually has correct behavior now! I've committed the test I changed as well.
