### PR TITLE
fix: Manually dispose ModeHandler when no longer needed

### DIFF
--- a/src/mode/modeHandlerMap.ts
+++ b/src/mode/modeHandlerMap.ts
@@ -29,11 +29,17 @@ class ModeHandlerMapImpl {
   }
 
   delete(key: string) {
+    if (key in this.modeHandlerMap) {
+      this.modeHandlerMap[key].dispose();
+    }
+
     delete this.modeHandlerMap[key];
   }
 
   clear() {
-    this.modeHandlerMap = {};
+    for (const key of Object.keys(this.modeHandlerMap)) {
+      this.delete(key);
+    }
   }
 }
 


### PR DESCRIPTION
VSC only automatically disposes resources when an extension is shutdown. Since every time a new ``TextEditor`` is opened, we also instantiate a new ``ModeHandler`` (along other Disposables like neovim processes), those pile up and will not get properly disposed until we get shutdown one way or the other.

One issue this is causing is that neovim processes are not being cleaned up and hang around until our shutdown.

Thus, every time we remove a ``ModeHandler``, we manually dispose it to free its resources.

Fixes #2558.