### PR TITLE
Fix autoindent on cc/S #2497

### DIFF
--- a/src/actions/commands/actions.ts
+++ b/src/actions/commands/actions.ts
@@ -2130,16 +2130,7 @@ class CommandClearLine extends BaseCommand {
   runsOnceForEachCountPrefix = false;
 
   public async exec(position: Position, vimState: VimState): Promise<VimState> {
-    let count = vimState.recordedState.count || 1;
-    let end = position
-      .getDownByCount(Math.max(0, count - 1))
-      .getLineEnd()
-      .getLeft();
-    return new operator.ChangeOperator().run(
-      vimState,
-      position.getLineBeginRespectingIndent(),
-      end
-    );
+    return new operator.ChangeOperator(this.multicursorIndex).runRepeat(vimState, position, 1);
   }
 
   // Don't clash with sneak

--- a/src/actions/commands/actions.ts
+++ b/src/actions/commands/actions.ts
@@ -2130,7 +2130,11 @@ class CommandClearLine extends BaseCommand {
   runsOnceForEachCountPrefix = false;
 
   public async exec(position: Position, vimState: VimState): Promise<VimState> {
-    return new operator.ChangeOperator(this.multicursorIndex).runRepeat(vimState, position, 1);
+    return new operator.ChangeOperator(this.multicursorIndex).runRepeat(
+      vimState,
+      position,
+      vimState.recordedState.count || 1
+    );
   }
 
   // Don't clash with sneak

--- a/src/actions/operator.ts
+++ b/src/actions/operator.ts
@@ -566,7 +566,7 @@ export class ChangeOperator extends BaseOperator {
   }
 
   public async runRepeat(vimState: VimState, position: Position, count: number): Promise<VimState> {
-    let thisLineIndent = vimState.editor.document.getText(
+    const thisLineIndent = vimState.editor.document.getText(
       new vscode.Range(position.getLineBegin(), position.getLineBeginRespectingIndent())
     );
 

--- a/src/mode/modeHandler.ts
+++ b/src/mode/modeHandler.ts
@@ -980,6 +980,20 @@ export class ModeHandler implements vscode.Disposable {
             accumulatedPositionDifferences[command.cursorIndex].push(command.diff);
           }
           break;
+        case 'reindent':
+          await vscode.commands.executeCommand('editor.action.reindentselectedlines');
+          if (command.diff) {
+            if (command.cursorIndex === undefined) {
+              throw new Error('No cursor index - this should never ever happen!');
+            }
+
+            if (!accumulatedPositionDifferences[command.cursorIndex]) {
+              accumulatedPositionDifferences[command.cursorIndex] = [];
+            }
+
+            accumulatedPositionDifferences[command.cursorIndex].push(command.diff);
+          }
+          break;
         default:
           console.warn(`Unhandled text transformation type: ${command.type}.`);
           break;

--- a/src/transformations/transformations.ts
+++ b/src/transformations/transformations.ts
@@ -216,6 +216,19 @@ export interface Tab {
 }
 
 /**
+ * Represents reindenting the selected line
+ */
+export interface Reindent {
+  type: 'reindent';
+  cursorIndex?: number;
+
+  /**
+   * Move the cursor this much.
+   */
+  diff?: PositionDiff;
+}
+
+/**
  * Represents macro
  */
 export interface Macro {
@@ -246,7 +259,8 @@ export type Transformation =
   | Macro
   | ContentChangeTransformation
   | DeleteTextTransformation
-  | Tab;
+  | Tab
+  | Reindent;
 
 /**
  * Text Transformations

--- a/test/mode/modeNormal.test.ts
+++ b/test/mode/modeNormal.test.ts
@@ -1840,6 +1840,14 @@ suite('Mode Normal', () => {
   });
 
   newTest({
+    title: 'Resets cursor to indent end with cc',
+    start: ['{', ' | int a;'],
+    keysPressed: 'cc',
+    end: ['{', '  |'],
+    endMode: ModeName.Insert,
+  });
+
+  newTest({
     title: "can handle 'cc' on empty line",
     start: ['foo', '|', 'bar'],
     keysPressed: 'cc',
@@ -1901,10 +1909,10 @@ suite('Mode Normal', () => {
   });
 
   newTest({
-    title: 'cc on whitespace-only line clears line',
+    title: 'cc on whitespace-only treats whitespace as indent',
     start: ['|     '],
     keysPressed: 'cc',
-    end: ['|'],
+    end: ['     |'],
   });
 
   newTest({


### PR DESCRIPTION
<!--
Yay! Thanks for sending us a PR! 🎊

Please ensure your PR adheres to:

- [ ] Commit messages has a short & issue references when necessary
- [ ] Each commit does a logical chunk of work.
- [ ] It builds and tests pass (e.g `gulp`)
-->

**What this PR does / why we need it**:
Changes the `cc` and `S` commands to delete the whole line's contents and reindent it when `autoindent` is enabled. Originally these commands would only delete the text after the indent, which could leave the cursor inside the untouched indent text rather than moving it to the end of the indent.

I think that since commands like `o` already 'reindent' the new line that `cc` and `S` should too, and this implementation also moves the cursor to the end of the line automatically.

**Which issue(s) this PR fixes**
fixes #2497

<!--
Commits in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)
-->