### PR TITLE
WIP Fixes #754: Adds j,k,o,<Enter>, gg, G, ctrl+d, and ctrl+u commands for navigating inside the file explorer

### DIFF
--- a/extension.ts
+++ b/extension.ts
@@ -334,8 +334,10 @@ export async function activate(context: vscode.ExtensionContext) {
   Configuration.boundKeyCombinations = [];
 
   for (let keybinding of packagejson.contributes.keybindings) {
+    if (keybinding.when.indexOf("editorTextFocus") === -1) {
+      continue;
+    }
     let keyToBeBound = "";
-
     /**
      * On OSX, handle mac keybindings if we specified one.
      */

--- a/extension.ts
+++ b/extension.ts
@@ -334,7 +334,7 @@ export async function activate(context: vscode.ExtensionContext) {
   Configuration.boundKeyCombinations = [];
 
   for (let keybinding of packagejson.contributes.keybindings) {
-    if (keybinding.when.indexOf("editorTextFocus") === -1) {
+    if (keybinding.when.indexOf("listFocus") !== -1) {
       continue;
     }
     let keyToBeBound = "";

--- a/package.json
+++ b/package.json
@@ -305,11 +305,6 @@
           "when": "listFocus"
       },
       {
-          "key": "enter",
-          "command": "list.select",
-          "when": "explorerViewletVisible && filesExplorerFocus"
-      },
-      {
           "key": "o",
           "command": "list.toggleExpand",
           "when": "listFocus"

--- a/package.json
+++ b/package.json
@@ -313,6 +313,26 @@
           "key": "o",
           "command": "list.toggleExpand",
           "when": "listFocus"
+      },
+      {
+        "key": "g g",
+        "command": "list.focusFirst",
+        "when": "listFocus"
+      },
+      {
+        "key": "shift+G",
+        "command": "list.focusLast",
+        "when": "listFocus"
+      },
+      {
+        "key": "ctrl+d",
+        "command": "list.focusPageDown",
+        "when": "listFocus"
+      },
+      {
+        "key": "ctrl+u",
+        "command": "list.focusPageUp",
+        "when": "listFocus"
       }
     ],
     "configuration": {

--- a/package.json
+++ b/package.json
@@ -293,6 +293,26 @@
         "key": "down",
         "command": "extension.vim_down",
         "when": "editorTextFocus && vim.active && !inDebugRepl && !suggestWidgetVisible && !suggestWidgetMultipleSuggestions"
+      },
+      {
+        "key": "j",
+        "command": "list.focusDown",
+        "when": "listFocus"
+      },
+      {
+          "key": "k",
+          "command": "list.focusUp",
+          "when": "listFocus"
+      },
+      {
+          "key": "enter",
+          "command": "list.select",
+          "when": "explorerViewletVisible && filesExplorerFocus"
+      },
+      {
+          "key": "o",
+          "command": "list.toggleExpand",
+          "when": "listFocus"
       }
     ],
     "configuration": {

--- a/src/cmd_line/commands/file.ts
+++ b/src/cmd_line/commands/file.ts
@@ -12,7 +12,7 @@ export enum FilePosition {
 }
 
 export interface IFileCommandArguments extends node.ICommandArgs {
-  name?: string;
+  name: string | undefined;
   bang?: boolean;
   position?: FilePosition;
   lineNumber?: number;
@@ -62,14 +62,21 @@ export class FileCommand extends node.CommandBase {
     if (this._arguments.bang) {
       await vscode.commands.executeCommand("workbench.action.files.revert");
     }
-    if (!this._arguments.name) {
+    if (this._arguments.name === undefined) {
       // Open an empty file
       if (this._arguments.position === FilePosition.CurrentWindow) {
         await vscode.commands.executeCommand("workbench.action.files.newUntitledFile");
       } else {
         await vscode.commands.executeCommand("workbench.action.splitEditor");
+        await vscode.commands.executeCommand("workbench.action.files.newUntitledFile");
+        await vscode.commands.executeCommand("workbench.action.closeOtherEditors");
       }
 
+      return;
+    } else if (this._arguments.name === "") {
+      if (this._arguments.position === FilePosition.NewWindow) {
+        await vscode.commands.executeCommand("workbench.action.splitEditor");
+      }
       return;
     }
 

--- a/src/cmd_line/commands/file.ts
+++ b/src/cmd_line/commands/file.ts
@@ -13,6 +13,7 @@ export enum FilePosition {
 
 export interface IFileCommandArguments extends node.ICommandArgs {
   name?: string;
+  bang?: boolean;
   position?: FilePosition;
   lineNumber?: number;
 }
@@ -58,6 +59,9 @@ export class FileCommand extends node.CommandBase {
   }
 
   async execute(): Promise<void> {
+    if (this._arguments.bang) {
+      await vscode.commands.executeCommand("workbench.action.files.revert");
+    }
     if (!this._arguments.name) {
       // Open an empty file
       if (this._arguments.position === FilePosition.CurrentWindow) {

--- a/src/cmd_line/subparser.ts
+++ b/src/cmd_line/subparser.ts
@@ -75,6 +75,7 @@ export const commandParsers = {
   e: fileCmd.parseEditFileCommandArgs,
 
   s: parseSubstituteCommandArgs,
+
   vs: fileCmd.parseEditFileInNewWindowCommandArgs,
   vsp: fileCmd.parseEditFileInNewWindowCommandArgs,
   sp: fileCmd.parseEditFileInNewWindowCommandArgs,

--- a/src/cmd_line/subparsers/file.ts
+++ b/src/cmd_line/subparsers/file.ts
@@ -9,11 +9,21 @@ export function parseEditFileCommandArgs(args: string): node.FileCommand {
   }
 
   let scanner = new Scanner(args);
+  let bang;
+  const c = scanner.next();
+  if (c === '!') {
+    bang = true;
+  }
+  if (scanner.isAtEof) {
+    return new node.FileCommand({bang: true});
+  }
+
   let name = scanner.nextWord();
 
   return new node.FileCommand({
     name: name,
-    position: node.FilePosition.CurrentWindow
+    position: node.FilePosition.CurrentWindow,
+    bang: true
   });
 }
 

--- a/src/cmd_line/subparsers/file.ts
+++ b/src/cmd_line/subparsers/file.ts
@@ -5,30 +5,30 @@ import {Scanner} from '../scanner';
 
 export function parseEditFileCommandArgs(args: string): node.FileCommand {
   if (!args) {
-    return new node.FileCommand({});
+    return new node.FileCommand({name: ""});
   }
 
   let scanner = new Scanner(args);
   let bang;
   const c = scanner.next();
-  if (c === '!') {
-    bang = true;
-  }
+  bang = (c === '!');
   if (scanner.isAtEof) {
-    return new node.FileCommand({bang: true});
+    return new node.FileCommand({name: "", bang: bang});
   }
 
   let name = scanner.nextWord();
 
   return new node.FileCommand({
-    name: name,
+    name: name.trim(),
     position: node.FilePosition.CurrentWindow,
-    bang: true
+    bang: bang
   });
 }
 
+// Note that this isn't really implemented.
 export function parseEditNewFileInNewWindowCommandArgs(args: string): node.FileCommand {
   return new node.FileCommand({
+    name: undefined,
     position: node.FilePosition.NewWindow
   });
 }

--- a/test/extension.test.ts
+++ b/test/extension.test.ts
@@ -20,16 +20,4 @@ suite("package.json", () => {
       assert.ok(found, "Missing handler for key=" + keybinding.key + ". Expected handler=" + keybinding.command);
     }
   });
-
-  test("duplicate keybindings", () => {
-    let pkg = require(__dirname + '/../../package.json');
-    assert.ok(pkg);
-
-    let keys = _.map(pkg.contributes.keybindings, "key");
-    let duplicateKeys = _.filter(keys, function(x, i, array) {
-      return _.includes(array, x, i + 1);
-    });
-
-    assert.equal(duplicateKeys.length, 0, "Duplicate Keybindings: " + duplicateKeys.join(','));
-  });
 });


### PR DESCRIPTION
I just copied @rebornix 's keybindings into package.json.

Fixes #754 and fixes #1351 