### PR TITLE
Fixes #1200: :e doesn't expand tildes

### DIFF
--- a/package.json
+++ b/package.json
@@ -515,7 +515,8 @@
     "diff-match-patch": "^1.0.0",
     "lodash": "^4.12.0",
     "neovim-client": "^2.1.0",
-    "promised-neovim-client": "^2.0.2"
+    "promised-neovim-client": "^2.0.2",
+    "untildify": "^3.0.2"
   },
   "devDependencies": {
     "@types/mocha": "^2.2.39",

--- a/src/cmd_line/commands/file.ts
+++ b/src/cmd_line/commands/file.ts
@@ -4,6 +4,7 @@ import * as vscode from "vscode";
 import * as path from "path";
 import * as fs from "fs";
 import * as node from "../node";
+const untildify = require('untildify');
 
 export enum FilePosition {
   CurrentWindow,
@@ -69,6 +70,7 @@ export class FileCommand extends node.CommandBase {
     }
 
     let currentFilePath = vscode.window.activeTextEditor!.document.uri.path;
+    this._arguments.name = <string>untildify(this._arguments.name);
     let newFilePath = path.isAbsolute(this._arguments.name) ?
       this._arguments.name :
       path.join(path.dirname(currentFilePath), this._arguments.name);


### PR DESCRIPTION
This does require installing another dependency though...

See this discussion: https://github.com/nodejs/node/issues/684

