### PR TITLE
refactor: move modehandlermap to own class

### DIFF
--- a/src/mode/modeHandlerMap.ts
+++ b/src/mode/modeHandlerMap.ts
@@ -1,0 +1,36 @@
+import * as vscode from 'vscode';
+import { EditorIdentity } from '../editorIdentity';
+import { ModeHandler } from './modeHandler';
+
+class ModeHandlerMapClass {
+  modeHandlerMap: { [key: string]: ModeHandler } = {};
+
+  async getOrCreate(key: string): Promise<[ModeHandler, boolean]> {
+    let isNew = false;
+    let modeHandler = this.modeHandlerMap[key];
+    if (!modeHandler) {
+      isNew = true;
+      modeHandler = await new ModeHandler();
+      this.modeHandlerMap[key] = modeHandler;
+    }
+    return [modeHandler, isNew];
+  }
+
+  getKeys(): string[] {
+    return Object.keys(this.modeHandlerMap);
+  }
+
+  getAll(): ModeHandler[] {
+    return this.getKeys().map(key => this.modeHandlerMap[key]);
+  }
+
+  delete(key: string) {
+    delete this.modeHandlerMap[key];
+  }
+
+  clear() {
+    this.modeHandlerMap = {};
+  }
+}
+
+export let ModeHandlerMap = new ModeHandlerMapClass();

--- a/test/mode/modeHandlerMap.test.ts
+++ b/test/mode/modeHandlerMap.test.ts
@@ -1,0 +1,42 @@
+import * as assert from 'assert';
+
+import { getAndUpdateModeHandler } from '../../extension';
+import { ModeName } from '../../src/mode/mode';
+import { ModeHandlerMap } from '../../src/mode/modeHandlerMap';
+import { cleanUpWorkspace, setupWorkspace } from './../testUtils';
+
+suite('Mode Handler Map', () => {
+  setup(() => {
+    ModeHandlerMap.clear();
+  });
+
+  teardown(() => {
+    ModeHandlerMap.clear();
+  });
+
+  test('getOrCreate', async () => {
+    // getOrCreate
+    let key = Math.random()
+      .toString(36)
+      .substring(7);
+    let [modeHandler, isNew] = await ModeHandlerMap.getOrCreate(key);
+    assert.equal(isNew, true);
+    assert.notEqual(modeHandler, undefined);
+
+    [, isNew] = await ModeHandlerMap.getOrCreate(key);
+    assert.equal(isNew, false);
+
+    // getKeys
+    let keys = ModeHandlerMap.getKeys();
+    assert.equal(keys.length, 1);
+    assert.equal(keys[0], key);
+
+    // getAll
+    let modeHandlerList = ModeHandlerMap.getAll();
+    assert.equal(modeHandlerList.length, 1);
+
+    // delete
+    ModeHandlerMap.delete(key);
+    assert.equal(ModeHandlerMap.getAll().length, 0);
+  });
+});


### PR DESCRIPTION
<!--
Yay! Thanks for sending us a PR! 🎊

Please ensure your PR adheres to:

- [ ] Commit messages has a short & issue references when necessary
- [ ] Each commit does a logical chunk of work.
- [ ] It builds and tests pass (e.g `gulp`)
-->

**What this PR does / why we need it**:

code-cleanup. move `modehandlermap` to it's own static class.

**Which issue(s) this PR fixes**

<!--
Commits in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)
-->

**Special notes for your reviewer**: