### PR TITLE
Fixed #2688. Revert "Removed viewcolumn from editoridentity information"

### DIFF
--- a/src/editorIdentity.ts
+++ b/src/editorIdentity.ts
@@ -2,13 +2,19 @@ import * as vscode from 'vscode';
 
 export class EditorIdentity {
   private _fileName: string;
+  private _viewColumn: vscode.ViewColumn;
 
   constructor(textEditor?: vscode.TextEditor) {
     this._fileName = (textEditor && textEditor.document && textEditor.document.fileName) || '';
+    this._viewColumn = (textEditor && textEditor.viewColumn) || vscode.ViewColumn.One;
   }
 
   get fileName() {
     return this._fileName;
+  }
+
+  get viewColumn() {
+    return this._viewColumn;
   }
 
   public hasSameBuffer(identity: EditorIdentity): boolean {
@@ -16,10 +22,10 @@ export class EditorIdentity {
   }
 
   public isEqual(other: EditorIdentity): boolean {
-    return this.fileName === other.fileName;
+    return this.fileName === other.fileName && this.viewColumn === other.viewColumn;
   }
 
   public toString() {
-    return this.fileName;
+    return this.fileName + this.viewColumn;
   }
 }


### PR DESCRIPTION
I've pinpointed breaking change using git bisect. Just tried to revert this and see if it helps. Not sure if it breaks anything or relates to some other changes so feel free to treat this PR as a simple hint.