### PR TITLE
Fix #2155, Fix #2133: escape delimiter substitute

### DIFF
--- a/src/cmd_line/subparsers/substitute.ts
+++ b/src/cmd_line/subparsers/substitute.ts
@@ -33,6 +33,8 @@ function parsePattern(pattern: string, scanner: Scanner, delimiter: string): [st
               pattern += currentChar;
               break;
           }
+        } else {
+          pattern += currentChar;
         }
       }
 

--- a/test/cmd_line/subparser.substitute.test.ts
+++ b/test/cmd_line/subparser.substitute.test.ts
@@ -4,7 +4,7 @@ import * as assert from 'assert';
 import { commandParsers } from '../../src/cmd_line/subparser';
 
 suite(':substitute args parser', () => {
-  test('can parse pattern ,replace and flags', () => {
+  test('can parse pattern, replace, and flags', () => {
     var args = commandParsers.s('/a/b/g');
     assert.equal(args.arguments.pattern, 'a');
     assert.equal(args.arguments.replace, 'b');
@@ -21,6 +21,12 @@ suite(':substitute args parser', () => {
     assert.equal(args.arguments.pattern, 'a');
     assert.equal(args.arguments.replace, 'b');
     assert.equal(args.arguments.flags, 8);
+  });
+
+  test('can escape delimiter', () => {
+    var args = commandParsers.s('/\\/\\/a/b/');
+    assert.equal(args.arguments.pattern, '//a');
+    assert.equal(args.arguments.replace, 'b');
   });
 
   test('can parse flag KeepPreviousFlags', () => {

--- a/test/cmd_line/substitute.test.ts
+++ b/test/cmd_line/substitute.test.ts
@@ -205,5 +205,12 @@ suite('Basic substitute', () => {
 
       assertEqualLines(['dbc', 'dbc', 'abc']);
     });
+
+    test('Substitute with escaped delimiter', async () => {
+      await modeHandler.handleMultipleKeyEvents(['i', 'b', '/', '/', 'f', '<Esc>']);
+      await runCmdLine('s/\\/\\/f/z/g', modeHandler);
+
+      assertEqualLines(['bz']);
+    });
   });
 });


### PR DESCRIPTION
This PR addresses the issue where the slash `/` character could not be substituted using standard Vim syntax. I have added tests for the substitute and subparser substitute to cover this functionality.

<!--
Yay! We love PRs! 🎊

Please include a description of your change and ensure:

- [ ] Commit message has a short title & issue references
- [ ] Each commit does a logical chunk of work.
- [ ] It builds and tests pass (e.g `gulp`)

More info can be found on our [contribution guide](https://github.com/VSCodeVim/Vim/blob/master/.github/CONTRIBUTING.md).
-->
