### PR TITLE
An option to show the colon at the start of the command line box

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,10 @@ We have removed this option, due to it making VSCodeVim's performance suffer imm
     * etc.
 * Type: Boolean (Default: `true`)
 
+#### `"vim.cmdLineInitialColon"`
+* Set this to have VSCodeVim mimick Vim, showing the ':' colon character in the Vim command line when it is called.
+* Type: Boolean (Default: `false`)
+
 #### `"vim.handleKeys"`
 * Allows user to select certain modifier keybindings and delegate them back to VSCode so that VSCodeVim does not process them.
 * Complete list of keys that can be delegated back to VSCode can be found in our [package.json](https://github.com/VSCodeVim/Vim/blob/master/package.json#L44). Each key that has a vim.use<C-...> in the when argument can be delegated back to vscode by doing "<C-...>":false.

--- a/extension.ts
+++ b/extension.ts
@@ -310,6 +310,21 @@ export async function activate(context: vscode.ExtensionContext) {
     });
   });
 
+  vscode.workspace.onDidCloseTextDocument(event => {
+    const documents = vscode.workspace.textDocuments;
+
+    // Delete modehandler if vscode knows NOTHING about this document. This does
+    // not handle the case of the same file open twice. This only handles the
+    // case of deleting a modehandler once all tabs of this document have been
+    // closed
+    for (let mh in modeHandlerToEditorIdentity) {
+      const editor = modeHandlerToEditorIdentity[mh].vimState.editor.document;
+      if (documents.indexOf(editor) === -1) {
+        delete modeHandlerToEditorIdentity[mh];
+      }
+    }
+  });
+
   registerCommand(context, 'toggleVim', async () => {
     Globals.active = !Globals.active;
     if (Globals.active) {

--- a/package.json
+++ b/package.json
@@ -550,11 +550,7 @@
         "vim.cmdLineInitialColon": {
           "type": "boolean",
           "description": "When typing a command show the initial colon ':' character",
-<<<<<<< HEAD
           "default": false
-=======
-          "default": "true"
->>>>>>> dc7602fc44b873ee881c60155fd6065cc27c29be
         }
       }
     }

--- a/package.json
+++ b/package.json
@@ -550,7 +550,7 @@
         "vim.cmdLineInitialColon": {
           "type": "boolean",
           "description": "When typing a command show the initial colon ':' character",
-          "default": "true"
+          "default": false
         }
       }
     }

--- a/package.json
+++ b/package.json
@@ -541,7 +541,7 @@
         "vim.substituteGlobalFlag": {
           "type": "boolean",
           "description": "Automatically apply the global flag, /g, to substitute commands. When set to true, use /g to mean only first match should be replaced.",
-          "default": "false"
+          "default": false
         },
         "vim.cursorStylePerMode": {
           "type": "object",

--- a/package.json
+++ b/package.json
@@ -546,6 +546,11 @@
         "vim.cursorStylePerMode": {
           "type": "object",
           "description": "Customize cursor style per mode"
+        },
+        "vim.cmdLineInitialColon": {
+          "type": "boolean",
+          "description": "When typing a command show the initial colon ':' character",
+          "default": "true"
         }
       }
     }

--- a/package.json
+++ b/package.json
@@ -550,7 +550,11 @@
         "vim.cmdLineInitialColon": {
           "type": "boolean",
           "description": "When typing a command show the initial colon ':' character",
+<<<<<<< HEAD
           "default": false
+=======
+          "default": "true"
+>>>>>>> dc7602fc44b873ee881c60155fd6065cc27c29be
         }
       }
     }

