### PR TITLE
Fixed #1803: zc automatically reopens folds if the fold is performed in the middle.

### DIFF
--- a/src/actions/commands/actions.ts
+++ b/src/actions/commands/actions.ts
@@ -1521,7 +1521,7 @@ class CommandCloseFold extends CommandFold {
   public async exec(position: Position, vimState: VimState): Promise<VimState> {
     let timesToRepeat = vimState.recordedState.count || 1;
     await vscode.commands.executeCommand("editor.fold", {levels: timesToRepeat, direction: "up"});
-
+    vimState.allCursors = await allowVSCodeToPropagateCursorUpdatesAndReturnThem();
     return vimState;
   }
 }

--- a/src/actions/motion.ts
+++ b/src/actions/motion.ts
@@ -479,7 +479,7 @@ export class MarkMovement extends BaseMovement {
 
 
 @RegisterAction
-class MoveLeft extends BaseMovement {
+export class MoveLeft extends BaseMovement {
   keys = ["h"];
 
   public async execAction(position: Position, vimState: VimState): Promise<Position> {
@@ -790,7 +790,7 @@ class MoveScreenLineCenter extends MoveByScreenLine {
 }
 
 @RegisterAction
-class MoveUpByScreenLine extends MoveByScreenLine {
+export class MoveUpByScreenLine extends MoveByScreenLine {
   modes = [ModeName.Insert, ModeName.Normal, ModeName.Visual];
   keys = [["g", "k"],
   ["g", "<up>"]];


### PR DESCRIPTION
We just need to wait for the cursors to come back before continuing.