### PR TITLE
Update README for Mac key repeat

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ All common Vim commands are supported. For a detailed list of supported features
 If key repeating isn't working for you, execute this in your Terminal.
 
 ```sh
+defaults delete -g ApplePressAndHoldEnabled                                      # Reset global default
 defaults write com.microsoft.VSCode ApplePressAndHoldEnabled -bool false         # For VS Code
 defaults write com.microsoft.VSCodeInsiders ApplePressAndHoldEnabled -bool false # For VS Code Insider
 ```

--- a/README.md
+++ b/README.md
@@ -51,9 +51,10 @@ All common Vim commands are supported. For a detailed list of supported features
 If key repeating isn't working for you, execute this in your Terminal.
 
 ```sh
-defaults delete -g ApplePressAndHoldEnabled                                      # Reset global default
 defaults write com.microsoft.VSCode ApplePressAndHoldEnabled -bool false         # For VS Code
 defaults write com.microsoft.VSCodeInsiders ApplePressAndHoldEnabled -bool false # For VS Code Insider
+defaults delete -g ApplePressAndHoldEnabled                                      # If necessary, reset global default
+
 ```
 
 We also recommend going into *System Preferences -> Keyboard* and increasing the Key Repeat and Delay Until Repeat settings to improve your speed.


### PR DESCRIPTION
I was having trouble getting my Mac to key repeat, I did some quick research and found https://github.com/Microsoft/vscode/issues/31919. The issue was that I had a global default that was true, which was overriding the application level `com.microsoft.VSCode` setting.

<!--
Yay! Thanks for sending us a PR! 🎊

Please ensure your PR adheres to:

- [x] Commit messages has a short & issue references when necessary
- [x] Each commit does a logical chunk of work.
- [x] It builds and tests pass (e.g `gulp`)
-->

**What this PR does / why we need it**:

Fixes key repeat for Mac users that already have a global default set for `ApplePressAndHoldEnabled`.

**Which issue(s) this PR fixes**
https://github.com/VSCodeVim/Vim/issues/2315

<!--
Commits in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)
-->

**Special notes for your reviewer**:
There might be a better way than resetting the global default.