### PR TITLE
Fixes #1750: gq doesn't work for JSDoc type comments

### DIFF
--- a/src/actions/operator.ts
+++ b/src/actions/operator.ts
@@ -617,14 +617,15 @@ class ActionVisualReflowParagraph extends BaseOperator {
   keys = ["g", "q"];
 
   public static CommentTypes: CommentType[] = [
+    { singleLine: false, start: "/**", inner: "*", final: "*/" },
+    { singleLine: false, start: "/*", inner: "*", final: "*/" },
+    { singleLine: false, start: "{-", inner: "-", final: "-}" },
     { singleLine: true, start: "///"},
     { singleLine: true, start: "//" },
     { singleLine: true, start: "--" },
     { singleLine: true, start: "#" },
     { singleLine: true, start: ";" },
-    { singleLine: false, start: "/**", inner: "*", final: "*/" },
-    { singleLine: false, start: "/*", inner: "*", final: "*/" },
-    { singleLine: false, start: "{-", inner: "-", final: "-}" },
+    { singleLine: true, start: "*" },
 
     // Needs to come last, since everything starts with the emtpy string!
     { singleLine: true, start: "" },


### PR DESCRIPTION
Fix was just like @johnfn said. Only thing was that I needed to move the single line comments after the multiline comments