### PR TITLE
Fixes #1503: Undo history isn't kept when switching tabs

### DIFF
--- a/extension.ts
+++ b/extension.ts
@@ -73,27 +73,23 @@ let modeHandlerToEditorIdentity: { [key: string]: ModeHandler } = {};
 let previousActiveEditorId: EditorIdentity = new EditorIdentity();
 
 export async function getAndUpdateModeHandler(): Promise<ModeHandler> {
-  const oldHandler = modeHandlerToEditorIdentity[previousActiveEditorId.toString()];
+  const prevHandler = modeHandlerToEditorIdentity[previousActiveEditorId.toString()];
   const activeEditorId = new EditorIdentity(vscode.window.activeTextEditor);
 
-  const oldModeHandler = modeHandlerToEditorIdentity[activeEditorId.toString()];
-
-  if (!oldModeHandler ||
-      oldModeHandler.vimState.editor !== vscode.window.activeTextEditor) {
-
+  let curHandler = modeHandlerToEditorIdentity[activeEditorId.toString()];
+  if (!curHandler) {
     const newModeHandler = new ModeHandler();
 
     modeHandlerToEditorIdentity[activeEditorId.toString()] = newModeHandler;
-    extensionContext.subscriptions.push(newModeHandler);
-
-    if (oldModeHandler) {
-      oldModeHandler.dispose();
-    }
+    curHandler = newModeHandler;
   }
 
-  const handler = modeHandlerToEditorIdentity[activeEditorId.toString()];
-
-  handler.vimState.editor = vscode.window.activeTextEditor!;
+  curHandler.vimState.editor = vscode.window.activeTextEditor!;
+  if (!prevHandler || curHandler.identity !== prevHandler.identity) {
+    setTimeout(() => {
+      curHandler.syncCursors();
+    }, 0);
+  }
 
   if (previousActiveEditorId.hasSameBuffer(activeEditorId)) {
     if (!previousActiveEditorId.isEqual(activeEditorId)) {
@@ -103,32 +99,32 @@ export async function getAndUpdateModeHandler(): Promise<ModeHandler> {
   } else {
     previousActiveEditorId = activeEditorId;
 
-    await handler.updateView(handler.vimState, {drawSelection: false, revealRange: false});
+    await curHandler.updateView(curHandler.vimState, {drawSelection: false, revealRange: false});
   }
 
-  if (oldHandler && oldHandler.vimState.focusChanged) {
-    oldHandler.vimState.focusChanged = false;
-    handler.vimState.focusChanged = true;
+  if (prevHandler && curHandler.vimState.focusChanged) {
+    curHandler.vimState.focusChanged = false;
+    prevHandler.vimState.focusChanged = true;
   }
 
-  vscode.commands.executeCommand('setContext', 'vim.mode', handler.vimState.currentModeName());
+  vscode.commands.executeCommand('setContext', 'vim.mode', curHandler.vimState.currentModeName());
 
   // Temporary workaround for vscode bug not changing cursor style properly
   // https://github.com/Microsoft/vscode/issues/17472
   // https://github.com/Microsoft/vscode/issues/17513
-  const options = handler.vimState.editor.options;
+  const options = curHandler.vimState.editor.options;
   const desiredStyle = options.cursorStyle;
 
   // Temporarily change to any other cursor style besides the desired type, then change back
   if (desiredStyle === vscode.TextEditorCursorStyle.Block) {
-    handler.vimState.editor.options.cursorStyle = vscode.TextEditorCursorStyle.Line;
-    handler.vimState.editor.options.cursorStyle = desiredStyle;
+    curHandler.vimState.editor.options.cursorStyle = vscode.TextEditorCursorStyle.Line;
+    curHandler.vimState.editor.options.cursorStyle = desiredStyle;
   } else {
-    handler.vimState.editor.options.cursorStyle = vscode.TextEditorCursorStyle.Block;
-    handler.vimState.editor.options.cursorStyle = desiredStyle;
+    curHandler.vimState.editor.options.cursorStyle = vscode.TextEditorCursorStyle.Block;
+    curHandler.vimState.editor.options.cursorStyle = desiredStyle;
   }
 
-  return handler;
+  return curHandler;
 }
 
 class CompositionState {

--- a/extension.ts
+++ b/extension.ts
@@ -81,6 +81,8 @@ export async function getAndUpdateModeHandler(): Promise<ModeHandler> {
     const newModeHandler = new ModeHandler();
 
     modeHandlerToEditorIdentity[activeEditorId.toString()] = newModeHandler;
+    extensionContext.subscriptions.push(newModeHandler);
+
     curHandler = newModeHandler;
   }
 

--- a/src/mode/modeHandler.ts
+++ b/src/mode/modeHandler.ts
@@ -536,13 +536,7 @@ export class ModeHandler implements vscode.Disposable {
     // For whatever reason, the editor positions aren't updated until after the
     // stack clears, which is why this setTimeout is necessary
     setTimeout(() => {
-      if (this._vimState.editor) {
-        this._vimState.cursorStartPosition = Position.FromVSCodePosition(this._vimState.editor.selection.start);
-        this._vimState.cursorPosition      = Position.FromVSCodePosition(this._vimState.editor.selection.start);
-        this._vimState.desiredColumn       = this._vimState.cursorPosition.character;
-
-        this._vimState.whatILastSetTheSelectionTo = this._vimState.editor.selection;
-      }
+      this.syncCursors();
     }, 0);
 
     // Handle scenarios where mouse used to change current position.
@@ -1930,5 +1924,16 @@ export class ModeHandler implements vscode.Disposable {
     for (const disposable of this._toBeDisposed) {
       disposable.dispose();
     }
+  }
+
+  // Syncs cursors between vscode representation and vim representation
+  syncCursors() {
+      if (this._vimState.editor) {
+        this._vimState.cursorStartPosition = Position.FromVSCodePosition(this._vimState.editor.selection.start);
+        this._vimState.cursorPosition      = Position.FromVSCodePosition(this._vimState.editor.selection.start);
+        this._vimState.desiredColumn       = this._vimState.cursorPosition.character;
+
+        this._vimState.whatILastSetTheSelectionTo = this._vimState.editor.selection;
+      }
   }
 }


### PR DESCRIPTION
<!--
Yay! We love PRs! 🎊

Please include a description of your change and ensure:

- [ ] Commit message has a short title & issue references
- [ ] Each commit does a logical chunk of work.
- [ ] It builds and tests pass (e.g `gulp`)

More info can be found on our [contribution guide](https://github.com/VSCodeVim/Vim/blob/master/.github/CONTRIBUTING.md).
-->

It seems that whenever we switch editors, we don't have access to cursorPosition until after the stack clears?

Whatever it is, it's similar to this PR: https://github.com/VSCodeVim/Vim/pull/1605
