### PR TITLE
fix: don't call prettier when no files updated

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -45,6 +45,10 @@ function runPrettier(command, cb) {
       })
       .join(' ');
 
+    if (!files) {
+      return cb();
+    }
+
     exec(
       `node ./node_modules/.bin/prettier --write --print-width 100 --single-quote --trailing-comma es5 ${files}`,
       function(err, stdout, stderr) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1003,7 +1003,7 @@
     },
     "event-stream": {
       "version": "3.3.4",
-      "resolved": "http://registry.npmjs.org/event-stream/-/event-stream-3.3.4.tgz",
+      "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-3.3.4.tgz",
       "integrity": "sha1-SrTJoPWlTbkzi0w02Gv86PSzVXE=",
       "dev": true,
       "requires": {


### PR DESCRIPTION
<!--
Yay! Thanks for sending us a PR! 🎊

Please ensure your PR adheres to:

- [ ] Commit messages has a short & issue references when necessary
- [ ] Each commit does a logical chunk of work.
- [ ] It builds and tests pass (e.g `gulp`)
-->

**What this PR does / why we need it**:

When running `gulp`, prettier would sometimes never return when no `files`is empty.

**Which issue(s) this PR fixes**

<!--
Commits in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)
-->

**Special notes for your reviewer**: