### PR TITLE
Fixed difference in behavior for ]) and ]} when combined with certain operators

### DIFF
--- a/src/actions/motion.ts
+++ b/src/actions/motion.ts
@@ -12,7 +12,7 @@ import { VimState } from './../state/vimState';
 import { CursorMoveByUnit, CursorMovePosition, TextEditor } from './../textEditor';
 import { BaseAction } from './base';
 import { RegisterAction } from './base';
-import { ChangeOperator } from './operator';
+import { ChangeOperator, DeleteOperator, YankOperator } from './operator';
 
 export function isIMovement(o: IMovement | Position): o is IMovement {
   return (o as IMovement).start !== undefined && (o as IMovement).stop !== undefined;
@@ -1732,6 +1732,15 @@ class MoveToUnclosedRoundBracketForward extends MoveToMatchingBracket {
     if (!result) {
       return failure;
     }
+
+    if (
+      vimState.recordedState.operator instanceof ChangeOperator ||
+      vimState.recordedState.operator instanceof DeleteOperator ||
+      vimState.recordedState.operator instanceof YankOperator
+    ) {
+      return result.getLeftThroughLineBreaks();
+    }
+
     return result;
   }
 }
@@ -1772,6 +1781,15 @@ class MoveToUnclosedCurlyBracketForward extends MoveToMatchingBracket {
     if (!result) {
       return failure;
     }
+
+    if (
+      vimState.recordedState.operator instanceof ChangeOperator ||
+      vimState.recordedState.operator instanceof DeleteOperator ||
+      vimState.recordedState.operator instanceof YankOperator
+    ) {
+      return result.getLeftThroughLineBreaks();
+    }
+
     return result;
   }
 }

--- a/test/mode/modeNormal.test.ts
+++ b/test/mode/modeNormal.test.ts
@@ -220,6 +220,20 @@ suite('Mode Normal', () => {
   });
 
   newTest({
+    title: "Can handle 'd])' without deleting closing parenthesis",
+    start: ['(hello, |world)'],
+    keysPressed: 'd])',
+    end: ['(hello, |)'],
+  });
+
+  newTest({
+    title: "Can handle 'd]}' without deleting closing bracket",
+    start: ['{hello, |world}'],
+    keysPressed: 'd]}',
+    end: ['{hello, |}'],
+  });
+
+  newTest({
     title: "Can handle 'cw'",
     start: ['text text tex|t'],
     keysPressed: '^lllllllcw',
@@ -248,6 +262,22 @@ suite('Mode Normal', () => {
     start: ['|text;', 'text'],
     keysPressed: 'llllcw',
     end: ['text|', 'text'],
+    endMode: ModeName.Insert,
+  });
+
+  newTest({
+    title: "Can handle 'c])' without deleting closing parenthesis",
+    start: ['(hello, |world)'],
+    keysPressed: 'c])',
+    end: ['(hello, |)'],
+    endMode: ModeName.Insert,
+  });
+
+  newTest({
+    title: "Can handle 'c]}' without deleting closing bracket",
+    start: ['{hello, |world}'],
+    keysPressed: 'c]}',
+    end: ['{hello, |}'],
     endMode: ModeName.Insert,
   });
 
@@ -1149,6 +1179,20 @@ suite('Mode Normal', () => {
     start: ['|one', 'two', 'three'],
     keysPressed: "majjy'ap",
     end: ['one', 'two', 'three', '|one', 'two', 'three'],
+  });
+
+  newTest({
+    title: "Can handle 'p' after 'y])' without including closing parenthesis",
+    start: ['(hello, |world)'],
+    keysPressed: 'y])$p',
+    end: ['(hello, world)worl|d'],
+  });
+
+  newTest({
+    title: "Can handle 'p' after 'y]}' without including closing bracket",
+    start: ['{hello, |world}'],
+    keysPressed: 'y]}$p',
+    end: ['{hello, world}worl|d'],
   });
 
   newTest({


### PR DESCRIPTION
**What this PR does / why we need it**:
When using ]) and ]} motions combined with change ('c'), delete ('d'), or yank ('y') operators, vim doesn't include the closing parenthesis/bracket in the operation. The same does not apply the equivalent backwards motions ( '[(' / '[{' )

**Which issue(s) this PR fixes**
fixes #2670

<!--
Commits in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)
-->

**Special notes for your reviewer**: