### PR TITLE
Do not open open file dialog when calling `:e!`

### DIFF
--- a/src/cmd_line/commands/file.ts
+++ b/src/cmd_line/commands/file.ts
@@ -59,6 +59,7 @@ export class FileCommand extends node.CommandBase {
   async execute(): Promise<void> {
     if (this._arguments.bang) {
       await vscode.commands.executeCommand('workbench.action.files.revert');
+      return;
     }
     if (this._arguments.name === undefined) {
       // Open an empty file


### PR DESCRIPTION
Changes:

- When using a hash bang, return after the file is reverted. This prevents opening an open-file-dialog.

Fixes:  #2172