### PR TITLE
fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -486,7 +486,7 @@ Command | Description
 
 ## VSCodeVim tricks!
 
-Vim has a lot of nifty tricks and we try to perserve some of them:
+Vim has a lot of nifty tricks and we try to preserve some of them:
 
 * `gd` - jump to definition.
 * `gq` - on a visual selection reflow and wordwrap blocks of text, preserving commenting style. Great for formatting documentation comments.


### PR DESCRIPTION
Changes `perserve` to `preserve` in the README.