### PR TITLE
Dispose modehandler if NO documents match the modehandler document anymore

### DIFF
--- a/extension.ts
+++ b/extension.ts
@@ -310,6 +310,21 @@ export async function activate(context: vscode.ExtensionContext) {
     });
   });
 
+  vscode.workspace.onDidCloseTextDocument(event => {
+    const documents = vscode.workspace.textDocuments;
+
+    // Delete modehandler if vscode knows NOTHING about this document. This does
+    // not handle the case of the same file open twice. This only handles the
+    // case of deleting a modehandler once all tabs of this document have been
+    // closed
+    for (let mh in modeHandlerToEditorIdentity) {
+      const editor = modeHandlerToEditorIdentity[mh].vimState.editor.document;
+      if (documents.indexOf(editor) === -1) {
+        delete modeHandlerToEditorIdentity[mh];
+      }
+    }
+  });
+
   registerCommand(context, 'toggleVim', async () => {
     Globals.active = !Globals.active;
     if (Globals.active) {


### PR DESCRIPTION
This MIGHT help with the undo issue (#2007)

This is a change I had made before. It was reverted in this PR:

https://github.com/VSCodeVim/Vim/pull/981

The problem was that when switching tabs we would dispose before. Now the check operates a little differently and only disposes if the vscode workspace has NO idea what this file is (all instances of this file in a tab are closed)