### PR TITLE
Join HTML on single line to prevent extraneous <br>s

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,22 +1,6 @@
-<h1 align="center">
-    <img src="https://raw.githubusercontent.com/VSCodeVim/Vim/master/images/icon.png" height="128">
-    <br>
-    VSCodeVim
-</h1>
-
+<h1 align="center"><img src="./images/icon.png" height="128"><br>VSCodeVim</h1>
 <p align="center"><strong>Vim emulation for Visual Studio Code.</strong></p>
-<p align="center">
-    <a href="http://aka.ms/vscodevim">
-        <img src="http://vsmarketplacebadge.apphb.com/version/vscodevim.vim.svg" alt="Version">
-    </a>
-    <a href="https://travis-ci.org/VSCodeVim/Vim.svg?branch=master">
-        <img src="https://travis-ci.org/VSCodeVim/Vim.svg?branch=master" alt="Build Status">
-    </a>
-    <a href="https://vscodevim-slackin.azurewebsites.net">
-        <img src="https://vscodevim-slackin.azurewebsites.net/badge.svg" alt="Slack Status">
-    </a>
-</p>
-
+<p align="center"><a href="http://aka.ms/vscodevim"><img src="http://vsmarketplacebadge.apphb.com/version/vscodevim.vim.svg" alt="Version"></a><a href="https://travis-ci.org/VSCodeVim/Vim.svg?branch=master"><img src="https://travis-ci.org/VSCodeVim/Vim.svg?branch=master" alt="Build Status"></a><a href="https://vscodevim-slackin.azurewebsites.net"><img src="https://vscodevim-slackin.azurewebsites.net/badge.svg" alt="Slack Status"></a></p>
 <hr>
 
 VSCodeVim is a [Visual Studio Code](https://code.visualstudio.com/) extension that enables Vim keybindings, including:


### PR DESCRIPTION
It would appear that the marketplace website (https://marketplace.visualstudio.com/items?itemName=vscodevim.vim)
is converting line-breaks in the HTML source into <br> tags, creating heaps of ugly whitespace.
This is a test to see if we remove most of the line-breaks that it'll clean all the extra whitespace.
