### PR TITLE
[Fix] p in visual-mode should save last selection

### DIFF
--- a/src/actions/commands/actions.ts
+++ b/src/actions/commands/actions.ts
@@ -1325,6 +1325,26 @@ export class PutCommand extends BaseCommand {
       }
     }
 
+    // After using "p" or "P" in Visual mode the text that was put will be
+    // selected (from Vim's ":help gv").
+    if (
+      vimState.currentMode === ModeName.Visual ||
+      vimState.currentMode === ModeName.VisualLine ||
+      vimState.currentMode === ModeName.VisualBlock
+    ) {
+      vimState.lastVisualMode = vimState.currentMode;
+      vimState.lastVisualSelectionStart = whereToAddText;
+      let textToEnd = textToAdd;
+      if (
+        vimState.currentMode === ModeName.VisualLine &&
+        textToAdd[textToAdd.length - 1] === '\n'
+      ) {
+        // don't go next line
+        textToEnd = textToAdd.substring(0, textToAdd.length - 1);
+      }
+      vimState.lastVisualSelectionEnd = whereToAddText.advancePositionByText(textToEnd);
+    }
+
     // More vim weirdness: If the thing you're pasting has a newline, the cursor
     // stays in the same place. Otherwise, it moves to the end of what you pasted.
 

--- a/test/mode/modeVisual.test.ts
+++ b/test/mode/modeVisual.test.ts
@@ -939,4 +939,83 @@ suite('Mode Visual', () => {
       assertEqual(modeHandler.currentMode.name, ModeName.Normal);
     });
   });
+
+  suite('replace text in characterwise visual-mode with characterwise register content', () => {
+    test('gv selects the last pasted text (which is shorter than original)', async () => {
+      await modeHandler.handleMultipleKeyEvents(
+        'ireplace this\nwith me\nor with me longer than the target'.split('')
+      );
+      await modeHandler.handleMultipleKeyEvents(['<Esc>']);
+      await modeHandler.handleMultipleKeyEvents(
+        '2ggv$hy'.split('') // yank the second line
+      );
+      await modeHandler.handleMultipleKeyEvents(
+        'ggv$hp'.split('') // replace the first line
+      );
+      await modeHandler.handleMultipleKeyEvents(['g', 'v']);
+
+      assertEqual(modeHandler.currentMode.name, ModeName.Visual);
+      assertEqualLines(['with me', 'with me', 'or with me longer than the target']);
+
+      const selection = TextEditor.getSelection();
+
+      // ensuring selecting 'with me' at the first line
+      assertEqual(selection.start.character, 0);
+      assertEqual(selection.start.line, 0);
+      assertEqual(selection.end.character, 'with me'.length);
+      assertEqual(selection.end.line, 0);
+    });
+
+    test('gv selects the last pasted text (which is longer than original)', async () => {
+      await modeHandler.handleMultipleKeyEvents(
+        'ireplace this\nwith me\nor with me longer than the target'.split('')
+      );
+      await modeHandler.handleMultipleKeyEvents(['<Esc>']);
+      await modeHandler.handleMultipleKeyEvents(
+        'v0y'.split('') // yank the last line
+      );
+      await modeHandler.handleMultipleKeyEvents(
+        'ggv$hp'.split('') // replace the first line
+      );
+      await modeHandler.handleMultipleKeyEvents(['g', 'v']);
+
+      assertEqual(modeHandler.currentMode.name, ModeName.Visual);
+      assertEqualLines([
+        'or with me longer than the target',
+        'with me',
+        'or with me longer than the target',
+      ]);
+
+      const selection = TextEditor.getSelection();
+
+      // ensuring selecting 'or with me longer than the target' at the first line
+      assertEqual(selection.start.character, 0);
+      assertEqual(selection.start.line, 0);
+      assertEqual(selection.end.character, 'or with me longer than the target'.length);
+      assertEqual(selection.end.line, 0);
+    });
+
+    test('gv selects the last pasted text (multiline)', async () => {
+      await modeHandler.handleMultipleKeyEvents('ireplace this\nfoo\nbar'.split(''));
+      await modeHandler.handleMultipleKeyEvents(['<Esc>']);
+      await modeHandler.handleMultipleKeyEvents(
+        '2ggvjey'.split('') // yank 'foo\nbar'
+      );
+      await modeHandler.handleMultipleKeyEvents(
+        'ggvep'.split('') // replace 'replace'
+      );
+      await modeHandler.handleMultipleKeyEvents(['g', 'v']);
+
+      assertEqual(modeHandler.currentMode.name, ModeName.Visual);
+      assertEqualLines(['foo', 'bar this', 'foo', 'bar']);
+
+      const selection = TextEditor.getSelection();
+
+      // ensuring selecting 'foo\nbar'
+      assertEqual(selection.start.character, 0);
+      assertEqual(selection.start.line, 0);
+      assertEqual(selection.end.character, 3);
+      assertEqual(selection.end.line, 1);
+    });
+  });
 });

