### PR TITLE
Fixes #1441: Ctrl-c dropping a character when selecting from right to left in insert mode

### DIFF
--- a/src/actions/actions.ts
+++ b/src/actions/actions.ts
@@ -1639,10 +1639,11 @@ class CommandOverrideCopy extends BaseCommand {
 
         // Insert selecting from the left to the right is a special case that
         // selects one more on the right.
-        if (vimState.currentMode === ModeName.Insert && start.isEqual(range.start)) {
-          return vimState.editor.document.getText(new vscode.Range(start, stop));
-        } else {
+        // The order of the if statements is to check for the case where start=stop
+        if (vimState.currentMode !== ModeName.Insert || start.isEqual(range.stop)) {
           return vimState.editor.document.getText(new vscode.Range(start, stop.getRight()));
+        } else {
+          return vimState.editor.document.getText(new vscode.Range(start, stop));
         }
       }).join("\n");
     } else if (vimState.currentMode === ModeName.VisualLine) {

--- a/src/actions/actions.ts
+++ b/src/actions/actions.ts
@@ -1637,12 +1637,13 @@ class CommandOverrideCopy extends BaseCommand {
         const start = Position.EarlierOf(range.start, range.stop);
         const stop  = Position.LaterOf(range.start, range.stop);
 
-        return vimState.editor.document.getText(new vscode.Range(
-          start,
-          vimState.currentMode === ModeName.Insert ?
-            stop :
-            stop.getRight()
-        ));
+        // Insert selecting from the left to the right is a special case that
+        // selects one more on the right.
+        if (vimState.currentMode === ModeName.Insert && start.isEqual(range.start)) {
+          return vimState.editor.document.getText(new vscode.Range(start, stop));
+        } else {
+          return vimState.editor.document.getText(new vscode.Range(start, stop.getRight()));
+        }
       }).join("\n");
     } else if (vimState.currentMode === ModeName.VisualLine) {
       text = vimState.allCursors.map(range => {


### PR DESCRIPTION
<!--
Yay! We love PRs! 🎊

Please include a description of your change and ensure:

- [ ] Commit message has a short title & issue references
- [ ] Each commit does a logical chunk of work.
- [ ] It builds and tests pass (e.g `gulp`)

More info can be found on our [contribution guide](https://github.com/VSCodeVim/Vim/blob/master/.github/CONTRIBUTING.md).
-->

In insert mode, selecting from left to right results in one more character being selected, so our old workaround was to shift the end of the selection to the left if we're in insert mode. 

So this is how the cursor selections look when we're in "<copy>".
In Normal mode dragging from left to right or right to left,
"|fooba|r"
In Insert mode dragging from left to right,
"|foobar|"
In Insert mode dragging from right to left,
"|fooba|r"

Thus, it works normally if we're selecting from right to left.

Also fixes #1355 


