### PR TITLE
fix: selection in search in visual mode #2406

### DIFF
--- a/src/mode/modeHandler.ts
+++ b/src/mode/modeHandler.ts
@@ -1140,12 +1140,16 @@ export class ModeHandler implements vscode.Disposable {
 
     if (args.drawSelection) {
       let selections: vscode.Selection[];
+      const selectionMode: ModeName =
+        vimState.currentMode === ModeName.SearchInProgressMode
+          ? vimState.globalState.searchState!.previousMode
+          : vimState.currentMode;
 
       if (!vimState.isMultiCursor) {
         let start = vimState.cursorStartPosition;
         let stop = vimState.cursorPosition;
 
-        if (vimState.currentMode === ModeName.Visual) {
+        if (selectionMode === ModeName.Visual) {
           /**
            * Always select the letter that we started visual mode on, no matter
            * if we are in front or behind it. Imagine that we started visual mode
@@ -1163,7 +1167,7 @@ export class ModeHandler implements vscode.Disposable {
           }
 
           selections = [new vscode.Selection(start, stop)];
-        } else if (vimState.currentMode === ModeName.VisualLine) {
+        } else if (selectionMode === ModeName.VisualLine) {
           selections = [
             new vscode.Selection(
               Position.EarlierOf(start, stop).getLineBegin(),
@@ -1188,7 +1192,7 @@ export class ModeHandler implements vscode.Disposable {
           ) {
             selections = [new vscode.Selection(selections[0].end, selections[0].start)];
           }
-        } else if (vimState.currentMode === ModeName.VisualBlock) {
+        } else if (selectionMode === ModeName.VisualBlock) {
           selections = [];
 
           for (const { start: lineStart, end } of Position.IterateLine(vimState)) {
@@ -1200,7 +1204,7 @@ export class ModeHandler implements vscode.Disposable {
       } else {
         // MultiCursor mode is active.
 
-        if (vimState.currentMode === ModeName.Visual) {
+        if (selectionMode === ModeName.Visual) {
           selections = [];
 
           for (let { start: cursorStart, stop: cursorStop } of vimState.allCursors) {
@@ -1210,11 +1214,7 @@ export class ModeHandler implements vscode.Disposable {
 
             selections.push(new vscode.Selection(cursorStart, cursorStop));
           }
-        } else if (
-          vimState.currentMode === ModeName.Normal ||
-          vimState.currentMode === ModeName.Insert ||
-          vimState.currentMode === ModeName.SearchInProgressMode
-        ) {
+        } else if (selectionMode === ModeName.Normal || selectionMode === ModeName.Insert) {
           selections = [];
 
           for (const { stop: cursorStop } of vimState.allCursors) {

--- a/test/mode/modeVisual.test.ts
+++ b/test/mode/modeVisual.test.ts
@@ -751,6 +751,19 @@ suite('Mode Visual', () => {
       keysPressed: 'v?foo\nx',
       end: ['|z'],
     });
+
+    test('Selects correct range', async () => {
+      await modeHandler.handleMultipleKeyEvents('ifoo bar fun baz'.split(''));
+      await modeHandler.handleMultipleKeyEvents(['<Esc>', 'g', 'g', 'v', 'w', '/']);
+
+      const selection = TextEditor.getSelection();
+
+      // ensuring selection range starts from the beginning
+      assertEqual(selection.start.character, 0);
+      assertEqual(selection.start.line, 0);
+      assertEqual(selection.end.character, 4);
+      assertEqual(selection.end.line, 0);
+    });
   });
 
   suite('X will delete linewise', () => {


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix the selection range in search in visual mode.
When you start search by `/` or `?` in visual mode, the start of selection remains the position you started the visual mode in vim, but it reset to the position you started the search in VSCodeVim without this fix.
See the issue #2406 for detail.

**Which issue(s) this PR fixes**
fixes #2406 

**Special notes for your reviewer**:
This is my first pull request in github.
Although I read the contributing guidelines, I am sorry if something is missing.