### PR TITLE
refactor: normalize keys when loading configuration

### DIFF
--- a/extension.ts
+++ b/extension.ts
@@ -16,7 +16,7 @@ import { Globals } from './src/globals';
 import { ModeName } from './src/mode/mode';
 import { ModeHandler } from './src/mode/modeHandler';
 import { Neovim } from './src/neovim/nvimUtil';
-import { AngleBracketNotation } from './src/notation';
+import { AngleBracketNotation } from './src/configuration/notation';
 import { StatusBar } from './src/statusBar';
 import { taskQueue } from './src/taskQueue';
 

--- a/extension.ts
+++ b/extension.ts
@@ -110,13 +110,7 @@ export async function activate(context: vscode.ExtensionContext) {
 
   // Event to update active configuration items when changed without restarting vscode
   vscode.workspace.onDidChangeConfiguration((e: void) => {
-    Configuration.updateConfiguration();
-
-    /* tslint:disable:forin */
-    // Update the remappers foreach modehandler
-    for (let mh in modeHandlerToEditorIdentity) {
-      modeHandlerToEditorIdentity[mh].createRemappers();
-    }
+    Configuration.reload();
   });
 
   vscode.window.onDidChangeActiveTextEditor(handleActiveEditorChange, this);
@@ -315,7 +309,7 @@ export async function activate(context: vscode.ExtensionContext) {
   }
 
   // Update configuration now that bound keys array is populated
-  Configuration.updateConfiguration();
+  Configuration.reload();
 
   // Initialize mode handler for current active Text Editor at startup.
   if (vscode.window.activeTextEditor) {

--- a/extension.ts
+++ b/extension.ts
@@ -16,7 +16,7 @@ import { Globals } from './src/globals';
 import { ModeName } from './src/mode/mode';
 import { ModeHandler } from './src/mode/modeHandler';
 import { Neovim } from './src/neovim/nvimUtil';
-import { AngleBracketNotation } from './src/configuration/notation';
+import { Notation } from './src/configuration/notation';
 import { StatusBar } from './src/statusBar';
 import { taskQueue } from './src/taskQueue';
 
@@ -210,7 +210,7 @@ export async function activate(context: vscode.ExtensionContext) {
       const mh = await getAndUpdateModeHandler();
       if (args.after) {
         for (const key of args.after) {
-          await mh.handleKeyEvent(AngleBracketNotation.Normalize(key));
+          await mh.handleKeyEvent(Notation.NormalizeKey(key));
         }
         return;
       }

--- a/extension.ts
+++ b/extension.ts
@@ -20,20 +20,6 @@ import { AngleBracketNotation } from './src/configuration/notation';
 import { StatusBar } from './src/statusBar';
 import { taskQueue } from './src/taskQueue';
 
-interface VSCodeKeybinding {
-  key: string;
-  mac?: string;
-  linux?: string;
-  command: string;
-  when: string;
-}
-
-const packagejson: {
-  contributes: {
-    keybindings: VSCodeKeybinding[];
-  };
-} = require('../package.json'); // out/../package.json
-
 let extensionContext: vscode.ExtensionContext;
 
 /**
@@ -284,32 +270,9 @@ export async function activate(context: vscode.ExtensionContext) {
     toggleExtension(Configuration.disableExt);
   });
 
-  // Clear boundKeyCombinations array incase there are any entries in it so
-  // that we have a clean list of keys with no duplicates
-  Configuration.boundKeyCombinations = [];
-
-  for (let keybinding of packagejson.contributes.keybindings) {
-    if (keybinding.when.indexOf('listFocus') !== -1) {
-      continue;
-    }
-    let keyToBeBound = '';
-    if (process.platform === 'darwin') {
-      keyToBeBound = keybinding.mac || keybinding.key;
-    } else if (process.platform === 'linux') {
-      keyToBeBound = keybinding.linux || keybinding.key;
-    } else {
-      keyToBeBound = keybinding.key;
-    }
-
-    // Store registered key bindings in bracket notation form
-    const bracketedKey = AngleBracketNotation.Normalize(keyToBeBound);
-    Configuration.boundKeyCombinations.push(bracketedKey);
-
-    registerCommand(context, keybinding.command, () => handleKeyEvent(`${bracketedKey}`));
+  for (const boundKey of Configuration.boundKeyCombinations) {
+    registerCommand(context, boundKey.command, () => handleKeyEvent(`${boundKey.key}`));
   }
-
-  // Update configuration now that bound keys array is populated
-  Configuration.reload();
 
   // Initialize mode handler for current active Text Editor at startup.
   if (vscode.window.activeTextEditor) {

--- a/src/configuration/configuration.ts
+++ b/src/configuration/configuration.ts
@@ -3,7 +3,7 @@ import { ConfigurationTarget, WorkspaceConfiguration } from 'vscode';
 
 import { Globals } from '../globals';
 import { taskQueue } from '../taskQueue';
-import { AngleBracketNotation } from './notation';
+import { Notation } from './notation';
 
 const packagejson: {
   contributes: {
@@ -85,10 +85,11 @@ class ConfigurationClass {
       }
     }
 
-    // <space> is special, change it to " " internally
-    if (this.leader.toLowerCase() === '<space>') {
-      this.leader = ' ';
-    }
+    // resolve and normalize leader key
+    this.leader =
+      this.leader.toLocaleLowerCase() === '<leader>'
+        ? this.leaderDefault
+        : Notation.NormalizeKey(this.leader);
 
     // normalize keys
     const keybindingList: IKeyRemapping[][] = [
@@ -101,13 +102,13 @@ class ConfigurationClass {
       for (let remapping of keybindings) {
         if (remapping.before) {
           remapping.before.forEach(
-            (key, idx) => (remapping.before[idx] = AngleBracketNotation.Normalize(key))
+            (key, idx) => (remapping.before[idx] = Notation.NormalizeKey(key))
           );
         }
 
         if (remapping.after) {
           remapping.after.forEach(
-            (key, idx) => (remapping.after![idx] = AngleBracketNotation.Normalize(key))
+            (key, idx) => (remapping.after![idx] = Notation.NormalizeKey(key))
           );
         }
       }
@@ -128,7 +129,7 @@ class ConfigurationClass {
       }
 
       this.boundKeyCombinations.push({
-        key: AngleBracketNotation.Normalize(key),
+        key: Notation.NormalizeKey(key),
         command: keybinding.command,
       });
     }
@@ -257,7 +258,8 @@ class ConfigurationClass {
   /**
    * What key should <leader> map to in key remappings?
    */
-  leader = '\\';
+  private leaderDefault = '\\';
+  leader = this.leaderDefault;
 
   /**
    * How much search or command history should be remembered

--- a/src/configuration/configuration.ts
+++ b/src/configuration/configuration.ts
@@ -3,7 +3,7 @@ import { ConfigurationTarget, WorkspaceConfiguration } from 'vscode';
 
 import { Globals } from '../globals';
 import { taskQueue } from '../taskQueue';
-import { AngleBracketNotation } from '../notation';
+import { AngleBracketNotation } from './notation';
 
 type OptionValue = number | string | boolean;
 type ValueMapping = {

--- a/src/configuration/notation.ts
+++ b/src/configuration/notation.ts
@@ -1,6 +1,6 @@
 import * as _ from 'lodash';
 
-import { Configuration } from './configuration/configuration';
+import { Configuration } from './configuration';
 
 export class AngleBracketNotation {
   // Mapping from the nomalized string to regex strings that could match it.

--- a/src/configuration/notation.ts
+++ b/src/configuration/notation.ts
@@ -2,7 +2,7 @@ import * as _ from 'lodash';
 
 import { Configuration } from './configuration';
 
-export class AngleBracketNotation {
+export class Notation {
   // Mapping from the nomalized string to regex strings that could match it.
   private static _notationMap: { [key: string]: string[] } = {
     'C-': ['ctrl\\+', 'c\\-'],
@@ -14,23 +14,24 @@ export class AngleBracketNotation {
 
   /**
    * Normalizes key to AngleBracketNotation
-   * For instance, <ctrl+x>, Ctrl+x, <c-x> normalized to <C-x>
+   * (e.g. <ctrl+x>, Ctrl+x, <c-x> normalized to <C-x>)
+   * and resolves special cases such as '<leader>'
    */
-  public static Normalize(key: string): string {
+  public static NormalizeKey(key: string): string {
     if (!this.isSurroundedByAngleBrackets(key) && key.length > 1) {
       key = `<${key.toLocaleLowerCase()}>`;
     }
 
     // Special cases that we handle incorrectly (internally)
-    if (key.toLowerCase() === '<space>') {
+    if (key.toLocaleLowerCase() === '<space>') {
       return ' ';
     }
 
-    if (key.toLowerCase() === '<cr>') {
+    if (key.toLocaleLowerCase() === '<cr>') {
       return '\n';
     }
 
-    if (key.toLowerCase() === '<leader>') {
+    if (key.toLocaleLowerCase() === '<leader>') {
       return Configuration.leader;
     }
 

--- a/src/configuration/remapper.ts
+++ b/src/configuration/remapper.ts
@@ -45,7 +45,7 @@ interface IRemapper {
 class Remapper implements IRemapper {
   private readonly _remappedModes: ModeName[];
   private readonly _recursive: boolean;
-  private _remappings: IKeybinding[] = [];
+  private readonly _remappings: IKeybinding[] = [];
 
   /**
    * Have the keys pressed so far potentially be a remap
@@ -58,26 +58,7 @@ class Remapper implements IRemapper {
   constructor(configKey: string, remappedModes: ModeName[], recursive: boolean) {
     this._recursive = recursive;
     this._remappedModes = remappedModes;
-
-    const remappings = Configuration[configKey] as IKeybinding[];
-
-    for (let remapping of remappings) {
-      let before: string[] = [];
-      if (remapping.before) {
-        remapping.before.forEach(item => before.push(AngleBracketNotation.Normalize(item)));
-      }
-
-      let after: string[] = [];
-      if (remapping.after) {
-        remapping.after.forEach(item => after.push(AngleBracketNotation.Normalize(item)));
-      }
-
-      this._remappings.push(<IKeybinding>{
-        before: before,
-        after: after,
-        commands: remapping.commands,
-      });
-    }
+    this._remappings = Configuration[configKey] as IKeybinding[];
   }
 
   public async sendKey(

--- a/src/configuration/remapper.ts
+++ b/src/configuration/remapper.ts
@@ -5,7 +5,6 @@ import { CommandLine } from '../cmd_line/commandLine';
 import { Configuration, IKeybinding } from '../configuration/configuration';
 import { ModeName } from '../mode/mode';
 import { ModeHandler } from '../mode/modeHandler';
-import { AngleBracketNotation } from './../notation';
 import { VimState } from './../state/vimState';
 
 export class Remappers implements IRemapper {

--- a/src/configuration/remapper.ts
+++ b/src/configuration/remapper.ts
@@ -2,7 +2,7 @@ import * as _ from 'lodash';
 import * as vscode from 'vscode';
 
 import { CommandLine } from '../cmd_line/commandLine';
-import { Configuration, IKeybinding } from '../configuration/configuration';
+import { Configuration, IKeyRemapping } from '../configuration/configuration';
 import { ModeName } from '../mode/mode';
 import { ModeHandler } from '../mode/modeHandler';
 import { VimState } from './../state/vimState';
@@ -44,7 +44,7 @@ interface IRemapper {
 class Remapper implements IRemapper {
   private readonly _remappedModes: ModeName[];
   private readonly _recursive: boolean;
-  private readonly _remappings: IKeybinding[] = [];
+  private readonly _remappings: IKeyRemapping[] = [];
 
   /**
    * Have the keys pressed so far potentially be a remap
@@ -57,7 +57,7 @@ class Remapper implements IRemapper {
   constructor(configKey: string, remappedModes: ModeName[], recursive: boolean) {
     this._recursive = recursive;
     this._remappedModes = remappedModes;
-    this._remappings = Configuration[configKey] as IKeybinding[];
+    this._remappings = Configuration[configKey] as IKeyRemapping[];
   }
 
   public async sendKey(
@@ -71,7 +71,7 @@ class Remapper implements IRemapper {
       return false;
     }
 
-    let remapping: IKeybinding | undefined;
+    let remapping: IKeyRemapping | undefined;
     const longestKeySequence = this._longestKeySequence();
 
     /**

--- a/src/mode/modeHandler.ts
+++ b/src/mode/modeHandler.ts
@@ -43,8 +43,7 @@ export class ModeHandler implements vscode.Disposable {
   }
 
   constructor() {
-    this.createRemappers();
-
+    this._remappers = new Remappers();
     this._modes = [
       new modes.NormalMode(),
       new modes.InsertMode(),
@@ -92,13 +91,6 @@ export class ModeHandler implements vscode.Disposable {
 
     this._disposables.push(disposable);
     this._disposables.push(this.vimState);
-  }
-
-  /**
-   * create remappers after a configuration change
-   */
-  createRemappers() {
-    this._remappers = new Remappers();
   }
 
   /**

--- a/src/mode/modes.ts
+++ b/src/mode/modes.ts
@@ -17,7 +17,7 @@ export enum VisualBlockInsertionType {
 
 export class EasyMotionMode extends Mode {
   constructor() {
-    super(ModeName.EasyMotionMode, '-- EasyMotion Mode --', VSCodeVimCursorType.Block);
+    super(ModeName.EasyMotionMode, '-- EasyMotion --', VSCodeVimCursorType.Block);
   }
 
   getStatusBarCommandText(vimState: VimState): string {
@@ -46,7 +46,7 @@ export class EasyMotionInputMode extends Mode {
 
 export class InsertMode extends Mode {
   constructor() {
-    super(ModeName.Insert, '-- Insert Mode --', VSCodeVimCursorType.Native);
+    super(ModeName.Insert, '-- Insert --', VSCodeVimCursorType.Native);
   }
 
   getStatusBarCommandText(vimState: VimState): string {
@@ -56,7 +56,7 @@ export class InsertMode extends Mode {
 
 export class NormalMode extends Mode {
   constructor() {
-    super(ModeName.Normal, '-- Normal Mode --', VSCodeVimCursorType.Block);
+    super(ModeName.Normal, '-- Normal --', VSCodeVimCursorType.Block);
   }
 }
 
@@ -82,18 +82,13 @@ export class SearchInProgressMode extends Mode {
 
 export class VisualMode extends Mode {
   constructor() {
-    super(ModeName.Visual, '-- Visual Mode --', VSCodeVimCursorType.TextDecoration, true);
+    super(ModeName.Visual, '-- Visual --', VSCodeVimCursorType.TextDecoration, true);
   }
 }
 
 export class VisualBlockMode extends Mode {
   constructor() {
-    super(
-      ModeName.VisualBlock,
-      '-- Visual Block Mode --',
-      VSCodeVimCursorType.TextDecoration,
-      true
-    );
+    super(ModeName.VisualBlock, '-- Visual Block --', VSCodeVimCursorType.TextDecoration, true);
   }
 
   public static getTopLeftPosition(start: Position, stop: Position): Position {
@@ -107,13 +102,13 @@ export class VisualBlockMode extends Mode {
 
 export class VisualLineMode extends Mode {
   constructor() {
-    super(ModeName.VisualLine, '-- Visual Line Mode --', VSCodeVimCursorType.Block, true);
+    super(ModeName.VisualLine, '-- Visual Line --', VSCodeVimCursorType.Block, true);
   }
 }
 
 export class SurroundInputMode extends Mode {
   constructor() {
-    super(ModeName.SurroundInputMode, '-- Surround Input Mode --', VSCodeVimCursorType.Block);
+    super(ModeName.SurroundInputMode, '-- Surround Input --', VSCodeVimCursorType.Block);
   }
 
   getStatusBarCommandText(vimState: VimState): string {

--- a/test/notation.test.ts
+++ b/test/notation.test.ts
@@ -1,6 +1,6 @@
 import * as assert from 'assert';
 
-import { AngleBracketNotation } from '../src/notation';
+import { AngleBracketNotation } from '../src/configuration/notation';
 
 suite('Notation', () => {
   test('Normalize', () => {

--- a/test/notation.test.ts
+++ b/test/notation.test.ts
@@ -1,6 +1,6 @@
 import * as assert from 'assert';
 
-import { AngleBracketNotation } from '../src/configuration/notation';
+import { Notation } from '../src/configuration/notation';
 
 suite('Notation', () => {
   test('Normalize', () => {
@@ -15,7 +15,7 @@ suite('Notation', () => {
       if (testCases.hasOwnProperty(test)) {
         let expected = testCases[test];
 
-        let actual = AngleBracketNotation.Normalize(test);
+        let actual = Notation.NormalizeKey(test);
         assert.equal(actual, expected);
       }
     }


### PR DESCRIPTION
<!--
Yay! Thanks for sending us a PR! 🎊

Please ensure your PR adheres to:

- [ ] Commit messages has a short & issue references when necessary
- [ ] Each commit does a logical chunk of work.
- [ ] It builds and tests pass (e.g `gulp`)
-->

**What this PR does / why we need it**:

* move logic out of modeHandler into configuration simplifying modeHandler, and simplifying accessing keybindings/remappedKeys settings as the keys will already be normalized to angle bracket notation.
* update status bar text to be more like vanilla vim


**Which issue(s) this PR fixes**

<!--
Commits in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)
-->

**Special notes for your reviewer**:
  
  