### PR TITLE
fix: closes #730. setcontext when switching active text editors

### DIFF
--- a/extension.ts
+++ b/extension.ts
@@ -55,7 +55,6 @@ export async function getAndUpdateModeHandler(): Promise<ModeHandler> {
     }
   } else {
     previousActiveEditorId = activeEditorId;
-
     await curHandler.updateView(curHandler.vimState, { drawSelection: false, revealRange: false });
   }
 
@@ -80,8 +79,13 @@ export async function getAndUpdateModeHandler(): Promise<ModeHandler> {
 }
 
 class CompositionState {
-  public isInComposition: boolean = false;
-  public composingText: string = '';
+  isInComposition: boolean = false;
+  composingText: string = '';
+
+  reset() {
+    this.isInComposition = false;
+    this.composingText = '';
+  }
 }
 
 export async function activate(context: vscode.ExtensionContext) {
@@ -89,7 +93,7 @@ export async function activate(context: vscode.ExtensionContext) {
   let compositionState = new CompositionState();
 
   // Event to update active configuration items when changed without restarting vscode
-  vscode.workspace.onDidChangeConfiguration((e: void) => {
+  vscode.workspace.onDidChangeConfiguration(() => {
     Configuration.reload();
   });
 
@@ -182,7 +186,7 @@ export async function activate(context: vscode.ExtensionContext) {
     taskQueue.enqueueTask(async () => {
       const mh = await getAndUpdateModeHandler();
       let text = compositionState.composingText;
-      compositionState = new CompositionState();
+      compositionState.reset();
       await mh.handleMultipleKeyEvents(text.split(''));
     });
   });
@@ -251,7 +255,7 @@ export async function activate(context: vscode.ExtensionContext) {
     let mh = await getAndUpdateModeHandler();
     if (isDisabled) {
       await mh.handleKeyEvent('<ExtensionDisable>');
-      compositionState = new CompositionState();
+      compositionState.reset();
       ModeHandlerMap.clear();
     } else {
       await mh.handleKeyEvent('<ExtensionEnable>');

--- a/src/configuration/configuration.ts
+++ b/src/configuration/configuration.ts
@@ -151,6 +151,13 @@ class ConfigurationClass {
 
       vscode.commands.executeCommand('setContext', `vim.use${boundKey.key}`, useKey);
     }
+
+    vscode.commands.executeCommand('setContext', 'vim.overrideCopy', Configuration.overrideCopy);
+    vscode.commands.executeCommand(
+      'setContext',
+      'vim.overrideCtrlC',
+      Configuration.overrideCopy || Configuration.useCtrlKeys
+    );
   }
 
   getConfiguration(section: string = ''): vscode.WorkspaceConfiguration {

--- a/src/mode/modeHandler.ts
+++ b/src/mode/modeHandler.ts
@@ -1359,16 +1359,6 @@ export class ModeHandler implements vscode.Disposable {
       'vim.mode',
       ModeName[this.vimState.currentMode]
     );
-    await vscode.commands.executeCommand(
-      'setContext',
-      'vim.overrideCopy',
-      Configuration.overrideCopy
-    );
-    await vscode.commands.executeCommand(
-      'setContext',
-      'vim.overrideCtrlC',
-      Configuration.overrideCopy || Configuration.useCtrlKeys
-    );
   }
 
   private _renderStatusBar(): void {

--- a/src/mode/modeHandler.ts
+++ b/src/mode/modeHandler.ts
@@ -1356,6 +1356,11 @@ export class ModeHandler implements vscode.Disposable {
 
     await vscode.commands.executeCommand(
       'setContext',
+      'vim.mode',
+      ModeName[this.vimState.currentMode]
+    );
+    await vscode.commands.executeCommand(
+      'setContext',
       'vim.overrideCopy',
       Configuration.overrideCopy
     );

--- a/src/state/vimState.ts
+++ b/src/state/vimState.ts
@@ -184,8 +184,6 @@ export class VimState implements vscode.Disposable {
 
   public set currentMode(value: number) {
     this._currentMode = value;
-
-    vscode.commands.executeCommand('setContext', 'vim.mode', ModeName[value]);
   }
 
   public currentRegisterMode = RegisterMode.AscertainFromCurrentMode;


### PR DESCRIPTION
**What this PR does / why we need it**: We need to `setContext` following a switch of the active text editor. 

**Which issue(s) this PR fixes** #730

<!--
Commits in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)
-->

**Special notes for your reviewer**: