### PR TITLE
fix: handle when commandLineHistory is empty

### DIFF
--- a/extension.ts
+++ b/extension.ts
@@ -8,9 +8,9 @@ import './src/actions/include-all';
 import * as _ from 'lodash';
 import * as vscode from 'vscode';
 
-import { CommandLine } from './src/cmd_line/commandLine';
-import { Position } from './src/common/motion/position';
 import { configuration } from './src/configuration/configuration';
+import { commandLine } from './src/cmd_line/commandLine';
+import { Position } from './src/common/motion/position';
 import { EditorIdentity } from './src/editorIdentity';
 import { Globals } from './src/globals';
 import { ModeName } from './src/mode/mode';
@@ -200,7 +200,7 @@ export async function activate(context: vscode.ExtensionContext) {
     let [modeHandler] = await ModeHandlerMap.getOrCreate(
       new EditorIdentity(vscode.window.activeTextEditor).toString()
     );
-    CommandLine.PromptAndRun('', modeHandler.vimState);
+    commandLine.PromptAndRun('', modeHandler.vimState);
     modeHandler.updateView(modeHandler.vimState);
   });
 
@@ -218,7 +218,7 @@ export async function activate(context: vscode.ExtensionContext) {
         for (const command of args.commands) {
           // Check if this is a vim command by looking for :
           if (command.command.slice(0, 1) === ':') {
-            await CommandLine.Run(command.command.slice(1, command.command.length), mh.vimState);
+            await commandLine.Run(command.command.slice(1, command.command.length), mh.vimState);
             await mh.updateView(mh.vimState);
           } else {
             await vscode.commands.executeCommand(command.command, command.args);
@@ -232,8 +232,6 @@ export async function activate(context: vscode.ExtensionContext) {
     configuration.disableExt = !configuration.disableExt;
     toggleExtension(configuration.disableExt, compositionState);
   });
-
-  CommandLine.LoadHistory();
 
   for (const boundKey of configuration.boundKeyCombinations) {
     registerCommand(context, boundKey.command, () => handleKeyEvent(`${boundKey.key}`));

--- a/src/cmd_line/commandLineHistory.ts
+++ b/src/cmd_line/commandLineHistory.ts
@@ -99,13 +99,13 @@ export class CommandLineHistory {
 
     try {
       let parsedData = JSON.parse(data);
-      if (Array.isArray(parsedData)) {
-        this._history = parsedData;
-      } else {
-        logger.error('CommandLineHistory: Corrupted history file.');
+      if (!Array.isArray(parsedData)) {
+        throw Error('Expected JSON');
       }
+      this._history = parsedData;
     } catch (e) {
-      logger.error(`CommandLineHistory: Failed to load history. err=${e}.`);
+      logger.error(`CommandLineHistory: Deleting corrupted history file. err=${e}.`);
+      this.clear();
     }
   }
 }

--- a/src/cmd_line/commandLineHistory.ts
+++ b/src/cmd_line/commandLineHistory.ts
@@ -1,111 +1,111 @@
-import * as vscode from 'vscode';
-
+import * as fs from 'fs';
+import * as path from 'path';
 import { configuration } from '../configuration/configuration';
 import { logger } from '../util/logger';
 
 export class CommandLineHistory {
+  private static readonly _historyFileName = '.cmdline_history';
+  private _historyDir: string;
   private _history: string[] = [];
-  private _is_loading: boolean = false;
-  private _filePath: string = '';
+  private get _historyFilePath(): string {
+    return path.join(this._historyDir, CommandLineHistory._historyFileName);
+  }
+
+  constructor(historyDir: string) {
+    this._historyDir = historyDir;
+    this._loadFromFile();
+  }
 
   public add(command: string | undefined): void {
     if (!command || command.length === 0) {
       return;
     }
 
+    // remove duplicates
     let index: number = this._history.indexOf(command);
     if (index !== -1) {
       this._history.splice(index, 1);
     }
+
+    // append to beginning
     this._history.unshift(command);
 
+    // resize array if necessary
     if (this._history.length > configuration.history) {
-      this._history.pop();
+      this._history = this._history.slice(0, configuration.history);
     }
+
+    this.save();
   }
 
   public get(): string[] {
+    // resize array if necessary
     if (this._history.length > configuration.history) {
-      // resize history because "vim.history" is updated.
       this._history = this._history.slice(0, configuration.history);
-      this.save();
     }
 
     return this._history;
   }
 
-  public setFilePath(filePath: string): void {
-    this._filePath = filePath;
-  }
-
-  public async load(): Promise<void> {
-    this._history = [];
-    this._is_loading = true;
-
-    return new Promise<void>((resolve, reject) => {
-      const fs = require('fs');
-      fs.readFile(this._filePath, 'utf-8', (err: any, data: string) => {
-        this._is_loading = false;
-
-        if (err) {
-          if (err.code === 'ENOENT') {
-            logger.debug('CommandLineHistory: History does not exist.');
-            // add ccommands that were run before history was loaded.
-            if (this._history.length > 0) {
-              this.save();
-            }
-            resolve();
-          } else {
-            logger.error(`CommandLineHistory: Failed to load history. err=${err}.`);
-            reject();
-          }
-          return;
-        }
-
-        try {
-          let parsedData = JSON.parse(data);
-          if (Array.isArray(parsedData)) {
-            let not_saved_history: string[] = this._history;
-            this._history = parsedData;
-
-            // add ccommands that were run before history was loaded.
-            if (not_saved_history.length > 0) {
-              for (let cmd of not_saved_history.reverse()) {
-                this.add(cmd);
-              }
-              this.save();
-            }
-            resolve();
-          } else {
-            logger.error('CommandLineHistory: The history format is unknown.');
-            reject();
-          }
-        } catch (e) {
-          logger.error(`CommandLineHistory: Failed to load history. err=${e}.`);
-          reject(e);
-        }
-      });
-    });
+  public clear() {
+    try {
+      fs.unlinkSync(this._historyFilePath);
+    } catch (err) {
+      logger.warn(`CommandLineHistory: unable to delete ${this._historyFilePath}. err=${err}.`);
+    }
   }
 
   public async save(): Promise<void> {
     return new Promise<void>((resolve, reject) => {
-      if (this._is_loading) {
-        logger.debug('CommandLineHistory: Failed to save history because history is loading.');
-        resolve();
-        return;
+      try {
+        if (!fs.existsSync(this._historyDir)) {
+          fs.mkdirSync(this._historyDir, 0o775);
+        }
+      } catch (err) {
+        logger.error(
+          `CommandLineHistory: Failed to create directory. path=${this._historyDir}. err=${err}.`
+        );
+        reject(err);
       }
 
-      const fs = require('fs');
+      try {
+        fs.writeFileSync(this._historyFilePath, JSON.stringify(this._history), 'utf-8');
+      } catch (err) {
+        logger.error(`CommandLineHistory: Failed to save history. err=${err}.`);
+        reject(err);
+      }
 
-      fs.writeFile(this._filePath, JSON.stringify(this._history), 'utf-8', (err: Error) => {
-        if (!err) {
-          resolve();
-        } else {
-          logger.error(`CommandLineHistory: Failed to save history. err=${err}.`);
-          reject();
-        }
-      });
+      resolve();
     });
+  }
+
+  private _loadFromFile() {
+    let data = '';
+
+    try {
+      data = fs.readFileSync(this._historyFilePath, 'utf-8');
+    } catch (err) {
+      if (err.code === 'ENOENT') {
+        logger.debug('CommandLineHistory: History does not exist.');
+      } else {
+        logger.error(`CommandLineHistory: Failed to load history. err=${err}.`);
+        return;
+      }
+    }
+
+    if (data.length === 0) {
+      return;
+    }
+
+    try {
+      let parsedData = JSON.parse(data);
+      if (Array.isArray(parsedData)) {
+        this._history = parsedData;
+      } else {
+        logger.error('CommandLineHistory: Corrupted history file.');
+      }
+    } catch (e) {
+      logger.error(`CommandLineHistory: Failed to load history. err=${e}.`);
+    }
   }
 }

--- a/src/configuration/remapper.ts
+++ b/src/configuration/remapper.ts
@@ -1,7 +1,7 @@
 import * as _ from 'lodash';
 import * as vscode from 'vscode';
 
-import { CommandLine } from '../cmd_line/commandLine';
+import { commandLine } from '../cmd_line/commandLine';
 import { configuration } from '../configuration/configuration';
 import { ModeName } from '../mode/mode';
 import { ModeHandler } from '../mode/modeHandler';
@@ -152,7 +152,7 @@ class Remapper implements IRemapper {
         for (const command of remapping.commands) {
           // Check if this is a vim command by looking for :
           if (command.command.slice(0, 1) === ':') {
-            await CommandLine.Run(
+            await commandLine.Run(
               command.command.slice(1, command.command.length),
               modeHandler.vimState
             );

--- a/src/mode/modeHandler.ts
+++ b/src/mode/modeHandler.ts
@@ -1,7 +1,7 @@
 import * as vscode from 'vscode';
 import * as modes from './modes';
 
-import { CommandLine } from '../cmd_line/commandLine';
+import { commandLine } from '../cmd_line/commandLine';
 import { configuration } from '../configuration/configuration';
 import { Decoration } from '../configuration/decoration';
 import { Remappers } from '../configuration/remapper';
@@ -901,14 +901,14 @@ export class ModeHandler implements vscode.Disposable {
           break;
 
         case 'showCommandLine':
-          await CommandLine.PromptAndRun(vimState.commandInitialText, this.vimState);
+          await commandLine.PromptAndRun(vimState.commandInitialText, this.vimState);
           this.updateView(this.vimState);
           break;
 
         case 'showCommandHistory':
-          let cmd = await CommandLine.ShowHistory(vimState.commandInitialText, this.vimState);
+          let cmd = await commandLine.ShowHistory(vimState.commandInitialText, this.vimState);
           if (cmd && cmd.length !== 0) {
-            await CommandLine.PromptAndRun(cmd, this.vimState);
+            await commandLine.PromptAndRun(cmd, this.vimState);
             this.updateView(this.vimState);
           }
           break;

--- a/src/util/util.ts
+++ b/src/util/util.ts
@@ -1,5 +1,6 @@
 import * as vscode from 'vscode';
-
+import * as os from 'os';
+import * as path from 'path';
 import { Position } from '../common/motion/position';
 import { Range } from '../common/motion/range';
 import { logger } from './logger';
@@ -36,23 +37,6 @@ export async function getCursorsAfterSync(timeout: number = 0): Promise<Range[]>
   );
 }
 
-export async function getExternalExtensionDirPath(): Promise<string> {
-  return new Promise<string>((resolve, reject) => {
-    const os = require('os');
-    const homeDir: string = os.homedir();
-    const path = require('path');
-    const extensionFolder = path.join(homeDir, '.VSCodeVim');
-    const fs = require('fs');
-
-    fs.mkdir(extensionFolder, 0o775, (err: any) => {
-      if (!err || err.code === 'EEXIST') {
-        resolve(extensionFolder);
-      } else {
-        logger.error(
-          `getExternalExtensionDirPath: Failed to retrieve extension path. err=${err}.`
-        );
-        reject(err);
-      }
-    });
-  });
+export function getExtensionDirPath(): string {
+  return path.join(os.homedir(), '.VSCodeVim');
 }

--- a/test/cmd_line/commandLineHistory.test.ts
+++ b/test/cmd_line/commandLineHistory.test.ts
@@ -4,7 +4,7 @@ import { Configuration } from '../testConfiguration';
 import { configuration } from '../../src/configuration/configuration';
 import * as path from 'path';
 import * as os from 'os';
-import * as fs from 'fs';
+import * as assert from 'assert';
 
 suite('command-line history', () => {
   let history: CommandLineHistory;
@@ -97,15 +97,13 @@ suite('command-line history', () => {
   });
 
   test('change configuration.history', async () => {
-    configuration.history = 10;
-    assertArrayEquals(
-      run_cmds
-        .slice()
-        .splice(run_cmds.length - 10)
-        .reverse(),
-      history.get()
-    );
+    for (let cmd of run_cmds) {
+      history.add(cmd);
+    }
 
+    assert.equal(history.get().length, configuration.history);
+
+    configuration.history = 10;
     for (let cmd of run_cmds) {
       history.add(cmd);
     }

--- a/test/cmd_line/sort.test.ts
+++ b/test/cmd_line/sort.test.ts
@@ -1,5 +1,5 @@
 import { getAndUpdateModeHandler } from '../../extension';
-import { CommandLine } from '../../src/cmd_line/commandLine';
+import { commandLine } from '../../src/cmd_line/commandLine';
 import { ModeHandler } from '../../src/mode/modeHandler';
 import { VimState } from '../../src/state/vimState';
 import { assertEqualLines, cleanUpWorkspace, setupWorkspace } from './../testUtils';
@@ -28,7 +28,7 @@ suite('Basic sort', () => {
       'c',
       '<Esc>',
     ]);
-    await CommandLine.Run('sort', vimState);
+    await commandLine.Run('sort', vimState);
 
     assertEqualLines(['a', 'b', 'c']);
   });
@@ -45,7 +45,7 @@ suite('Basic sort', () => {
       'c',
       '<Esc>',
     ]);
-    await CommandLine.Run('sort!', modeHandler.vimState);
+    await commandLine.Run('sort!', modeHandler.vimState);
 
     assertEqualLines(['c', 'b', 'a']);
   });
@@ -65,7 +65,7 @@ suite('Basic sort', () => {
       'c',
       '<Esc>',
     ]);
-    await CommandLine.Run('1,3sort', vimState);
+    await commandLine.Run('1,3sort', vimState);
 
     assertEqualLines(['a', 'b', 'd', 'c']);
   });
@@ -85,7 +85,7 @@ suite('Basic sort', () => {
       'c',
       '<Esc>',
     ]);
-    await CommandLine.Run('2,4sort!', vimState);
+    await commandLine.Run('2,4sort!', vimState);
 
     assertEqualLines(['b', 'd', 'c', 'a']);
   });

--- a/test/cmd_line/substitute.test.ts
+++ b/test/cmd_line/substitute.test.ts
@@ -1,5 +1,5 @@
 import { getAndUpdateModeHandler } from '../../extension';
-import { CommandLine } from '../../src/cmd_line/commandLine';
+import { commandLine } from '../../src/cmd_line/commandLine';
 import { Globals } from '../../src/globals';
 import { ModeHandler } from '../../src/mode/modeHandler';
 import {
@@ -21,28 +21,28 @@ suite('Basic substitute', () => {
 
   test('Replace single word once', async () => {
     await modeHandler.handleMultipleKeyEvents(['i', 'a', 'b', 'a', '<Esc>']);
-    await CommandLine.Run('%s/a/d', modeHandler.vimState);
+    await commandLine.Run('%s/a/d', modeHandler.vimState);
 
     assertEqualLines(['dba']);
   });
 
   test('Replace with `g` flag', async () => {
     await modeHandler.handleMultipleKeyEvents(['i', 'a', 'b', 'a', '<Esc>']);
-    await CommandLine.Run('%s/a/d/g', modeHandler.vimState);
+    await commandLine.Run('%s/a/d/g', modeHandler.vimState);
 
     assertEqualLines(['dbd']);
   });
 
   test('Replace multiple lines', async () => {
     await modeHandler.handleMultipleKeyEvents(['i', 'a', 'b', 'a', '<Esc>', 'o', 'a', 'b']);
-    await CommandLine.Run('%s/a/d/g', modeHandler.vimState);
+    await commandLine.Run('%s/a/d/g', modeHandler.vimState);
 
     assertEqualLines(['dbd', 'db']);
   });
 
   test('Replace across specific lines', async () => {
     await modeHandler.handleMultipleKeyEvents(['i', 'a', 'b', 'a', '<Esc>', 'o', 'a', 'b']);
-    await CommandLine.Run('1,1s/a/d/g', modeHandler.vimState);
+    await commandLine.Run('1,1s/a/d/g', modeHandler.vimState);
 
     assertEqualLines(['dbd', 'ab']);
   });
@@ -59,7 +59,7 @@ suite('Basic substitute', () => {
       'b',
       '<Esc>',
     ]);
-    await CommandLine.Run('s/a/d/g', modeHandler.vimState);
+    await commandLine.Run('s/a/d/g', modeHandler.vimState);
 
     assertEqualLines(['aba', 'db']);
   });
@@ -80,7 +80,7 @@ suite('Basic substitute', () => {
       'k',
       '0',
     ]);
-    await CommandLine.Run("'<,'>s/a/d/g", modeHandler.vimState);
+    await commandLine.Run("'<,'>s/a/d/g", modeHandler.vimState);
 
     assertEqualLines(['dbd', 'db']);
   });
@@ -104,7 +104,7 @@ suite('Basic substitute', () => {
       'm',
       'b',
     ]);
-    await CommandLine.Run("'a,'bs/a/d/g", modeHandler.vimState);
+    await commandLine.Run("'a,'bs/a/d/g", modeHandler.vimState);
 
     assertEqualLines(['dbc', 'dbc', 'abc']);
   });
@@ -117,28 +117,28 @@ suite('Basic substitute', () => {
 
     test('Replace all matches in the line', async () => {
       await modeHandler.handleMultipleKeyEvents(['i', 'a', 'b', 'a', '<Esc>']);
-      await CommandLine.Run('%s/a/d', modeHandler.vimState);
+      await commandLine.Run('%s/a/d', modeHandler.vimState);
 
       assertEqualLines(['dbd']);
     });
 
     test('Replace with `g` flag inverts global flag', async () => {
       await modeHandler.handleMultipleKeyEvents(['i', 'a', 'b', 'a', '<Esc>']);
-      await CommandLine.Run('%s/a/d/g', modeHandler.vimState);
+      await commandLine.Run('%s/a/d/g', modeHandler.vimState);
 
       assertEqualLines(['dba']);
     });
 
     test('Replace multiple lines', async () => {
       await modeHandler.handleMultipleKeyEvents(['i', 'a', 'b', 'a', '<Esc>', 'o', 'a', 'b']);
-      await CommandLine.Run('%s/a/d/', modeHandler.vimState);
+      await commandLine.Run('%s/a/d/', modeHandler.vimState);
 
       assertEqualLines(['dbd', 'db']);
     });
 
     test('Replace across specific lines', async () => {
       await modeHandler.handleMultipleKeyEvents(['i', 'a', 'b', 'a', '<Esc>', 'o', 'a', 'b']);
-      await CommandLine.Run('1,1s/a/d/', modeHandler.vimState);
+      await commandLine.Run('1,1s/a/d/', modeHandler.vimState);
 
       assertEqualLines(['dbd', 'ab']);
     });
@@ -155,7 +155,7 @@ suite('Basic substitute', () => {
         'b',
         '<Esc>',
       ]);
-      await CommandLine.Run('s/a/d/', modeHandler.vimState);
+      await commandLine.Run('s/a/d/', modeHandler.vimState);
 
       assertEqualLines(['aba', 'db']);
     });
@@ -176,7 +176,7 @@ suite('Basic substitute', () => {
         'k',
         '0',
       ]);
-      await CommandLine.Run("'<,'>s/a/d/", modeHandler.vimState);
+      await commandLine.Run("'<,'>s/a/d/", modeHandler.vimState);
 
       assertEqualLines(['dbd', 'db']);
     });
