### PR TITLE
Fix :tabm to use moveActiveEditor command

### DIFF
--- a/src/cmd_line/commands/tab.ts
+++ b/src/cmd_line/commands/tab.ts
@@ -119,17 +119,17 @@ export class TabCommand extends node.CommandBase {
         await vscode.commands.executeCommand('workbench.action.closeOtherEditors');
         break;
       case Tab.Move:
-        if (this._arguments.count !== undefined) {
-          if (this._arguments.count === 0) {
-            vscode.commands.executeCommand('activeEditorMove', { to: 'first' });
-          } else {
-            vscode.commands.executeCommand('activeEditorMove', {
-              to: 'position',
-              amount: this._arguments.count,
-            });
-          }
+        // Documentation: https://github.com/Microsoft/vscode/issues/8234#issuecomment-234573410
+        if (this.arguments.count === 0) {
+          await vscode.commands.executeCommand('moveActiveEditor', { to: 'first' });
+        } else if (this.arguments.count === undefined) {
+          await vscode.commands.executeCommand('moveActiveEditor', { to: 'last' });
         } else {
-          vscode.commands.executeCommand('activeEditorMove', { to: 'last' });
+          await vscode.commands.executeCommand('moveActiveEditor', {
+            to: 'position',
+            by: 'tab',
+            value: this.arguments.count + 1,
+          });
         }
         break;
 

--- a/src/cmd_line/commands/tab.ts
+++ b/src/cmd_line/commands/tab.ts
@@ -119,7 +119,6 @@ export class TabCommand extends node.CommandBase {
         await vscode.commands.executeCommand('workbench.action.closeOtherEditors');
         break;
       case Tab.Move:
-        // Documentation: https://github.com/Microsoft/vscode/issues/8234#issuecomment-234573410
         if (this.arguments.count === 0) {
           await vscode.commands.executeCommand('moveActiveEditor', { to: 'first' });
         } else if (this.arguments.count === undefined) {


### PR DESCRIPTION
**What this PR does / why we need it**:
Updates `:tabm` to use `moveActiveEditor` so that it works.

**Which issue(s) this PR fixes**:
Fixes #2401 

**Special notes for your reviewer**:
I did not write automated tests for this because I could not figure out how to inspect an editor index position. Does anyone know how to access that information?