### PR TITLE
Fixes #1786: Adds relative line ranges

### DIFF
--- a/src/cmd_line/main.ts
+++ b/src/cmd_line/main.ts
@@ -38,10 +38,7 @@ export async function runCmdLine(command : string, modeHandler : ModeHandler) : 
 
   try {
     var cmd = parser.parse(command);
-    if (cmd.isEmpty) {
-      return;
-    }
-    if (cmd.command && cmd.command.neovimCapable && Configuration.enableNeovim) {
+    if (!cmd.command || (cmd.command && cmd.command.neovimCapable && Configuration.enableNeovim)) {
       await Neovim.command(modeHandler.vimState, command).then(() => {
         console.log("Substituted for neovim command");
       }).catch((err) => console.log(err));


### PR DESCRIPTION
We were doing an incorrect check for `.isEmpty()` that occurred as a result of incomplete command line parsing.