### PR TITLE
Fix ^, $, add case sensitivity override in search

### DIFF
--- a/test/mode/modeNormal.test.ts
+++ b/test/mode/modeNormal.test.ts
@@ -1541,6 +1541,34 @@ suite('Mode Normal', () => {
   });
 
   newTest({
+    title: '/ matches ^ per line',
+    start: ['|  asdf', 'asasdf', 'asdf', 'asdf'],
+    keysPressed: crossPlatformIt('/^asdf\n'),
+    end: ['  asdf', 'asasdf', '|asdf', 'asdf'],
+  });
+
+  newTest({
+    title: '/ matches $ per line',
+    start: ['|asdfjkl', 'asdf  ', 'asdf', 'asdf'],
+    keysPressed: crossPlatformIt('/asdf$\n'),
+    end: ['asdfjkl', 'asdf  ', '|asdf', 'asdf'],
+  });
+
+  newTest({
+    title: '/\\c forces case insensitive search',
+    start: ['|__ASDF', 'asdf'],
+    keysPressed: crossPlatformIt('/\\casdf\n'),
+    end: ['__|ASDF', 'asdf'],
+  });
+
+  newTest({
+    title: '/\\C forces case sensitive search',
+    start: ['|__ASDF', 'asdf'],
+    keysPressed: crossPlatformIt('/\\Casdf\n'),
+    end: ['__ASDF', '|asdf'],
+  });
+
+  newTest({
     title: 'Can do C',
     start: ['export const options = {', '|', '};'],
     keysPressed: 'C',


### PR DESCRIPTION
- Fixes #2086 and #2101 by adding the 'm' flag to the search regex, which causes `^` and `$` to match per-line instead of per-file.
- Implements #2100 by stripping all `\c` and `\C` from the search pattern and changing `ignorecase` for that search based on the first one found - this mimics vim's behavior.

Substitute is not affected by either of these issues - `^` and `$` already work there, and `/i` to override case is already implemented - vim doesn't support `\c` there.