### PR TITLE
[Fix] aW doesn't work at the end of lines

### DIFF
--- a/src/actions/textobject.ts
+++ b/src/actions/textobject.ts
@@ -105,8 +105,18 @@ export class SelectABigWord extends TextObjectMovement {
       stop = position.getCurrentBigWordEnd();
     } else {
       // Check 'aw' code for much of the reasoning behind this logic.
-      let nextWord = position.getBigWordRight();
+      const nextWord = position.getBigWordRight();
       if (
+        (nextWord.line > position.line || nextWord.isAtDocumentEnd()) &&
+        vimState.recordedState.count === 0
+      ) {
+        if (position.getLastBigWordEnd().isLineBeginning()) {
+          start = position.getLastBigWordEnd();
+        } else {
+          start = position.getLastBigWordEnd().getRight();
+        }
+        stop = position.getLineEnd();
+      } else if (
         (nextWord.isEqual(nextWord.getFirstLineNonBlankChar()) || nextWord.isLineEnd()) &&
         vimState.recordedState.count === 0
       ) {

--- a/test/mode/modeNormal.test.ts
+++ b/test/mode/modeNormal.test.ts
@@ -726,6 +726,13 @@ suite('Mode Normal', () => {
   });
 
   newTest({
+    title: "Can handle 'daW' around word at whitespace",
+    start: ['<div  | class="btn"> foo'],
+    keysPressed: 'daW',
+    end: ['<div| foo'],
+  });
+
+  newTest({
     title: "Can handle 'daW' on word with trailing spaces",
     start: ['one   tw|o   three,   four  '],
     keysPressed: 'daW',
@@ -772,11 +779,47 @@ suite('Mode Normal', () => {
     end: ['on|e'],
     endMode: ModeName.Normal,
   });
+
   newTest({
-    title: "Can handle 'daW' around word at end of line",
+    title: "Can handle 'daW' around word at the last WORD (t|wo)",
     start: ['one t|wo', ' three'],
     keysPressed: 'daW',
     end: ['on|e', ' three'],
+  });
+
+  newTest({
+    title: "Can handle 'daW' around word at the last WORD (tw|o)",
+    start: ['one tw|o', ' three'],
+    keysPressed: 'daW',
+    end: ['on|e', ' three'],
+  });
+
+  newTest({
+    title: 'Can handle \'daW\' around word at the last WORD (class="btn"|>)',
+    start: ['<div class="btn"|>', 'foo'],
+    keysPressed: 'daW',
+    end: ['<di|v', 'foo'],
+  });
+
+  newTest({
+    title: 'Can handle \'daW\' around word at the last WORD of the end of document (class="btn"|>)',
+    start: ['<div class="btn"|>'],
+    keysPressed: 'daW',
+    end: ['<di|v'],
+  });
+
+  newTest({
+    title: 'Can handle \'daW\' around word at the last WORD (c|lass="btn">)',
+    start: ['<div c|lass="btn">', 'foo'],
+    keysPressed: 'daW',
+    end: ['<di|v', 'foo'],
+  });
+
+  newTest({
+    title: 'Can handle \'daW\' around word at the last WORD of the end of document (c|lass="btn">)',
+    start: ['<div c|lass="btn">'],
+    keysPressed: 'daW',
+    end: ['<di|v'],
   });
 
   newTest({


### PR DESCRIPTION
<!--
Yay! Thanks for sending us a PR! 🎊

Please ensure your PR adheres to:

- [x] Commit messages has a short & issue references when necessary
- [x] Each commit does a logical chunk of work.
- [x] It builds and tests pass (e.g `gulp`)
-->

# What this PR does / why we need it

This fixes aW behavior at the WORD (big word) of the end of line or the end of document.

# Which issue(s) this PR fixes

Fixes #2571