### PR TITLE
Add o command in visual block mode

### DIFF
--- a/src/actions/commands/actions.ts
+++ b/src/actions/commands/actions.ts
@@ -1932,7 +1932,7 @@ class CommandBottomScrollFirstChar extends BaseCommand {
 
 @RegisterAction
 class CommandGoToOtherEndOfHighlightedText extends BaseCommand {
-  modes = [ModeName.Visual, ModeName.VisualLine];
+  modes = [ModeName.Visual, ModeName.VisualLine, ModeName.VisualBlock];
   keys = ['o'];
 
   public async exec(position: Position, vimState: VimState): Promise<VimState> {

--- a/test/mode/modeVisualBlock.test.ts
+++ b/test/mode/modeVisualBlock.test.ts
@@ -152,4 +152,11 @@ suite('Mode Visual Block', () => {
     keysPressed: '<C-v>$4jAaa<Esc>',
     end: ['Doga|a', 'Angryaa', 'Dogaa', 'Angryaa', 'Dogaa'],
   });
+
+  newTest({
+    title: 'o works in visual block mode',
+    start: ['|foo', 'bar', 'baz'],
+    keysPressed: '<C-v>jjllold',
+    end: ['|f', 'b', 'b'],
+  });
 });


### PR DESCRIPTION
<!--
Yay! Thanks for sending us a PR! 🎊

Please ensure your PR adheres to:

- [ ] Commit messages has a short & issue references when necessary
- [ ] Each commit does a logical chunk of work.
- [ ] It builds and tests pass (e.g `gulp`)
-->

# What this PR does / why we need it

Currently `o` command in visual block mode is missing.
This PR adds the command.

# Which issue(s) this PR fixes

Fixes #2456