### PR TITLE
Vertical split shortcut keys

### DIFF
--- a/src/actions/commands/actions.ts
+++ b/src/actions/commands/actions.ts
@@ -2242,6 +2242,21 @@ class BaseTabCommand extends BaseCommand {
 }
 
 @RegisterAction
+class VerticalSplit extends BaseCommand {
+  modes = [ModeName.Normal, ModeName.Visual, ModeName.VisualLine];
+  keys = ["<C-w>", "v"];
+
+  public async exec(position: Position, vimState: VimState): Promise<VimState> {
+    vimState.postponedCodeViewChanges.push({
+      command: "workbench.action.splitEditor",
+      args: {}
+    });
+
+    return vimState;
+  }
+}
+
+@RegisterAction
 class CommandTabNext extends BaseTabCommand {
   keys = [
     ["g", "t"],


### PR DESCRIPTION
This PR binds `C-w v` to `workbench.action.splitEditor`, achieving similar functionality to what happens in Vim.

I've previously manually maintained a shortcut to match the Vim vertical split shortcut, but thought it might be helpful to add it for everyone else. Please close if it's not a complete fit, I'm happy to maintain the shortcut configuration myself.

At the moment it's just the binding, had a look at the automated tests and not entirely sure how I'd go about testing it. If this is required, some rough direction would be greatly appreciated.

Keep up the great work, this is one of the best Vim modes I've ever used, if not the best.

Relates to #1451.