### PR TITLE
Fixes #2569. Fix vi{ for nested braces.

### DIFF
--- a/src/actions/motion.ts
+++ b/src/actions/motion.ts
@@ -1433,18 +1433,14 @@ export abstract class MoveInsideCharacter extends BaseMovement {
       }
     } else {
       startPos = startPlusOne;
+
+      // If the closing character is the first on the line, don't swallow it.
+      if (endPos.isInLeadingWhitespace()) {
+        endPos = endPos.getLineBegin();
+      }
+
       if (vimState.currentMode === ModeName.Visual) {
         endPos = endPos.getLeftThroughLineBreaks();
-      }
-    }
-
-    // If the closing character is the first on the line, don't swallow it.
-    if (!this.includeSurrounding) {
-      if (endPos.getLeft().isInLeadingWhitespace()) {
-        endPos = endPos.getLineBegin();
-        if (vimState.currentMode === ModeName.Visual) {
-          endPos = endPos.getLeftThroughLineBreaks();
-        }
       }
     }
 

--- a/test/mode/modeVisual.test.ts
+++ b/test/mode/modeVisual.test.ts
@@ -564,6 +564,22 @@ suite('Mode Visual', () => {
     endMode: ModeName.Normal,
   });
 
+  newTest({
+    title: 'Can do vi{ on outer pair of nested braces',
+    start: ['{', '  te|st', '  {', '    test', '  }', '}'],
+    keysPressed: 'vi{d',
+    end: ['{', '|}'],
+    endMode: ModeName.Normal,
+  });
+
+  newTest({
+    title: 'Can do vi{ on braces indented by 1 and preserve indent',
+    start: ['{', '  t|est', ' }'],
+    keysPressed: 'vi{d',
+    end: ['{', '| }'],
+    endMode: ModeName.Normal,
+  });
+
   suite('handles replace in visual mode', () => {
     newTest({
       title: 'Can do a single line replace',


### PR DESCRIPTION
<!--
Yay! Thanks for sending us a PR! 🎊

Please ensure your PR adheres to:

- [ ] Commit messages has a short & issue references when necessary
- [ ] Each commit does a logical chunk of work.
- [ ] It builds and tests pass (e.g `gulp`)
-->

**What this PR does / why we need it**:
Fixes the logic for selecting within pairs of braces in certain specific cases:
* Nested braces where the outer closing brace has no leading whitespace and the brace above does
* Closing braces indented by only one space

**Which issue(s) this PR fixes**
#2569

<!--
Commits in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)
-->

**Special notes for your reviewer**: