### PR TITLE
fix: immediately exit travis on build error

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,15 +35,14 @@ before_install:
     sleep 3;
   fi
 
-script:
+before_script:
+- npm run build
 - npm run forceprettier
 - if [[ $(git diff-index HEAD -- *.js *.ts) ]]; then
     git diff;
     echo "Prettier Failed. Run `gulp` or `gulp forceprettier`";
     exit 1;
   fi
-- npm run build
-- npm test --silent;
 
 before_deploy:
 - npm install -g vsce;


### PR DESCRIPTION
As per https://docs.travis-ci.com/user/customizing-the-build#Customizing-the-Build-Step, for scripts in `script`, build continues until the end regardless of returned exit codes. 

If build fails, I don't think we should even bother with running tests. Moving build and forceprettier to `before_script`. 