### PR TITLE
Select in visual mode when scrolling

### DIFF
--- a/src/actions/commands/actions.ts
+++ b/src/actions/commands/actions.ts
@@ -522,7 +522,7 @@ class CommandCtrlOpenBracket extends CommandEsc {
 }
 
 abstract class CommandEditorScroll extends BaseCommand {
-  modes = [ModeName.Normal];
+  modes = [ModeName.Normal, ModeName.Visual, ModeName.VisualLine, ModeName.VisualBlock];
   runsOnceForEachCountPrefix = false;
   keys: string[];
   to: EditorScrollDirection;
@@ -561,7 +561,6 @@ class CommandCtrlY extends CommandEditorScroll {
 
 @RegisterAction
 class CommandMoveFullPageUp extends CommandEditorScroll {
-  modes = [ModeName.Normal, ModeName.Visual, ModeName.VisualLine, ModeName.VisualBlock];
   keys = ["<C-b>"];
   to: EditorScrollDirection = "up";
   by: EditorScrollByUnit = "page";
@@ -569,7 +568,6 @@ class CommandMoveFullPageUp extends CommandEditorScroll {
 
 @RegisterAction
 class CommandMoveFullPageDown extends CommandEditorScroll {
-  modes = [ModeName.Normal, ModeName.Visual, ModeName.VisualLine, ModeName.VisualBlock];
   keys = ["<C-f>"];
   to: EditorScrollDirection = "down";
   by: EditorScrollByUnit = "page";
@@ -577,7 +575,6 @@ class CommandMoveFullPageDown extends CommandEditorScroll {
 
 @RegisterAction
 class CommandMoveHalfPageDown extends CommandEditorScroll {
-  modes = [ModeName.Normal, ModeName.Visual, ModeName.VisualLine, ModeName.VisualBlock];
   keys = ["<C-d>"];
   to: EditorScrollDirection = "down";
   by: EditorScrollByUnit = "halfPage";
@@ -585,7 +582,6 @@ class CommandMoveHalfPageDown extends CommandEditorScroll {
 
 @RegisterAction
 class CommandMoveHalfPageUp extends CommandEditorScroll {
-  modes = [ModeName.Normal, ModeName.Visual, ModeName.VisualLine, ModeName.VisualBlock];
   keys = ["<C-u>"];
   to: EditorScrollDirection = "up";
   by: EditorScrollByUnit = "halfPage";
@@ -1080,7 +1076,7 @@ export class MarkCommand extends BaseCommand {
   public async exec(position: Position, vimState: VimState): Promise<VimState> {
     const markName = this.keysPressed[1];
 
-
+    vimState.historyTracker.addMark(position, markName);
 
     return vimState;
   }

--- a/src/actions/commands/actions.ts
+++ b/src/actions/commands/actions.ts
@@ -537,10 +537,10 @@ abstract class CommandEditorScroll extends BaseCommand {
         to: this.to,
         by: this.by,
         value: timesToRepeat,
-        revealCursor: true
+        revealCursor: true,
+        select: [ModeName.Visual, ModeName.VisualBlock, ModeName.VisualLine].indexOf(vimState.currentMode) >= 0
       }
     });
-
     return vimState;
   }
 }
@@ -1080,7 +1080,7 @@ export class MarkCommand extends BaseCommand {
   public async exec(position: Position, vimState: VimState): Promise<VimState> {
     const markName = this.keysPressed[1];
 
-    vimState.historyTracker.addMark(position, markName);
+
 
     return vimState;
   }

--- a/src/mode/modeHandler.ts
+++ b/src/mode/modeHandler.ts
@@ -43,6 +43,7 @@ import { Globals } from '../../src/globals';
 import { ReplaceState } from './../state/replaceState';
 import { GlobalState } from './../state/globalState';
 import { Nvim } from "promised-neovim-client";
+import { allowVSCodeToPropagateCursorUpdatesAndReturnThem } from "../util";
 
 export class ViewChange {
   public command: string;
@@ -1782,6 +1783,7 @@ export class ModeHandler implements vscode.Disposable {
     for (let i = 0; i < this.vimState.postponedCodeViewChanges.length; i++) {
       let viewChange = this.vimState.postponedCodeViewChanges[i];
       await vscode.commands.executeCommand(viewChange.command, viewChange.args);
+      vimState.allCursors = await allowVSCodeToPropagateCursorUpdatesAndReturnThem();
     }
 
     // If user wants to change status bar color based on mode


### PR DESCRIPTION
Based off @rebornix's changes.

We just need to make sure we wait for the right cursor after doing the view change. Otherwise, the cursor change that's a result of `revealCursor: true` isn't propagated, and we get stuck once we're at the edge.

Fixes #907,