### PR TITLE
[Fix] Don't add beginning newline of linewise put in visual-mode

### DIFF
--- a/test/mode/modeVisualLine.test.ts
+++ b/test/mode/modeVisualLine.test.ts
@@ -315,4 +315,13 @@ suite('Mode Visual Line', () => {
       assertEqualLines(['one two threeone two three', 'one two three']);
     });
   });
+
+  suite('replace text in linewise visual-mode with linewise register content', () => {
+    newTest({
+      title: 'yyVp does not change the content but changes cursor position',
+      start: ['fo|o', 'bar', 'fun', 'baz'],
+      keysPressed: 'yyVp',
+      end: ['|foo', 'bar', 'fun', 'baz'],
+    });
+  });
 });


### PR DESCRIPTION
<!--
- [ ] Commit messages has a short & issue references when necessary
  - little bit exceeded ... sorry 😇
- [x] Each commit does a logical chunk of work.
- [x] It builds and tests pass (e.g `gulp`)
-->

Thanks for great work.
I'm using Vim for primary text editor but I have to use VSCode at work.
But I found this extension is awesome because Vim like keybinding helps me a lot to concentrate :)

# What this PR does / why we need it

In original Vim behavior, `p` command in visual-mode replaces current text.
VSCodeVim also does it but it is slightly different.
Unnecessary newline is inserted before the text when the text is yanked as linewise.

1. Yank current line's text by `yy`
1. Replace current line's text by `Vp`

In original Vim, it does not change the text (the buffer is marked modified, though).
But VSCodeVim inserts a newline before the current line.

# Which issue(s) this PR fixes

No exact issue yet.
But the problem is touched by #1991 comment.

> Note: there are extraneous newlines in the VSCode output, but I believe this is a separate issue