@@ -200,14 +200,14 @@ suite('Basic substitute', () => {
         'm',
         'b',
       ]);
-      await CommandLine.Run("'a,'bs/a/d/", modeHandler.vimState);
+      await commandLine.Run("'a,'bs/a/d/", modeHandler.vimState);
 
       assertEqualLines(['dbc', 'dbc', 'abc']);
     });
 
     test('Substitute with escaped delimiter', async () => {
       await modeHandler.handleMultipleKeyEvents(['i', 'b', '/', '/', 'f', '<Esc>']);
-      await CommandLine.Run('s/\\/\\/f/z/g', modeHandler.vimState);
+      await commandLine.Run('s/\\/\\/f/z/g', modeHandler.vimState);
 
       assertEqualLines(['bz']);
     });
@@ -239,7 +239,7 @@ suite('Basic substitute', () => {
         'g', // back to the first line
         '*', // search for foo
       ]);
-      await CommandLine.Run('%s//fighters', modeHandler.vimState);
+      await commandLine.Run('%s//fighters', modeHandler.vimState);
 
       assertEqualLines(['fighters', 'bar', 'fighters', 'bar']);
     });
@@ -267,7 +267,7 @@ suite('Basic substitute', () => {
         '<Esc>',
         '#', // search for bar
       ]);
