### PR TITLE
Fix BaseAction.couldActionApply to work with two-dimensional keys array

### DIFF
--- a/src/actions/base.ts
+++ b/src/actions/base.ts
@@ -140,9 +140,13 @@ export class BaseAction {
     if (this.modes.indexOf(vimState.currentMode) === -1) {
       return false;
     }
-    if (!compareKeypressSequence(this.keys.slice(0, keysPressed.length), keysPressed)) {
+
+    const keys2D = is2DArray(this.keys) ? this.keys : [this.keys];
+    const keysSlice = keys2D.map(x => x.slice(0, keysPressed.length));
+    if (!compareKeypressSequence(keysSlice, keysPressed)) {
       return false;
     }
+
     if (
       this.mustBeFirstKey &&
       vimState.recordedState.numberOfKeysInCommandWithoutCountPrefix - keysPressed.length > 0

--- a/test/baseAction.test.ts
+++ b/test/baseAction.test.ts
@@ -29,58 +29,42 @@ suite('base action', () => {
   suiteTeardown(cleanUpWorkspace);
 
   test('couldActionApply 1D keys positive', () => {
-    assert.strictEqual(
-      action1D.couldActionApply(vimState, ['a']),
-      true
-    );
+    const result = action1D.couldActionApply(vimState, ['a']);
+    assert.strictEqual(result, true);
   });
 
   test('couldActionApply 1D keys negative', () => {
-    assert.strictEqual(
-      action1D.couldActionApply(vimState, ['b']),
-      false
-    );
+    const result = action1D.couldActionApply(vimState, ['b']);
+    assert.strictEqual(result, false);
   });
 
   test('couldActionApply 2D keys positive', () => {
-    assert.strictEqual(
-      action2D.couldActionApply(vimState, ['c']),
-      true
-    );
+    const result = action2D.couldActionApply(vimState, ['c']);
+    assert.strictEqual(result, true);
   });
 
   test('couldActionApply 2D keys negative', () => {
-    assert.strictEqual(
-      action2D.couldActionApply(vimState, ['b']),
-      false
-    );
+    const result = action2D.couldActionApply(vimState, ['b']);
+    assert.strictEqual(result, false);
   });
 
   test('doesActionApply 1D keys positive', () => {
-    assert.strictEqual(
-      action1D.doesActionApply(vimState, ['a', 'b']),
-      true
-    );
+    const result = action1D.doesActionApply(vimState, ['a', 'b']);
+    assert.strictEqual(result, true);
   });
 
   test('doesActionApply 1D keys negative', () => {
-    assert.strictEqual(
-      action1D.doesActionApply(vimState, ['a', 'a']),
-      false
-    );
+    const result = action1D.doesActionApply(vimState, ['a', 'a']);
+    assert.strictEqual(result, false);
   });
 
   test('doesActionApply 2D keys positive', () => {
-    assert.strictEqual(
-      action2D.doesActionApply(vimState, ['c', 'd']),
-      true
-    );
+    const result = action2D.doesActionApply(vimState, ['c', 'd']);
+    assert.strictEqual(result, true);
   });
 
   test('doesActionApply 2D keys negative', () => {
-    assert.strictEqual(
-      action2D.doesActionApply(vimState, ['a', 'a']),
-      false
-    );
+    const result = action2D.doesActionApply(vimState, ['a', 'a']);
+    assert.strictEqual(result, false);
   });
 });

--- a/test/baseAction.test.ts
+++ b/test/baseAction.test.ts
@@ -1,0 +1,86 @@
+import * as assert from 'assert';
+import * as vscode from 'vscode';
+
+import { BaseAction } from '../src/actions/base';
+import { VimState } from '../src/state/vimState';
+import { setupWorkspace, cleanUpWorkspace } from './testUtils';
+import { ModeName } from '../src/mode/mode';
+
+class TestAction1D extends BaseAction {
+  keys = ['a', 'b'];
+  modes = [ModeName.Normal];
+}
+
+class TestAction2D extends BaseAction {
+  keys = [['a', 'b'], ['c', 'd']];
+  modes = [ModeName.Normal];
+}
+
+suite('base action', () => {
+  const action1D = new TestAction1D();
+  const action2D = new TestAction2D();
+  let vimState: VimState;
+
+  suiteSetup(async () => {
+    await setupWorkspace();
+    vimState = new VimState(vscode.window.activeTextEditor!, false);
+  });
+
+  suiteTeardown(cleanUpWorkspace);
+
+  test('couldActionApply 1D keys positive', () => {
+    assert.strictEqual(
+      action1D.couldActionApply(vimState, ['a']),
+      true
+    );
+  });
+
+  test('couldActionApply 1D keys negative', () => {
+    assert.strictEqual(
+      action1D.couldActionApply(vimState, ['b']),
+      false
+    );
+  });
+
+  test('couldActionApply 2D keys positive', () => {
+    assert.strictEqual(
+      action2D.couldActionApply(vimState, ['c']),
+      true
+    );
+  });
+
+  test('couldActionApply 2D keys negative', () => {
+    assert.strictEqual(
+      action2D.couldActionApply(vimState, ['b']),
+      false
+    );
+  });
+
+  test('doesActionApply 1D keys positive', () => {
+    assert.strictEqual(
+      action1D.doesActionApply(vimState, ['a', 'b']),
+      true
+    );
+  });
+
+  test('doesActionApply 1D keys negative', () => {
+    assert.strictEqual(
+      action1D.doesActionApply(vimState, ['a', 'a']),
+      false
+    );
+  });
+
+  test('doesActionApply 2D keys positive', () => {
+    assert.strictEqual(
+      action2D.doesActionApply(vimState, ['c', 'd']),
+      true
+    );
+  });
+
+  test('doesActionApply 2D keys negative', () => {
+    assert.strictEqual(
+      action2D.doesActionApply(vimState, ['a', 'a']),
+      false
+    );
+  });
+});


### PR DESCRIPTION
When `BaseAction.couldActionApply` slices the `keys` array it assumes it is one-dimensional (e.g. `['a', 'b']`). This pull request fixes it so that it also works when the `keys` array is two-dimensional (e.g. `[['a', 'b'], ['c', 'd']]`).