### PR TITLE
Revert "[Fix] Restore 'when' conditions in <C-v>, <C-j>, <C-k>"

### DIFF
--- a/package.json
+++ b/package.json
@@ -184,12 +184,12 @@
       {
         "key": "ctrl+j",
         "command": "extension.vim_ctrl+j",
-        "when": "editorTextFocus && vim.active && vim.use<C-j> && vim.mode != 'Insert' && !inDebugRepl"
+        "when": "editorTextFocus && vim.active && vim.use<C-j> && !inDebugRepl"
       },
       {
         "key": "ctrl+k",
         "command": "extension.vim_ctrl+k",
-        "when": "editorTextFocus && vim.active && vim.use<C-k> && vim.mode != 'Insert' && !inDebugRepl"
+        "when": "editorTextFocus && vim.active && vim.use<C-k> && !inDebugRepl"
       },
       {
         "key": "ctrl+l",
@@ -239,7 +239,7 @@
       {
         "key": "ctrl+v",
         "command": "extension.vim_ctrl+v",
-        "when": "editorTextFocus && vim.active && vim.use<C-v> && vim.mode != 'Insert' && !inDebugRepl"
+        "when": "editorTextFocus && vim.active && vim.use<C-v> && !inDebugRepl"
       },
       {
         "key": "ctrl+w",


### PR DESCRIPTION
Reverts VSCodeVim/Vim#2628

The extension should handle these `ctrl` keys regardless of the vim.mode. In doing so, it allows remaps such as the one suggested here: https://github.com/VSCodeVim/Vim/issues/2624 