### PR TITLE
Stay cursor option

### DIFF
--- a/package.json
+++ b/package.json
@@ -570,6 +570,46 @@
           "type": "boolean",
           "description": "When typing a command show the initial colon ':' character",
           "default": false
+        },
+        "vim.stayOnYank": {
+          "type": "boolean",
+          "description": "Keep the cursor in the original starting position after yanking text",
+          "default": false
+        },
+        "vim.stayOnUpperCase": {
+          "type": "boolean",
+          "description": "Keep the cursor in the original starting position after uppercasing text",
+          "default": false
+        },
+        "vim.stayOnLowerCase": {
+          "type": "boolean",
+          "description": "Keep the cursor in the original starting position after lowercasing text",
+          "default": false
+        },
+        "vim.stayOnToggleCase": {
+          "type": "boolean",
+          "description": "Keep the cursor in the original starting position after toggling the case of text",
+          "default": false
+        },
+        "vim.stayOnIndentCase": {
+          "type": "boolean",
+          "description": "Keep the cursor in the original starting position after indenting",
+          "default": false
+        },
+        "vim.stayOnVisualBlockIndentCase": {
+          "type": "boolean",
+          "description": "Keep the cursor in the original starting position after indenting in visual block mode",
+          "default": false
+        },
+        "vim.stayOnOutdentCase": {
+          "type": "boolean",
+          "description": "Keep the cursor in the original starting position after indenting",
+          "default": false
+        },
+        "vim.stayOnVisualBlockOutdentCase": {
+          "type": "boolean",
+          "description": "Keep the cursor in the original starting position after indenting in visual block mode",
+          "default": false
         }
       }
     }

--- a/src/actions/operator.ts
+++ b/src/actions/operator.ts
@@ -245,8 +245,8 @@ export class YankOperator extends BaseOperator {
     if (vimState.surround) {
       vimState.surround.range = new Range(start, end);
       vimState.currentMode = ModeName.SurroundInputMode;
-      vimState.cursorPosition = start;
-      vimState.cursorStartPosition = start;
+      // vimState.cursorPosition = start;
+      // vimState.cursorStartPosition = start;
 
       return vimState;
     }
@@ -278,22 +278,14 @@ export class YankOperator extends BaseOperator {
     Register.put(text, vimState, this.multicursorIndex);
 
     vimState.currentMode = ModeName.Normal;
-    vimState.cursorStartPosition = start;
+    // vimState.cursorStartPosition = start;
 
-    // Only change cursor position if we ran a text object movement
-    let moveCursor = false;
-    if (vimState.recordedState.actionsRun.length > 1) {
-      if (vimState.recordedState.actionsRun[1] instanceof TextObjectMovement) {
-        moveCursor = true;
-      }
-    }
-
-    if (originalMode === ModeName.Normal && !moveCursor) {
+    if (originalMode === ModeName.Normal) {
       vimState.allCursors = vimState.cursorPositionJustBeforeAnythingHappened.map(
         x => new Range(x, x)
       );
     } else {
-      vimState.cursorPosition = start;
+      // vimState.cursorPosition = start;
     }
 
     return vimState;
@@ -371,7 +363,7 @@ export class UpperCaseOperator extends BaseOperator {
     await TextEditor.replace(range, text.toUpperCase());
 
     vimState.currentMode = ModeName.Normal;
-    vimState.cursorPosition = start;
+    // vimState.cursorPosition = start;
 
     return vimState;
   }
@@ -396,8 +388,8 @@ class UpperCaseVisualBlockOperator extends BaseOperator {
     }
 
     const cursorPosition = startPos.isBefore(endPos) ? startPos : endPos;
-    vimState.cursorPosition = cursorPosition;
-    vimState.cursorStartPosition = cursorPosition;
+    // vimState.cursorPosition = cursorPosition;
+    // vimState.cursorStartPosition = cursorPosition;
     vimState.currentMode = ModeName.Normal;
 
     return vimState;
@@ -416,7 +408,7 @@ export class LowerCaseOperator extends BaseOperator {
     await TextEditor.replace(range, text.toLowerCase());
 
     vimState.currentMode = ModeName.Normal;
-    vimState.cursorPosition = start;
+    // vimState.cursorPosition = start;
 
     return vimState;
   }
@@ -441,8 +433,8 @@ class LowerCaseVisualBlockOperator extends BaseOperator {
     }
 
     const cursorPosition = startPos.isBefore(endPos) ? startPos : endPos;
-    vimState.cursorPosition = cursorPosition;
-    vimState.cursorStartPosition = cursorPosition;
+    // vimState.cursorPosition = cursorPosition;
+    // vimState.cursorStartPosition = cursorPosition;
     vimState.currentMode = ModeName.Normal;
 
     return vimState;
@@ -460,7 +452,7 @@ class IndentOperator extends BaseOperator {
     await vscode.commands.executeCommand('editor.action.indentLines');
 
     vimState.currentMode = ModeName.Normal;
-    vimState.cursorPosition = start.getFirstLineNonBlankChar();
+    // vimState.cursorPosition = start.getFirstLineNonBlankChar();
 
     return vimState;
   }
@@ -486,7 +478,7 @@ class IndentOperatorInVisualModesIsAWeirdSpecialCase extends BaseOperator {
     }
 
     vimState.currentMode = ModeName.Normal;
-    vimState.cursorPosition = start.getFirstLineNonBlankChar();
+    // vimState.cursorPosition = start.getFirstLineNonBlankChar();
 
     return vimState;
   }
@@ -502,7 +494,7 @@ class OutdentOperator extends BaseOperator {
 
     await vscode.commands.executeCommand('editor.action.outdentLines');
     vimState.currentMode = ModeName.Normal;
-    vimState.cursorPosition = start.getFirstLineNonBlankChar();
+    // vimState.cursorPosition = start.getFirstLineNonBlankChar();
 
     return vimState;
   }
@@ -522,7 +514,7 @@ class OutdentOperatorInVisualModesIsAWeirdSpecialCase extends BaseOperator {
     }
 
     vimState.currentMode = ModeName.Normal;
-    vimState.cursorPosition = start.getFirstLineNonBlankChar();
+    // vimState.cursorPosition = start.getFirstLineNonBlankChar();
 
     return vimState;
   }
@@ -603,7 +595,7 @@ export class YankVisualBlockMode extends BaseOperator {
     Register.put(toCopy, vimState, this.multicursorIndex);
 
     vimState.currentMode = ModeName.Normal;
-    vimState.cursorPosition = start;
+    // vimState.cursorPosition = start;
     return vimState;
   }
 }