--- a/test/mode/modeVisualLine.test.ts
+++ b/test/mode/modeVisualLine.test.ts
@@ -324,4 +324,83 @@ suite('Mode Visual Line', () => {
       end: ['|foo', 'bar', 'fun', 'baz'],
     });
   });
+
+  suite('replace text in linewise visual-mode with linewise register content', () => {
+    test('gv selects the last pasted text (which is shorter than original)', async () => {
+      await modeHandler.handleMultipleKeyEvents(
+        'ireplace this\nwith me\nor with me longer than the target'.split('')
+      );
+      await modeHandler.handleMultipleKeyEvents(['<Esc>']);
+      await modeHandler.handleMultipleKeyEvents(
+        '2ggyy'.split('') // yank the second line
+      );
+      await modeHandler.handleMultipleKeyEvents(
+        'ggVp'.split('') // replace the first line
+      );
+      await modeHandler.handleMultipleKeyEvents(['g', 'v']);
+
+      assertEqual(modeHandler.currentMode.name, ModeName.VisualLine);
+      assertEqualLines(['with me', 'with me', 'or with me longer than the target']);
+
+      const selection = TextEditor.getSelection();
+
+      // ensuring selecting 'with me' at the first line
+      assertEqual(selection.start.character, 0);
+      assertEqual(selection.start.line, 0);
+      assertEqual(selection.end.character, 'with me'.length);
+      assertEqual(selection.end.line, 0);
+    });
+
+    test('gv selects the last pasted text (which is longer than original)', async () => {
+      await modeHandler.handleMultipleKeyEvents(
+        'ireplace this\nwith me\nor with me longer than the target'.split('')
+      );
+      await modeHandler.handleMultipleKeyEvents(['<Esc>']);
+      await modeHandler.handleMultipleKeyEvents(
+        'yy'.split('') // yank the last line
+      );
+      await modeHandler.handleMultipleKeyEvents(
+        'ggVp'.split('') // replace the first line
+      );
+      await modeHandler.handleMultipleKeyEvents(['g', 'v']);
+
+      assertEqual(modeHandler.currentMode.name, ModeName.VisualLine);
+      assertEqualLines([
+        'or with me longer than the target',
+        'with me',
+        'or with me longer than the target',
+      ]);
+
+      const selection = TextEditor.getSelection();
+
+      // ensuring selecting 'or with me longer than the target' at the first line
+      assertEqual(selection.start.character, 0);
+      assertEqual(selection.start.line, 0);
+      assertEqual(selection.end.character, 'or with me longer than the target'.length);
+      assertEqual(selection.end.line, 0);
+    });
+
+    test('gv selects the last pasted text (multiline)', async () => {
+      await modeHandler.handleMultipleKeyEvents('ireplace this\nfoo\nbar'.split(''));
+      await modeHandler.handleMultipleKeyEvents(['<Esc>']);
+      await modeHandler.handleMultipleKeyEvents(
+        'Vky'.split('') // yank 'foo\nbar\n'
+      );
+      await modeHandler.handleMultipleKeyEvents(
+        'ggVp'.split('') // replace the first line
+      );
+      await modeHandler.handleMultipleKeyEvents(['g', 'v']);
+
+      assertEqual(modeHandler.currentMode.name, ModeName.VisualLine);
+      assertEqualLines(['foo', 'bar', 'foo', 'bar']);
+
+      const selection = TextEditor.getSelection();
+
+      // ensuring selecting 'foo\nbar\n'
+      assertEqual(selection.start.character, 0);
+      assertEqual(selection.start.line, 0);
+      assertEqual(selection.end.character, 3);
+      assertEqual(selection.end.line, 1);
+    });
+  });
 });


### PR DESCRIPTION
<!--
Yay! Thanks for sending us a PR! 🎊

Please ensure your PR adheres to:

- [x] Commit messages has a short & issue references when necessary
- [x] Each commit does a logical chunk of work.
- [ ] It builds and tests pass (e.g `gulp`)
-->

# What this PR does / why we need it

Please see #2587

This PR covers characterwise and linewise.
Blockwise put seems unimplemented (also in normal-mode), so this PR does not care.

# Which issue(s) this PR fixes

Fixes #2587 