### PR TITLE
Set the timeout to 0 for waitforcursorupdatestopropagate

### DIFF
--- a/src/actions/commands/actions.ts
+++ b/src/actions/commands/actions.ts
@@ -1694,7 +1694,7 @@ class CommandCloseFold extends CommandFold {
   public async exec(position: Position, vimState: VimState): Promise<VimState> {
     let timesToRepeat = vimState.recordedState.count || 1;
     await vscode.commands.executeCommand('editor.fold', { levels: timesToRepeat, direction: 'up' });
-    vimState.allCursors = await allowVSCodeToPropagateCursorUpdatesAndReturnThem();
+    vimState.allCursors = await allowVSCodeToPropagateCursorUpdatesAndReturnThem(0);
     return vimState;
   }
 }
@@ -2370,7 +2370,7 @@ class CommandInsertNewLineAbove extends BaseCommand {
       await vscode.commands.executeCommand('editor.action.insertLineBefore');
     }
 
-    vimState.allCursors = await allowVSCodeToPropagateCursorUpdatesAndReturnThem();
+    vimState.allCursors = await allowVSCodeToPropagateCursorUpdatesAndReturnThem(0);
     for (let i = 0; i < count; i++) {
       const newPos = new Position(
         vimState.allCursors[0].start.line + i,
@@ -2400,7 +2400,7 @@ class CommandInsertNewLineBefore extends BaseCommand {
     for (let i = 0; i < count; i++) {
       await vscode.commands.executeCommand('editor.action.insertLineAfter');
     }
-    vimState.allCursors = await allowVSCodeToPropagateCursorUpdatesAndReturnThem();
+    vimState.allCursors = await allowVSCodeToPropagateCursorUpdatesAndReturnThem(0);
     for (let i = 1; i < count; i++) {
       const newPos = new Position(
         vimState.allCursors[0].start.line - i,
@@ -3578,7 +3578,7 @@ class ActionOverrideCmdD extends BaseCommand {
 
   public async exec(position: Position, vimState: VimState): Promise<VimState> {
     await vscode.commands.executeCommand('editor.action.addSelectionToNextFindMatch');
-    vimState.allCursors = await allowVSCodeToPropagateCursorUpdatesAndReturnThem();
+    vimState.allCursors = await allowVSCodeToPropagateCursorUpdatesAndReturnThem(0);
 
     // If this is the first cursor, select 1 character less
     // so that only the word is selected, no extra character
@@ -3631,7 +3631,7 @@ class ActionOverrideCmdDInsert extends BaseCommand {
       }
     );
     await vscode.commands.executeCommand('editor.action.addSelectionToNextFindMatch');
-    vimState.allCursors = await allowVSCodeToPropagateCursorUpdatesAndReturnThem();
+    vimState.allCursors = await allowVSCodeToPropagateCursorUpdatesAndReturnThem(0);
     return vimState;
   }
 }
@@ -3650,7 +3650,7 @@ class ActionOverrideCmdAltDown extends BaseCommand {
 
   public async exec(position: Position, vimState: VimState): Promise<VimState> {
     await vscode.commands.executeCommand('editor.action.insertCursorBelow');
-    vimState.allCursors = await allowVSCodeToPropagateCursorUpdatesAndReturnThem();
+    vimState.allCursors = await allowVSCodeToPropagateCursorUpdatesAndReturnThem(0);
 
     return vimState;
   }
@@ -3670,7 +3670,7 @@ class ActionOverrideCmdAltUp extends BaseCommand {
 
   public async exec(position: Position, vimState: VimState): Promise<VimState> {
     await vscode.commands.executeCommand('editor.action.insertCursorAbove');
-    vimState.allCursors = await allowVSCodeToPropagateCursorUpdatesAndReturnThem();
+    vimState.allCursors = await allowVSCodeToPropagateCursorUpdatesAndReturnThem(0);
 
     return vimState;
   }

--- a/src/mode/modeHandler.ts
+++ b/src/mode/modeHandler.ts
@@ -1331,7 +1331,7 @@ export class ModeHandler implements vscode.Disposable {
     for (let i = 0; i < this.vimState.postponedCodeViewChanges.length; i++) {
       let viewChange = this.vimState.postponedCodeViewChanges[i];
       await vscode.commands.executeCommand(viewChange.command, viewChange.args);
-      vimState.allCursors = await allowVSCodeToPropagateCursorUpdatesAndReturnThem();
+      vimState.allCursors = await allowVSCodeToPropagateCursorUpdatesAndReturnThem(0);
     }
     this.vimState.postponedCodeViewChanges = [];
 

--- a/src/util.ts
+++ b/src/util.ts
@@ -29,9 +29,9 @@ export class Clipboard {
  * is that writing editor.selection = new Position() won't immediately
  * update the position of the cursor. So we have to wait!
  */
-export async function waitForCursorUpdatesToHappen(): Promise<void> {
+export async function waitForCursorUpdatesToHappen(timeout: number): Promise<void> {
   await new Promise((resolve, reject) => {
-    setTimeout(resolve, 100);
+    setTimeout(resolve, timeout);
 
     const disposer = vscode.window.onDidChangeTextEditorSelection(x => {
       disposer.dispose();
@@ -58,8 +58,10 @@ export async function waitForTabChange(): Promise<void> {
     });
   });
 }
-export async function allowVSCodeToPropagateCursorUpdatesAndReturnThem(): Promise<Range[]> {
-  await waitForCursorUpdatesToHappen();
+export async function allowVSCodeToPropagateCursorUpdatesAndReturnThem(
+  timeout: number
+): Promise<Range[]> {
+  await waitForCursorUpdatesToHappen(timeout);
 
   return vscode.window.activeTextEditor!.selections.map(
     x => new Range(Position.FromVSCodePosition(x.start), Position.FromVSCodePosition(x.end))

--- a/test/testSimplifier.ts
+++ b/test/testSimplifier.ts
@@ -227,7 +227,7 @@ async function testIt(modeHandler: ModeHandler, testObj: ITestObject): Promise<v
 
   await modeHandler.handleMultipleKeyEvents(['<Esc>', 'g', 'g']);
 
-  await waitForCursorUpdatesToHappen();
+  await waitForCursorUpdatesToHappen(0);
 
   // Since we bypassed VSCodeVim to add text,
   // we need to tell the history tracker that we added it.
@@ -237,7 +237,7 @@ async function testIt(modeHandler: ModeHandler, testObj: ITestObject): Promise<v
   // move cursor to start position using 'hjkl'
   await modeHandler.handleMultipleKeyEvents(helper.getKeyPressesToMoveToStartPosition());
 
-  await waitForCursorUpdatesToHappen();
+  await waitForCursorUpdatesToHappen(0);
 
   Globals.mockModeHandler = modeHandler;
 


### PR DESCRIPTION
This should hopefully fix the ctrl-e problems, as well as fix performance for it, so long as it doesn't create race conditions elsewhere.

Fixes #1943, #1985, 