### PR TITLE
Fixes #1814: Undo history getting deleted when file changes

### DIFF
--- a/extension.ts
+++ b/extension.ts
@@ -198,11 +198,6 @@ export async function activate(context: vscode.ExtensionContext) {
         });
     }
 
-    setTimeout(() => {
-      if (!event.document.isDirty && !event.document.isUntitled) {
-        handleContentChangedFromDisk(event.document);
-      }
-    }, 0);
   });
 
   overrideCommand(context, 'type', async (args) => {


### PR DESCRIPTION
So I'm currently fixing the issue by simply getting rid of the offending code. So pretty much what happens when you remove that code is that when the file changes on disk, an undo simply reverts back the disk file change first, which I think is perfectly fine behavior.