### PR TITLE
remove system clipboard hack for UTF-8

### DIFF
--- a/package.json
+++ b/package.json
@@ -486,7 +486,7 @@
     "postinstall": "node ./node_modules/vscode/bin/install && gulp init"
   },
   "dependencies": {
-    "clipboardy": "^1.1.1",
+    "clipboardy": "^1.1.2",
     "diff-match-patch": "^1.0.0",
     "lodash": "^4.12.0"
   },

--- a/src/util.ts
+++ b/src/util.ts
@@ -16,11 +16,6 @@ export async function showError(message : string): Promise<{}> {
 const clipboardy = require('clipboardy');
 
 export function clipboardCopy(text: string) {
-  // Set utf-8 if on macOS
-  if (process.platform === 'darwin') {
-    process.env.LANG = 'en_US.UTF-8';
-  }
-
   clipboardy.writeSync(text);
 }
 


### PR DESCRIPTION
noticed that the clipboard library was updated to use utf-8 on macos now too

https://github.com/sindresorhus/clipboardy/pull/16