### PR TITLE
Fix deref of undefined race on startup.

### DIFF
--- a/src/mode/modeHandler.ts
+++ b/src/mode/modeHandler.ts
@@ -685,7 +685,10 @@ export class ModeHandler implements vscode.Disposable {
     }
 
     // See comment about whatILastSetTheSelectionTo.
-    if (this._vimState.whatILastSetTheSelectionTo.isEqual(selection)) {
+    if (
+      this._vimState.whatILastSetTheSelectionTo &&
+      this._vimState.whatILastSetTheSelectionTo.isEqual(selection)
+    ) {
       return;
     }
 


### PR DESCRIPTION
This can happen if you interact with the editor while vim mode is still
loading.