### PR TITLE
fix(build): position does not exist for replacetexttransformation

### DIFF
--- a/src/actions/commands/actions.ts
+++ b/src/actions/commands/actions.ts
@@ -3206,7 +3206,6 @@ class ActionGoToInsertVisualBlockModeAppend extends BaseCommand {
           text: TextEditor.setIndentationLevel(line, end.character),
           start: new Position(end.line, 0),
           end: new Position(end.line, end.character),
-          position: new Position(end.line, 0),
         });
       }
       vimState.allCursors.push(new Range(end, end));


### PR DESCRIPTION
<!--
Yay! We love PRs! 🎊

Please include a description of your change and ensure:

- [ ] Commit message has a short title & issue references
- [ ] Each commit does a logical chunk of work.
- [ ] It builds and tests pass (e.g `gulp`)

More info can be found on our [contribution guide](https://github.com/VSCodeVim/Vim/blob/master/.github/CONTRIBUTING.md).
-->

```
src/actions/commands/actions.ts(3230,11): error TS2345: Argument of type '{ type: "replaceText"; text: string; start: Position; end: Position; position: Position; }' is not assignable to parameter of type 'Transformation'.
  Object literal may only specify known properties, and 'position' does not exist in type 'ReplaceTextTransformation'.
```