### PR TITLE
Fixes #1668: Self closing tags not properly handled.

### DIFF
--- a/src/common/matching/tagMatcher.ts
+++ b/src/common/matching/tagMatcher.ts
@@ -2,7 +2,7 @@ type Tag = { name: string; type: "close" | "open"; startPos: number; endPos: num
 type MatchedTag = {tag: string, openingTagStart: number, openingTagEnd: number, closingTagStart: number, closingTagEnd: number};
 
 export class TagMatcher {
-  static TAG_REGEX = /\<(\/)?([^\>\<\s]+)[^\>\<]*(\/?)\>/g;
+  static TAG_REGEX = /\<(\/)?([^\>\<\s]+)[^\>\<]*?(\/?)\>/g;
   static OPEN_FORWARD_SLASH = 1;
   static TAG_NAME = 2;
   static CLOSE_FORWARD_SLASH = 3;
@@ -20,6 +20,7 @@ export class TagMatcher {
     while (match) {
       // Node is a self closing tag, skip.
       if (match[TagMatcher.CLOSE_FORWARD_SLASH]) {
+        match = TagMatcher.TAG_REGEX.exec(corpus);
         continue;
       }
 

--- a/test/mode/modeNormal.test.ts
+++ b/test/mode/modeNormal.test.ts
@@ -1548,6 +1548,14 @@ suite("Mode Normal", () => {
       endMode: ModeName.Insert
     });
 
+    newTestOnly({
+      title: "can do cit with self closing tags",
+      start: ["<div><div a=1/>{{c|ursor here}}</div>"],
+      keysPressed: "cit",
+      end: ["<div>|</div>"],
+      endMode: ModeName.Insert
+    });
+
     newTest({
       title: "Respects indentation with cc",
       start: ["{", "  int| a;"],


### PR DESCRIPTION
Pretty straightforward bug fix.

I needed to make the second regex capturing group lazy so that the closing slash could always be matched if it existed.

I also needed to move onto the next tag if we found a self closing tag.

Fixes #1668 