### PR TITLE
Hopefully fixing the rest of our undo issues

### DIFF
--- a/src/editorIdentity.ts
+++ b/src/editorIdentity.ts
@@ -2,30 +2,25 @@ import * as vscode from 'vscode';
 
 export class EditorIdentity {
   private _fileName: string;
-  private _viewColumn: vscode.ViewColumn;
 
   constructor(textEditor?: vscode.TextEditor) {
     this._fileName = (textEditor && textEditor.document && textEditor.document.fileName) || '';
-    this._viewColumn = (textEditor && textEditor.viewColumn) || vscode.ViewColumn.One;
   }
 
   get fileName() {
     return this._fileName;
   }
 
-  get viewColumn() {
-    return this._viewColumn;
-  }
 
   public hasSameBuffer(identity: EditorIdentity): boolean {
     return this.fileName === identity.fileName;
   }
 
   public isEqual(other: EditorIdentity): boolean {
-    return this.fileName === other.fileName && this.viewColumn === other.viewColumn;
+    return this.fileName === other.fileName;
   }
 
   public toString() {
-    return this.fileName + this.viewColumn;
+    return this.fileName;
   }
 }

--- a/src/editorIdentity.ts
+++ b/src/editorIdentity.ts
@@ -11,7 +11,6 @@ export class EditorIdentity {
     return this._fileName;
   }
 
-
   public hasSameBuffer(identity: EditorIdentity): boolean {
     return this.fileName === identity.fileName;
   }


### PR DESCRIPTION
As has been noted previously, I think the issue behind this second "undo" problem is because we separate EditorIdentity not only by  `fileName`, but also by `viewColumn`. This is problematic for several reasons.

1. The `viewColumn` isn't how we think about what our current editor is. For example, if one drags a file from column 1 to column 2, one'd expect that to be the same editor.
2. We'd expect most state to be shared from a file open in 2 different columns. For example, undo doesn't really make sense (we can't undo locally; we're not building a collaborative editor here).

Looking at these 2 problems, we arrive at what is the fundamental problem: There can be multiple `undoStates` for the same file, indexed by `viewColumn`. Here are a couple of cases where this is a problem.
Case 1:
The repro @johnfn reported: https://github.com/VSCodeVim/Vim/issues/928#issuecomment-327879977
I'll write it out here for clarity. For the sake of succinctness, I'll assume there's only one file in each column so "making a few changes in column 1" has the same meaning as "making a few changes in column 1's version of the file".

1. Open same file in 2 columns.
2. Make a few changes in column 1.
3. Switch to column 2 and hit u. All changes made in first column are undone.

Case 2:
1. Open the same file in 2 columns
2. Make a few changes in the the first column.
3. Close the first colum.
4. Hit undo. All the changes made have now been undone.

Case 3:
1. Open 2 columns (but only have the file we're using be in Column 1).
2. Drag the file over to Column 2.
3. Make a few changes in Column 2.
4. Drag the file back to the first column.
5. Hit undo. All changes made in the second column are now undone.

I suspect that most of the bugs people have seen are variations of one of these.

Luckily, there's a simple fix: Don't separate `ModeHandler` by `viewColumn`. I'm not sure what that breaks. You can still have different positions in different columns at the same time just fine; we use VSCode's concept of "saved position" for that. I think somebody mentioned that it lets us have different modes in different files (so insert mode in Column 1, normal mode in Column 2). If that's the only issue, I strongly believe that we should break that for now, and add it in later (perhaps with a separate structure from `modeHandler`).

cc @jpoon @xconverge @rebornix @johnfn 