### PR TITLE
Correct behavior of mouseSelectionGoesIntoVisualMode

### DIFF
--- a/src/mode/modeHandler.ts
+++ b/src/mode/modeHandler.ts
@@ -756,9 +756,9 @@ export class ModeHandler implements vscode.Disposable {
         }
 
         if (
+          Configuration.mouseSelectionGoesIntoVisualMode &&
           !this._vimState.getModeObject(this).isVisualMode &&
-          (this._vimState.getModeObject(this).name !== ModeName.Insert ||
-            Configuration.mouseSelectionGoesIntoVisualMode)
+          this._vimState.getModeObject(this).name !== ModeName.Insert
         ) {
           this._vimState.currentMode = ModeName.Visual;
           this.setCurrentModeByName(this._vimState);


### PR DESCRIPTION
At the moment even when `mouseSelectionGoesIntoVisualMode` set to `false` then the visual mode is still turned on when the mouse is clicked or dragged.

This PR ensure that if the `mouseSlectionGoeIntoVisualMode` is `false` then regardless the current mode, visual mode will not be not turned on.