### PR TITLE
Fixes #1720: Removed unused <c- > bindings from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -140,16 +140,6 @@
         "when": "editorTextFocus && vim.active && vim.use<C-b> && vim.mode != 'Insert' && !inDebugRepl"
       },
       {
-        "key": "ctrl+j",
-        "command": "extension.vim_ctrl+j",
-        "when": "editorTextFocus && vim.active && vim.use<C-j> && vim.mode != 'Insert' && !inDebugRepl"
-      },
-      {
-        "key": "ctrl+k",
-        "command": "extension.vim_ctrl+k",
-        "when": "editorTextFocus && vim.active && vim.use<C-k> && vim.mode != 'Insert' && !inDebugRepl"
-      },
-      {
         "key": "ctrl+h",
         "command": "extension.vim_ctrl+h",
         "when": "editorTextFocus && vim.active && vim.use<C-h> && vim.mode == 'Insert' && !inDebugRepl"


### PR DESCRIPTION
Just to be a good extension citizen, we should only be capturing as much as we use. We can re-add them back in if we need them.

Fixes #1720 