### PR TITLE
Use extension dir as cwd for neovim process

### DIFF
--- a/src/neovim/neovim.ts
+++ b/src/neovim/neovim.ts
@@ -15,9 +15,8 @@ export class Neovim implements vscode.Disposable {
   private nvim: Nvim;
 
   async initialize() {
-    const dir = dirname(vscode.window.activeTextEditor!.document.uri.fsPath);
     this.process = spawn(configuration.neovimPath, ['-u', 'NONE', '-N', '--embed'], {
-      cwd: dir,
+      cwd: __dirname,
     });
     this.process.on('error', err => {
       console.log(err);


### PR DESCRIPTION
Not everything that is being edited has a file backing it. Thus, ``vscode.window.activeTextEditor!.document.uri.fsPath`` might not return something that resolves to an actual existing file/path on disk. We might end up with an invalid cwd for the neovim process which will
lead to a failure to start the neovim process and thus an inoperable plugin state (needs fixing as well).

Opening the vscode settings is one such case where vscode returns an imaginary path "/0/settings.json".

For now, always use the extension directory to be on the safe side. But if further commands are passed through to neovim that might rely on the correct working directory of the file being edited, this will need fixing.