-      await CommandLine.Run('%s//fighters', modeHandler.vimState);
+      await commandLine.Run('%s//fighters', modeHandler.vimState);
 
       assertEqualLines(['foo', 'fighters', 'foo', 'fighters']);
     });
@@ -299,7 +299,7 @@ suite('Basic substitute', () => {
         'o', // search for foo
         '\n',
       ]);
-      await CommandLine.Run('%s//fighters', modeHandler.vimState);
+      await commandLine.Run('%s//fighters', modeHandler.vimState);
 
       assertEqualLines(['fighters', 'bar', 'fighters', 'bar']);
     });
@@ -335,7 +335,7 @@ suite('Basic substitute', () => {
         'g',
         '*', // now search for bar
       ]);
-      await CommandLine.Run('%s//fighters', modeHandler.vimState);
+      await commandLine.Run('%s//fighters', modeHandler.vimState);
 
       assertEqualLines(['foo', 'fighters', 'foo', 'fighters']);
     });

--- a/test/cmd_line/tab.test.ts
+++ b/test/cmd_line/tab.test.ts
@@ -2,7 +2,7 @@ import * as vscode from 'vscode';
 import * as assert from 'assert';
 
 import { getAndUpdateModeHandler } from '../../extension';
-import { CommandLine } from '../../src/cmd_line/commandLine';
+import { commandLine } from '../../src/cmd_line/commandLine';
 import { ModeHandler } from '../../src/mode/modeHandler';
 import { createRandomFile, setupWorkspace, cleanUpWorkspace } from '../testUtils';
 
