### PR TITLE
Fixed <C-e>/<C-y> being very slow

### DIFF
--- a/src/mode/modeHandler.ts
+++ b/src/mode/modeHandler.ts
@@ -43,7 +43,6 @@ import { Globals } from '../../src/globals';
 import { ReplaceState } from './../state/replaceState';
 import { GlobalState } from './../state/globalState';
 import { Nvim } from 'promised-neovim-client';
-import { allowVSCodeToPropagateCursorUpdatesAndReturnThem } from '../util';
 
 export class ViewChange {
   public command: string;
@@ -1913,7 +1912,6 @@ export class ModeHandler implements vscode.Disposable {
     for (let i = 0; i < this.vimState.postponedCodeViewChanges.length; i++) {
       let viewChange = this.vimState.postponedCodeViewChanges[i];
       await vscode.commands.executeCommand(viewChange.command, viewChange.args);
-      vimState.allCursors = await allowVSCodeToPropagateCursorUpdatesAndReturnThem();
     }
 
     // If user wants to change status bar color based on mode


### PR DESCRIPTION
This is the line causing all of the issues. In general, we should try *very* hard to avoid calling `allowVSCodeToPropagateCursorUpdatesAndReturnThem()`. It's very slow.

Fixes #1943, #1985,

Ah I see why I added it. If you don't do this, then the selection will block you from scrolling down more. Sigh...