### PR TITLE
fix: immediately exit if there is an error on ts

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -9,12 +9,22 @@ var gulp = require('gulp'),
 
 // compile
 gulp.task('compile', function() {
+  let isError = false;
+
   var tsProject = ts.createProject('tsconfig.json', { noEmitOnError: true });
-  return tsProject
+  var tsResult = tsProject
     .src()
     .pipe(sourcemaps.init())
     .pipe(tsProject())
-    .js.pipe(sourcemaps.write('.', { includeContent: false, sourceRoot: '' }))
+    .on('error', function(error) {
+      isError = true;
+    })
+    .on('finish', function() {
+      isError && process.exit(1);
+    });
+
+  return tsResult.js
+    .pipe(sourcemaps.write('.', { includeContent: false, sourceRoot: '' }))
     .pipe(gulp.dest('out'));
 });
 


### PR DESCRIPTION
https://github.com/VSCodeVim/Vim/pull/2599 updates the build to no longer emit files when a transpile fails. however, the builds still continue to pass.  This PR makes it fail as soon as there is an error thus making it more obvious what's broken.