### PR TITLE
[Fix] p in visual-mode should update register content

### DIFF
--- a/src/actions/commands/actions.ts
+++ b/src/actions/commands/actions.ts
@@ -1527,11 +1527,18 @@ export class PutCommandVisual extends BaseCommand {
     let oldMode = vimState.currentMode;
     let register = await Register.get(vimState);
     if (register.registerMode === RegisterMode.LineWise) {
+      const replaceRegister = await Register.getByKey(vimState.recordedState.registerName);
       let deleteResult = await new operator.DeleteOperator(this.multicursorIndex).run(
         vimState,
         start,
         end,
-        false
+        true
+      );
+      const deletedRegister = await Register.getByKey(vimState.recordedState.registerName);
+      Register.putByKey(
+        replaceRegister.text,
+        vimState.recordedState.registerName,
+        replaceRegister.registerMode
       );
       // to ensure, that the put command nows this is
       // an linewise register insertion in visual mode of
@@ -1540,6 +1547,11 @@ export class PutCommandVisual extends BaseCommand {
       deleteResult.currentMode = oldMode;
       deleteResult = await new PutCommand().exec(start, deleteResult, true);
       deleteResult.currentMode = resultMode;
+      Register.putByKey(
+        deletedRegister.text,
+        vimState.recordedState.registerName,
+        deletedRegister.registerMode
+      );
       return deleteResult;
     }
 

--- a/test/mode/modeVisualLine.test.ts
+++ b/test/mode/modeVisualLine.test.ts
@@ -320,6 +320,8 @@ suite('Mode Visual Line', () => {
     title: 'Vp updates register content',
     start: ['|hello', 'world'],
     keysPressed: 'ddVpP',
+    // TODO: this is not the same behavior as original Vim.
+    // But currently unnecessary line is left at the end (see #2602).
     end: ['|world', 'hello', ''],
   });
 

--- a/test/mode/modeVisualLine.test.ts
+++ b/test/mode/modeVisualLine.test.ts
@@ -316,6 +316,13 @@ suite('Mode Visual Line', () => {
     });
   });
 
+  newTest({
+    title: 'Vp updates register content',
+    start: ['|hello', 'world'],
+    keysPressed: 'ddVpP',
+    end: ['|world', 'hello', ''],
+  });
+
   suite('replace text in linewise visual-mode with linewise register content', () => {
     newTest({
       title: 'yyVp does not change the content but changes cursor position',


### PR DESCRIPTION
<!--
Yay! Thanks for sending us a PR! 🎊

Please ensure your PR adheres to:

- [ ] Commit messages has a short & issue references when necessary
- [ ] Each commit does a logical chunk of work.
- [ ] It builds and tests pass (e.g `gulp`)
-->

# What this PR does / why we need it

This PR fixes `p` command to update register content, when it is executed in visual-mode.
Please see #1991 for the original Vim's behavior.

NOTE: this PR only fix to update register content.
`p` command is yet not Vim compatible behavior.
For example, the buffer content is:

```
hello
world
```

And cursor position is line 1, and type `ddVpP` results in:

```
world
hello

```

Unnecessary newline at the end.
Expected is:

```
world
hello
```

But this is another problem.
I will fix it later at the another PR.

# Which issue(s) this PR fixes

Fixes #1991 