### PR TITLE
[Fix] p in visual line appends unnecessary newline

### DIFF
--- a/src/common/motion/position.ts
+++ b/src/common/motion/position.ts
@@ -776,6 +776,10 @@ export class Position extends vscode.Position {
     return Position.getFirstNonBlankCharAtLine(this.line) === this.character;
   }
 
+  public isAtDocumentBegin(): boolean {
+    return this.line === 0 && this.isLineBeginning();
+  }
+
   public isAtDocumentEnd(): boolean {
     return this.line === TextEditor.getLineCount() - 1 && this.isLineEnd();
   }

--- a/test/mode/modeVisualLine.test.ts
+++ b/test/mode/modeVisualLine.test.ts
@@ -320,9 +320,7 @@ suite('Mode Visual Line', () => {
     title: 'Vp updates register content',
     start: ['|hello', 'world'],
     keysPressed: 'ddVpP',
-    // TODO: this is not the same behavior as original Vim.
-    // But currently unnecessary line is left at the end (see #2602).
-    end: ['|world', 'hello', ''],
+    end: ['|world', 'hello'],
   });
 
   suite('replace text in linewise visual-mode with linewise register content', () => {

--- a/test/mode/modeVisualLine.test.ts
+++ b/test/mode/modeVisualLine.test.ts
@@ -323,6 +323,27 @@ suite('Mode Visual Line', () => {
     end: ['|world', 'hello'],
   });
 
+  newTest({
+    title: 'Vp does not append unnecessary newlines (first line)',
+    start: ['|begin', 'middle', 'end'],
+    keysPressed: 'yyVp',
+    end: ['|begin', 'middle', 'end'],
+  });
+
+  newTest({
+    title: 'Vp does not append unnecessary newlines (middle line)',
+    start: ['begin', '|middle', 'end'],
+    keysPressed: 'yyVp',
+    end: ['begin', '|middle', 'end'],
+  });
+
+  newTest({
+    title: 'Vp does not append unnecessary newlines (last line)',
+    start: ['begin', 'middle', '|end'],
+    keysPressed: 'yyVp',
+    end: ['begin', 'middle', '|end'],
+  });
+
   suite('replace text in linewise visual-mode with linewise register content', () => {
     newTest({
       title: 'yyVp does not change the content but changes cursor position',

--- a/test/mode/modeVisualLine.test.ts
+++ b/test/mode/modeVisualLine.test.ts
@@ -337,9 +337,7 @@ suite('Mode Visual Line', () => {
       keysPressed: 'yyVp',
       end: ['foo', 'bar', 'fun', '|baz'],
     });
-  });
 
-  suite('replace text in linewise visual-mode with linewise register content', () => {
     test('gv selects the last pasted text (which is shorter than original)', async () => {
       await modeHandler.handleMultipleKeyEvents(
         'ireplace this\nwith me\nor with me longer than the target'.split('')


### PR DESCRIPTION
<!--
Yay! Thanks for sending us a PR! 🎊

Please ensure your PR adheres to:

- [ ] Commit messages has a short & issue references when necessary
- [ ] Each commit does a logical chunk of work.
- [ ] It builds and tests pass (e.g `gulp`)
-->

# What this PR does / why we need it

```
hello
world
```

Typing `ggddVp` results in

```

world
hello
```

The behavior of the issue (#2608) was changed by #2601, but it's wrong yet.

After this PR is merged, the result is (no newline at the beginning or end)

```
world
hello
```

# Which issue(s) this PR fixes

Fixes #2608