### PR TITLE
[Fix] p won't work in linewise visual-mode at the end of document

### DIFF
--- a/src/actions/commands/actions.ts
+++ b/src/actions/commands/actions.ts
@@ -1289,7 +1289,9 @@ export class PutCommand extends BaseCommand {
       textToAdd = text;
       whereToAddText = dest;
     } else if (
-      (vimState.currentMode === ModeName.Visual || vimState.currentMode === ModeName.VisualLine) &&
+      (vimState.currentMode === ModeName.Visual ||
+        (vimState.currentMode === ModeName.VisualLine &&
+          !vimState.cursorPosition.isAtDocumentEnd())) &&
       register.registerMode === RegisterMode.LineWise
     ) {
       // in the specific case of linewise register data during visual mode,
@@ -1314,6 +1316,12 @@ export class PutCommand extends BaseCommand {
           .join('\n');
       }
 
+      if (
+        vimState.currentMode === ModeName.VisualLine &&
+        vimState.cursorPosition.isAtDocumentEnd()
+      ) {
+        after = false;
+      }
       if (after) {
         // P insert before current line
         textToAdd = text + '\n';

--- a/test/mode/modeVisualLine.test.ts
+++ b/test/mode/modeVisualLine.test.ts
@@ -323,5 +323,12 @@ suite('Mode Visual Line', () => {
       keysPressed: 'yyVp',
       end: ['|foo', 'bar', 'fun', 'baz'],
     });
+
+    newTest({
+      title: 'linewise visual put works also in the end of document',
+      start: ['foo', 'bar', 'fun', '|baz'],
+      keysPressed: 'yyVp',
+      end: ['foo', 'bar', 'fun', '|baz'],
+    });
   });
 });


### PR DESCRIPTION
<!--
Yay! Thanks for sending us a PR! 🎊

Please ensure your PR adheres to:

- [ ] Commit messages has a short & issue references when necessary
- [ ] Each commit does a logical chunk of work.
- [ ] It builds and tests pass (e.g `gulp`)
-->

# What this PR does / why we need it

The fix of #2579 was incomplete.
Because it didn't care the line at the end of document.

# Which issue(s) this PR fixes

No