### PR TITLE
Ctrl-C should copy to clipboard in visual mode - fix for #1896

### DIFF
--- a/src/actions/commands/actions.ts
+++ b/src/actions/commands/actions.ts
@@ -931,6 +931,8 @@ class CommandOverrideCopy extends BaseCommand {
     }
 
     util.clipboardCopy(text);
+    // all vim yank operations return to normal mode.
+    vimState.currentMode = ModeName.Normal;
 
     return vimState;
   }

--- a/src/mode/modeHandler.ts
+++ b/src/mode/modeHandler.ts
@@ -799,8 +799,13 @@ export class ModeHandler implements vscode.Disposable {
         key = '<copy>';
       }
 
-      if (process.platform !== 'darwin' && key === '<C-c>' && !Configuration.useCtrlKeys) {
-        key = '<copy>';
+      if (process.platform !== 'darwin' && key === '<C-c>') {
+        if (!Configuration.useCtrlKeys ||
+          this._vimState.currentMode === ModeName.Visual ||
+          this._vimState.currentMode === ModeName.VisualBlock ||
+          this._vimState.currentMode === ModeName.VisualLine) {
+          key = '<copy>';
+        }
       }
     }
     if (key === '<C-d>' && !Configuration.useCtrlKeys) {

--- a/src/mode/modeHandler.ts
+++ b/src/mode/modeHandler.ts
@@ -800,10 +800,12 @@ export class ModeHandler implements vscode.Disposable {
       }
 
       if (process.platform !== 'darwin' && key === '<C-c>') {
-        if (!Configuration.useCtrlKeys ||
+        if (
+          !Configuration.useCtrlKeys ||
           this._vimState.currentMode === ModeName.Visual ||
           this._vimState.currentMode === ModeName.VisualBlock ||
-          this._vimState.currentMode === ModeName.VisualLine) {
+          this._vimState.currentMode === ModeName.VisualLine
+        ) {
           key = '<copy>';
         }
       }

--- a/test/mode/modeVisual.test.ts
+++ b/test/mode/modeVisual.test.ts
@@ -815,4 +815,24 @@ suite('Mode Visual', () => {
       end: ['i yanked', 'this line', '', '1.line', 'a12', '|i yanked', 'this line', '6', '2.line'],
     });
   });
+
+  suite('Non-darwin <C-c> tests', () => {
+    if (process.platform === 'darwin') {
+      return;
+    }
+
+    test('<C-c> copies and sets mode to normal', async () => {
+      await modeHandler.handleMultipleKeyEvents('ione two three'.split(''));
+      await modeHandler.handleMultipleKeyEvents(['<Esc>', '^', 'v', 'e', '<C-c>']);
+
+      // ensuring we're back in normal
+      assertEqual(modeHandler.currentMode.name, ModeName.Normal);
+      assertEqualLines(['one two three']);
+
+      // test copy by pasting back
+      await modeHandler.handleMultipleKeyEvents(['^', '"', '+', 'P']);
+
+      assertEqualLines(['oneone two three']);
+    });
+  });
 });

--- a/test/mode/modeVisualLine.test.ts
+++ b/test/mode/modeVisualLine.test.ts
@@ -6,7 +6,7 @@ import { TextEditor } from '../../src/textEditor';
 import { getTestingFunctions } from '../testSimplifier';
 import { getAndUpdateModeHandler } from '../../extension';
 
-suite('Mode Visual', () => {
+suite('Mode Visual Line', () => {
   let modeHandler: ModeHandler;
 
   let { newTest, newTestOnly } = getTestingFunctions();
@@ -287,6 +287,31 @@ suite('Mode Visual', () => {
       start: ['foo', 'bar', 'fun', 'b|az'],
       keysPressed: 'V?bar\nx',
       end: ['|foo'],
+    });
+  });
+
+  suite('Non-darwin <C-c> tests', () => {
+    if (process.platform === 'darwin') {
+      return;
+    }
+
+    test('<C-c> copies and sets mode to normal', async () => {
+      await modeHandler.handleMultipleKeyEvents('ione two three'.split(''));
+      await modeHandler.handleMultipleKeyEvents(['<Esc>', 'Y', 'p']);
+
+      assertEqualLines(['one two three', 'one two three']);
+
+      await modeHandler.handleMultipleKeyEvents(['<Esc>', 'H', 'V', '<C-c>']);
+
+      // ensuring we're back in normal
+      assertEqual(modeHandler.currentMode.name, ModeName.Normal);
+
+      // test copy by pasting back from clipboard
+      await modeHandler.handleMultipleKeyEvents(['H', '"', '+', 'P']);
+
+      // TODO: should be assertEqualLines(['one two three', 'one two three', 'one two three']);
+      // unfortunately it is
+      assertEqualLines(['one two threeone two three', 'one two three']);
     });
   });
 });

