### PR TITLE
Fixed incorrect styling of 'fake' cursors

### DIFF
--- a/src/mode/modeHandler.ts
+++ b/src/mode/modeHandler.ts
@@ -512,15 +512,14 @@ export class ModeHandler implements vscode.Disposable {
   public identity: EditorIdentity;
 
   private _caretDecoration = vscode.window.createTextEditorDecorationType({
+    backgroundColor: new vscode.ThemeColor('editorCursor.foreground'),
+    borderColor: new vscode.ThemeColor('editorCursor.foreground'),
     dark: {
-      // used for dark colored themes
-      backgroundColor: 'rgba(224, 224, 224, 0.4)',
-      borderColor: 'rgba(0, 0, 0, 1.0)',
+      color: '#515052',
     },
     light: {
       // used for light colored themes
-      backgroundColor: 'rgba(32, 32, 32, 0.4)',
-      borderColor: 'rgba(0, 0, 0, 1.0)',
+      color: 'rgb(255, 255, 255)',
     },
     borderStyle: 'solid',
     borderWidth: '1px',

--- a/src/mode/modeHandler.ts
+++ b/src/mode/modeHandler.ts
@@ -515,7 +515,7 @@ export class ModeHandler implements vscode.Disposable {
     backgroundColor: new vscode.ThemeColor('editorCursor.foreground'),
     borderColor: new vscode.ThemeColor('editorCursor.foreground'),
     dark: {
-      color: '#515052',
+      color: 'rgb(81,80,82)',
     },
     light: {
       // used for light colored themes


### PR DESCRIPTION
Our decorations were stupidly done. I just copied over the relevant CSS from the actual cursor in VSCode. Now they should be indistinguishable.

Before:
![](https://i.imgur.com/TixSYrf.jpg)
After:
![](https://i.imgur.com/Zq2k85I.jpg)