### PR TITLE
await openEditorAtIndex1 command

### DIFF
--- a/src/cmd_line/commands/tab.ts
+++ b/src/cmd_line/commands/tab.ts
@@ -47,8 +47,7 @@ export class TabCommand extends node.CommandBase {
     switch (this._arguments.tab) {
       case Tab.Next:
         if (this._arguments.count /** not undefined or 0 */) {
-          // do not await workbench.action.openEditorAtIndex1 because it will never resolve
-          vscode.commands.executeCommand('workbench.action.openEditorAtIndex1');
+          await vscode.commands.executeCommand('workbench.action.openEditorAtIndex1');
           await this.executeCommandWithCount(
             this._arguments.count! - 1,
             'workbench.action.nextEditorInGroup'
@@ -68,8 +67,7 @@ export class TabCommand extends node.CommandBase {
         );
         break;
       case Tab.First:
-        // do not await workbench.action.openEditorAtIndex1 because it will never resolve
-        vscode.commands.executeCommand('workbench.action.openEditorAtIndex1');
+        await vscode.commands.executeCommand('workbench.action.openEditorAtIndex1');
         break;
       case Tab.Last:
         await vscode.commands.executeCommand('workbench.action.openLastEditorInGroup');


### PR DESCRIPTION
Previously there was a bug in VSCode which prevented me from doing:
```
await
vscode.commands.executeCommand('workbench.action.openEditorAtIndex1')
```

The most recent release of VSCode (1.21.0) fixes the bug. See
https://github.com/Microsoft/vscode/issues/44636

**What this PR does / why we need it**:
This PR ties up a loose end because the latest VSCode release fixed a bug.

**Which issue(s) this PR fixes**
No specific issue though I mentioned this in https://github.com/VSCodeVim/Vim/pull/2400#discussion_r170515948

**Special notes for your reviewer**:
This change will impact users who use `:tabn` or `:tabfirst` but do not have the latest version of VSCode. For such users, `:tabn` or `:tabfirst` will cause the command line (`:`) to be disabled until VSCodeVim is restarted. What is VSCodeVim's policy on breaking changes (albeit limited) like this?