### PR TITLE
Use 'editor.unfold' with direction: 'down'

### DIFF
--- a/src/actions/commands/actions.ts
+++ b/src/actions/commands/actions.ts
@@ -1652,7 +1652,7 @@ class CommandOpenFold extends CommandFold {
     let timesToRepeat = vimState.recordedState.count || 1;
     await vscode.commands.executeCommand('editor.unfold', {
       levels: timesToRepeat,
-      direction: 'down'
+      direction: 'down',
     });
 
     return vimState;

--- a/src/actions/commands/actions.ts
+++ b/src/actions/commands/actions.ts
@@ -1652,7 +1652,7 @@ class CommandOpenFold extends CommandFold {
     let timesToRepeat = vimState.recordedState.count || 1;
     await vscode.commands.executeCommand('editor.unfold', {
       levels: timesToRepeat,
-      direction: 'up',
+      direction: 'down'
     });
 
     return vimState;


### PR DESCRIPTION
Fixes #2103.

The VSCode command `editor.unfold` didn't support `direction` yet (`editor.fold` did).
I added it to VSCode for consistency reasons, but that breaks the VIM extension as unfolding with multiple levels is expected to work down, not up.
