### PR TITLE
Add :close support based on :quit

### DIFF
--- a/src/cmd_line/commands/close.ts
+++ b/src/cmd_line/commands/close.ts
@@ -1,0 +1,45 @@
+"use strict";
+
+import * as vscode from "vscode";
+import * as node from "../node";
+import * as error from '../../error';
+
+export interface ICloseCommandArguments extends node.ICommandArgs {
+  bang?: boolean;
+  range?: node.LineRange;
+  quitAll?: boolean;
+}
+
+//
+//  Implements :close
+//  http://vimdoc.sourceforge.net/htmldoc/windows.html#:close
+//
+export class CloseCommand extends node.CommandBase {
+  protected _arguments : ICloseCommandArguments;
+
+  constructor(args : ICloseCommandArguments) {
+    super();
+    this._name = 'close';
+    this._arguments = args;
+  }
+
+  get arguments() : ICloseCommandArguments {
+    return this._arguments;
+  }
+
+  async execute() : Promise<void> {
+    if (this.activeTextEditor!.document.isDirty && !this.arguments.bang) {
+      throw error.VimError.fromCode(error.ErrorCode.E37);
+    }
+
+    if (vscode.window.visibleTextEditors.length === 1) {
+      throw error.VimError.fromCode(error.ErrorCode.E444);
+    }
+
+    let oldViewColumn = this.activeTextEditor!.viewColumn;
+    await vscode.commands.executeCommand('workbench.action.closeActiveEditor');
+
+    if (vscode.window.activeTextEditor !== undefined && vscode.window.activeTextEditor.viewColumn === oldViewColumn) {
+      await vscode.commands.executeCommand('workbench.action.previousEditor');
+    }
+  }}

--- a/src/cmd_line/subparser.ts
+++ b/src/cmd_line/subparser.ts
@@ -14,6 +14,7 @@ import { parseReadCommandArgs } from './subparsers/read';
 import { parseRegisterCommandArgs } from './subparsers/register';
 import { parseDeleteRangeLinesCommandArgs } from './subparsers/deleteRange';
 import { parseSortCommandArgs } from './subparsers/sort';
+import { parseCloseCommandArgs } from './subparsers/close';
 
 // maps command names to parsers for said commands.
 export const commandParsers = {
@@ -26,6 +27,9 @@ export const commandParsers = {
   nohlsearch: parseNohlCommandArgs,
   noh: parseNohlCommandArgs,
   nohl: parseNohlCommandArgs,
+
+  close: parseCloseCommandArgs,
+  clo: parseCloseCommandArgs,
 
   quit: parseQuitCommandArgs,
   q: parseQuitCommandArgs,

--- a/src/cmd_line/subparsers/close.ts
+++ b/src/cmd_line/subparsers/close.ts
@@ -1,0 +1,25 @@
+"use strict";
+
+import * as node from "../commands/close";
+import {Scanner} from '../scanner';
+import {VimError, ErrorCode} from '../../error';
+
+export function parseCloseCommandArgs(args : string) : node.CloseCommand {
+  if (!args) {
+    return new node.CloseCommand({});
+  }
+  var scannedArgs : node.ICloseCommandArguments = {};
+  var scanner = new Scanner(args);
+  const c = scanner.next();
+  if (c === '!') {
+    scannedArgs.bang = true;
+    scanner.ignore();
+  } else if (c !== ' ') {
+    throw VimError.fromCode(ErrorCode.E488);
+  }
+  scanner.skipWhiteSpace();
+  if (!scanner.isAtEof) {
+    throw VimError.fromCode(ErrorCode.E488);
+  }
+  return new node.CloseCommand(scannedArgs);
+}

--- a/src/error.ts
+++ b/src/error.ts
@@ -11,6 +11,7 @@ export enum ErrorCode {
   E32 = 32,
   E208 = 208,
   E348 = 348,
+  E444 = 444,
   E488 = 488
 }
 
@@ -19,6 +20,7 @@ const errors : IVimErrors = {
   37: "No write since last change (add ! to override)",
   208: "Error writing to file",
   348: "No string under cursor",
+  444: "Cannot close last window",
   488: "Trailing characters"
 };
 

--- a/test/cmd_line/subparser.close.test.ts
+++ b/test/cmd_line/subparser.close.test.ts
@@ -1,0 +1,46 @@
+"use strict";
+
+// The module 'assert' provides assertion methods from node
+import * as assert from 'assert';
+
+import {commandParsers} from '../../src/cmd_line/subparser';
+
+suite(":close args parser", () => {
+
+  test("has all aliases", () => {
+     assert.equal(commandParsers.close.name, commandParsers.clo.name);
+  });
+
+  test("can parse empty args", () => {
+    var args = commandParsers.close("");
+    assert.equal(args.arguments.bang, undefined);
+    assert.equal(args.arguments.range, undefined);
+  });
+
+  test("ignores trailing white space", () => {
+    var args = commandParsers.close("  ");
+    assert.equal(args.arguments.bang, undefined);
+    assert.equal(args.arguments.range, undefined);
+  });
+
+  test("can parse !", () => {
+    var args = commandParsers.close("!");
+    assert.ok(args.arguments.bang);
+    assert.equal(args.arguments.range, undefined);
+  });
+
+  test("throws if space before !", () => {
+    assert.throws(() => commandParsers.close(" !"));
+  });
+
+  test("ignores space after !", () => {
+
+    var args = commandParsers.close("! ");
+    assert.equal(args.arguments.bang, true);
+    assert.equal(args.arguments.range, undefined);
+  });
+
+  test("throws if bad input", () => {
+    assert.throws(() => commandParsers.close("x"));
+  });
+});

--- a/test/error.test.ts
+++ b/test/error.test.ts
@@ -9,6 +9,7 @@ suite("ErrorCode", () => {
     assert.equal(ErrorCode.E37, 37);
     assert.equal(ErrorCode.E208, 208);
     assert.equal(ErrorCode.E348, 348);
+    assert.equal(ErrorCode.E444, 444);
     assert.equal(ErrorCode.E488, 488);
   });
 });
@@ -28,6 +29,10 @@ suite("vimError", () => {
     e = VimError.fromCode(ErrorCode.E37);
     assert.equal(e.code, 37);
     assert.equal(e.message, "No write since last change (add ! to override)");
+
+    e = VimError.fromCode(ErrorCode.E444);
+    assert.equal(e.code, 444);
+    assert.equal(e.message, "Cannot close last window");
 
     e = VimError.fromCode(ErrorCode.E488);
     assert.equal(e.code, 488);


### PR DESCRIPTION
This pull request implements the close command.  It is largely based on the existing quit command.  The difference is that it will refuse to close the last window as stated in the vim documentation.

http://vimdoc.sourceforge.net/htmldoc/windows.html#:close
