### PR TITLE
Fixes #979: Adds q! to close without saving

### DIFF
--- a/src/cmd_line/commands/quit.ts
+++ b/src/cmd_line/commands/quit.ts
@@ -36,10 +36,10 @@ export class QuitCommand extends node.CommandBase {
       await vscode.commands.executeCommand('workbench.action.closeAllEditors');
     } else {
       let oldViewColumn = this.activeTextEditor!.viewColumn;
-      if (this.arguments.bang) {
+      if (!this.arguments.bang) {
         await vscode.commands.executeCommand('workbench.action.closeActiveEditor');
       } else {
-        await vscode.commands.executeCommand('workbench.action.revertAndCloseActiveEditor')
+        await vscode.commands.executeCommand('workbench.action.revertAndCloseActiveEditor');
       }
 
       if (vscode.window.activeTextEditor !== undefined && vscode.window.activeTextEditor.viewColumn === oldViewColumn) {

--- a/src/cmd_line/commands/quit.ts
+++ b/src/cmd_line/commands/quit.ts
@@ -36,7 +36,11 @@ export class QuitCommand extends node.CommandBase {
       await vscode.commands.executeCommand('workbench.action.closeAllEditors');
     } else {
       let oldViewColumn = this.activeTextEditor!.viewColumn;
-      await vscode.commands.executeCommand('workbench.action.closeActiveEditor');
+      if (this.arguments.bang) {
+        await vscode.commands.executeCommand('workbench.action.closeActiveEditor');
+      } else {
+        await vscode.commands.executeCommand('workbench.action.revertAndCloseActiveEditor')
+      }
 
       if (vscode.window.activeTextEditor !== undefined && vscode.window.activeTextEditor.viewColumn === oldViewColumn) {
         await vscode.commands.executeCommand('workbench.action.previousEditor');


### PR DESCRIPTION
To be honest, I'm not able to properly test this locally. As @misoguy notes over here, `workbench.action.closeEditor` has some weird behavior when running in local development mode.

However, it's only one if statement. How badly could I possibly mess this up?