### PR TITLE
[Fix] <C-h> should work as same as <BS> in search mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -158,7 +158,7 @@
       {
         "key": "ctrl+h",
         "command": "extension.vim_ctrl+h",
-        "when": "editorTextFocus && vim.active && vim.use<C-h> && vim.mode == 'Insert' && !inDebugRepl"
+        "when": "editorTextFocus && vim.active && vim.use<C-h> && !inDebugRepl"
       },
       {
         "key": "ctrl+e",

--- a/src/actions/commands/actions.ts
+++ b/src/actions/commands/actions.ts
@@ -782,7 +782,7 @@ class CommandReplaceInReplaceMode extends BaseCommand {
 @RegisterAction
 class CommandInsertInSearchMode extends BaseCommand {
   modes = [ModeName.SearchInProgressMode];
-  keys = [['<character>'], ['<up>'], ['<down>']];
+  keys = [['<character>'], ['<up>'], ['<down>'], ['<C-h>']];
   runsOnceForEveryCursor() {
     return this.keysPressed[0] === '\n';
   }
@@ -793,7 +793,7 @@ class CommandInsertInSearchMode extends BaseCommand {
     const prevSearchList = vimState.globalState.searchStatePrevious!;
 
     // handle special keys first
-    if (key === '<BS>' || key === '<shift+BS>') {
+    if (key === '<BS>' || key === '<shift+BS>' || key === '<C-h>') {
       searchState.searchString = searchState.searchString.slice(0, -1);
     } else if (key === '\n') {
       vimState.currentMode = vimState.globalState.searchState!.previousMode;

--- a/test/mode/modeNormal.test.ts
+++ b/test/mode/modeNormal.test.ts
@@ -1616,6 +1616,30 @@ suite('Mode Normal', () => {
   });
 
   newTest({
+    title: '<BS> deletes the last character in search in progress mode',
+    start: ['|foo', 'bar', 'abd'],
+    keysPressed: '/abc<BS>d\n',
+    end: ['foo', 'bar', '|abd'],
+    endMode: ModeName.Normal,
+  });
+
+  newTest({
+    title: '<S-BS> deletes the last character in search in progress mode',
+    start: ['|foo', 'bar', 'abd'],
+    keysPressed: '/abc<shift+BS>d\n',
+    end: ['foo', 'bar', '|abd'],
+    endMode: ModeName.Normal,
+  });
+
+  newTest({
+    title: '<C-h> deletes the last character in search in progress mode',
+    start: ['|foo', 'bar', 'abd'],
+    keysPressed: '/abc<C-h>d\n',
+    end: ['foo', 'bar', '|abd'],
+    endMode: ModeName.Normal,
+  });
+
+  newTest({
     title: 'Can do C',
     start: ['export const options = {', '|', '};'],
     keysPressed: 'C',


### PR DESCRIPTION
<!--
Yay! Thanks for sending us a PR! 🎊

Please ensure your PR adheres to:

- [x] Commit messages has a short & issue references when necessary
- [x] Each commit does a logical chunk of work.
- [x] It builds and tests pass (e.g `gulp`)
-->

# What this PR does / why we need it

Nothing happened when typing `<C-h>` in search in progress mode.
See #2592 for the details.

# Which issue(s) this PR fixes

Fixes #2592