### PR TITLE
Extend statusBarColors setting to be able to set foreground color of status bar based on current mode

### DIFF
--- a/src/configuration/configuration.ts
+++ b/src/configuration/configuration.ts
@@ -13,12 +13,12 @@ export interface IHandleKeys {
 }
 
 export interface IModeSpecificStrings {
-  normal: string | undefined;
-  insert: string | undefined;
-  visual: string | undefined;
-  visualline: string | undefined;
-  visualblock: string | undefined;
-  replace: string | undefined;
+  normal: string | string[] | undefined;
+  insert: string | string[] | undefined;
+  visual: string | string[] | undefined;
+  visualline: string | string[] | undefined;
+  visualblock: string | string[] | undefined;
+  replace: string | string[] | undefined;
 }
 
 /**

--- a/src/mode/modeHandler.ts
+++ b/src/mode/modeHandler.ts
@@ -2044,13 +2044,28 @@ export class ModeHandler implements vscode.Disposable {
     ModeHandler._statusBarItem.show();
   }
 
-  setStatusBarColor(color: string): void {
+  setStatusBarColor(colorToSet: string[] | string): void {
+    const defaultForeground = '#9da5b4';
+
+    const color = (function() {
+      if (Array.isArray(colorToSet)) {
+        if (colorToSet.length === 1) {
+          colorToSet.push(defaultForeground);
+        }
+
+        return colorToSet;
+      }
+
+      return [colorToSet, defaultForeground];
+    })();
+
     vscode.workspace.getConfiguration('workbench').update(
       'colorCustomizations',
       {
-        'statusBar.background': `${color}`,
-        'statusBar.noFolderBackground': `${color}`,
-        'statusBar.debuggingBackground': `${color}`,
+        'statusBar.background': `${color[0]}`,
+        'statusBar.noFolderBackground': `${color[0]}`,
+        'statusBar.debuggingBackground': `${color[0]}`,
+        'statusBar.foreground': `${color[1]}`,
       },
       true
     );


### PR DESCRIPTION
You're able to define your status bar customizations like:

``` JSON
  "vim.statusBarColors": {
    "normal": ["#007BFF", "#000"],
    "insert": ["#FF004E", "#F00"],
    "visual": "#FFC200",
    "visualline": "#FFC200",
    "visualblock": "#FFC200",
    "replace": "#FF00AE"
  }
```

Where `[backgroundColor, foregroundColor]`
You can also use default string form to change only background