### PR TITLE
Default to vim behaviour for Ctrl+D

### DIFF
--- a/package.json
+++ b/package.json
@@ -514,7 +514,10 @@
         },
         "vim.handleKeys": {
           "type": "object",
-          "description": "Option to delegate certain key combinations back to VSCode to be handled natively"
+          "description": "Option to delegate certain key combinations back to VSCode to be handled natively",
+          "default": {
+            "<C-d>": true
+          }
         },
         "vim.statusBarColorControl": {
           "type": "boolean",


### PR DESCRIPTION


<!--
Yay! Thanks for sending us a PR! 🎊

Please ensure your PR adheres to:

- [ ] Commit messages has a short & issue references when necessary
- [ ] Each commit does a logical chunk of work.
- [ ] It builds and tests pass (e.g `gulp`)
-->

**What this PR does / why we need it**:
Users installing a vim plugin will probably expect Ctrl+D to work like
vim. So this changes the default settings to do that.

**Which issue(s) this PR fixes**
Fixes #2312

<!--
Commits in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)
-->

**Special notes for your reviewer**:
I tried adding tests, but then realized that <kbd>Ctrl+D</kbd> / <kbd>Cmd+D</kbd> doesn't actually work as per https://github.com/VSCodeVim/Vim/issues/1348 and I've been using the workaround posted there.