### PR TITLE
Bugfix #1951: text selection in insert mode

### DIFF
--- a/src/actions/commands/actions.ts
+++ b/src/actions/commands/actions.ts
@@ -882,10 +882,7 @@ class CommandOverrideCopy extends BaseCommand {
   public async exec(position: Position, vimState: VimState): Promise<VimState> {
     let text = '';
 
-    if (
-      vimState.currentMode === ModeName.Visual ||
-      vimState.currentMode === ModeName.Normal
-    ) {
+    if (vimState.currentMode === ModeName.Visual || vimState.currentMode === ModeName.Normal) {
       text = vimState.allCursors
         .map(range => {
           const start = Position.EarlierOf(range.start, range.stop);
@@ -917,9 +914,11 @@ class CommandOverrideCopy extends BaseCommand {
         text += line + '\n';
       }
     } else if (vimState.currentMode === ModeName.Insert) {
-      text = vimState.editor.selections.map(selection => {
-        return vimState.editor.document.getText(new vscode.Range(selection.start, selection.end));
-      }).join('\n');
+      text = vimState.editor.selections
+        .map(selection => {
+          return vimState.editor.document.getText(new vscode.Range(selection.start, selection.end));
+        })
+        .join('\n');
     }
 
     util.clipboardCopy(text);

--- a/src/actions/commands/actions.ts
+++ b/src/actions/commands/actions.ts
@@ -884,8 +884,7 @@ class CommandOverrideCopy extends BaseCommand {
 
     if (
       vimState.currentMode === ModeName.Visual ||
-      vimState.currentMode === ModeName.Normal ||
-      vimState.currentMode === ModeName.Insert
+      vimState.currentMode === ModeName.Normal
     ) {
       text = vimState.allCursors
         .map(range => {
@@ -917,6 +916,10 @@ class CommandOverrideCopy extends BaseCommand {
       for (const { line } of Position.IterateLine(vimState)) {
         text += line + '\n';
       }
+    } else if (vimState.currentMode === ModeName.Insert) {
+      text = vimState.editor.selections.map(selection => {
+        return vimState.editor.document.getText(new vscode.Range(selection.start, selection.end));
+      }).join('\n');
     }
 
     util.clipboardCopy(text);


### PR DESCRIPTION
Use the normal selection in insert mode.
This fixes #1951. Selection in insert mode seems to be
specific to this plugin and is not easily possible in normal Vim.
