### PR TITLE
feat(surround): support complex tags surround

### DIFF
--- a/src/actions/plugins/surround.ts
+++ b/src/actions/plugins/surround.ts
@@ -277,7 +277,12 @@ export class CommandSurroundAddToReplacement extends BaseCommand {
     let endReplace = replacement;
 
     if (startReplace[0] === "<") {
-      endReplace = startReplace[0] + "/" + startReplace.slice(1);
+      let tagName = /([-\w]+)/.exec(startReplace);
+      if (tagName) {
+        endReplace = `</${tagName[1]}>`;
+      } else {
+        endReplace = "</" + startReplace.slice(1);
+      }
     }
 
     if (startReplace.length === 1 && startReplace in PairMatcher.pairings) {

--- a/test/plugins/surround.test.ts
+++ b/test/plugins/surround.test.ts
@@ -34,6 +34,13 @@ suite("surround plugin", () => {
     });
 
     newTest({
+      title: "ysiw< surrounds word with tags and attributes",
+      start: ["first li|ne test"],
+      keysPressed: 'ysiw<abc attr1 attr2="test">',
+      end: ['first <abc attr1 attr2="test">|line</abc> test'],
+    });
+
+    newTest({
       title: "change surround",
       start: ["first 'li|ne' test"],
       keysPressed: "cs')",


### PR DESCRIPTION
Fixes issue with complex tag surround by only including the actual tag name instead of the whole contents of the tag.

Before:
![image](https://cloud.githubusercontent.com/assets/4655972/25878477/f5f7542a-34f8-11e7-975d-20016afa7237.png)

After:
![image](https://cloud.githubusercontent.com/assets/4655972/25878497/143d6348-34f9-11e7-91ff-ecbad730e195.png)

Couldn't find any tests written for surround... So no tests. If someone lets me know where I should put tests for this; I'll update the PR.
