### PR TITLE
Change ignoreFocusOut to false for the command line

### DIFF
--- a/src/cmd_line/main.ts
+++ b/src/cmd_line/main.ts
@@ -17,7 +17,7 @@ export async function showCmdLine(
   const options: vscode.InputBoxOptions = {
     prompt: 'Vim command line',
     value: Configuration.cmdLineInitialColon ? ':' + initialText : initialText,
-    ignoreFocusOut: true,
+    ignoreFocusOut: false,
     valueSelection: [
       Configuration.cmdLineInitialColon ? initialText.length + 1 : initialText.length,
       Configuration.cmdLineInitialColon ? initialText.length + 1 : initialText.length,


### PR DESCRIPTION
This makes the command line behave like the builtin VSCode command palette and fuzzy file opening box. It also makes a lot of sense to not block the user until he reaches the mouse and refocuses on that box just to be able to close it. Vim users don't like to leave their home row :-)

<!--
Yay! We love PRs! 🎊

Please include a description of your change and ensure:

- [ ] Commit message has a short title & issue references
- [ ] Each commit does a logical chunk of work.
- [ ] It builds and tests pass (e.g `gulp`)

More info can be found on our [contribution guide](https://github.com/VSCodeVim/Vim/blob/master/.github/CONTRIBUTING.md).
-->