### PR TITLE
Fixes #1535, #1467, #1311: D-d doesn't work in insert mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
       {
         "key": "ctrl+d",
         "command": "extension.vim_ctrl+d",
-        "when": "editorTextFocus && vim.active && vim.use<C-d> && !inDebugRepl"
+        "when": "editorTextFocus && vim.active && !inDebugRepl"
       },
       {
         "key": "ctrl+alt+down",

--- a/src/mode/modeHandler.ts
+++ b/src/mode/modeHandler.ts
@@ -771,7 +771,9 @@ export class ModeHandler implements vscode.Disposable {
         key = "<copy>";
       }
     }
-
+    if (key === "<C-d>" && !Configuration.useCtrlKeys) {
+      key = "<D-d>";
+    }
     this._vimState.cursorPositionJustBeforeAnythingHappened = this._vimState.allCursors.map(x => x.stop);
     this._vimState.recordedState.commandList.push(key);
 


### PR DESCRIPTION
<!--
Yay! We love PRs! 🎊

Please include a description of your change and ensure:

- [ ] Commit message has a short title & issue references
- [ ] Each commit does a logical chunk of work.
- [ ] It builds and tests pass (e.g `gulp`)

More info can be found on our [contribution guide](https://github.com/VSCodeVim/Vim/blob/master/.github/CONTRIBUTING.md).
-->
It's not really idiomatic, but I don't really see a way around it.

One thing I'd like to add before we merge is a rebinding of C-d to D-d. 

Also fixes #1467 and fixes #1311.