### PR TITLE
Fixes #1436: extension prevents 'find all references' pop-up from closing through <esc> if it's empty.

### DIFF
--- a/src/actions/commands/actions.ts
+++ b/src/actions/commands/actions.ts
@@ -431,8 +431,9 @@ class CommandEsc extends BaseCommand {
 
   public async exec(position: Position, vimState: VimState): Promise<VimState> {
     if (vimState.currentMode === ModeName.Normal && !vimState.isMultiCursor) {
-      // If there's nothing to do on the vim side, we might as well call vscode's default "close notification" actions.
-      await vscode.commands.executeCommand('workbench.action.closeMessages');
+      // If there's nothing to do on the vim side, we might as well call some
+      // of vscode's default "close notification" actions. I think we should
+      // just add to this list as needed.
       await vscode.commands.executeCommand('closeReferenceSearchEditor');
       return vimState;
     }

--- a/src/actions/commands/actions.ts
+++ b/src/actions/commands/actions.ts
@@ -431,6 +431,9 @@ class CommandEsc extends BaseCommand {
 
   public async exec(position: Position, vimState: VimState): Promise<VimState> {
     if (vimState.currentMode === ModeName.Normal && !vimState.isMultiCursor) {
+      // If there's nothing to do on the vim side, we might as well call vscode's default "close notification" actions.
+      await vscode.commands.executeCommand('workbench.action.closeMessages');
+      await vscode.commands.executeCommand('closeReferenceSearchEditor');
       return vimState;
     }
 


### PR DESCRIPTION
So pretty much the issue is that here, because nothing pops up, vscode doesn't think we're in the "find all references" context, and lets vscodevim capture keystrokes again.

Thus, all we need to is call API calls that close stuff when the user presses `<Esc>` in normal mode. Doesn't seem to have any performance impact, and fixes an annoyance.