### PR TITLE
Fixes #1760: Deindenting not working properly with neovim ex-commands

### DIFF
--- a/src/neovim/nvimUtil.ts
+++ b/src/neovim/nvimUtil.ts
@@ -26,6 +26,9 @@ export class Neovim {
   static async syncVSToVim(vimState: VimState) {
     const nvim = vimState.nvim;
     const buf = await nvim.getCurrentBuf();
+    if (Configuration.expandtab) {
+      await vscode.commands.executeCommand("editor.action.indentationToTabs");
+    }
     await buf.setLines(0, -1, true, TextEditor.getText().split('\n'));
     const [rangeStart, rangeEnd] = [Position.EarlierOf(vimState.cursorPosition, vimState.cursorStartPosition),
     Position.LaterOf(vimState.cursorPosition, vimState.cursorStartPosition)];


### PR DESCRIPTION
Pretty much, the problem was that we convert the indentation to spaces (if that's the user setting).

However, the problem raised here: https://github.com/VSCodeVim/Vim/pull/1769 will still be present here (ie: we don't detect language-specific indentation settings).