### PR TITLE
fix: use 'fsPath'. closes #2422

### DIFF
--- a/src/cmd_line/commands/file.ts
+++ b/src/cmd_line/commands/file.ts
@@ -86,7 +86,7 @@ export class FileCommand extends node.CommandBase {
       return;
     }
 
-    let editorFilePath = vscode.window.activeTextEditor!.document.uri.path;
+    let editorFilePath = vscode.window.activeTextEditor!.document.uri.fsPath;
     this._arguments.name = <string>untildify(this._arguments.name);
     let filePath = path.isAbsolute(this._arguments.name)
       ? this._arguments.name

--- a/src/cmd_line/commands/tab.ts
+++ b/src/cmd_line/commands/tab.ts
@@ -81,7 +81,7 @@ export class TabCommand extends node.CommandBase {
           const isInWorkspace =
             vscode.workspace.workspaceFolders !== undefined &&
             vscode.workspace.workspaceFolders.length > 0;
-          const currentFilePath = vscode.window.activeTextEditor!.document.uri.path;
+          const currentFilePath = vscode.window.activeTextEditor!.document.uri.fsPath;
 
           let toOpenPath: string;
           if (isAbsolute) {


### PR DESCRIPTION
Use `fspath` as that is corresponds to file system path

<!--
Yay! Thanks for sending us a PR! 🎊

Please ensure your PR adheres to:

- [ ] Commit messages has a short & issue references when necessary
- [ ] Each commit does a logical chunk of work.
- [ ] It builds and tests pass (e.g `gulp`)
-->

**What this PR does / why we need it**: Fixes errors with Windows pathing when opening/creating new files through the vim cmd-line.

**Which issue(s) this PR fixes**: #2422

<!--
Commits in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)
-->

**Special notes for your reviewer**: