### PR TITLE
fix: <C-d> remapping disabled by default. functionality controlled by "handleKeys"

### DIFF
--- a/src/mode/modeHandler.ts
+++ b/src/mode/modeHandler.ts
@@ -286,17 +286,10 @@ export class ModeHandler implements vscode.Disposable {
       }
     }
 
-    // Now keep the remapping but check if <C-d> is explicitly defined
-    // within the handleKeys scope firstly
-    if (key === '<C-d>') {
-      const useKeyCtrlD = Configuration.handleKeys['<C-d>'];
-      if (useKeyCtrlD !== undefined) {
-        if (!useKeyCtrlD) {
-          key = '<D-d>';
-        }
-      } else if (!Configuration.useCtrlKeys) {
-        key = '<D-d>';
-      }
+    // <C-d> triggers "add selection to next find match" by default,
+    // unless users explicity make <C-d>: true
+    if (key === '<C-d>' && !(Configuration.handleKeys['<C-d>'] === true)) {
+      key = '<D-d>';
     }
 
     this.vimState.cursorPositionJustBeforeAnythingHappened = this.vimState.allCursors.map(

--- a/src/mode/modeHandler.ts
+++ b/src/mode/modeHandler.ts
@@ -285,9 +285,21 @@ export class ModeHandler implements vscode.Disposable {
         }
       }
     }
-    if (key === '<C-d>' && !Configuration.useCtrlKeys) {
-      key = '<D-d>';
+
+    // #2162 fixed by 5cc821e except <C-d> key due to this remapping
+    // Now keep the remapping but check if <C-d> is explicitly defined
+    // within the handleKeys scope firstly
+    if (key === '<C-d>') {
+      const useKeyCtrlD = Configuration.handleKeys['<C-d>'];
+      if (useKeyCtrlD !== undefined) {
+        if (!useKeyCtrlD) {
+          key = '<D-d>';
+        }
+      } else if (!Configuration.useCtrlKeys) {
+        key = '<D-d>';
+      }
     }
+
     this.vimState.cursorPositionJustBeforeAnythingHappened = this.vimState.allCursors.map(
       x => x.stop
     );

--- a/src/mode/modeHandler.ts
+++ b/src/mode/modeHandler.ts
@@ -286,7 +286,6 @@ export class ModeHandler implements vscode.Disposable {
       }
     }
 
-    // #2162 fixed by 5cc821e except <C-d> key due to this remapping
     // Now keep the remapping but check if <C-d> is explicitly defined
     // within the handleKeys scope firstly
     if (key === '<C-d>') {


### PR DESCRIPTION
<!--
Yay! Thanks for sending us a PR! 🎊

Please ensure your PR adheres to:

- [ * ] Commit messages has a short & issue references when necessary
- [ * ] Each commit does a logical chunk of work.
- [ * ] It builds and tests pass (e.g `gulp`)
-->

**What this PR does / why we need it**:
This PR make ```<C-d>``` disabled by default, unless users explicitly defined ```<C-d>:true``` in ```handleKeys```.

> handleKeys config trumps usectrlkeys conifg 

This configuration
```
"vim.useCtrlKeys": false,
"vim.handleKeys": {
    "<C-d>": true
}
```
It should have ```<C-d>``` working as **Vim move page half down**, now it behaviors as ```add selection to next find match```.
 
This PR modified [this line](https://github.com/VSCodeVim/Vim/blob/master/src/mode/modeHandler.ts#L289), eventually results in this logic:

|                             | useCtrlKeys = true                     | useCtrlKeys  = false                |
|--------------------- | ------------------------------|-----------------------------|
| handleKeys = true | VSCodeVim move page half down | VSCodeVim move page half down
| handleKeys = false | remap to ```<D-d>``` | remap to ```<D-d>```
| undefined               | VS Code default behavior | VS Code default behavior


**Which issue(s) this PR fixes**
#2162 


<!--
Commits in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)
-->

**Special notes for your reviewer**:
```<D-d>``` perform as **VS Code default behavior**, which is ```add selection to next find match```.