### PR TITLE
Readds vimState.lastClickWasPastEOL. Fixes #2404

### DIFF
--- a/src/mode/modeHandler.ts
+++ b/src/mode/modeHandler.ts
@@ -234,6 +234,7 @@ export class ModeHandler implements vscode.Disposable {
           const newStart = new Position(selection.anchor.line, selection.anchor.character + 1);
           this.vimState.editor.selection = new vscode.Selection(newStart, selection.end);
           this.vimState.cursorStartPosition = selectionStart;
+          this.vimState.lastClickWasPastEol = false;
         }
 
         if (

--- a/src/mode/modeHandler.ts
+++ b/src/mode/modeHandler.ts
@@ -181,7 +181,6 @@ export class ModeHandler implements vscode.Disposable {
     }
 
     let toDraw = false;
-    let isLastClickPastEol = false;
 
     if (selection) {
       let newPosition = new Position(selection.active.line, selection.active.character);
@@ -189,7 +188,7 @@ export class ModeHandler implements vscode.Disposable {
       // Only check on a click, not a full selection (to prevent clicking past EOL)
       if (newPosition.character >= newPosition.getLineEnd().character && selection.isEmpty) {
         if (this.vimState.currentMode !== ModeName.Insert) {
-          isLastClickPastEol = true;
+          this.vimState.lastClickWasPastEol = true;
 
           // This prevents you from mouse clicking past the EOL
           newPosition = new Position(
@@ -202,6 +201,8 @@ export class ModeHandler implements vscode.Disposable {
 
           toDraw = true;
         }
+      } else if (selection.isEmpty) {
+        this.vimState.lastClickWasPastEol = false;
       }
 
       this.vimState.cursorPosition = newPosition;
@@ -229,7 +230,7 @@ export class ModeHandler implements vscode.Disposable {
         }
 
         // If we prevented from clicking past eol but it is part of this selection, include the last char
-        if (isLastClickPastEol) {
+        if (this.vimState.lastClickWasPastEol) {
           const newStart = new Position(selection.anchor.line, selection.anchor.character + 1);
           this.vimState.editor.selection = new vscode.Selection(newStart, selection.end);
           this.vimState.cursorStartPosition = selectionStart;

--- a/src/state/vimState.ts
+++ b/src/state/vimState.ts
@@ -172,6 +172,10 @@ export class VimState implements vscode.Disposable {
    */
   public lastVisualSelectionStart: Position;
   public lastVisualSelectionEnd: Position;
+  /**
+   * Was the previous mouse click past EOL
+   */
+  public lastClickWasPastEol: boolean = false;
 
   /**
    * The mode Vim will be in once this action finishes.


### PR DESCRIPTION
We need it to be part of vimstate because we need state that persists between multiple calls to handleSelectionChange.