@@ -619,8 +611,8 @@ export class ToggleCaseOperator extends BaseOperator {
     await ToggleCaseOperator.toggleCase(range);
 
     const cursorPosition = start.isBefore(end) ? start : end;
-    vimState.cursorPosition = cursorPosition;
-    vimState.cursorStartPosition = cursorPosition;
+    // vimState.cursorPosition = cursorPosition;
+    // vimState.cursorStartPosition = cursorPosition;
     vimState.currentMode = ModeName.Normal;
 
     return vimState;
@@ -656,8 +648,8 @@ class ToggleCaseVisualBlockOperator extends BaseOperator {
     }
 
     const cursorPosition = startPos.isBefore(endPos) ? startPos : endPos;
-    vimState.cursorPosition = cursorPosition;
-    vimState.cursorStartPosition = cursorPosition;
+    // vimState.cursorPosition = cursorPosition;
+    // vimState.cursorStartPosition = cursorPosition;
     vimState.currentMode = ModeName.Normal;
 
     return vimState;

--- a/src/actions/operator.ts
+++ b/src/actions/operator.ts
@@ -245,8 +245,10 @@ export class YankOperator extends BaseOperator {
     if (vimState.surround) {
       vimState.surround.range = new Range(start, end);
       vimState.currentMode = ModeName.SurroundInputMode;
-      // vimState.cursorPosition = start;
-      // vimState.cursorStartPosition = start;
+      if (!configuration.stayOnYank) {
+        vimState.cursorPosition = start;
+        vimState.cursorStartPosition = start;
+      }
 
       return vimState;
     }
@@ -278,14 +280,26 @@ export class YankOperator extends BaseOperator {
     Register.put(text, vimState, this.multicursorIndex);
 
     vimState.currentMode = ModeName.Normal;
-    // vimState.cursorStartPosition = start;
+    // Only change cursor position if we ran a text object movement
+    let moveCursor = false;
+    if (!configuration.stayOnYank) {
+      vimState.cursorStartPosition = start;
 
-    if (originalMode === ModeName.Normal) {
+      if (vimState.recordedState.actionsRun.length > 1) {
+        if (vimState.recordedState.actionsRun[1] instanceof TextObjectMovement) {
+          moveCursor = true;
+        }
+      }
+    }
+
+    if (originalMode === ModeName.Normal && !moveCursor) {
       vimState.allCursors = vimState.cursorPositionJustBeforeAnythingHappened.map(
         x => new Range(x, x)
       );
     } else {
-      // vimState.cursorPosition = start;
+      if (!configuration.stayOnYank) {
+        vimState.cursorPosition = start;
+      }
     }
 
     return vimState;
@@ -363,7 +377,9 @@ export class UpperCaseOperator extends BaseOperator {
     await TextEditor.replace(range, text.toUpperCase());
 
     vimState.currentMode = ModeName.Normal;
-    // vimState.cursorPosition = start;
+    if (!configuration.stayOnUpperCase) {
+      vimState.cursorPosition = start;
+    }
 
     return vimState;
   }
@@ -388,8 +404,10 @@ class UpperCaseVisualBlockOperator extends BaseOperator {
     }
 
     const cursorPosition = startPos.isBefore(endPos) ? startPos : endPos;
-    // vimState.cursorPosition = cursorPosition;
-    // vimState.cursorStartPosition = cursorPosition;
+    if (!configuration.stayOnUpperCase) {
+      vimState.cursorPosition = cursorPosition;
+      vimState.cursorStartPosition = cursorPosition;
+    }
     vimState.currentMode = ModeName.Normal;
 
     return vimState;
@@ -408,7 +426,9 @@ export class LowerCaseOperator extends BaseOperator {
     await TextEditor.replace(range, text.toLowerCase());
 
     vimState.currentMode = ModeName.Normal;
-    // vimState.cursorPosition = start;
+    if (!configuration.stayOnLowerCase) {
+      vimState.cursorPosition = start;
+    }
 
     return vimState;
   }
@@ -433,8 +453,10 @@ class LowerCaseVisualBlockOperator extends BaseOperator {
     }
 
     const cursorPosition = startPos.isBefore(endPos) ? startPos : endPos;
-    // vimState.cursorPosition = cursorPosition;
-    // vimState.cursorStartPosition = cursorPosition;
+    if (!configuration.stayOnLowerCase) {
+      vimState.cursorPosition = cursorPosition;
+      vimState.cursorStartPosition = cursorPosition;
+    }
     vimState.currentMode = ModeName.Normal;
 
     return vimState;
@@ -452,7 +474,9 @@ class IndentOperator extends BaseOperator {
     await vscode.commands.executeCommand('editor.action.indentLines');
 
     vimState.currentMode = ModeName.Normal;
-    // vimState.cursorPosition = start.getFirstLineNonBlankChar();
+    if (!configuration.stayOnIndent) {
+      vimState.cursorPosition = start.getFirstLineNonBlankChar();
+    }
 
     return vimState;
   }
@@ -478,7 +502,9 @@ class IndentOperatorInVisualModesIsAWeirdSpecialCase extends BaseOperator {
     }
 
     vimState.currentMode = ModeName.Normal;
-    // vimState.cursorPosition = start.getFirstLineNonBlankChar();
+    if (!configuration.stayOnIndent) {
+      vimState.cursorPosition = start.getFirstLineNonBlankChar();
+    }
 
     return vimState;
   }
@@ -494,7 +520,9 @@ class OutdentOperator extends BaseOperator {
 
     await vscode.commands.executeCommand('editor.action.outdentLines');
     vimState.currentMode = ModeName.Normal;
-    // vimState.cursorPosition = start.getFirstLineNonBlankChar();
+    if (!configuration.stayOnOutdent) {
+      vimState.cursorPosition = start.getFirstLineNonBlankChar();
+    }
 
     return vimState;
   }
@@ -514,7 +542,9 @@ class OutdentOperatorInVisualModesIsAWeirdSpecialCase extends BaseOperator {
     }
 
     vimState.currentMode = ModeName.Normal;
-    // vimState.cursorPosition = start.getFirstLineNonBlankChar();
+    if (!configuration.stayOnOutdent) {
+      vimState.cursorPosition = start.getFirstLineNonBlankChar();
+    }
 
     return vimState;
   }
@@ -595,7 +625,9 @@ export class YankVisualBlockMode extends BaseOperator {
     Register.put(toCopy, vimState, this.multicursorIndex);
 
     vimState.currentMode = ModeName.Normal;
-    // vimState.cursorPosition = start;
+    if (!configuration.stayOnYank) {
+      vimState.cursorPosition = start;
+    }
     return vimState;
   }
 }
@@ -611,8 +643,10 @@ export class ToggleCaseOperator extends BaseOperator {
     await ToggleCaseOperator.toggleCase(range);
 
     const cursorPosition = start.isBefore(end) ? start : end;
-    // vimState.cursorPosition = cursorPosition;
-    // vimState.cursorStartPosition = cursorPosition;
+    if (!configuration.stayOnToggleCase) {
+      vimState.cursorPosition = cursorPosition;
+      vimState.cursorStartPosition = cursorPosition;
+    }
     vimState.currentMode = ModeName.Normal;
 
     return vimState;
@@ -648,8 +682,10 @@ class ToggleCaseVisualBlockOperator extends BaseOperator {
     }
 
     const cursorPosition = startPos.isBefore(endPos) ? startPos : endPos;
-    // vimState.cursorPosition = cursorPosition;
-    // vimState.cursorStartPosition = cursorPosition;
+    if (!configuration.stayOnToggleCase) {
+      vimState.cursorPosition = cursorPosition;
+      vimState.cursorStartPosition = cursorPosition;
+    }
     vimState.currentMode = ModeName.Normal;
 
     return vimState;

--- a/src/actions/operator.ts
+++ b/src/actions/operator.ts
@@ -502,7 +502,7 @@ class IndentOperatorInVisualModesIsAWeirdSpecialCase extends BaseOperator {
     }
 
     vimState.currentMode = ModeName.Normal;
-    if (!configuration.stayOnIndent) {
+    if (!configuration.stayOnVisualBlockIndent) {
       vimState.cursorPosition = start.getFirstLineNonBlankChar();
     }
 
@@ -542,7 +542,7 @@ class OutdentOperatorInVisualModesIsAWeirdSpecialCase extends BaseOperator {
     }
 
     vimState.currentMode = ModeName.Normal;
-    if (!configuration.stayOnOutdent) {
+    if (!configuration.stayOnVisualBlockOutdent) {
       vimState.cursorPosition = start.getFirstLineNonBlankChar();
     }
 

--- a/src/configuration/configuration.ts
+++ b/src/configuration/configuration.ts
@@ -329,7 +329,9 @@ class Configuration implements IConfiguration {
   stayOnLowerCase = false;
   stayOnToggleCase = false;
   stayOnIndent = false;
+  stayOnVisualBlockIndent = false;
   stayOnOutdent = false;
+  stayOnVisualBlockOutdent = false;
 }
 
 function overlapSetting(args: {

--- a/src/configuration/configuration.ts
+++ b/src/configuration/configuration.ts
@@ -322,6 +322,14 @@ class Configuration implements IConfiguration {
   insertModeKeyBindingsNonRecursive: IKeyRemapping[] = [];
   otherModesKeyBindings: IKeyRemapping[] = [];
   otherModesKeyBindingsNonRecursive: IKeyRemapping[] = [];
+
+  // stay on ...
+  stayOnYank = false;
+  stayOnUpperCase = false;
+  stayOnLowerCase = false;
+  stayOnToggleCase = false;
+  stayOnIndent = false;
+  stayOnOutdent = false;
 }
 
 function overlapSetting(args: {

--- a/src/configuration/iconfiguration.ts
+++ b/src/configuration/iconfiguration.ts
@@ -205,4 +205,14 @@ export interface IConfiguration {
   insertModeKeyBindingsNonRecursive: IKeyRemapping[];
   otherModesKeyBindings: IKeyRemapping[];
   otherModesKeyBindingsNonRecursive: IKeyRemapping[];
+
+  /**
+   * Cursor movement options
+   */
+  stayOnYank: boolean;
+  stayOnUpperCase: boolean;
+  stayOnLowerCase: boolean;
+  stayOnToggleCase: boolean;
+  stayOnIndent: boolean;
+  stayOnOutdent: boolean;
 }

--- a/src/configuration/iconfiguration.ts
+++ b/src/configuration/iconfiguration.ts
@@ -214,5 +214,7 @@ export interface IConfiguration {
   stayOnLowerCase: boolean;
   stayOnToggleCase: boolean;
   stayOnIndent: boolean;
+  stayOnVisualBlockIndent: boolean;
   stayOnOutdent: boolean;
+  stayOnVisualBlockOutdent: boolean;
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds options to keep the cursor in it's original position after an operation. See #2397 for more context.

**Which issue(s) this PR fixes**
Fixes #2397