### PR TITLE
Fix #2148: vertical split command

### DIFF
--- a/src/cmd_line/commands/file.ts
+++ b/src/cmd_line/commands/file.ts
@@ -72,6 +72,10 @@ export class FileCommand extends node.CommandBase {
 
       return;
     } else if (this._arguments.name === '') {
+      if (this._arguments.position === FilePosition.NewWindow) {
+        await vscode.commands.executeCommand('workbench.action.splitEditor');
+        return;
+      }
       const fileList = await vscode.window.showOpenDialog({});
       if (fileList) {
         const doc = await vscode.workspace.openTextDocument(fileList[0]);

--- a/test/cmd_line/vsplit.test.ts
+++ b/test/cmd_line/vsplit.test.ts
@@ -1,0 +1,65 @@
+import { ModeHandler } from '../../src/mode/modeHandler';
+import { setupWorkspace, cleanUpWorkspace, assertEqualLines, assertEqual } from './../testUtils';
+import { runCmdLine } from '../../src/cmd_line/main';
+import * as vscode from 'vscode';
+import { join } from 'path';
+import * as assert from 'assert';
+import { getAndUpdateModeHandler } from '../../extension';
+
+async function WaitForEditorOpen(): Promise<void> {
+  // cleanUpWorkspace - testUtils.ts
+  let poll = new Promise((c, e) => {
+    if (vscode.window.visibleTextEditors.length === 2) {
+      return c();
+    }
+
+    let pollCount = 0;
+    // TODO: the visibleTextEditors variable doesn't seem to be
+    // up to date after a onDidChangeActiveTextEditor event, not
+    // even using a setTimeout 0... so we MUST poll :(
+    let interval = setInterval(() => {
+      // if visibleTextEditors is not updated after 1 sec
+      // we can expect that 'wq' failed
+      if (pollCount <= 100) {
+        pollCount++;
+        if (vscode.window.visibleTextEditors.length < 2) {
+          return;
+        }
+      }
+
+      clearInterval(interval);
+      c();
+    }, 10);
+  });
+
+  try {
+    await poll;
+  } catch (error) {
+    assert.fail(null, null, error.toString(), '');
+  }
+}
+
+suite('Vertical split', () => {
+  let modeHandler: ModeHandler;
+
+  suiteSetup(async () => {
+    await setupWorkspace();
+    modeHandler = await getAndUpdateModeHandler();
+  });
+
+  suiteTeardown(cleanUpWorkspace);
+
+  test('Run :vs', async () => {
+    await runCmdLine('vs', modeHandler);
+    await WaitForEditorOpen();
+
+    assertEqual(vscode.window.visibleTextEditors.length, 2, 'Editor did not split in 1 sec');
+  });
+
+  test('Run :vsp', async () => {
+    await runCmdLine('vsp', modeHandler);
+    await WaitForEditorOpen();
+
+    assertEqual(vscode.window.visibleTextEditors.length, 2, 'Editor did not split in 1 sec');
+  });
+});

--- a/test/cmd_line/vsplit.test.ts
+++ b/test/cmd_line/vsplit.test.ts
@@ -1,36 +1,16 @@
 import { ModeHandler } from '../../src/mode/modeHandler';
-import { setupWorkspace, cleanUpWorkspace, assertEqualLines, assertEqual } from './../testUtils';
+import {
+  setupWorkspace,
+  cleanUpWorkspace,
+  assertEqualLines,
+  assertEqual,
+  WaitForEditors,
+} from './../testUtils';
 import { runCmdLine } from '../../src/cmd_line/main';
 import * as vscode from 'vscode';
 import { join } from 'path';
 import * as assert from 'assert';
 import { getAndUpdateModeHandler } from '../../extension';
-
-/**
- * Waits for the number of text editors in the current window to equal the
- * given expected number of text editors.
- *
- * @param numEditors Expected number of editors in the window
- */
-async function WaitForEditors(numEditors: number): Promise<void> {
-  let waitForEditorChange = new Promise((c, e) => {
-    if (vscode.window.visibleTextEditors.length === numEditors) {
-      return c();
-    }
-
-    let editorChange = vscode.window.onDidChangeVisibleTextEditors(() => {
-      if (vscode.window.visibleTextEditors.length === numEditors) {
-        c();
-      }
-    });
-  });
-
-  try {
-    await waitForEditorChange;
-  } catch (error) {
-    assert.fail(null, null, error.toString(), '');
-  }
-}
 
 suite('Vertical split', () => {
   let modeHandler: ModeHandler;

--- a/test/testUtils.ts
+++ b/test/testUtils.ts
@@ -24,6 +24,32 @@ async function createRandomFile(contents: string, fileExtension: string): Promis
   }
 }
 
+/**
+ * Waits for the number of text editors in the current window to equal the
+ * given expected number of text editors.
+ *
+ * @param numExpectedEditors Expected number of editors in the window
+ */
+export async function WaitForEditors(numExpectedEditors: number): Promise<void> {
+  let waitForEditorChange = new Promise((c, e) => {
+    if (vscode.window.visibleTextEditors.length === numExpectedEditors) {
+      return c();
+    }
+
+    let editorChange = vscode.window.onDidChangeVisibleTextEditors(() => {
+      if (vscode.window.visibleTextEditors.length === numExpectedEditors) {
+        c();
+      }
+    });
+  });
+
+  try {
+    await waitForEditorChange;
+  } catch (error) {
+    assert.fail(null, null, error.toString(), '');
+  }
+}
+
 export function assertEqualLines(expectedLines: string[]) {
   for (let i = 0; i < expectedLines.length; i++) {
     let expected = expectedLines[i];


### PR DESCRIPTION
This PR fixes the vertical split command, which was a regression caused by PR #2067.

I have added unit tests for the `:vs` and `:vsp` commands.

<!--
Yay! We love PRs! 🎊

Please include a description of your change and ensure:

- [ ] Commit message has a short title & issue references
- [ ] Each commit does a logical chunk of work.
- [ ] It builds and tests pass (e.g `gulp`)

More info can be found on our [contribution guide](https://github.com/VSCodeVim/Vim/blob/master/.github/CONTRIBUTING.md).
-->
