### PR TITLE
added `showOpenDialog` when typing emtpy e

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "url": "https://github.com/VSCodeVim/Vim/issues"
   },
   "engines": {
-    "vscode": "^1.13.0"
+    "vscode": "^1.17.0"
   },
   "categories": [
     "Other",
@@ -590,6 +590,6 @@
     "mocha": "^4.0.1",
     "tslint": "^5.7.0",
     "typescript": "^2.5.3",
-    "vscode": "^1.1.5"
+    "vscode": "^1.1.6"
   }
 }

--- a/src/cmd_line/commands/file.ts
+++ b/src/cmd_line/commands/file.ts
@@ -73,13 +73,10 @@ export class FileCommand extends node.CommandBase {
       return;
     } else if (this._arguments.name === '') {
       const fileList = await vscode.window.showOpenDialog({});
-      await vscode.commands.executeCommand(
-        'vscode.open',
-        fileList[0],
-        this._arguments.position === FilePosition.NewWindow
-          ? this.getViewColumnToRight()
-          : this.getActiveViewColumn()
-      );
+      if (fileList) {
+        const doc = await vscode.workspace.openTextDocument(fileList[0]);
+        vscode.window.showTextDocument(doc);
+      }
       return;
     }
 

--- a/src/cmd_line/commands/file.ts
+++ b/src/cmd_line/commands/file.ts
@@ -72,9 +72,14 @@ export class FileCommand extends node.CommandBase {
 
       return;
     } else if (this._arguments.name === '') {
-      if (this._arguments.position === FilePosition.NewWindow) {
-        await vscode.commands.executeCommand('workbench.action.splitEditor');
-      }
+      const fileList = await vscode.window.showOpenDialog({});
+      await vscode.commands.executeCommand(
+        'vscode.open',
+        fileList[0],
+        this._arguments.position === FilePosition.NewWindow
+          ? this.getViewColumnToRight()
+          : this.getActiveViewColumn()
+      );
       return;
     }
 


### PR DESCRIPTION
Fixes #1877

I could test this commit on my local machine and it works.
But the `gulp watch` task always complains:
```
src/cmd_line/commands/file.ts(75,44): error TS2339: Property 'showOpenDialog' does not exist on type 'typeof window'.
```

Do I have to update the typings somehow?
How could I do that?
