### PR TITLE
Fix: Warnings when retrieving configurations w/o resource

### DIFF
--- a/src/cmd_line/commandLine.ts
+++ b/src/cmd_line/commandLine.ts
@@ -40,7 +40,7 @@ export class CommandLine {
     } catch (e) {
       console.log(e);
       if (e instanceof VimError) {
-        StatusBar.SetText(`${e.toString()}: ${command}`, vimState.currentMode, true);
+        StatusBar.SetText(`${e.toString()}. ${command}`, vimState.currentMode, true);
       } else {
         util.showError(e.toString());
       }

--- a/src/common/matching/matcher.ts
+++ b/src/common/matching/matcher.ts
@@ -2,6 +2,7 @@ import * as vscode from 'vscode';
 
 import { TextEditor } from './../../textEditor';
 import { Position, PositionDiff } from './../motion/position';
+import { Configuration } from '../../configuration/configuration';
 
 function escapeRegExpCharacters(value: string): string {
   return value.replace(/[\-\\\{\}\*\+\?\|\^\$\.\,\[\]\(\)\#\s]/g, '\\$&');
@@ -180,7 +181,7 @@ export class PairMatcher {
    */
   static immediateMatchingBracket(currentPosition: Position): vscode.Range | undefined {
     // Don't delete bracket unless autoClosingBrackets is set
-    if (!vscode.workspace.getConfiguration().get('editor.autoClosingBrackets')) {
+    if (!Configuration.getConfiguration().get('editor.autoClosingBrackets')) {
       return undefined;
     }
 

--- a/src/configuration/configuration.ts
+++ b/src/configuration/configuration.ts
@@ -75,7 +75,7 @@ class ConfigurationClass {
 
   reload() {
     // read configurations
-    let vimConfigs = getConfiguration('vim');
+    let vimConfigs = this.getConfiguration('vim');
     /* tslint:disable:forin */
     // Disable forin rule here as we make accessors enumerable.`
     for (const option in this) {
@@ -151,6 +151,15 @@ class ConfigurationClass {
 
       vscode.commands.executeCommand('setContext', `vim.use${boundKey.key}`, useKey);
     }
+  }
+
+  getConfiguration(section: string = ''): vscode.WorkspaceConfiguration {
+    let resource: vscode.Uri | undefined = undefined;
+    let activeTextEditor = vscode.window.activeTextEditor;
+    if (activeTextEditor) {
+      resource = activeTextEditor.document.uri;
+    }
+    return vscode.workspace.getConfiguration(section, resource);
   }
 
   cursorStyleFromString(cursorStyle: string): vscode.TextEditorCursorStyle | undefined {
@@ -368,7 +377,7 @@ class ConfigurationClass {
   }
   set disableExt(isDisabled: boolean) {
     this.disableExtension = isDisabled;
-    getConfiguration('vim').update('disableExtension', isDisabled, ConfigurationTarget.Global);
+    this.getConfiguration('vim').update('disableExtension', isDisabled, ConfigurationTarget.Global);
   }
 
   /**
@@ -408,15 +417,6 @@ class ConfigurationClass {
   otherModesKeyBindingsNonRecursive: IKeyRemapping[] = [];
 }
 
-function getConfiguration(section: string): vscode.WorkspaceConfiguration {
-  let resource: vscode.Uri | undefined = undefined;
-  let activeTextEditor = vscode.window.activeTextEditor;
-  if (activeTextEditor) {
-    resource = activeTextEditor.document.uri;
-  }
-  return vscode.workspace.getConfiguration(section, resource);
-}
-
 function overlapSetting(args: {
   codeName: string;
   default: OptionValue;
@@ -429,7 +429,7 @@ function overlapSetting(args: {
           return this['_' + propertyKey];
         }
 
-        let val = getConfiguration('editor').get(args.codeName, args.default);
+        let val = this.getConfiguration('editor').get(args.codeName, args.default);
         if (args.codeValueMapping && val !== undefined) {
           val = args.codeValueMapping[val as string];
         }
@@ -448,7 +448,7 @@ function overlapSetting(args: {
             value = args.codeValueMapping[value];
           }
 
-          await getConfiguration('editor').update(
+          await this.getConfiguration('editor').update(
             args.codeName,
             value,
             vscode.ConfigurationTarget.Global

--- a/src/mode/modeHandler.ts
+++ b/src/mode/modeHandler.ts
@@ -850,6 +850,8 @@ export class ModeHandler implements vscode.Disposable {
         case 'deleteRange':
           edit.delete(new vscode.Selection(command.range.start, command.range.stop));
           break;
+        case 'moveCursor':
+          break;
         default:
           console.warn(`Unhandled text transformation type: ${command.type}.`);
           break;

--- a/test/configuration/notation.test.ts
+++ b/test/configuration/notation.test.ts
@@ -1,6 +1,6 @@
 import * as assert from 'assert';
 
-import { Notation } from '../src/configuration/notation';
+import { Notation } from '../../src/configuration/notation';
 
 suite('Notation', () => {
   test('Normalize', () => {


### PR DESCRIPTION
<!--
Yay! Thanks for sending us a PR! 🎊

Please ensure your PR adheres to:

- [ ] Commit messages has a short & issue references when necessary
- [ ] Each commit does a logical chunk of work.
- [ ] It builds and tests pass (e.g `gulp`)
-->

**What this PR does / why we need it**: 

Fixes VSCode warnings when retrieving configurations without resource

**Which issue(s) this PR fixes**

<!--
Commits in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)
-->

**Special notes for your reviewer**: