### PR TITLE
Fixes #792: Selecting range before Ex-commands highlights initial text

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "url": "https://github.com/VSCodeVim/Vim/issues"
   },
   "engines": {
-    "vscode": "^1.11.0"
+    "vscode": "^1.12.0"
   },
   "categories": [
     "Other",

--- a/src/cmd_line/main.ts
+++ b/src/cmd_line/main.ts
@@ -14,7 +14,8 @@ export async function showCmdLine(initialText: string, modeHandler : ModeHandler
   const options : vscode.InputBoxOptions = {
     prompt: "Vim command line",
     value: initialText,
-    ignoreFocusOut: true
+    ignoreFocusOut: true,
+    valueSelection: [initialText.length, initialText.length]
   };
 
   try {


### PR DESCRIPTION
<!--
Yay! We love PRs! 🎊

Please include a description of your change and ensure:

- [ ] Commit message has a short title & issue references
- [ ] Each commit does a logical chunk of work.
- [ ] It builds and tests pass (e.g `gulp`)

More info can be found on our [contribution guide](https://github.com/VSCodeVim/Vim/blob/master/.github/CONTRIBUTING.md).
-->

Bumps required version of VSCode to 1.12 though.