### PR TITLE
Fix #2766.

### DIFF
--- a/src/actions/commands/actions.ts
+++ b/src/actions/commands/actions.ts
@@ -661,7 +661,7 @@ class CommandMoveHalfPageDown extends CommandEditorScroll {
     let editor = vscode.window.activeTextEditor!;
     let startColumn = vimState.cursorStartPosition.character;
     let firstLine = editor.visibleRanges[0].start.line;
-    let currentSelectionLine = editor.selection.end.line;
+    let currentSelectionLine = vimState.cursorPosition.line;
     lineOffset = currentSelectionLine - firstLine;
 
     let timesToRepeat = vimState.recordedState.count || 1;
@@ -695,7 +695,7 @@ class CommandMoveHalfPageUp extends CommandEditorScroll {
     let startColumn = vimState.cursorStartPosition.character;
 
     let firstLine = editor.visibleRanges[0].start.line;
-    let currentSelectionLine = editor.selection.start.line;
+    let currentSelectionLine = vimState.cursorPosition.line;
     lineOffset = currentSelectionLine - firstLine;
 
     let timesToRepeat = vimState.recordedState.count || 1;


### PR DESCRIPTION
The issue we ran into is there are inconsistency of start/end between vscode's selection and vimState's internal one. As we already track the real position in Visual Mode (as it's controlled by vimState), I use `vimState.cursorPosition` instead of `editor.selection.end` .