### PR TITLE
Fixes #1768: Backspace deletes more than one tab when tabs are mandated by language specific settings

### DIFF
--- a/src/actions/commands/insert.ts
+++ b/src/actions/commands/insert.ts
@@ -219,7 +219,7 @@ export class CommandInsertInInsertMode extends BaseCommand {
           range: new Range(selection.start as Position, selection.end as Position),
         });
       } else {
-        if (line.length > 0 && line.match(/^\s+$/) && Configuration.expandtab) {
+        if (line.length > 0 && line.match(/^ +$/) && Configuration.expandtab) {
           // If the line is empty except whitespace, backspace should return to
           // the next lowest level of indentation.
 


### PR DESCRIPTION
When a language specific syntax setting overrides the user's configuration settings, I'm not sure how to handle that.

This fix handles this specific issue, but there may be more bugs surrounding this kind of stuff.