### PR TITLE
Fixes #1749: <D-d> in insert mode doesn't work when the word isn't by itself

### DIFF
--- a/src/actions/commands/actions.ts
+++ b/src/actions/commands/actions.ts
@@ -3148,10 +3148,18 @@ class ActionOverrideCmdD extends BaseCommand {
      // determine where to add a word, we need to do a hack and manually set the
      // selections to the word boundaries before we make the api call.
      vscode.window.activeTextEditor!.selections =
-       vscode.window.activeTextEditor!.selections.map(x => {
+       vscode.window.activeTextEditor!.selections.map((x, idx) => {
          const curPos = Position.FromVSCodePosition(x.active);
-         return new vscode.Selection(curPos.getWordLeft(true),
-           curPos.getLeft().getCurrentWordEnd(true).getRight());
+         if (idx === 0) {
+           return new vscode.Selection(curPos.getWordLeft(false),
+             curPos.getLeft().getCurrentWordEnd(true).getRight());
+         } else {
+           const matchWordPos = Position.FromVSCodePosition(vscode.window.activeTextEditor!.selections[0].active);
+           const matchWordLength = matchWordPos.getLeft().getCurrentWordEnd(true).getRight().character -
+                                    matchWordPos.getWordLeft(false).character;
+           const wordBegin = curPos.getLeftByCount(matchWordLength);
+           return new vscode.Selection(wordBegin, curPos);
+         }
        });
      await vscode.commands.executeCommand('editor.action.addSelectionToNextFindMatch');
      vimState.allCursors = await allowVSCodeToPropagateCursorUpdatesAndReturnThem();

--- a/src/actions/commands/actions.ts
+++ b/src/actions/commands/actions.ts
@@ -3154,6 +3154,8 @@ class ActionOverrideCmdD extends BaseCommand {
            return new vscode.Selection(curPos.getWordLeft(false),
              curPos.getLeft().getCurrentWordEnd(true).getRight());
          } else {
+           // Since we're adding the selections ourselves, we need to make sure
+           // that our selection is actually over what our original word is
            const matchWordPos = Position.FromVSCodePosition(vscode.window.activeTextEditor!.selections[0].active);
            const matchWordLength = matchWordPos.getLeft().getCurrentWordEnd(true).getRight().character -
                                     matchWordPos.getWordLeft(false).character;


### PR DESCRIPTION
Specifically, this one: https://github.com/VSCodeVim/Vim/issues/1467#issuecomment-303904886 and the 4th bullet point here: https://github.com/VSCodeVim/Vim/issues/1467#issuecomment-303909797
