### PR TITLE
Pass and receive buffer to/from nvim without indentation conversion

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -475,7 +475,7 @@ Status | Command | Default Value | Description
 :white_check_mark:| smartcase (scs) | true | Override the 'ignorecase' option if the search pattern contains upper case characters.
 :white_check_mark:| iskeyword (isk) | `@,48-57,_,128-167,224-235` | keywords contain alphanumeric characters and '_'. If there is no user setting for `iskeyword`, we use `editor.wordSeparators` properties.
 :white_check_mark:| scroll (scr) | 20 | Number of lines to scroll with CTRL-U and CTRL-D commands.
-:white_check_mark:| expandtab (et) | True. we use Code's default value `inserSpaces` instead of Vim | use spaces when &lt;Tab&gt; is inserted
+:white_check_mark:| expandtab (et) | True. we use Code's default value `insertSpaces` instead of Vim | use spaces when &lt;Tab&gt; is inserted
 :white_check_mark:| autoindent | true | Keep indentation when doing `cc` or `S` in normal mode to replace a line.
 
 ## Undo/Redo commands

--- a/src/neovim/nvimUtil.ts
+++ b/src/neovim/nvimUtil.ts
@@ -25,10 +25,6 @@ export class Neovim {
   static async syncVSToVim(vimState: VimState) {
     const nvim = vimState.nvim;
     const buf = await nvim.getCurrentBuf();
-    if (Configuration.expandtab) {
-      await vscode.commands.executeCommand('editor.action.indentationToTabs');
-    }
-
     await nvim.setOption('gdefault', Configuration.substituteGlobalFlag === true);
     await buf.setLines(0, -1, true, TextEditor.getText().split('\n'));
     const [rangeStart, rangeEnd] = [
@@ -104,9 +100,6 @@ export class Neovim {
       new Position(row - 1, character)
     );
 
-    if (Configuration.expandtab) {
-      await vscode.commands.executeCommand('editor.action.indentationToSpaces');
-    }
     // We're only syncing back the default register for now, due to the way we could
     // be storing macros in registers.
     const vimRegToVsReg = {


### PR DESCRIPTION
```
[
    {
         "_id": "0008",
         "startDate": "2009-07-21",
         "endDate": null,
    },
    ....
]
```
I execute command  `g/endDate/d`. But if I want to undo it, what i expected is I just need to press `u` only once to revert back. In fact, I have to press `u` twice. The reason is, at the moment, we convert tabs and spaces before passing and after receiving buffer to/from nvim when `insertSpaces: true` (or equivalent to `expandtab: true`). So the first `u` actually does nothing and the second `u` is to undo.

In more general case, I think we shouldn't modify the buffer because when the user set `insertSpaces: true`, he/she expect both vscode and nvim should share the same view instead of indentation conversion.