### PR TITLE
Fix #2032 g$ end of wrapped line

### DIFF
--- a/src/actions/motion.ts
+++ b/src/actions/motion.ts
@@ -162,6 +162,9 @@ abstract class MoveByScreenLine extends BaseMovement {
     });
 
     if (vimState.currentMode === ModeName.Normal) {
+      if (this.movementType === "wrappedLineEnd") {
+        return Position.FromVSCodePosition(vimState.editor.selection.active).getLeft();
+      }
       return Position.FromVSCodePosition(vimState.editor.selection.active);
     } else {
       /**

--- a/src/actions/motion.ts
+++ b/src/actions/motion.ts
@@ -162,7 +162,7 @@ abstract class MoveByScreenLine extends BaseMovement {
     });
 
     if (vimState.currentMode === ModeName.Normal) {
-      if (this.movementType === "wrappedLineEnd") {
+      if (this.keys[0] === 'g' && this.keys[1] === '$') {
         return Position.FromVSCodePosition(vimState.editor.selection.active).getLeft();
       }
       return Position.FromVSCodePosition(vimState.editor.selection.active);


### PR DESCRIPTION
<!--
Yay! We love PRs! 🎊

Please include a description of your change and ensure:

- [ ] Commit message has a short title & issue references
- [ ] Each commit does a logical chunk of work.
- [ ] It builds and tests pass (e.g `gulp`)

More info can be found on our [contribution guide](https://github.com/VSCodeVim/Vim/blob/master/.github/CONTRIBUTING.md).
-->
Goes one character to the left so cursor lands on end of wrapped line instead of start of next line