### PR TITLE
Update `list.*` command keybindings

### DIFF
--- a/package.json
+++ b/package.json
@@ -303,37 +303,37 @@
       {
         "key": "j",
         "command": "list.focusDown",
-        "when": "listFocus"
+        "when": "listFocus && !inputFocus"
       },
       {
         "key": "k",
         "command": "list.focusUp",
-        "when": "listFocus"
+        "when": "listFocus && !inputFocus"
       },
       {
         "key": "o",
         "command": "list.toggleExpand",
-        "when": "listFocus"
+        "when": "listFocus && !inputFocus"
       },
       {
         "key": "g g",
         "command": "list.focusFirst",
-        "when": "listFocus"
+        "when": "listFocus && !inputFocus"
       },
       {
         "key": "shift+G",
         "command": "list.focusLast",
-        "when": "listFocus"
+        "when": "listFocus && !inputFocus"
       },
       {
         "key": "ctrl+d",
         "command": "list.focusPageDown",
-        "when": "listFocus"
+        "when": "listFocus && !inputFocus"
       },
       {
         "key": "ctrl+u",
         "command": "list.focusPageUp",
-        "when": "listFocus"
+        "when": "listFocus && !inputFocus"
       }
     ],
     "configuration": {


### PR DESCRIPTION
Hi, VS Code dev here! ✋ 

Due to https://github.com/Microsoft/vscode/commit/234e2db9d7cb28bca2e07290b2b587bbea42b649, the `when` context keys for `list.*` commands need to be updated.

This should be merged ASAP. It is compatible with the current stable release and fixes the VIM integration for the upcoming November release.