### PR TITLE
fix(travis): use lts/carbon (v8.9.1) for travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ os:
 language: node_js
 
 node_js:
-- 6.3.1
+- 8.9.1
 
 env:
   global:


### PR DESCRIPTION
<!--
Yay! We love PRs! 🎊

Please include a description of your change and ensure:

- [ ] Commit message has a short title & issue references
- [ ] Each commit does a logical chunk of work.
- [ ] It builds and tests pass (e.g `gulp`)

More info can be found on our [contribution guide](https://github.com/VSCodeVim/Vim/blob/master/.github/CONTRIBUTING.md).
-->

As discovered by @parkovski in https://github.com/VSCodeVim/Vim/pull/2123, prettier is a different version on Travis. I suspect it's because we are using npm v3 on Travis. Upgrade it to use lts/carbon (node v8.9.1 // npm v5.5.1) as npm@5 introduced support for package-lock.json