### PR TITLE
Left shift fix 2299

### DIFF
--- a/src/actions/operator.ts
+++ b/src/actions/operator.ts
@@ -491,7 +491,7 @@ class OutdentOperator extends BaseOperator {
   keys = ['<'];
 
   public async run(vimState: VimState, start: Position, end: Position): Promise<VimState> {
-    vimState.editor.selection = new vscode.Selection(start, end);
+    vimState.editor.selection = new vscode.Selection(start, end.getLineEnd());
 
     await vscode.commands.executeCommand('editor.action.outdentLines');
     vimState.currentMode = ModeName.Normal;

--- a/test/operator/shift.test.ts
+++ b/test/operator/shift.test.ts
@@ -1,0 +1,52 @@
+import { getAndUpdateModeHandler } from '../../extension';
+import { ModeHandler } from '../../src/mode/modeHandler';
+import { getTestingFunctions } from '../testSimplifier';
+import { cleanUpWorkspace, setupWorkspace } from '../testUtils';
+
+suite('shift operator', () => {
+  let modeHandler: ModeHandler;
+
+  let { newTest, newTestOnly } = getTestingFunctions();
+
+  setup(async () => {
+    await setupWorkspace();
+    modeHandler = await getAndUpdateModeHandler();
+  });
+
+  teardown(cleanUpWorkspace);
+
+  newTest({
+    title: 'basic shift left test',
+    start: ['  |zxcv', '  zxcv', '  zxcv'],
+    keysPressed: '<<',
+    end: ['|zxcv', '  zxcv', '  zxcv'],
+  });
+
+  newTest({
+    title: 'shift left goto end test',
+    start: ['  |zxcv', '  zxcv', '  zxcv'],
+    keysPressed: '<G',
+    end: ['|zxcv', 'zxcv', 'zxcv'],
+  });
+
+  newTest({
+    title: 'shift left goto line test',
+    start: ['  |zxcv', '  zxcv', '  zxcv'],
+    keysPressed: '<2G',
+    end: ['|zxcv', 'zxcv', '  zxcv'],
+  });
+
+  newTest({
+    title: 'shift right goto end test',
+    start: ['|zxcv', 'zxcv', 'zxcv'],
+    keysPressed: '>G',
+    end: ['  |zxcv', '  zxcv', '  zxcv'],
+  });
+
+  newTest({
+    title: 'shift right goto line test',
+    start: ['|zxcv', 'zxcv', 'zxcv'],
+    keysPressed: '>2G',
+    end: ['  |zxcv', '  zxcv', 'zxcv'],
+  });
+});

--- a/test/testSimplifier.ts
+++ b/test/testSimplifier.ts
@@ -171,11 +171,23 @@ function tokenizeKeySequence(sequence: string): string[] {
   let key = '';
   let result: string[] = [];
 
+  // no close bracket, probably trying to do a left shift, take literal
+  // char sequence
+  function rawTokenize(): void {
+    for (const char of key) {
+      result.push(char);
+    }
+  }
+
   for (const char of sequence) {
     key += char;
 
     if (char === '<') {
-      isBracketedKey = true;
+      if (isBracketedKey) {
+        rawTokenize();
+      } else {
+        isBracketedKey = true;
+      }
     }
 
     if (char === '>') {
@@ -188,6 +200,10 @@ function tokenizeKeySequence(sequence: string): string[] {
 
     result.push(key);
     key = '';
+  }
+
+  if (isBracketedKey) {
+    rawTokenize();
   }
 
   return result;


### PR DESCRIPTION
<!--
Yay! Thanks for sending us a PR! 🎊

Please ensure your PR adheres to:

- [ ] Commit messages has a short & issue references when necessary
- [ ] Each commit does a logical chunk of work.
- [ ] It builds and tests pass (e.g `gulp`)
-->

**What this PR does / why we need it**:
Fixes [https://github.com/VSCodeVim/Vim/issues/2299](https://github.com/VSCodeVim/Vim/issues/2299)

Left shift operator with G goto line/end command was not indenting last line. Seems to be because editor.action.outdentLines ignores last line of vscode.Selection when the end position is at the beginning of the last line. Taking end.getLineEnd() in the selection fixes this.
**Which issue(s) this PR fixes**
#2299 
<!--
Commits in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)
-->