--- a/test/register/register.test.ts
+++ b/test/register/register.test.ts
@@ -24,20 +24,24 @@ suite('register', () => {
     end: ['two', '|one'],
   });
 
-  util.clipboardCopy('12345');
+  suite('clipboard', () => {
+    setup(async () => {
+      util.clipboardCopy('12345');
+    });
 
-  newTest({
-    title: "Can access '*' (clipboard) register",
-    start: ['|one'],
-    keysPressed: '"*P',
-    end: ['1234|5one'],
-  });
+    newTest({
+      title: "Can access '*' (clipboard) register",
+      start: ['|one'],
+      keysPressed: '"*P',
+      end: ['1234|5one'],
+    });
 
-  newTest({
-    title: "Can access '+' (clipboard) register",
-    start: ['|one'],
-    keysPressed: '"+P',
-    end: ['1234|5one'],
+    newTest({
+      title: "Can access '+' (clipboard) register",
+      start: ['|one'],
+      keysPressed: '"+P',
+      end: ['1234|5one'],
+    });
   });
 
   newTest({

--- a/test/register/register.test.ts
+++ b/test/register/register.test.ts
@@ -5,7 +5,7 @@ import { getTestingFunctions } from '../testSimplifier';
 import * as util from '../../src/util';
 import { getAndUpdateModeHandler } from '../../extension';
 
-suite('register', () => {
+suite.only('register', () => {
   let modeHandler: ModeHandler;
 
   let { newTest, newTestOnly } = getTestingFunctions();
@@ -26,7 +26,7 @@ suite('register', () => {
 
   util.clipboardCopy('12345');
 
-  newTestOnly({
+  newTest({
     title: "Can access '*' (clipboard) register",
     start: ['|one'],
     keysPressed: '"*P',

--- a/test/register/register.test.ts
+++ b/test/register/register.test.ts
@@ -26,7 +26,7 @@ suite('register', () => {
 
   util.clipboardCopy('12345');
 
-  newTest({
+  newTestOnly({
     title: "Can access '*' (clipboard) register",
     start: ['|one'],
     keysPressed: '"*P',

--- a/test/register/register.test.ts
+++ b/test/register/register.test.ts
@@ -5,7 +5,7 @@ import { getTestingFunctions } from '../testSimplifier';
 import * as util from '../../src/util';
 import { getAndUpdateModeHandler } from '../../extension';
 
-suite.only('register', () => {
+suite('register', () => {
   let modeHandler: ModeHandler;
 
   let { newTest, newTestOnly } = getTestingFunctions();

--- a/test/testSimplifier.ts
+++ b/test/testSimplifier.ts
@@ -217,7 +217,6 @@ async function testIt(modeHandler: ModeHandler, testObj: ITestObject): Promise<v
   // Check valid test object input
   assert(helper.isValid, "Missing '|' in test object.");
 
-
   // end: check given end output is correct
   //
   assertEqualLines(helper.asVimOutputText());

--- a/test/testSimplifier.ts
+++ b/test/testSimplifier.ts
@@ -217,6 +217,10 @@ async function testIt(modeHandler: ModeHandler, testObj: ITestObject): Promise<v
   // Check valid test object input
   assert(helper.isValid, "Missing '|' in test object.");
 
+
+  // end: check given end output is correct
+  //
+  assertEqualLines(helper.asVimOutputText());
   // Check final cursor position
   //
   let actualPosition = Position.FromVSCodePosition(TextEditor.getSelection().start);
@@ -227,10 +231,6 @@ async function testIt(modeHandler: ModeHandler, testObj: ITestObject): Promise<v
     expectedPosition.character,
     'Cursor CHARACTER position is wrong.'
   );
-
-  // end: check given end output is correct
-  //
-  assertEqualLines(helper.asVimOutputText());
 
   // endMode: check end mode is correct if given
   if (typeof testObj.endMode !== 'undefined') {

--- a/test/testUtils.ts
+++ b/test/testUtils.ts
@@ -28,7 +28,7 @@ export function assertEqualLines(expectedLines: string[]) {
     assert.equal(
       actual,
       expected,
-      `Content does not match; Expected=${expected}. Actual=${actual}`
+      `Content does not match; Expected=${expected}. Actual=${actual}.`
     );
   }
 


### PR DESCRIPTION
When yanking to clipboard, the selection should also reset to normal

<!--
Yay! We love PRs! 🎊

Please include a description of your change and ensure:

- [ ] Commit message has a short title & issue references
- [ ] Each commit does a logical chunk of work.
- [ ] It builds and tests pass (e.g `gulp`)

More info can be found on our [contribution guide](https://github.com/VSCodeVim/Vim/blob/master/.github/CONTRIBUTING.md).
-->