@@ -18,7 +18,7 @@ suite('cmd_line tab', () => {
 
   test('tabe with no arguments when not in workspace opens an untitled file', async () => {
     const beforeEditor = vscode.window.activeTextEditor;
-    await CommandLine.Run('tabe', modeHandler.vimState);
+    await commandLine.Run('tabe', modeHandler.vimState);
     const afterEditor = vscode.window.activeTextEditor;
 
     assert.notEqual(beforeEditor, afterEditor, 'Active editor did not change');
@@ -26,7 +26,7 @@ suite('cmd_line tab', () => {
 
   test('tabedit with no arguments when not in workspace opens an untitled file', async () => {
     const beforeEditor = vscode.window.activeTextEditor;
-    await CommandLine.Run('tabedit', modeHandler.vimState);
+    await commandLine.Run('tabedit', modeHandler.vimState);
     const afterEditor = vscode.window.activeTextEditor;
 
     assert.notEqual(beforeEditor, afterEditor, 'Active editor did not change');
@@ -34,7 +34,7 @@ suite('cmd_line tab', () => {
 
   test('tabe with absolute path when not in workspace opens file', async () => {
     const filePath = await createRandomFile('', '');
-    await CommandLine.Run(`tabe ${filePath}`, modeHandler.vimState);
+    await commandLine.Run(`tabe ${filePath}`, modeHandler.vimState);
     const editor = vscode.window.activeTextEditor;
 
     if (editor === undefined) {
@@ -54,10 +54,10 @@ suite('cmd_line tab', () => {
 
   test('tabe with current file path does nothing', async () => {
     const filePath = await createRandomFile('', '');
-    await CommandLine.Run(`tabe ${filePath}`, modeHandler.vimState);
+    await commandLine.Run(`tabe ${filePath}`, modeHandler.vimState);
 
     const beforeEditor = vscode.window.activeTextEditor;
-    await CommandLine.Run(`tabe ${filePath}`, modeHandler.vimState);
+    await commandLine.Run(`tabe ${filePath}`, modeHandler.vimState);
     const afterEditor = vscode.window.activeTextEditor;
 
     assert.equal(

--- a/test/cmd_line/vsplit.test.ts
+++ b/test/cmd_line/vsplit.test.ts
@@ -1,7 +1,7 @@
 import * as vscode from 'vscode';
 
 import { getAndUpdateModeHandler } from '../../extension';
-import { CommandLine } from '../../src/cmd_line/commandLine';
+import { commandLine } from '../../src/cmd_line/commandLine';
 import { ModeHandler } from '../../src/mode/modeHandler';
 import {
   assertEqual,
@@ -21,14 +21,14 @@ suite('Vertical split', () => {
   teardown(cleanUpWorkspace);
 
   test('Run :vs', async () => {
-    await CommandLine.Run('vs', modeHandler.vimState);
+    await commandLine.Run('vs', modeHandler.vimState);
     await WaitForEditorsToClose(2);
 
     assertEqual(vscode.window.visibleTextEditors.length, 2, 'Editor did not split in 1 sec');
   });
 
   test('Run :vsp', async () => {
-    await CommandLine.Run('vsp', modeHandler.vimState);
+    await commandLine.Run('vsp', modeHandler.vimState);
     await WaitForEditorsToClose(2);
 
     assertEqual(vscode.window.visibleTextEditors.length, 2, 'Editor did not split in 1 sec');

--- a/test/cmd_line/writequit.test.ts
+++ b/test/cmd_line/writequit.test.ts
@@ -1,7 +1,7 @@
 import * as vscode from 'vscode';
 
 import { getAndUpdateModeHandler } from '../../extension';
-import { CommandLine } from '../../src/cmd_line/commandLine';
+import { commandLine } from '../../src/cmd_line/commandLine';
 import { ModeHandler } from '../../src/mode/modeHandler';
 import {
   assertEqual,
@@ -23,7 +23,7 @@ suite('Basic write-quit', () => {
   test('Run write and quit', async () => {
     await modeHandler.handleMultipleKeyEvents(['i', 'a', 'b', 'a', '<Esc>']);
 
-    await CommandLine.Run('wq', modeHandler.vimState);
+    await commandLine.Run('wq', modeHandler.vimState);
     await WaitForEditorsToClose();
 
     assertEqual(vscode.window.visibleTextEditors.length, 0, 'Window after 1sec still open');

--- a/test/testConfiguration.ts
+++ b/test/testConfiguration.ts
@@ -41,7 +41,7 @@ export class Configuration implements IConfiguration {
     replace: '#000000';
   };
   debug: {
-    loggingLevel: 'info';
+    loggingLevel: 'warn';
   };
   searchHighlightColor = 'rgba(150, 150, 255, 0.3)';
   tabstop = 2;


### PR DESCRIPTION
<!--
Yay! Thanks for sending us a PR! 🎊

Please ensure your PR adheres to:

- [ ] Commit messages has a short & issue references when necessary
- [ ] Each commit does a logical chunk of work.
- [ ] It builds and tests pass (e.g `gulp`)
-->

**What this PR does / why we need it**:

bug fixes:
* resolve issue where if the command line history file was empty, it would fail to load
* delete command line history file if it is corrupted instead of infinitely retrying
* resolves issue where max history as defined by `configuration.history` was not being honored

refactor:
* make `commandLineHistory` and `commandLine` real classes instead of static methods

**Which issue(s) this PR fixes**

<!--
Commits in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)
-->

**Special notes for your reviewer**: