### PR TITLE
Update tests due to VSCode PR 28238

### DIFF
--- a/test/operator/comment.test.ts
+++ b/test/operator/comment.test.ts
@@ -33,14 +33,14 @@ suite('comment operator', () => {
     title: 'block comment with motion',
     start: ['function test(arg|1, arg2, arg3) {'],
     keysPressed: 'gCi)',
-    end: ['function test(|/*arg1, arg2, arg3*/) {'],
+    end: ['function test(|/* arg1, arg2, arg3 */) {'],
   });
 
   newTest({
     title: 'block comment in Visual Mode',
     start: ['blah |blah blah'],
     keysPressed: 'vllllgC',
-    end: ['blah |/*blah*/ blah'],
+    end: ['blah |/* blah */ blah'],
     endMode: ModeName.Normal,
   });
 });


### PR DESCRIPTION
This PR: Microsoft/vscode#28238 inserts spaces inside block comments, which affects VSCodeVim tests.

<!--
Yay! We love PRs! 🎊

Please include a description of your change and ensure:

- [ ] Commit message has a short title & issue references
- [ ] Each commit does a logical chunk of work.
- [ ] It builds and tests pass (e.g `gulp`)

More info can be found on our [contribution guide](https://github.com/VSCodeVim/Vim/blob/master/.github/CONTRIBUTING.md).
-->
