### PR TITLE
Embedding Neovim for Ex commands

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,5 +6,7 @@ node_modules
 .DS_Store
 *.vsix
 *.log
-typings
+
+typings/*
+!typings/custom/
 testing

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 notifications:
   email: false
 
-sudo: false
+sudo: required
 
 os:
 - linux
@@ -21,6 +21,7 @@ before_install:
     sh -e /etc/init.d/xvfb start;
     sleep 3;
   fi
+  - sudo apt-get install neovim
 
 install:
 - npm install -g gulp;

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 notifications:
   email: false
 
-sudo: required
+sudo: false
 
 os:
 - linux
@@ -16,7 +16,7 @@ env:
     secure: "tzpL/lQ2L2mVDS0sPY0LnJ3idspKmiOAuKFFfBZbBk4vA6NtJYveXILiskNDWK4p3JIWux/JBxgU3auXU4t7BZy7bMfUpTm0PpsMQfvDV2/rsf3QUQgYvROZkVpeH6b73hxxyTy0wfDHrb0SIUjB9IChUiSDIBjwteVAb/HuIWNKRQ6mbmkZKiQ3xHisFOG9xTkrEO31BfA+nKxUOTtXiZtoHTOWK9+H67QKd19BTRn/vJrwhTUsYqyOBAoFQjDjpAbhRNgs4YxHJz2jn1rmeE8kotf3LsfBrws07Mu9O9CnEcJKsqgJW+ezbHCO/HjLfpul/v0HtF/UQM00v5J2mDFz/ii8OWQ41TjYgkAHhtXIkMDQiM6K1x+gsaq0wm4QDX+Akg3r4sFqzhKsIuSLr1QTAMh9nn9G2asQvVJNNgH1QFvuLMF3bX1xp4l79/xoCEAWqlxx1mScYcmGFtYtQd107U5qPcHrR66vTMV5VqiZ0XapJympE+D5xIiSb4CTFGpl9+PSBk69MjynMEbGsLsudYWp6HZA5CyosxoStXxR1fD+ypqsSyzynSpThZ6IpFJ7Pk95GR3Z78CPhkNZvBvJ62xW/6/hAykWcelRHZy0N5XT2+HP+xcx77Fpqj8ZEAI6ECHNnnZ1KQROodu5LI06oZ2hiM1P1gdBx6xrljg="
 
 before_install:
-- sudo apt-get install neovim;
+- eval "$(curl -Ss https://raw.githubusercontent.com/neovim/bot-ci/master/scripts/travis-setup.sh) nightly-x64"
 - if [ $TRAVIS_OS_NAME == "linux" ]; then
     export CXX="g++-4.9" CC="gcc-4.9" DISPLAY=:99.0;
     sh -e /etc/init.d/xvfb start;

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,12 +16,12 @@ env:
     secure: "tzpL/lQ2L2mVDS0sPY0LnJ3idspKmiOAuKFFfBZbBk4vA6NtJYveXILiskNDWK4p3JIWux/JBxgU3auXU4t7BZy7bMfUpTm0PpsMQfvDV2/rsf3QUQgYvROZkVpeH6b73hxxyTy0wfDHrb0SIUjB9IChUiSDIBjwteVAb/HuIWNKRQ6mbmkZKiQ3xHisFOG9xTkrEO31BfA+nKxUOTtXiZtoHTOWK9+H67QKd19BTRn/vJrwhTUsYqyOBAoFQjDjpAbhRNgs4YxHJz2jn1rmeE8kotf3LsfBrws07Mu9O9CnEcJKsqgJW+ezbHCO/HjLfpul/v0HtF/UQM00v5J2mDFz/ii8OWQ41TjYgkAHhtXIkMDQiM6K1x+gsaq0wm4QDX+Akg3r4sFqzhKsIuSLr1QTAMh9nn9G2asQvVJNNgH1QFvuLMF3bX1xp4l79/xoCEAWqlxx1mScYcmGFtYtQd107U5qPcHrR66vTMV5VqiZ0XapJympE+D5xIiSb4CTFGpl9+PSBk69MjynMEbGsLsudYWp6HZA5CyosxoStXxR1fD+ypqsSyzynSpThZ6IpFJ7Pk95GR3Z78CPhkNZvBvJ62xW/6/hAykWcelRHZy0N5XT2+HP+xcx77Fpqj8ZEAI6ECHNnnZ1KQROodu5LI06oZ2hiM1P1gdBx6xrljg="
 
 before_install:
+- sudo apt-get install neovim;
 - if [ $TRAVIS_OS_NAME == "linux" ]; then
     export CXX="g++-4.9" CC="gcc-4.9" DISPLAY=:99.0;
     sh -e /etc/init.d/xvfb start;
     sleep 3;
   fi
-  - sudo apt-get install neovim
 
 install:
 - npm install -g gulp;

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Donations help convince me to work on this project rather than my other (non-ope
     * [Windows setup](#windows-setup)
 * [Settings](#settings)
     * [VSCodeVim settings](#vscodevim-settings)
+    * [Neovim Integration](#neovim-integration)
     * [Key remapping](#key-remapping)
     * [Vim settings](#vim-settings)
     * [Status bar colors (vim-airline)](#status-bar-color-settings)
@@ -168,6 +169,11 @@ These settings are specific to VSCodeVim.
 * In visual mode, start a search with * or # using the current selection
 * Type: Boolean (Default: `false`)
 
+### Neovim Integration
+
+We now have neovim integration for Ex-commands. If you want to take advantage of this integration, set `"vim.enableNeovim"` to `true`, and set your `"vim.neovimPath"`. If you don't have neovim installed, [install neovim here](https://github.com/neovim/neovim/wiki/Installing-Neovim). If you don't want to install neovim, all of the old functionality should still work as is (we would really suggest neovim installing though. The new Ex support is super cool, and we'd like to integrate neovim more in the future).
+
+Please leave feedback on neovim [here](https://github.com/VSCodeVim/Vim/issues/1735).
 ### Key remapping
 
 There's several different settings you can use to define custom remappings. Also related are the [`useCtrlKeys`](#vimusectrlkeys) and [`handleKeys`](#vimhandlekeys) settings.
@@ -451,6 +457,18 @@ Vim has a lot of nooks and crannies. VSCodeVim preserves some of the coolest noo
 ### Help! None of the vim `ctrl` (e.g. `ctrl+f`, `ctrl+v`) commands work
 
 Set the [`useCtrlKeys` setting](#vimusectrlkeys) to `true`.
+
+### Moving j and k over folds opens up the folds! This extension is unusable!
+
+You can try setting `vim.foldfix` to `true`. Note, however, that it is a hack. It works fine, but there are side effects. We are unable to fix this issue properly due to VSCode API limitations. Go to [here](https://github.com/Microsoft/vscode/issues/22276) for updates on the issue.
+
+### Key repeat doesn't work! And I'm on Mac!
+
+Take a look [here](#mac-setup).
+
+### There are annoying intellisense/notifications/popups that I can't close with `<esc>`!
+
+Press `shift+<esc>` to close all of those boxes.
 
 ## Contributing
 

--- a/extension.ts
+++ b/extension.ts
@@ -83,13 +83,12 @@ export async function getAndUpdateModeHandler(): Promise<ModeHandler> {
 
   let curHandler = modeHandlerToEditorIdentity[activeEditorId.toString()];
   if (!curHandler) {
-    if (!Configuration.disableAnnoyingNeovimComment) {
-
+    if (!Configuration.disableAnnoyingNeovimMessage) {
       vscode.window.showInformationMessage("We have now added neovim integration for Ex-commands.\
       Enable it with vim.enableNeovim in settings", "Never show again").then((result) => {
           if (result === "Never show again") {
             vscode.workspace.getConfiguration("vim").update("disableAnnoyingNeovimMessage", true, true);
-            Configuration.disableAnnoyingNeovimComment = true;
+            Configuration.disableAnnoyingNeovimMessage = true;
           }
         });
     }

--- a/extension.ts
+++ b/extension.ts
@@ -20,6 +20,8 @@ import { ICodeKeybinding } from './src/mode/remapper';
 import { runCmdLine } from './src/cmd_line/main';
 
 import './src/actions/vim.all';
+import { attach } from "promised-neovim-client";
+import { spawn } from "child_process";
 
 interface VSCodeKeybinding {
   key: string;
@@ -81,6 +83,8 @@ export async function getAndUpdateModeHandler(): Promise<ModeHandler> {
   let curHandler = modeHandlerToEditorIdentity[activeEditorId.toString()];
   if (!curHandler) {
     const newModeHandler = new ModeHandler();
+    const proc = spawn('nvim', ['-u', 'NONE', '-N', '--embed'], {cwd: __dirname });
+    newModeHandler.vimState.nvim = await attach(proc.stdin, proc.stdout);
 
     modeHandlerToEditorIdentity[activeEditorId.toString()] = newModeHandler;
     extensionContext.subscriptions.push(newModeHandler);

--- a/extension.ts
+++ b/extension.ts
@@ -22,6 +22,7 @@ import { runCmdLine } from './src/cmd_line/main';
 import './src/actions/vim.all';
 import { attach } from "promised-neovim-client";
 import { spawn } from "child_process";
+import { Neovim } from "./src/neovim/nvimUtil";
 
 interface VSCodeKeybinding {
   key: string;
@@ -83,9 +84,9 @@ export async function getAndUpdateModeHandler(): Promise<ModeHandler> {
   let curHandler = modeHandlerToEditorIdentity[activeEditorId.toString()];
   if (!curHandler) {
     const newModeHandler = await new ModeHandler();
-    const proc = spawn('nvim', ['-u', 'NONE', '-N', '--embed'], {cwd: __dirname });
-    newModeHandler.vimState.nvim = await attach(proc.stdin, proc.stdout);
-
+    if (Configuration.enableNeovim) {
+      await Neovim.initNvim(newModeHandler.vimState);
+    }
     modeHandlerToEditorIdentity[activeEditorId.toString()] = newModeHandler;
     extensionContext.subscriptions.push(newModeHandler);
 

--- a/extension.ts
+++ b/extension.ts
@@ -83,6 +83,16 @@ export async function getAndUpdateModeHandler(): Promise<ModeHandler> {
 
   let curHandler = modeHandlerToEditorIdentity[activeEditorId.toString()];
   if (!curHandler) {
+    if (!Configuration.disableAnnoyingNeovimComment) {
+
+      vscode.window.showInformationMessage("We have now added neovim integration for Ex-commands.\
+      Enable it with vim.enableNeovim in settings", "Never show again").then((result) => {
+          if (result === "Never show again") {
+            vscode.workspace.getConfiguration("vim").update("disableAnnoyingNeovimMessage", true, true);
+            Configuration.disableAnnoyingNeovimComment = true;
+          }
+        });
+    }
     const newModeHandler = await new ModeHandler();
     if (Configuration.enableNeovim) {
       await Neovim.initNvim(newModeHandler.vimState);

--- a/extension.ts
+++ b/extension.ts
@@ -82,7 +82,7 @@ export async function getAndUpdateModeHandler(): Promise<ModeHandler> {
 
   let curHandler = modeHandlerToEditorIdentity[activeEditorId.toString()];
   if (!curHandler) {
-    const newModeHandler = new ModeHandler();
+    const newModeHandler = await new ModeHandler();
     const proc = spawn('nvim', ['-u', 'NONE', '-N', '--embed'], {cwd: __dirname });
     newModeHandler.vimState.nvim = await attach(proc.stdin, proc.stdout);
 

--- a/package.json
+++ b/package.json
@@ -498,7 +498,8 @@
   "dependencies": {
     "clipboardy": "^1.1.2",
     "diff-match-patch": "^1.0.0",
-    "lodash": "^4.12.0"
+    "lodash": "^4.12.0",
+    "neovim-client": "^2.1.0"
   },
   "devDependencies": {
     "@types/mocha": "^2.2.39",

--- a/package.json
+++ b/package.json
@@ -499,7 +499,8 @@
     "clipboardy": "^1.1.2",
     "diff-match-patch": "^1.0.0",
     "lodash": "^4.12.0",
-    "neovim-client": "^2.1.0"
+    "neovim-client": "^2.1.0",
+    "promised-neovim-client": "^2.0.2"
   },
   "devDependencies": {
     "@types/mocha": "^2.2.39",

--- a/package.json
+++ b/package.json
@@ -485,6 +485,16 @@
           "type": "boolean",
           "description": "Get rid of that annoying pop up that shows up everytime you type gc or gb",
           "default": false
+        },
+        "vim.enableNeovim": {
+          "type": "boolean",
+          "description": "Use neovim on backend. (only works for Ex commands right now). You should restart VScode after enable/disabling this for the changes to take effect.",
+          "default": true
+        },
+        "vim.neovimPath": {
+          "type": "string",
+          "description": "Path to run neovim",
+          "default": "nvim"
         }
       }
     }

--- a/package.json
+++ b/package.json
@@ -489,7 +489,7 @@
         "vim.enableNeovim": {
           "type": "boolean",
           "description": "Use neovim on backend. (only works for Ex commands right now). You should restart VScode after enable/disabling this for the changes to take effect.",
-          "default": true
+          "default": false
         },
         "vim.neovimPath": {
           "type": "string",

--- a/package.json
+++ b/package.json
@@ -481,7 +481,7 @@
           "description": "Uses a hack to move around folds properly",
           "default": false
         },
-        "vim.disableAnnoyingGcComment": {
+        "vim.disableAnnoyingGcMessage": {
           "type": "boolean",
           "description": "Get rid of that annoying pop up that shows up everytime you type gc or gb",
           "default": false
@@ -495,6 +495,11 @@
           "type": "string",
           "description": "Path to run neovim",
           "default": "nvim"
+        },
+        "vim.disableAnnoyingNeovimMessage": {
+          "type": "boolean",
+          "description": "Get rid of that annoying message that shows up everytime you make a new file",
+          "default": false
         }
       }
     }

--- a/src/actions/commands/actions.ts
+++ b/src/actions/commands/actions.ts
@@ -1480,6 +1480,7 @@ class CommandShowCommandLine extends BaseCommand {
     } else {
       vimState.commandInitialText = "'<,'>";
     }
+    vimState.currentMode = ModeName.Normal;
 
     return vimState;
   }

--- a/src/actions/commands/actions.ts
+++ b/src/actions/commands/actions.ts
@@ -19,6 +19,7 @@ import * as util from './../../util';
 import { RegisterAction } from './../base';
 import * as operator from './../operator';
 import { BaseAction } from './../base';
+import { Neovim } from "../../neovim/nvimUtil";
 
 export class DocumentContentChangeAction extends BaseAction {
   contentChanges: {
@@ -2506,6 +2507,8 @@ class ActionJoinVisualMode extends BaseCommand {
 
     return vimState;
   }
+
+
 }
 
 

--- a/src/actions/commands/actions.ts
+++ b/src/actions/commands/actions.ts
@@ -19,7 +19,6 @@ import * as util from './../../util';
 import { RegisterAction } from './../base';
 import * as operator from './../operator';
 import { BaseAction } from './../base';
-import { Neovim } from "../../neovim/nvimUtil";
 
 export class DocumentContentChangeAction extends BaseAction {
   contentChanges: {

--- a/src/actions/commands/actions.ts
+++ b/src/actions/commands/actions.ts
@@ -3112,9 +3112,14 @@ class ActionOverrideCmdD extends BaseCommand {
   runsOnceForEachCountPrefix = true;
 
   public async exec(position: Position, vimState: VimState): Promise<VimState> {
-    if (!Configuration.disableAnnoyingGcComment) {
-      vscode.window.showErrorMessage("gc is now commentOperator. gb is now 'add new cursor'.\
-       Disable this annoying message with vim.disableAnnoyingGcComment");
+    if (!Configuration.disableAnnoyingGcMessage) {
+      vscode.window.showInformationMessage("gc is now commentOperator. gb is now 'add new cursor'", "Never show again").then(
+        (result) => {
+          if (result === "Never show again") {
+            vscode.workspace.getConfiguration("vim").update("disableAnnoyingGcMessage", true, true);
+            Configuration.disableAnnoyingGcMessage = true;
+          }
+        });
     }
     await vscode.commands.executeCommand('editor.action.addSelectionToNextFindMatch');
     vimState.allCursors = await allowVSCodeToPropagateCursorUpdatesAndReturnThem();

--- a/src/actions/operator.ts
+++ b/src/actions/operator.ts
@@ -558,10 +558,16 @@ export class CommentOperator extends BaseOperator {
   public modes = [ModeName.Normal, ModeName.Visual, ModeName.VisualLine];
 
   public async run(vimState: VimState, start: Position, end: Position): Promise<VimState> {
-    if (!Configuration.disableAnnoyingGcComment) {
-      vscode.window.showErrorMessage("gc is now commentOperator. gb is now 'add new cursor'\
-       Disable this annoying message with vim.disableAnnoyingGcComment");
+    if (!Configuration.disableAnnoyingGcMessage) {
+      vscode.window.showInformationMessage("gc is now commentOperator. gb is now 'add new cursor'", "Never show again").then(
+        (result) => {
+          if (result === "Never show again") {
+            vscode.workspace.getConfiguration("vim").update("disableAnnoyingGcMessage", true, true);
+            Configuration.disableAnnoyingGcMessage = true;
+          }
+        });
     }
+
     vimState.editor.selection = new vscode.Selection(start.getLineBegin(), end.getLineEnd());
     await vscode.commands.executeCommand("editor.action.commentLine");
 

--- a/src/cmd_line/commands/deleteRange.ts
+++ b/src/cmd_line/commands/deleteRange.ts
@@ -14,6 +14,7 @@ export interface IDeleteRangeCommandArguments extends node.ICommandArgs {
 
 
 export class DeleteRangeCommand extends node.CommandBase {
+  neovimCapable = true;
   protected _arguments : IDeleteRangeCommandArguments;
 
   constructor(args : IDeleteRangeCommandArguments) {

--- a/src/cmd_line/commands/read.ts
+++ b/src/cmd_line/commands/read.ts
@@ -16,6 +16,7 @@ export interface IReadCommandArguments extends node.ICommandArgs {
 //  http://vimdoc.sourceforge.net/htmldoc/insert.html#:read!
 //
 export class ReadCommand extends node.CommandBase {
+  neovimCapable = true;
   protected _arguments : IReadCommandArguments;
 
   constructor(args : IReadCommandArguments) {

--- a/src/cmd_line/commands/sort.ts
+++ b/src/cmd_line/commands/sort.ts
@@ -13,7 +13,7 @@ export interface ISortCommandArguments extends node.ICommandArgs {
 
 
 export class SortCommand extends node.CommandBase {
-
+  neovimCapable = true;
   protected _arguments : ISortCommandArguments;
 
   constructor(args: ISortCommandArguments) {

--- a/src/cmd_line/commands/substitute.ts
+++ b/src/cmd_line/commands/substitute.ts
@@ -47,6 +47,7 @@ export enum SubstituteFlags {
 }
 
 export class SubstituteCommand extends node.CommandBase {
+  neovimCapable = true;
   protected _arguments : ISubstituteCommandArguments;
 
   constructor(args : ISubstituteCommandArguments) {

--- a/src/cmd_line/main.ts
+++ b/src/cmd_line/main.ts
@@ -2,30 +2,34 @@
 
 import * as vscode from "vscode";
 import * as parser from "./parser";
-import {ModeHandler} from "../mode/modeHandler";
+import {VimState, ModeHandler} from "../mode/modeHandler";
+import { ModeName } from './../mode/mode';
 import {attach, RPCValue} from 'promised-neovim-client';
 import {spawn} from 'child_process';
 import { TextEditor } from "../textEditor";
 
-async function run(currentText: string[], command: string) {
+async function run(vimState: VimState, command: string) {
   const proc = spawn('nvim', ['-u', 'NONE', '-N', '--embed'], {cwd: __dirname });
 
   const nvim = await attach(proc.stdin, proc.stdout);
-  nvim.on('request', (method: string, args: RPCValue[], resp: RPCValue) => {
-      // handle msgpack-rpc request
-  });
 
-  nvim.on('notification', (method: string, args: RPCValue[]) => {
-      // handle msgpack-rpc notification
-  });
-
-  await nvim.command('vsp');
-
-  let lines: string[];
   const buf = await nvim.getCurrentBuf();
-  await buf.setLines(0, -1, true, currentText);
+  const window = await nvim.getCurrentWin();
+  await buf.setLines(0, -1, true, TextEditor.getText().split('\n'));
+  if (vimState.currentMode === ModeName.Visual || vimState.currentMode === ModeName.VisualLine) {
+    let t : RPCValue
+    await nvim.callFunction("cursor", [vimState.cursorStartPosition.line, vimState.cursorStartPosition.character]);
+    await nvim.input("V");
+    await nvim.callFunction("cursor", [vimState.cursorPosition.line, vimState.cursorPosition.character]);
+  } else {
+    await nvim.callFunction("cursor", [vimState.cursorPosition.line, vimState.cursorPosition.character]);
+  }
   await nvim.command(command);
-  return buf.getLines(0, -1, false);
+
+  await TextEditor.replace(new vscode.Range(0, 0, TextEditor.getLineCount() - 1, TextEditor.getLineMaxColumn(TextEditor.getLineCount() - 1)), (await buf.getLines(0, -1, false)).join('\n'));
+  nvim.quit();
+  return;
+
 }
 
 // Shows the vim command line.
@@ -34,6 +38,7 @@ export async function showCmdLine(initialText: string, modeHandler : ModeHandler
     console.log("No active document.");
     return;
   }
+
 
   const options : vscode.InputBoxOptions = {
     prompt: "Vim command line",
@@ -45,6 +50,7 @@ export async function showCmdLine(initialText: string, modeHandler : ModeHandler
   try {
     const cmdString = await vscode.window.showInputBox(options);
     await runCmdLine(cmdString!, modeHandler);
+    console.log("DONE");
     return;
   } catch (e) {
     modeHandler.setStatusBarText(e.toString());
@@ -57,16 +63,10 @@ export async function runCmdLine(command : string, modeHandler : ModeHandler) : 
     return;
   }
 
-  let t: string[] = [];
-  await run(TextEditor.getText().split('\n'), command).then((res) => {
-    console.log(res);
-    t = res;
-  });
-  await TextEditor.replace(new vscode.Range(0, 0, TextEditor.getLineCount() - 1, TextEditor.getLineMaxColumn(TextEditor.getLineCount() - 1)), t.join('\n'));
-
+  await run(modeHandler.vimState, command).then(() => {
+    console.log("SUCCESS");
+  }).catch((err)=>console.log(err));
   return;
-
-
   // try {
   //   var cmd = parser.parse(command);
   //   if (cmd.isEmpty) {
@@ -76,7 +76,9 @@ export async function runCmdLine(command : string, modeHandler : ModeHandler) : 
   //   await cmd.execute(modeHandler.vimState.editor, modeHandler);
   //   return;
   // } catch (e) {
-  //   modeHandler.setStatusBarText(e.toString());
+  //   await run(modeHandler, command).then(() => {
+  //     console.log("SUCCESS");
+  //   });
   //   return;
   // }
 }

--- a/src/cmd_line/main.ts
+++ b/src/cmd_line/main.ts
@@ -3,7 +3,7 @@
 import * as vscode from "vscode";
 import * as parser from "./parser";
 import {VimState, ModeHandler} from "../mode/modeHandler";
-import {attach} from 'promised-neovim-client';
+import {attach, RPCValue} from 'promised-neovim-client';
 import {spawn} from 'child_process';
 import { TextEditor } from "../textEditor";
 import { Configuration } from '../configuration/configuration';
@@ -12,6 +12,15 @@ async function run(vimState: VimState, command: string) {
 
   const proc = spawn('nvim', ['-u', 'NONE', '-N', '--embed'], {cwd: __dirname });
   const nvim = await attach(proc.stdin, proc.stdout);
+  nvim.on('request', (method: string, args: RPCValue[], resp: RPCValue) => {
+    console.log(method, args, resp)
+      // handle msgpack-rpc request
+  });
+
+  nvim.on('notification', (method: string, args: RPCValue[]) => {
+    console.log(method, args)
+      // handle msgpack-rpc notification
+  });
   const buf = await nvim.getCurrentBuf();
   await buf.setLines(0, -1, true, TextEditor.getText().split('\n'));
 

--- a/src/cmd_line/main.ts
+++ b/src/cmd_line/main.ts
@@ -8,53 +8,7 @@ import {attach, RPCValue} from 'promised-neovim-client';
 import {spawn} from 'child_process';
 import { TextEditor } from "../textEditor";
 import { Configuration } from '../configuration/configuration';
-
-async function run(vimState: VimState, command: string) {
-
-  const proc = spawn('nvim', ['-u', 'NONE', '-N', '--embed'], {cwd: __dirname });
-  const nvim = await attach(proc.stdin, proc.stdout);
-  nvim.on('request', (method: string, args: RPCValue[], resp: RPCValue) => {
-    console.log(method, args, resp);
-      // handle msgpack-rpc request
-  });
-
-  nvim.on('notification', (method: string, args: RPCValue[]) => {
-    console.log(method, args);
-      // handle msgpack-rpc notification
-  });
-  const buf = await nvim.getCurrentBuf();
-  await buf.setLines(0, -1, true, TextEditor.getText().split('\n'));
-
-  await nvim.callFunction("setpos", [".", [0, vimState.cursorPosition.line + 1, vimState.cursorPosition.character, false]]);
-  await nvim.callFunction("setpos", ["'>", [0, vimState.cursorPosition.line + 1, vimState.cursorPosition.character, false]]);
-  await nvim.callFunction("setpos", ["'<", [0, vimState.cursorStartPosition.line + 1, vimState.cursorStartPosition.character, false]]);
-  for (const mark of vimState.historyTracker.getMarks()){
-    await nvim.callFunction("setpos", [`'${mark.name}`, [0, mark.position.line + 1, mark.position.character, false]]);
-  }
-  command = ":" + command + "\n";
-  await nvim.input(command);
-
-  if ((await nvim.getMode()).blocking) {
-    await nvim.input('<esc>');
-  }
-
-  await TextEditor.replace(
-    new vscode.Range(0, 0, TextEditor.getLineCount() - 1,
-    TextEditor.getLineMaxColumn(TextEditor.getLineCount() - 1)),
-    (await buf.getLines(0, -1, false)).join('\n')
-  );
-
-  let [row, character]  = (await nvim.callFunction("getpos", ["."]) as Array<number>).slice(1, 3);
-  vimState.editor.selection = new vscode.Selection(new Position(row-1, character), new Position(row-1, character));
-
-  if (Configuration.expandtab) {
-    await vscode.commands.executeCommand("editor.action.indentationToSpaces");
-  }
-  nvim.quit();
-  proc.kill();
-  return;
-
-}
+import { Neovim } from "../neovim/nvimUtil";
 
 // Shows the vim command line.
 export async function showCmdLine(initialText: string, modeHandler : ModeHandler): Promise<undefined> {
@@ -92,7 +46,7 @@ export async function runCmdLine(command : string, modeHandler : ModeHandler) : 
       return;
     }
     if (cmd.command.neovimCapable) {
-      await run(modeHandler.vimState, command).then(() => {
+      await Neovim.command(modeHandler.vimState, command).then(() => {
         console.log("Substituted for neovim command");
       }).catch((err) => console.log(err));
     } else {
@@ -100,7 +54,7 @@ export async function runCmdLine(command : string, modeHandler : ModeHandler) : 
     }
     return;
   } catch (e) {
-    await run(modeHandler.vimState, command).then(() => {
+    await Neovim.command(modeHandler.vimState, command).then(() => {
       console.log("SUCCESS");
     }).catch((err) => console.log(err));
     return;

--- a/src/cmd_line/main.ts
+++ b/src/cmd_line/main.ts
@@ -16,13 +16,11 @@ async function run(vimState: VimState, command: string) {
   const buf = await nvim.getCurrentBuf();
   const window = await nvim.getCurrentWin();
   await buf.setLines(0, -1, true, TextEditor.getText().split('\n'));
-  if (vimState.currentMode === ModeName.Visual || vimState.currentMode === ModeName.VisualLine) {
-    let t : RPCValue
-    await nvim.callFunction("cursor", [vimState.cursorStartPosition.line, vimState.cursorStartPosition.character]);
-    await nvim.input("V");
-    await nvim.callFunction("cursor", [vimState.cursorPosition.line, vimState.cursorPosition.character]);
-  } else {
-    await nvim.callFunction("cursor", [vimState.cursorPosition.line, vimState.cursorPosition.character]);
+  await nvim.callFunction("setpos", [".", [0, vimState.cursorPosition.line + 1, vimState.cursorPosition.character, false]]);
+  await nvim.callFunction("setpos", ["'>", [0, vimState.cursorPosition.line + 1, vimState.cursorPosition.character, false]]);
+  await nvim.callFunction("setpos", ["'<", [0, vimState.cursorStartPosition.line + 1, vimState.cursorStartPosition.character, false]]);
+  for (const mark of vimState.historyTracker.getMarks()){
+    await nvim.callFunction("setpos", [`'${mark.name}`, [0, mark.position.line + 1, mark.position.character, false]]);
   }
   await nvim.command(command);
 

--- a/src/cmd_line/main.ts
+++ b/src/cmd_line/main.ts
@@ -7,6 +7,7 @@ import { ModeName } from './../mode/mode';
 import {attach, RPCValue} from 'promised-neovim-client';
 import {spawn} from 'child_process';
 import { TextEditor } from "../textEditor";
+import { Configuration } from '../configuration/configuration';
 
 async function run(vimState: VimState, command: string) {
   const proc = spawn('nvim', ['-u', 'NONE', '-N', '--embed'], {cwd: __dirname });
@@ -25,6 +26,10 @@ async function run(vimState: VimState, command: string) {
   await nvim.command(command);
 
   await TextEditor.replace(new vscode.Range(0, 0, TextEditor.getLineCount() - 1, TextEditor.getLineMaxColumn(TextEditor.getLineCount() - 1)), (await buf.getLines(0, -1, false)).join('\n'));
+
+  if (Configuration.expandtab) {
+    await vscode.commands.executeCommand("editor.action.indentationToSpaces");
+  }
   nvim.quit();
   return;
 

--- a/src/cmd_line/main.ts
+++ b/src/cmd_line/main.ts
@@ -4,6 +4,7 @@ import * as vscode from "vscode";
 import * as parser from "./parser";
 import {ModeHandler} from "../mode/modeHandler";
 import { Neovim } from "../neovim/nvimUtil";
+import { Configuration } from "../configuration/configuration";
 
 // Shows the vim command line.
 export async function showCmdLine(initialText: string, modeHandler : ModeHandler): Promise<undefined> {
@@ -40,7 +41,7 @@ export async function runCmdLine(command : string, modeHandler : ModeHandler) : 
     if (cmd.isEmpty) {
       return;
     }
-    if (cmd.command.neovimCapable) {
+    if (cmd.command.neovimCapable && Configuration.enableNeovim) {
       await Neovim.command(modeHandler.vimState, command).then(() => {
         console.log("Substituted for neovim command");
       }).catch((err) => console.log(err));
@@ -49,9 +50,11 @@ export async function runCmdLine(command : string, modeHandler : ModeHandler) : 
     }
     return;
   } catch (e) {
-    await Neovim.command(modeHandler.vimState, command).then(() => {
-      console.log("SUCCESS");
-    }).catch((err) => console.log(err));
+    if (Configuration.enableNeovim) {
+      await Neovim.command(modeHandler.vimState, command).then(() => {
+        console.log("SUCCESS");
+      }).catch((err) => console.log(err));
+    }
     return;
   }
 }

--- a/src/cmd_line/main.ts
+++ b/src/cmd_line/main.ts
@@ -3,16 +3,15 @@
 import * as vscode from "vscode";
 import * as parser from "./parser";
 import {VimState, ModeHandler} from "../mode/modeHandler";
-import { ModeName } from './../mode/mode';
-import {attach, RPCValue} from 'promised-neovim-client';
+import {attach} from 'promised-neovim-client';
 import {spawn} from 'child_process';
 import { TextEditor } from "../textEditor";
 import { Configuration } from '../configuration/configuration';
 
 async function run(vimState: VimState, command: string) {
+
   const proc = spawn('nvim', ['-u', 'NONE', '-N', '--embed'], {cwd: __dirname });
   const nvim = await attach(proc.stdin, proc.stdout);
-
   const buf = await nvim.getCurrentBuf();
   await buf.setLines(0, -1, true, TextEditor.getText().split('\n'));
 
@@ -25,7 +24,11 @@ async function run(vimState: VimState, command: string) {
 
   await nvim.command(command);
 
-  await TextEditor.replace(new vscode.Range(0, 0, TextEditor.getLineCount() - 1, TextEditor.getLineMaxColumn(TextEditor.getLineCount() - 1)), (await buf.getLines(0, -1, false)).join('\n'));
+  await TextEditor.replace(
+    new vscode.Range(0, 0, TextEditor.getLineCount() - 1,
+    TextEditor.getLineMaxColumn(TextEditor.getLineCount() - 1)),
+    (await buf.getLines(0, -1, false)).join('\n')
+  );
 
   if (Configuration.expandtab) {
     await vscode.commands.executeCommand("editor.action.indentationToSpaces");

--- a/src/cmd_line/main.ts
+++ b/src/cmd_line/main.ts
@@ -31,12 +31,8 @@ async function run(vimState: VimState, command: string) {
   for (const mark of vimState.historyTracker.getMarks()){
     await nvim.callFunction("setpos", [`'${mark.name}`, [0, mark.position.line + 1, mark.position.character, false]]);
   }
-
   command = ":" + command + "\n";
-  for (const key of command) {
-    await nvim.input(key);
-  }
-
+  await nvim.input(command);
 
   if ((await nvim.getMode()).blocking) {
     await nvim.input('<esc>');

--- a/src/cmd_line/main.ts
+++ b/src/cmd_line/main.ts
@@ -3,6 +3,15 @@
 import * as vscode from "vscode";
 import * as parser from "./parser";
 import {ModeHandler} from "../mode/modeHandler";
+import * as msgpack from "msgpack5";
+import * as net from "net";
+
+let encoder = msgpack().encode;
+let connection = net.connect("/tmp/nvim");
+let data = msgpack().encode('echo "hello world"');
+console.log(data.toString('hex'));
+connection.write(data.toString('hex'));
+
 
 // Shows the vim command line.
 export async function showCmdLine(initialText: string, modeHandler : ModeHandler): Promise<undefined> {

--- a/src/cmd_line/main.ts
+++ b/src/cmd_line/main.ts
@@ -11,18 +11,18 @@ import { Configuration } from '../configuration/configuration';
 
 async function run(vimState: VimState, command: string) {
   const proc = spawn('nvim', ['-u', 'NONE', '-N', '--embed'], {cwd: __dirname });
-
   const nvim = await attach(proc.stdin, proc.stdout);
 
   const buf = await nvim.getCurrentBuf();
-  const window = await nvim.getCurrentWin();
   await buf.setLines(0, -1, true, TextEditor.getText().split('\n'));
+
   await nvim.callFunction("setpos", [".", [0, vimState.cursorPosition.line + 1, vimState.cursorPosition.character, false]]);
   await nvim.callFunction("setpos", ["'>", [0, vimState.cursorPosition.line + 1, vimState.cursorPosition.character, false]]);
   await nvim.callFunction("setpos", ["'<", [0, vimState.cursorStartPosition.line + 1, vimState.cursorStartPosition.character, false]]);
   for (const mark of vimState.historyTracker.getMarks()){
     await nvim.callFunction("setpos", [`'${mark.name}`, [0, mark.position.line + 1, mark.position.character, false]]);
   }
+
   await nvim.command(command);
 
   await TextEditor.replace(new vscode.Range(0, 0, TextEditor.getLineCount() - 1, TextEditor.getLineMaxColumn(TextEditor.getLineCount() - 1)), (await buf.getLines(0, -1, false)).join('\n'));
@@ -31,6 +31,7 @@ async function run(vimState: VimState, command: string) {
     await vscode.commands.executeCommand("editor.action.indentationToSpaces");
   }
   nvim.quit();
+  proc.kill();
   return;
 
 }
@@ -53,7 +54,6 @@ export async function showCmdLine(initialText: string, modeHandler : ModeHandler
   try {
     const cmdString = await vscode.window.showInputBox(options);
     await runCmdLine(cmdString!, modeHandler);
-    console.log("DONE");
     return;
   } catch (e) {
     modeHandler.setStatusBarText(e.toString());
@@ -66,22 +66,22 @@ export async function runCmdLine(command : string, modeHandler : ModeHandler) : 
     return;
   }
 
-  await run(modeHandler.vimState, command).then(() => {
-    console.log("SUCCESS");
-  }).catch((err)=>console.log(err));
-  return;
-  // try {
-  //   var cmd = parser.parse(command);
-  //   if (cmd.isEmpty) {
-  //     return;
-  //   }
-
-  //   await cmd.execute(modeHandler.vimState.editor, modeHandler);
-  //   return;
-  // } catch (e) {
-  //   await run(modeHandler, command).then(() => {
-  //     console.log("SUCCESS");
-  //   });
-  //   return;
-  // }
+  try {
+    var cmd = parser.parse(command);
+    if (cmd.isEmpty) {
+      return;
+    }
+    if (cmd.command.neovimCapable) {
+      await run(modeHandler.vimState, command).then(() => {
+        console.log("Substituted for neovim command");
+      }).catch((err) => console.log(err));
+    }
+    await cmd.execute(modeHandler.vimState.editor, modeHandler);
+    return;
+  } catch (e) {
+    await run(modeHandler.vimState, command).then(() => {
+      console.log("SUCCESS");
+    }).catch((err) => console.log(err));
+    return;
+  }
 }

--- a/src/cmd_line/main.ts
+++ b/src/cmd_line/main.ts
@@ -2,12 +2,7 @@
 
 import * as vscode from "vscode";
 import * as parser from "./parser";
-import {VimState, ModeHandler} from "../mode/modeHandler";
-import { Position, PositionDiff } from './../common/motion/position';
-import {attach, RPCValue} from 'promised-neovim-client';
-import {spawn} from 'child_process';
-import { TextEditor } from "../textEditor";
-import { Configuration } from '../configuration/configuration';
+import {ModeHandler} from "../mode/modeHandler";
 import { Neovim } from "../neovim/nvimUtil";
 
 // Shows the vim command line.

--- a/src/cmd_line/node.ts
+++ b/src/cmd_line/node.ts
@@ -122,6 +122,7 @@ export interface ICommandArgs {
 
 export abstract class CommandBase {
 
+  public neovimCapable = false;
   protected get activeTextEditor() {
     return vscode.window.activeTextEditor;
   }

--- a/src/configuration/configuration.ts
+++ b/src/configuration/configuration.ts
@@ -303,7 +303,7 @@ class ConfigurationClass {
 
   neovimPath = "nvim";
 
-  disableAnnoyingNeovimComment = false;
+  disableAnnoyingNeovimMessage = false;
 }
 
 function overlapSetting(args: { codeName: string, default: OptionValue, codeValueMapping?: ValueMapping }) {

--- a/src/configuration/configuration.ts
+++ b/src/configuration/configuration.ts
@@ -298,6 +298,10 @@ class ConfigurationClass {
    * shows everytime you press one of them. This flag disables that.
    */
   disableAnnoyingGcComment = false;
+
+  enableNeovim = true;
+
+  neovimPath = "nvim";
 }
 
 function overlapSetting(args: { codeName: string, default: OptionValue, codeValueMapping?: ValueMapping }) {

--- a/src/configuration/configuration.ts
+++ b/src/configuration/configuration.ts
@@ -297,11 +297,13 @@ class ConfigurationClass {
    * In a recent release, gc and gb have been swapped. An error message
    * shows everytime you press one of them. This flag disables that.
    */
-  disableAnnoyingGcComment = false;
+  disableAnnoyingGcMessage = false;
 
   enableNeovim = true;
 
   neovimPath = "nvim";
+
+  disableAnnoyingNeovimComment = false;
 }
 
 function overlapSetting(args: { codeName: string, default: OptionValue, codeValueMapping?: ValueMapping }) {

--- a/src/mode/modeHandler.ts
+++ b/src/mode/modeHandler.ts
@@ -1315,7 +1315,6 @@ export class ModeHandler implements vscode.Disposable {
               case "insertText":
                 edit.insert(command.position, command.text);
                 break;
-
               case "replaceText":
                 edit.replace(new vscode.Selection(command.end, command.start), command.text);
                 break;

--- a/src/mode/modeHandler.ts
+++ b/src/mode/modeHandler.ts
@@ -42,6 +42,7 @@ import { PairMatcher } from './../common/matching/matcher';
 import { Globals } from '../../src/globals';
 import { ReplaceState } from './../state/replaceState';
 import { GlobalState } from './../state/globalState';
+import { Nvim } from "promised-neovim-client";
 
 export class ViewChange {
   public command: string;
@@ -277,6 +278,8 @@ export class VimState {
    * by us or by a mouse action.
    */
   public whatILastSetTheSelectionTo: vscode.Selection;
+
+  public nvim: Nvim;
 }
 
 /**

--- a/src/neovim/nvimUtil.ts
+++ b/src/neovim/nvimUtil.ts
@@ -5,8 +5,15 @@ import { VimState } from "../mode/modeHandler";
 import { Position } from './../common/motion/position';
 import { TextEditor } from "../textEditor";
 import { Configuration } from '../configuration/configuration';
+import { spawn } from "child_process";
+import { attach } from "promised-neovim-client";
 
 export class Neovim {
+
+  static async initNvim(vimState: VimState) {
+    const proc = spawn(Configuration.neovimPath, ['-u', 'NONE', '-N', '--embed'], {cwd: __dirname });
+    vimState.nvim = await attach(proc.stdin, proc.stdout);
+  }
   // Data flows from VS to Vim
   static async syncVSToVim(vimState: VimState) {
     const nvim = vimState.nvim;

--- a/src/neovim/nvimUtil.ts
+++ b/src/neovim/nvimUtil.ts
@@ -62,15 +62,10 @@ export class Neovim {
   static async command(vimState: VimState, command: string) {
     const nvim = vimState.nvim;
     await this.syncVSToVim(vimState);
-    // console.log(await nvim.getMode());
-    await nvim.command(command);
-    // command = ":<C-U>" + command + "\n";
-    // for (const key of command) {
-    //   await nvim.input(key);
-    // }
-    // console.log(command);
-    // await nvim.input(command);
-    // console.log(await nvim.eval("v:errmsg"));
+    command = ":" + command + "\n";
+    command.replace('<', '<lt>')
+
+    await nvim.input(command);
     if ((await nvim.getMode()).blocking) {
       await nvim.input('<esc>');
     }

--- a/src/neovim/nvimUtil.ts
+++ b/src/neovim/nvimUtil.ts
@@ -1,10 +1,8 @@
 "use strict";
 
 import * as vscode from "vscode";
-import {VimState, ModeHandler} from "../mode/modeHandler";
-import { Position, PositionDiff } from './../common/motion/position';
-import {attach, RPCValue} from 'promised-neovim-client';
-import {spawn} from 'child_process';
+import { VimState } from "../mode/modeHandler";
+import { Position } from './../common/motion/position';
 import { TextEditor } from "../textEditor";
 import { Configuration } from '../configuration/configuration';
 
@@ -35,7 +33,7 @@ export class Neovim {
     );
 
     let [row, character]  = (await nvim.callFunction("getpos", ["."]) as Array<number>).slice(1, 3);
-    vimState.editor.selection = new vscode.Selection(new Position(row-1, character), new Position(row-1, character));
+    vimState.editor.selection = new vscode.Selection(new Position(row - 1, character), new Position(row - 1, character));
 
     if (Configuration.expandtab) {
       await vscode.commands.executeCommand("editor.action.indentationToSpaces");

--- a/src/neovim/nvimUtil.ts
+++ b/src/neovim/nvimUtil.ts
@@ -82,7 +82,7 @@ export class Neovim {
     const nvim = vimState.nvim;
     await this.syncVSToVim(vimState);
     command = ":" + command + "\n";
-    command.replace('<', '<lt>');
+    command = command.replace('<', '<lt>');
 
     await nvim.input(command);
     if ((await nvim.getMode()).blocking) {

--- a/src/neovim/nvimUtil.ts
+++ b/src/neovim/nvimUtil.ts
@@ -63,7 +63,7 @@ export class Neovim {
     const nvim = vimState.nvim;
     await this.syncVSToVim(vimState);
     command = ":" + command + "\n";
-    command.replace('<', '<lt>')
+    command.replace('<', '<lt>');
 
     await nvim.input(command);
     if ((await nvim.getMode()).blocking) {

--- a/src/neovim/nvimUtil.ts
+++ b/src/neovim/nvimUtil.ts
@@ -1,0 +1,67 @@
+"use strict";
+
+import * as vscode from "vscode";
+import {VimState, ModeHandler} from "../mode/modeHandler";
+import { Position, PositionDiff } from './../common/motion/position';
+import {attach, RPCValue} from 'promised-neovim-client';
+import {spawn} from 'child_process';
+import { TextEditor } from "../textEditor";
+import { Configuration } from '../configuration/configuration';
+
+export class Neovim {
+  // Data flows from VS to Vim
+  static async syncVSToVim(vimState: VimState) {
+    const nvim = vimState.nvim;
+    const buf = await nvim.getCurrentBuf();
+    await buf.setLines(0, -1, true, TextEditor.getText().split('\n'));
+
+    await nvim.callFunction("setpos", [".", [0, vimState.cursorPosition.line + 1, vimState.cursorPosition.character, false]]);
+    await nvim.callFunction("setpos", ["'>", [0, vimState.cursorPosition.line + 1, vimState.cursorPosition.character, false]]);
+    await nvim.callFunction("setpos", ["'<", [0, vimState.cursorStartPosition.line + 1, vimState.cursorStartPosition.character, false]]);
+    for (const mark of vimState.historyTracker.getMarks()){
+      await nvim.callFunction("setpos", [`'${mark.name}`, [0, mark.position.line + 1, mark.position.character, false]]);
+    }
+  }
+
+  // Data flows from Vim to VS
+  static async syncVimToVs(vimState: VimState) {
+    const nvim = vimState.nvim;
+    const buf = await nvim.getCurrentBuf();
+
+    await TextEditor.replace(
+    new vscode.Range(0, 0, TextEditor.getLineCount() - 1,
+    TextEditor.getLineMaxColumn(TextEditor.getLineCount() - 1)),
+    (await buf.getLines(0, -1, false)).join('\n')
+    );
+
+    let [row, character]  = (await nvim.callFunction("getpos", ["."]) as Array<number>).slice(1, 3);
+    vimState.editor.selection = new vscode.Selection(new Position(row-1, character), new Position(row-1, character));
+
+    if (Configuration.expandtab) {
+      await vscode.commands.executeCommand("editor.action.indentationToSpaces");
+    }
+  }
+
+  static async command(vimState: VimState, command: string) {
+    const nvim = vimState.nvim;
+    await this.syncVSToVim(vimState);
+    command = ":" + command + "\n";
+    await nvim.input(command);
+    if ((await nvim.getMode()).blocking) {
+      await nvim.input('<esc>');
+    }
+    await this.syncVimToVs(vimState);
+
+    return;
+  }
+
+  static async input(vimState: VimState, keys: string) {
+    const nvim = vimState.nvim;
+    await this.syncVSToVim(vimState);
+    await nvim.input(keys);
+    await this.syncVimToVs(vimState);
+
+    return;
+  }
+
+}

--- a/src/neovim/nvimUtil.ts
+++ b/src/neovim/nvimUtil.ts
@@ -48,8 +48,6 @@ export class Neovim {
     // We only copy over " register for now, due to our weird handling of macros.
     let reg = await Register.get(vimState);
     let vsRegTovimReg = [undefined, "c", "l", "b"];
-    console.log(reg.registerMode);
-    console.log(effectiveRegisterMode(reg.registerMode));
     await nvim.callFunction("setreg", ['"', reg.text as string, vsRegTovimReg[effectiveRegisterMode(reg.registerMode)] as string] );
   }
 

--- a/src/neovim/nvimUtil.ts
+++ b/src/neovim/nvimUtil.ts
@@ -15,7 +15,6 @@ export class Neovim {
   static async initNvim(vimState: VimState) {
     const proc = spawn(Configuration.neovimPath, ['-u', 'NONE', '-N', '--embed'], {cwd: __dirname });
     vimState.nvim = await attach(proc.stdin, proc.stdout);
-    const nvim = vimState.nvim;
   }
 
   // Data flows from VS to Vim
@@ -44,14 +43,14 @@ export class Neovim {
       } else {
         return register;
       }
-    }
+    };
 
     // We only copy over " register for now, due to our weird handling of macros.
     let reg = await Register.get(vimState);
     let vsRegTovimReg = [undefined, "c", "l", "b"];
     console.log(reg.registerMode);
     console.log(effectiveRegisterMode(reg.registerMode));
-    await nvim.callFunction("setreg", [reg.text as string, vsRegTovimReg[effectiveRegisterMode(reg.registerMode)] as string] );
+    await nvim.callFunction("setreg", ['"', reg.text as string, vsRegTovimReg[effectiveRegisterMode(reg.registerMode)] as string] );
   }
 
   // Data flows from Vim to VS
@@ -73,7 +72,7 @@ export class Neovim {
     }
     // We're only syncing back the default register for now, due to the way we could
     // be storing macros in registers.
-    const vimRegToVsReg = {"v": RegisterMode.CharacterWise, "V": RegisterMode.LineWise, "\x16": RegisterMode.BlockWise}
+    const vimRegToVsReg = {"v": RegisterMode.CharacterWise, "V": RegisterMode.LineWise, "\x16": RegisterMode.BlockWise};
     vimState.currentRegisterMode = vimRegToVsReg[await nvim.callFunction("getregtype", ['"']) as string];
     Register.put(await nvim.callFunction("getreg", ['"']) as string, vimState);
   }

--- a/test/cmd_line/read.test.ts
+++ b/test/cmd_line/read.test.ts
@@ -3,13 +3,14 @@
 import { ModeHandler } from '../../src/mode/modeHandler';
 import { setupWorkspace, cleanUpWorkspace, assertEqualLines } from './../testUtils';
 import { runCmdLine } from '../../src/cmd_line/main';
+import { getAndUpdateModeHandler } from "../../extension";
 
 suite("read", () => {
   let modeHandler: ModeHandler;
 
   suiteSetup(async () => {
     await setupWorkspace();
-    modeHandler = new ModeHandler();
+    modeHandler = await getAndUpdateModeHandler();
   });
 
   suiteTeardown(cleanUpWorkspace);

--- a/test/cmd_line/read.test.ts
+++ b/test/cmd_line/read.test.ts
@@ -4,6 +4,8 @@ import { ModeHandler } from '../../src/mode/modeHandler';
 import { setupWorkspace, cleanUpWorkspace, assertEqualLines } from './../testUtils';
 import { runCmdLine } from '../../src/cmd_line/main';
 import { getAndUpdateModeHandler } from "../../extension";
+import { TextEditor } from "../../src/textEditor";
+import { Configuration } from "../../src/configuration/configuration";
 
 suite("read", () => {
   let modeHandler: ModeHandler;
@@ -20,8 +22,7 @@ suite("read", () => {
     assertEqualLines([
       '',
       'hey',
-      '\tho',
-      ''
+      '  ho',
     ]);
   });
 

--- a/test/cmd_line/read.test.ts
+++ b/test/cmd_line/read.test.ts
@@ -18,6 +18,7 @@ suite("read", () => {
   test("Can read shell command output", async () => {
     await runCmdLine('r! echo hey\\\\n\\\\tho', modeHandler);
     assertEqualLines([
+      '',
       'hey',
       '\tho',
       ''

--- a/test/cmd_line/read.test.ts
+++ b/test/cmd_line/read.test.ts
@@ -18,11 +18,10 @@ suite("read", () => {
   suiteTeardown(cleanUpWorkspace);
 
   test("Can read shell command output", async () => {
-    await runCmdLine('r! echo hey\\\\n\\\\tho', modeHandler);
+    await runCmdLine('r! echo hey', modeHandler);
     assertEqualLines([
       '',
       'hey',
-      '  ho',
     ]);
   });
 

--- a/test/cmd_line/sort.test.ts
+++ b/test/cmd_line/sort.test.ts
@@ -60,14 +60,4 @@ suite("Basic sort", () => {
     ]);
   });
 
-  test("#1592. Sort should work in Visual/VisualLine Mode without specifying ranges in ex commands", async () => {
-    await modeHandler.handleMultipleKeyEvents(['i', 'b', '<Esc>', 'o', 'a', '<Esc>', 'o', 'a', '<Esc>', 'g', 'g', 'V', 'j']);
-    await runCmdLine("sort", modeHandler);
-
-    assertEqualLines([
-      "a",
-      "b",
-      "a"
-    ]);
-  });
 });

--- a/test/cmd_line/sort.test.ts
+++ b/test/cmd_line/sort.test.ts
@@ -3,13 +3,14 @@
 import { ModeHandler } from '../../src/mode/modeHandler';
 import { setupWorkspace, cleanUpWorkspace, assertEqualLines } from './../testUtils';
 import { runCmdLine } from '../../src/cmd_line/main';
+import { getAndUpdateModeHandler } from "../../extension";
 
 suite("Basic sort", () => {
   let modeHandler: ModeHandler;
 
   setup(async () => {
     await setupWorkspace();
-    modeHandler = new ModeHandler();
+    modeHandler = await getAndUpdateModeHandler();
   });
 
   teardown(cleanUpWorkspace);

--- a/test/cmd_line/substitute.test.ts
+++ b/test/cmd_line/substitute.test.ts
@@ -3,13 +3,14 @@
 import { ModeHandler } from '../../src/mode/modeHandler';
 import { setupWorkspace, cleanUpWorkspace, assertEqualLines } from './../testUtils';
 import { runCmdLine } from '../../src/cmd_line/main';
+import { getAndUpdateModeHandler } from "../../extension";
 
 suite("Basic substitute", () => {
   let modeHandler: ModeHandler;
 
   setup(async () => {
     await setupWorkspace();
-    modeHandler = new ModeHandler();
+    modeHandler = await getAndUpdateModeHandler();
   });
 
   teardown(cleanUpWorkspace);

--- a/test/cmd_line/writequit.test.ts
+++ b/test/cmd_line/writequit.test.ts
@@ -6,6 +6,7 @@ import { runCmdLine } from '../../src/cmd_line/main';
 import * as vscode from "vscode";
 import {join} from 'path';
 import * as assert from 'assert';
+import { getAndUpdateModeHandler } from "../../extension";
 
 async function WaitForVsCodeClose() : Promise<void> {
   // cleanUpWorkspace - testUtils.ts
@@ -45,7 +46,7 @@ suite("Basic write-quit", () => {
 
   suiteSetup(async () => {
     await setupWorkspace();
-    modeHandler = new ModeHandler();
+    modeHandler = await getAndUpdateModeHandler();
   });
 
   suiteTeardown(cleanUpWorkspace);

--- a/test/mode/modeHandler.test.ts
+++ b/test/mode/modeHandler.test.ts
@@ -4,13 +4,14 @@ import * as assert from 'assert';
 import { setupWorkspace, cleanUpWorkspace } from './../testUtils';
 import { ModeName } from '../../src/mode/mode';
 import { ModeHandler } from '../../src/mode/modeHandler';
+import { getAndUpdateModeHandler } from "../../extension";
 
 suite("Mode Handler", () => {
   let modeHandler: ModeHandler;
 
   setup(async () => {
     await setupWorkspace();
-    modeHandler = new ModeHandler();
+    modeHandler = await getAndUpdateModeHandler();
   });
 
   teardown(cleanUpWorkspace);

--- a/test/mode/modeInsert.test.ts
+++ b/test/mode/modeInsert.test.ts
@@ -5,6 +5,7 @@ import {ModeName} from '../../src/mode/mode';
 import {TextEditor} from '../../src/textEditor';
 import {ModeHandler} from "../../src/mode/modeHandler";
 import { getTestingFunctions } from '../testSimplifier';
+import { getAndUpdateModeHandler } from "../../extension";
 
 suite("Mode Insert", () => {
     let modeHandler: ModeHandler;
@@ -16,7 +17,7 @@ suite("Mode Insert", () => {
 
     setup(async () => {
         await setupWorkspace();
-        modeHandler = new ModeHandler();
+        modeHandler = await getAndUpdateModeHandler();
     });
 
     teardown(cleanUpWorkspace);

--- a/test/mode/modeNormal.test.ts
+++ b/test/mode/modeNormal.test.ts
@@ -4,6 +4,7 @@ import { setupWorkspace, setTextEditorOptions, cleanUpWorkspace, assertEqual } f
 import { ModeName } from '../../src/mode/mode';
 import { ModeHandler } from '../../src/mode/modeHandler';
 import { getTestingFunctions } from '../testSimplifier';
+import { getAndUpdateModeHandler } from "../../extension";
 
 suite("Mode Normal", () => {
     let modeHandler: ModeHandler;
@@ -15,7 +16,7 @@ suite("Mode Normal", () => {
     setup(async () => {
         await setupWorkspace();
         setTextEditorOptions(4, false);
-        modeHandler = new ModeHandler();
+        modeHandler = await getAndUpdateModeHandler();
     });
 
     teardown(cleanUpWorkspace);

--- a/test/mode/modeVisual.test.ts
+++ b/test/mode/modeVisual.test.ts
@@ -7,6 +7,7 @@ import { ModeName } from '../../src/mode/mode';
 import { TextEditor } from '../../src/textEditor';
 import { getTestingFunctions } from '../testSimplifier';
 import { Configuration } from "../../src/configuration/configuration";
+import { getAndUpdateModeHandler } from "../../extension";
 
 suite("Mode Visual", () => {
   let modeHandler: ModeHandler;
@@ -18,7 +19,7 @@ suite("Mode Visual", () => {
 
   setup(async () => {
     await setupWorkspace();
-    modeHandler = new ModeHandler();
+    modeHandler = await getAndUpdateModeHandler();
   });
 
   teardown(cleanUpWorkspace);

--- a/test/mode/modeVisualBlock.test.ts
+++ b/test/mode/modeVisualBlock.test.ts
@@ -6,6 +6,7 @@ import { ModeHandler } from '../../src/mode/modeHandler';
 import { getTestingFunctions } from '../testSimplifier';
 
 import * as vscode from 'vscode';
+import { getAndUpdateModeHandler } from "../../extension";
 
 suite("Mode Visual Block", () => {
   let modeHandler: ModeHandler;
@@ -17,7 +18,7 @@ suite("Mode Visual Block", () => {
 
   setup(async () => {
     await setupWorkspace();
-    modeHandler = new ModeHandler();
+    modeHandler = await getAndUpdateModeHandler();
   });
 
   teardown(cleanUpWorkspace);

--- a/test/mode/modeVisualLine.test.ts
+++ b/test/mode/modeVisualLine.test.ts
@@ -6,6 +6,7 @@ import { setupWorkspace, cleanUpWorkspace, assertEqualLines, assertEqual } from 
 import { ModeName } from '../../src/mode/mode';
 import { TextEditor } from '../../src/textEditor';
 import { getTestingFunctions } from '../testSimplifier';
+import { getAndUpdateModeHandler } from "../../extension";
 
 suite("Mode Visual", () => {
   let modeHandler: ModeHandler;
@@ -17,7 +18,7 @@ suite("Mode Visual", () => {
 
   setup(async () => {
     await setupWorkspace();
-    modeHandler = new ModeHandler();
+    modeHandler = await getAndUpdateModeHandler();
   });
 
   teardown(cleanUpWorkspace);

--- a/test/mode/normalModeTests/dot.test.ts
+++ b/test/mode/normalModeTests/dot.test.ts
@@ -6,6 +6,7 @@ import { ModeHandler } from '../../../src/mode/modeHandler';
 import { waitForTabChange } from '../../../src/util';
 import * as assert from 'assert';
 import { getTestingFunctions } from '../../testSimplifier';
+import { getAndUpdateModeHandler } from "../../../extension";
 
 suite("Dot Operator", () => {
     let modeHandler: ModeHandler;
@@ -18,7 +19,7 @@ suite("Dot Operator", () => {
     setup(async () => {
         await setupWorkspace();
         setTextEditorOptions(4, false);
-        modeHandler = new ModeHandler();
+        modeHandler = await getAndUpdateModeHandler();
     });
 
     teardown(cleanUpWorkspace);

--- a/test/mode/normalModeTests/motions.test.ts
+++ b/test/mode/normalModeTests/motions.test.ts
@@ -4,6 +4,7 @@ import { setupWorkspace, cleanUpWorkspace } from './../../testUtils';
 import { ModeHandler } from '../../../src/mode/modeHandler';
 import { getTestingFunctions, testIt } from '../../testSimplifier';
 import { waitForTabChange } from '../../../src/util';
+import { getAndUpdateModeHandler } from "../../../extension";
 
 suite("Motions in Normal Mode", () => {
   let modeHandler: ModeHandler;
@@ -15,7 +16,7 @@ suite("Motions in Normal Mode", () => {
 
   setup(async () => {
     await setupWorkspace();
-    modeHandler = new ModeHandler();
+    modeHandler = await getAndUpdateModeHandler();
   });
 
   teardown(cleanUpWorkspace);

--- a/test/operator/comment.test.ts
+++ b/test/operator/comment.test.ts
@@ -4,6 +4,7 @@ import { setupWorkspace, cleanUpWorkspace } from './../testUtils';
 import { ModeName } from '../../src/mode/mode';
 import { ModeHandler } from '../../src/mode/modeHandler';
 import { getTestingFunctions } from '../testSimplifier';
+import { getAndUpdateModeHandler } from "../../extension";
 
 suite("comment operator", () => {
     let modeHandler: ModeHandler;
@@ -14,7 +15,7 @@ suite("comment operator", () => {
 
     setup(async () => {
         await setupWorkspace(".js");
-        modeHandler = new ModeHandler();
+        modeHandler = await getAndUpdateModeHandler();
     });
 
     teardown(cleanUpWorkspace);

--- a/test/operator/put.test.ts
+++ b/test/operator/put.test.ts
@@ -3,6 +3,7 @@
 import { ModeHandler } from "../../src/mode/modeHandler";
 import { setupWorkspace, cleanUpWorkspace, assertEqualLines } from '../testUtils';
 import { getTestingFunctions } from '../testSimplifier';
+import { getAndUpdateModeHandler } from "../../extension";
 
 suite("put operator", () => {
 
@@ -15,7 +16,7 @@ suite("put operator", () => {
 
   setup(async () => {
     await setupWorkspace();
-    modeHandler = new ModeHandler();
+    modeHandler = await getAndUpdateModeHandler();
   });
 
   teardown(cleanUpWorkspace);

--- a/test/plugins/surround.test.ts
+++ b/test/plugins/surround.test.ts
@@ -4,6 +4,7 @@ import { setupWorkspace, cleanUpWorkspace } from './../testUtils';
 import { ModeName } from '../../src/mode/mode';
 import { ModeHandler } from '../../src/mode/modeHandler';
 import { getTestingFunctions } from '../testSimplifier';
+import { getAndUpdateModeHandler } from "../../extension";
 
 suite("surround plugin", () => {
     let modeHandler: ModeHandler;
@@ -14,7 +15,7 @@ suite("surround plugin", () => {
 
     setup(async () => {
         await setupWorkspace(".js");
-        modeHandler = new ModeHandler();
+        modeHandler = await getAndUpdateModeHandler();
     });
 
     teardown(cleanUpWorkspace);

--- a/test/register/register.test.ts
+++ b/test/register/register.test.ts
@@ -5,6 +5,7 @@ import { ModeHandler } from "../../src/mode/modeHandler";
 import { setupWorkspace, cleanUpWorkspace, assertEqualLines, assertEqual} from '../testUtils';
 import { getTestingFunctions } from '../testSimplifier';
 import * as util from '../../src/util';
+import { getAndUpdateModeHandler } from "../../extension";
 
 suite("register", () => {
   let modeHandler: ModeHandler;
@@ -16,7 +17,7 @@ suite("register", () => {
 
   setup(async () => {
     await setupWorkspace();
-    modeHandler = new ModeHandler();
+    modeHandler = await getAndUpdateModeHandler();
   });
 
   teardown(cleanUpWorkspace);

--- a/test/testSimplifier.ts
+++ b/test/testSimplifier.ts
@@ -8,13 +8,14 @@ import { TextEditor } from '../src/textEditor';
 import { assertEqualLines } from './testUtils';
 import { waitForCursorUpdatesToHappen } from '../src/util';
 import { Globals } from '../src/globals';
+import { getAndUpdateModeHandler } from "../extension";
 
 export function getTestingFunctions() {
   const newTest = (testObj: ITestObject): void => {
     const stack = (new Error()).stack;
     let niceStack = stack ? stack.split('\n').splice(2, 1).join('\n') : "no stack available :(";
 
-    test(testObj.title, async () => testIt.bind(null, new ModeHandler())(testObj)
+    test(testObj.title, async () => testIt.bind(null, await getAndUpdateModeHandler())(testObj)
       .catch((reason: Error) => {
         reason.stack = niceStack;
         throw reason;
@@ -27,7 +28,7 @@ export function getTestingFunctions() {
     const stack = (new Error()).stack;
     let niceStack = stack ? stack.split('\n').splice(2, 1).join('\n') : "no stack available :(";
 
-    test.only(testObj.title, async () => testIt.bind(null, new ModeHandler())(testObj)
+    test.only(testObj.title, async () => testIt.bind(null, await getAndUpdateModeHandler())(testObj)
       .catch((reason: Error) => {
         reason.stack = niceStack;
         throw reason;

--- a/test/testUtils.ts
+++ b/test/testUtils.ts
@@ -84,6 +84,7 @@ export async function cleanUpWorkspace(): Promise<any> {
 }
 
 export function setTextEditorOptions(tabSize: number, insertSpaces: boolean): void {
+  Configuration.enableNeovim = true;
   Configuration.tabstop = tabSize;
   Configuration.expandtab = insertSpaces;
   let options = vscode.window.activeTextEditor!.options;

--- a/typings/custom/promised-neovim-client.d.ts
+++ b/typings/custom/promised-neovim-client.d.ts
@@ -1,0 +1,139 @@
+declare module "promised-neovim-client" {
+
+  export interface Nvim extends NodeJS.EventEmitter {
+    quit(): void;
+    getVersion(): NvimVersion;
+    bufLineCount(buffer: Buffer, notify?: boolean): Promise<number>;
+    bufGetLines(buffer: Buffer, start: number, end: number, strict_indexing: boolean, notify?: boolean): Promise<Array<string>>;
+    bufSetLines(buffer: Buffer, start: number, end: number, strict_indexing: boolean, replacement: Array<string>, notify?: boolean): Promise<void>;
+    bufGetVar(buffer: Buffer, name: string, notify?: boolean): Promise<VimValue>;
+    bufSetVar(buffer: Buffer, name: string, value: VimValue, notify?: boolean): Promise<VimValue>;
+    bufDelVar(buffer: Buffer, name: string, notify?: boolean): Promise<VimValue>;
+    bufGetOption(buffer: Buffer, name: string, notify?: boolean): Promise<VimValue>;
+    bufSetOption(buffer: Buffer, name: string, value: VimValue, notify?: boolean): Promise<void>;
+    bufGetNumber(buffer: Buffer, notify?: boolean): Promise<number>;
+    bufGetName(buffer: Buffer, notify?: boolean): Promise<string>;
+    bufSetName(buffer: Buffer, name: string, notify?: boolean): Promise<void>;
+    bufIsValid(buffer: Buffer, notify?: boolean): Promise<boolean>;
+    bufGetMark(buffer: Buffer, name: string, notify?: boolean): Promise<Array<number>>;
+    bufAddHighlight(buffer: Buffer, src_id: number, hl_group: string, line: number, col_start: number, col_end: number, notify?: boolean): Promise<number>;
+    bufClearHighlight(buffer: Buffer, src_id: number, line_start: number, line_end: number, notify?: boolean): Promise<void>;
+    tabpageGetWindows(tabpage: Tabpage, notify?: boolean): Promise<Array<Window>>;
+    tabpageGetVar(tabpage: Tabpage, name: string, notify?: boolean): Promise<VimValue>;
+    tabpageSetVar(tabpage: Tabpage, name: string, value: VimValue, notify?: boolean): Promise<VimValue>;
+    tabpageDelVar(tabpage: Tabpage, name: string, notify?: boolean): Promise<VimValue>;
+    tabpageGetWindow(tabpage: Tabpage, notify?: boolean): Promise<Window>;
+    tabpageIsValid(tabpage: Tabpage, notify?: boolean): Promise<boolean>;
+    uiAttach(width: number, height: number, enable_rgb: boolean, notify?: boolean): Promise<void>;
+    uiDetach(notify?: boolean): Promise<void>;
+    uiTryResize(width: number, height: number, notify?: boolean): Promise<void>;
+    uiSetOption(name: string, value: VimValue, notify?: boolean): Promise<void>;
+    command(str: string, notify?: boolean): Promise<void>;
+    feedkeys(keys: string, mode: string, escape_csi: boolean, notify?: boolean): Promise<void>;
+    input(keys: string, notify?: boolean): Promise<number>;
+    replaceTermcodes(str: string, from_part: boolean, do_lt: boolean, special: boolean, notify?: boolean): Promise<string>;
+    commandOutput(str: string, notify?: boolean): Promise<string>;
+    eval(str: string, notify?: boolean): Promise<VimValue>;
+    callFunction(fname: string, args: Array<RPCValue>, notify?: boolean): Promise<VimValue>;
+    strwidth(str: string, notify?: boolean): Promise<number>;
+    listRuntimePaths(notify?: boolean): Promise<Array<string>>;
+    changeDirectory(dir: string, notify?: boolean): Promise<void>;
+    getCurrentLine(notify?: boolean): Promise<string>;
+    setCurrentLine(line: string, notify?: boolean): Promise<void>;
+    delCurrentLine(notify?: boolean): Promise<void>;
+    getVar(name: string, notify?: boolean): Promise<VimValue>;
+    setVar(name: string, value: VimValue, notify?: boolean): Promise<VimValue>;
+    delVar(name: string, notify?: boolean): Promise<VimValue>;
+    getVvar(name: string, notify?: boolean): Promise<VimValue>;
+    getOption(name: string, notify?: boolean): Promise<VimValue>;
+    setOption(name: string, value: VimValue, notify?: boolean): Promise<void>;
+    outWrite(str: string, notify?: boolean): Promise<void>;
+    errWrite(str: string, notify?: boolean): Promise<void>;
+    reportError(str: string, notify?: boolean): Promise<void>;
+    getBuffers(notify?: boolean): Promise<Array<Buffer>>;
+    getCurrentBuf(notify?: boolean): Promise<Buffer>;
+    setCurrentBuffer(buffer: Buffer, notify?: boolean): Promise<void>;
+    getWindows(notify?: boolean): Promise<Array<Window>>;
+    getCurrentWindow(notify?: boolean): Promise<Window>;
+    setCurrentWindow(window: Window, notify?: boolean): Promise<void>;
+    getTabpages(notify?: boolean): Promise<Array<Tabpage>>;
+    getCurrentTabpage(notify?: boolean): Promise<Tabpage>;
+    setCurrentTabpage(tabpage: Tabpage, notify?: boolean): Promise<void>;
+    getMode(notify?: boolean): Promise<{[key: string]: RPCValue}>
+    subscribe(event: string, notify?: boolean): Promise<void>;
+    unsubscribe(event: string, notify?: boolean): Promise<void>;
+    nameToColor(name: string, notify?: boolean): Promise<number>;
+    getColorMap(notify?: boolean): Promise<{[key: string]: RPCValue}>;
+    getApiInfo(notify?: boolean): Promise<Array<RPCValue>>;
+    winGetBuffer(window: Window, notify?: boolean): Promise<Buffer>;
+    winGetHeight(window: Window, notify?: boolean): Promise<number>;
+    winSetHeight(window: Window, height: number, notify?: boolean): Promise<void>;
+    winGetWidth(window: Window, notify?: boolean): Promise<number>;
+    winSetWidth(window: Window, width: number, notify?: boolean): Promise<void>;
+    winGetVar(window: Window, name: string, notify?: boolean): Promise<VimValue>;
+    winSetVar(window: Window, name: string, value: VimValue, notify?: boolean): Promise<VimValue>;
+    winDelVar(window: Window, name: string, notify?: boolean): Promise<VimValue>;
+    winGetOption(window: Window, name: string, notify?: boolean): Promise<VimValue>;
+    winSetOption(window: Window, name: string, value: VimValue, notify?: boolean): Promise<void>;
+    winGetPosition(window: Window, notify?: boolean): Promise<Array<number>>;
+    winGetTabpage(window: Window, notify?: boolean): Promise<Tabpage>;
+    winIsValid(window: Window, notify?: boolean): Promise<boolean>;
+    equals(rhs: Nvim): boolean;
+  }
+  export interface Buffer {
+    getLine(index: number, notify?: boolean): Promise<string>;
+    setLine(index: number, line: string, notify?: boolean): Promise<void>;
+    delLine(index: number, notify?: boolean): Promise<void>;
+    getLineSlice(start: number, end: number, include_start: boolean, include_end: boolean, notify?: boolean): Promise<Array<string>>;
+    setLineSlice(start: number, end: number, include_start: boolean, include_end: boolean, replacement: Array<string>, notify?: boolean): Promise<void>;
+    insert(lnum: number, lines: Array<string>, notify?: boolean): Promise<void>;
+    lineCount(notify?: boolean): Promise<number>;
+    getLines(start: number, end: number, strict_indexing: boolean, notify?: boolean): Promise<Array<string>>;
+    setLines(start: number, end: number, strict_indexing: boolean, replacement: Array<string>, notify?: boolean): Promise<void>;
+    getVar(name: string, notify?: boolean): Promise<VimValue>;
+    setVar(name: string, value: VimValue, notify?: boolean): Promise<VimValue>;
+    delVar(name: string, notify?: boolean): Promise<VimValue>;
+    getOption(name: string, notify?: boolean): Promise<VimValue>;
+    setOption(name: string, value: VimValue, notify?: boolean): Promise<void>;
+    getNumber(notify?: boolean): Promise<number>;
+    getName(notify?: boolean): Promise<string>;
+    setName(name: string, notify?: boolean): Promise<void>;
+    isValid(notify?: boolean): Promise<boolean>;
+    getMark(name: string, notify?: boolean): Promise<Array<number>>;
+    addHighlight(src_id: number, hl_group: string, line: number, col_start: number, col_end: number, notify?: boolean): Promise<number>;
+    clearHighlight(src_id: number, line_start: number, line_end: number, notify?: boolean): Promise<void>;
+    equals(rhs: Buffer): boolean;
+  }
+  export interface Window {
+    getBuffer(notify?: boolean): Promise<Buffer>;
+    getCursor(notify?: boolean): Promise<Array<number>>;
+    setCursor(pos: Array<number>, notify?: boolean): Promise<void>;
+    getHeight(notify?: boolean): Promise<number>;
+    setHeight(height: number, notify?: boolean): Promise<void>;
+    getWidth(notify?: boolean): Promise<number>;
+    setWidth(width: number, notify?: boolean): Promise<void>;
+    getVar(name: string, notify?: boolean): Promise<VimValue>;
+    setVar(name: string, value: VimValue, notify?: boolean): Promise<VimValue>;
+    delVar(name: string, notify?: boolean): Promise<VimValue>;
+    getOption(name: string, notify?: boolean): Promise<VimValue>;
+    setOption(name: string, value: VimValue, notify?: boolean): Promise<void>;
+    getPosition(notify?: boolean): Promise<Array<number>>;
+    getTabpage(notify?: boolean): Promise<Tabpage>;
+    isValid(notify?: boolean): Promise<boolean>;
+    equals(rhs: Window): boolean;
+  }
+  export interface Tabpage {
+    getWindows(notify?: boolean): Promise<Array<Window>>;
+    getVar(name: string, notify?: boolean): Promise<VimValue>;
+    setVar(name: string, value: VimValue, notify?: boolean): Promise<VimValue>;
+    delVar(name: string, notify?: boolean): Promise<VimValue>;
+    getWindow(notify?: boolean): Promise<Window>;
+    isValid(notify?: boolean): Promise<boolean>;
+    equals(rhs: Tabpage): boolean;
+  }
+  export function attach(writer: NodeJS.WritableStream, reader: NodeJS.ReadableStream): Promise<Nvim>;
+
+  export interface NvimVersion { major: number; minor: number; patch: number; rest: string; }
+  export type RPCValue = Buffer | Window | Tabpage | number | boolean | string | any[] | {[key: string]: any};
+  export type VimValue = number | boolean | string | any[] | {[key: string]: any} | null
+}


### PR DESCRIPTION
This is sick. This solves all of our command line related issues! (that edit text at least).

Issues this would fix as is (I tested them):
fixes #737, fixes #828,  fixes #991, fixes #1032, fixes #1237, fixes #1401, fixes #1412, fixes #1517, fixes #1524, fixes #1525, fixes #1589, fixes #1611, fixes #1698, fixes #1723, fixes #1732 

I added another variable to each BaseCommand, showing whether it's possible to be replaced by Neovim or not. Thus, this should theoretically pass all unit tests right now.

I also made a couple changes to the Readme, one of which fixes #1360 .