### PR TITLE
Removed solid block cursor

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,8 +140,7 @@ These settings are specific to VSCodeVim.
 * Type: Color String (Default: `rgba(150, 150, 150, 0.3)`)
 
 #### `"vim.useSolidBlockCursor"`
-* Use a non-blinking block cursor
-* Type: Boolean (Default: `false`)
+We have removed this option, due to it making VSCodeVim's performance suffer immensely.
 
 #### `"vim.useCtrlKeys"`
 * Enable Vim ctrl keys overriding common VS Code operations (eg. copy, paste, find, etc). Enabling this setting will:

--- a/package.json
+++ b/package.json
@@ -350,11 +350,6 @@
           "description": "Timeout in milliseconds for remapped commands",
           "default": 1000
         },
-        "vim.useSolidBlockCursor": {
-          "type": "boolean",
-          "description": "Use a non blinking block cursor.",
-          "default": false
-        },
         "vim.scroll": {
           "type": "number",
           "description": "Number of lines to scroll with CTRL-U and CTRL-D commands.",

--- a/src/configuration/configuration.ts
+++ b/src/configuration/configuration.ts
@@ -130,10 +130,6 @@ class ConfigurationClass {
     }
   }
 
-  /**
-   * Should the block cursor not blink?
-   */
-  useSolidBlockCursor = false;
 
   /**
    * Use the system's clipboard when copying.

--- a/src/mode/modeHandler.ts
+++ b/src/mode/modeHandler.ts
@@ -1710,13 +1710,6 @@ export class ModeHandler implements vscode.Disposable {
 
     let cursorRange: vscode.Range[] = [];
 
-    // Draw block cursor.
-    if (Configuration.useSolidBlockCursor) {
-      await vscode.workspace
-        .getConfiguration("editor")
-        .update("cursorBlinking", this.currentMode.name !== ModeName.Insert ? "solid" : "blink", true);
-    }
-
     // Use native cursor if possible. Default to Block.
     let cursorStyle = vscode.TextEditorCursorStyle.Block;
     switch (this.currentMode.cursorType) {


### PR DESCRIPTION
As per some investigative work by @xconverge, this setting actually makes the extension a piece of crap.

We apologize if you were using this setting and wondered how this extension was so slow.