--- a/src/actions/commands/actions.ts
+++ b/src/actions/commands/actions.ts
@@ -887,15 +887,7 @@ class CommandOverrideCopy extends BaseCommand {
         .map(range => {
           const start = Position.EarlierOf(range.start, range.stop);
           const stop = Position.LaterOf(range.start, range.stop);
-
-          // Insert selecting from the left to the right is a special case that
-          // selects one more on the right.
-          // The order of the if statements is to check for the case where start=stop
-          if (vimState.currentMode !== ModeName.Insert || start.isEqual(range.stop)) {
-            return vimState.editor.document.getText(new vscode.Range(start, stop.getRight()));
-          } else {
-            return vimState.editor.document.getText(new vscode.Range(start, stop));
-          }
+          return vimState.editor.document.getText(new vscode.Range(start, stop.getRight()));
         })
         .join('\n');
     } else if (vimState.currentMode === ModeName.VisualLine) {

--- a/src/actions/commands/actions.ts
+++ b/src/actions/commands/actions.ts
@@ -882,11 +882,7 @@ class CommandOverrideCopy extends BaseCommand {
   public async exec(position: Position, vimState: VimState): Promise<VimState> {
     let text = '';
 
-    if (
-      vimState.currentMode === ModeName.Visual ||
-      vimState.currentMode === ModeName.Normal ||
-      vimState.currentMode === ModeName.Insert
-    ) {
+    if (vimState.currentMode === ModeName.Visual || vimState.currentMode === ModeName.Normal) {
       text = vimState.allCursors
         .map(range => {
           const start = Position.EarlierOf(range.start, range.stop);
@@ -917,6 +913,12 @@ class CommandOverrideCopy extends BaseCommand {
       for (const { line } of Position.IterateLine(vimState)) {
         text += line + '\n';
       }
+    } else if (vimState.currentMode === ModeName.Insert) {
+      text = vimState.editor.selections
+        .map(selection => {
+          return vimState.editor.document.getText(new vscode.Range(selection.start, selection.end));
+        })
+        .join('\n');
     }
 
     util.clipboardCopy(text);

--- a/src/cmd_line/main.ts
+++ b/src/cmd_line/main.ts
@@ -16,14 +16,21 @@ export async function showCmdLine(
 
   const options: vscode.InputBoxOptions = {
     prompt: 'Vim command line',
-    value: initialText,
+    value: Configuration.cmdLineInitialColon ? ':' + initialText : initialText,
     ignoreFocusOut: true,
-    valueSelection: [initialText.length, initialText.length],
+    valueSelection: [
+      Configuration.cmdLineInitialColon ? initialText.length + 1 : initialText.length,
+      Configuration.cmdLineInitialColon ? initialText.length + 1 : initialText.length,
+    ],
   };
 
   try {
     const cmdString = await vscode.window.showInputBox(options);
-    await runCmdLine(cmdString!, modeHandler);
+    const trimmedCmdString =
+      cmdString && Configuration.cmdLineInitialColon && cmdString[0] === ':'
+        ? cmdString.slice(1)
+        : cmdString;
+    await runCmdLine(trimmedCmdString!, modeHandler);
     return;
   } catch (e) {
     modeHandler.setStatusBarText(e.toString());

--- a/src/configuration/configuration.ts
+++ b/src/configuration/configuration.ts
@@ -328,7 +328,7 @@ class ConfigurationClass {
   /**
    * When typing a command show the initial colon ':' character
    */
-  cmdLineInitialColon = true;
+  cmdLineInitialColon = false;
 }
 
 function overlapSetting(args: {

--- a/src/configuration/configuration.ts
+++ b/src/configuration/configuration.ts
@@ -324,6 +324,11 @@ class ConfigurationClass {
     visualblock: undefined,
     replace: undefined,
   };
+
+  /**
+   * When typing a command show the initial colon ':' character
+   */
+  cmdLineInitialColon = true;
 }
 
 function overlapSetting(args: {

--- a/src/configuration/configuration.ts
+++ b/src/configuration/configuration.ts
@@ -328,7 +328,11 @@ class ConfigurationClass {
   /**
    * When typing a command show the initial colon ':' character
    */
+<<<<<<< HEAD
   cmdLineInitialColon = false;
+=======
+  cmdLineInitialColon = true;
+>>>>>>> dc7602fc44b873ee881c60155fd6065cc27c29be
 }
 
 function overlapSetting(args: {

--- a/src/configuration/configuration.ts
+++ b/src/configuration/configuration.ts
@@ -328,11 +328,7 @@ class ConfigurationClass {
   /**
    * When typing a command show the initial colon ':' character
    */
-<<<<<<< HEAD
   cmdLineInitialColon = false;
-=======
-  cmdLineInitialColon = true;
->>>>>>> dc7602fc44b873ee881c60155fd6065cc27c29be
 }
 
 function overlapSetting(args: {


### PR DESCRIPTION
Just a simple option to show the colon character at the start of the command line box.
Something I've been missing from vim itself, maybe others would find this useful too. If set to false the behavior should be the same like now.
I find it helps distinguish the vim command line with the command palette and the file search boxes.

<!--
Yay! We love PRs! 🎊

Please include a description of your change and ensure:

- [ ] Commit message has a short title & issue references
- [ ] Each commit does a logical chunk of work.
- [ ] It builds and tests pass (e.g `gulp`)

More info can be found on our [contribution guide](https://github.com/VSCodeVim/Vim/blob/master/.github/CONTRIBUTING.md).
-->