### PR TITLE
Fixes #1743: Fixed pasting over visual mode with named register overwriting the named register

### DIFF
--- a/src/actions/commands/actions.ts
+++ b/src/actions/commands/actions.ts
@@ -1121,9 +1121,12 @@ export class PutCommand extends BaseCommand {
 
         if (register.text instanceof RecordedState) {
           /**
-           *  Paste content from recordedState. This one is actually complex as Vim has internal key code for key strokes.
-           *  For example, Backspace is stored as `<80>kb`. So if you replay a macro, which is stored in a register as `a1<80>kb2`, you
-           *  shall just get `2` inserted as `a` represents entering Insert Mode, `<80>bk` represents Backspace. However here, we shall
+           *  Paste content from recordedState. This one is actually complex as
+           *  Vim has internal key code for key strokes.For example, Backspace
+           *  is stored as `<80>kb`. So if you replay a macro, which is stored
+           *  in a register as `a1<80>kb2`, youshall just get `2` inserted as
+           *  `a` represents entering Insert Mode, `<80>bk` represents
+           *  Backspace. However here, we shall
            *  insert the plain text content of the register, which is `a1<80>kb2`.
            */
           vimState.recordedState.transformations.push({
@@ -1362,13 +1365,11 @@ export class PutCommandVisual extends BaseCommand {
       [start, end] = [end, start];
     }
 
-    // If the to be inserted text is linewise
-    // we have a seperate logik
-    // delete the selection first
-    // than insert
+    // If the to be inserted text is linewise we have a seperate logik delete the
+    // selection first than insert
     let register = await Register.get(vimState);
     if (register.registerMode === RegisterMode.LineWise) {
-      let result = await new operator.DeleteOperator(this.multicursorIndex).run(vimState, start, end.getLeft(), false);
+      let result = await new operator.DeleteOperator(this.multicursorIndex).run(vimState, start, end, false);
       // to ensure, that the put command nows this is
       // an linewise register insertion in visual mode
       let oldMode = result.currentMode;
@@ -1383,12 +1384,12 @@ export class PutCommandVisual extends BaseCommand {
     // linewise but not necessarily delete linewise.
     let result =  await new PutCommand(this.multicursorIndex).exec(start, vimState, true);
     result.currentRegisterMode = isLineWise ? RegisterMode.LineWise : RegisterMode.CharacterWise;
+    result.recordedState.registerName = Configuration.useSystemClipboard ? '*' : '"';
     result = await new operator.YankOperator(this.multicursorIndex).run(result, start, end);
     result.currentRegisterMode = RegisterMode.CharacterWise;
     result = await new operator.DeleteOperator(this.multicursorIndex).run(result, start, end.getLeftIfEOL(), false);
     result.currentRegisterMode = RegisterMode.FigureItOutFromCurrentMode;
     return result;
-
   }
 
   // TODO - execWithCount

--- a/src/mode/modeHandler.ts
+++ b/src/mode/modeHandler.ts
@@ -306,8 +306,7 @@ export class VimState {
  */
 export class RecordedState {
   constructor() {
-    const useClipboard = Configuration.useSystemClipboard;
-    this.registerName = useClipboard ? '*' : '"';
+    this.registerName = Configuration.useSystemClipboard ? '*' : '"';
   }
 
   /**

--- a/test/mode/modeNormal.test.ts
+++ b/test/mode/modeNormal.test.ts
@@ -1103,6 +1103,13 @@ suite("Mode Normal", () => {
     });
 
     newTest({
+      title: "Can handle pasting in visual mode over selection",
+      start: ['|foo', 'bar', 'fun'],
+      keysPressed: 'Yjvll"ayjV"app',
+      end: ['foo', 'bar', 'bar', '|fun']
+    });
+
+    newTest({
       title: "Can repeat w",
       start: ['|one two three four'],
       keysPressed: '2w',

--- a/test/mode/modeVisual.test.ts
+++ b/test/mode/modeVisual.test.ts
@@ -918,7 +918,7 @@ suite("Mode Visual", () => {
               "a12",
               "|i yanked",
               "this line",
-              "56",
+              "6",
               "2.line"],
     });
 
@@ -939,7 +939,7 @@ suite("Mode Visual", () => {
               "a12",
               "|i yanked",
               "this line",
-              "56",
+              "6",
               "2.line"],
     });
   });


### PR DESCRIPTION
We just need to set the register to the default register before we yank.