### PR TITLE
Fixes #1137

### DIFF
--- a/src/actions/actions.ts
+++ b/src/actions/actions.ts
@@ -1058,7 +1058,7 @@ class CommandCtrlW extends BaseCommand {
     let wordBegin;
     if (position.isInLeadingWhitespace()) {
       wordBegin = position.getLineBegin();
-    } else if (position.isLineBeginning()){
+    } else if (position.isLineBeginning()) {
       wordBegin = position.getPreviousLineBegin().getLineEnd();
     } else {
       wordBegin = position.getWordLeft();
@@ -5908,7 +5908,7 @@ abstract class MoveInsideCharacter extends BaseMovement {
     if (!this.includeSurrounding) {
       if (endPos.character === 0 && vimState.currentMode !== ModeName.Visual) {
         endPos = endPos.getLeftThroughLineBreaks();
-      } else if (/^\s+$/.test(TextEditor.getText(new vscode.Range(endPos.getLineBegin(), endPos.getLeft())))) {
+      } else if (endPos.getLeft().isInLeadingWhitespace()) {
         endPos = endPos.getPreviousLineBegin().getLineEnd();
       }
     }

--- a/src/actions/actions.ts
+++ b/src/actions/actions.ts
@@ -1055,7 +1055,15 @@ class CommandCtrlW extends BaseCommand {
   keys = ["<C-w>"];
 
   public async exec(position: Position, vimState: VimState): Promise<VimState> {
-    const wordBegin = position.getWordLeft();
+    let wordBegin;
+    if (position.isInLeadingWhitespace()) {
+      wordBegin = position.getLineBegin();
+    } else if (position.isLineBeginning()){
+      wordBegin = position.getPreviousLineBegin().getLineEnd();
+    } else {
+      wordBegin = position.getWordLeft();
+    }
+
     await TextEditor.delete(new vscode.Range(wordBegin, position));
 
     vimState.cursorPosition = wordBegin;

--- a/src/motion/position.ts
+++ b/src/motion/position.ts
@@ -745,6 +745,18 @@ export class Position extends vscode.Position {
     return this.line === TextEditor.getLineCount() - 1 && this.isLineEnd();
   }
 
+  /**
+   * Returns whether the current position is in the leading whitespace of a line
+   * @param allowEmpty : Use true if "" is valid
+   */
+  public isInLeadingWhitespace(allowEmpty: boolean = false): boolean {
+    if (allowEmpty){
+      return /^\s+$/.test(TextEditor.getText(new vscode.Range(this.getLineBegin(), this)));
+    } else{
+      return /^\s+$/.test(TextEditor.getText(new vscode.Range(this.getLineBegin(), this)));
+    }
+  }
+
   public static getFirstNonBlankCharAtLine(line: number): number {
     return TextEditor.readLineAt(line).match(/^\s*/)![0].length;
   }

--- a/src/motion/position.ts
+++ b/src/motion/position.ts
@@ -750,9 +750,9 @@ export class Position extends vscode.Position {
    * @param allowEmpty : Use true if "" is valid
    */
   public isInLeadingWhitespace(allowEmpty: boolean = false): boolean {
-    if (allowEmpty){
-      return /^\s+$/.test(TextEditor.getText(new vscode.Range(this.getLineBegin(), this)));
-    } else{
+    if (allowEmpty) {
+      return /^\s*$/.test(TextEditor.getText(new vscode.Range(this.getLineBegin(), this)));
+    } else {
       return /^\s+$/.test(TextEditor.getText(new vscode.Range(this.getLineBegin(), this)));
     }
   }

--- a/test/mode/modeInsert.test.ts
+++ b/test/mode/modeInsert.test.ts
@@ -151,6 +151,20 @@ suite("Mode Insert", () => {
         assertEqualLines(["text "]);
     });
 
+    newTest({
+      title: "Can handle <C-w> on leading whitespace",
+      start: ['foo', '  |bar'],
+      keysPressed: 'i<C-w>',
+      end: ['foo', '|bar']
+    });
+
+    newTest({
+      title: "Can handle <C-w> at beginning of line",
+      start: ['foo', '|bar'],
+      keysPressed: 'i<C-w>',
+      end: ['foo|bar']
+    });
+
     test("Correctly places the cursor after deleting the previous line break", async() => {
         await modeHandler.handleMultipleKeyEvents([
             'i',


### PR DESCRIPTION
<!--
Yay! We love PRs! 🎊

Please include a description of your change and ensure:

- [ ] Commit message has a short title & issue references
- [ ] Each commit does a logical chunk of work.
- [ ] It builds and tests pass (e.g `gulp`)

More info can be found on our [contribution guide](https://github.com/VSCodeVim/Vim/blob/master/.github/CONTRIBUTING.md).
-->

I was really really hoping we could reuse code from 'diw' or something like that, but basically, this is the behavior we want from <C-w>.

Get the closest to you of either the beginning of the line or the beginning of the first word to the left of your current position (including your current word if you're on a word), or a newline.

It doesn't really fit well into how we're handling word boundaries anywhere else.

I also added a position utility function to determine whether the current position is in leading whitespace of a line.

Speaking of which, we really need to explain what some of our utility functions do. A lot of them are pretty self explanatory, but one that keeps tripping me up is `position.getLastWordEnd()`

Failed tests are not this PR's issue (pretty sure).