### PR TITLE
Added ability to register commands using simple strings (fixes #2806)

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,6 +257,26 @@ Custom remappings are defined on a per-mode basis.
 ]
 ```
 
+* Bind `<leader>m` to add a bookmark and `<leader>b` to open the list of all bookmarks (using the [Bookmarks](https://github.com/alefragnani/vscode-bookmarks) extension):
+    * *Note:* `"commands": [ "cmd" ]` is equivalent to `"commands": [ { "command": "cmd", "args": [] } ]`.
+
+```json
+    "vim.normalModeKeyBindingsNonRecursive": [
+        {
+            "before": ["<leader>", "m"],
+            "commands": [
+                "bookmarks.toggle"
+            ]
+        },
+        {
+            "before": ["<leader>", "b"],
+            "commands": [
+                "bookmarks.list"
+            ]
+        }
+    ]
+```
+
 * Bind `ZZ` to the vim command `:wq` (save and close the current file):
 
 ```json

--- a/README.md
+++ b/README.md
@@ -99,9 +99,7 @@ Below is an example of a [settings.json](https://code.visualstudio.com/Docs/cust
         {
             "before":["<C-n>"],
             "commands": [
-                {
-                    "command": ":nohl"
-                }
+                ":nohl"
             ]
         }
     ],
@@ -249,16 +247,13 @@ Custom remappings are defined on a per-mode basis.
         {
             "before": [":"],
             "commands": [
-                {
-                    "command": "workbench.action.showCommands",
-                }
+                "workbench.action.showCommands",
             ]
         }
     ]
 ```
 
 * Bind `<leader>m` to add a bookmark and `<leader>b` to open the list of all bookmarks (using the [Bookmarks](https://github.com/alefragnani/vscode-bookmarks) extension):
-    * *Note:* `"commands": [ "cmd" ]` is equivalent to `"commands": [ { "command": "cmd", "args": [] } ]`.
 
 ```json
     "vim.normalModeKeyBindingsNonRecursive": [
@@ -284,9 +279,7 @@ Custom remappings are defined on a per-mode basis.
         {
             "before": ["Z", "Z"],
             "commands": [
-                {
-                    "command": ":wq"
-                },
+                ":wq"
             ]
         }
     ]
@@ -299,17 +292,13 @@ Custom remappings are defined on a per-mode basis.
         {
             "before":["<C-n>"],
             "commands": [
-                {
-                    "command": ":nohl",
-                }
+                ":nohl",
             ]
         },
         {
             "before": ["leader", "w"],
             "commands": [
-                {
-                    "command": "workbench.action.files.save",
-                }
+                "workbench.action.files.save",
             ]
         }
     ]
@@ -335,7 +324,6 @@ Custom remappings are defined on a per-mode basis.
 
 * Bind `>` and `<` in visual mode to indent/outdent lines (repeatable)
 
-
 ```json
     "vim.visualModeKeyBindingsNonRecursive": [
         {
@@ -343,9 +331,7 @@ Custom remappings are defined on a per-mode basis.
                 ">"
             ],
             "commands": [
-                {
-                    "command": "editor.action.indentLines"
-                }
+                "editor.action.indentLines"
             ]
         },
         {
@@ -353,14 +339,29 @@ Custom remappings are defined on a per-mode basis.
                 "<"
             ],
             "commands": [
-                {
-                    "command": "editor.action.outdentLines"
-                }
+                "editor.action.outdentLines"
             ]
         },
     ]
 ```
 
+* Bind `<leader>vim` to clone this repository to the selected location.
+
+```json
+    "vim.visualModeKeyBindingsNonRecursive": [
+        {
+            "before": [
+                "<leader>", "v", "i", "m"
+            ],
+            "commands": [
+                {
+                    "command": "git.clone",
+                    "args": [ "https://github.com/VSCodeVim/Vim.git" ]
+                }
+            ]
+        }
+    ]
+```
 
 #### `"vim.insertModeKeyBindingsNonRecursive"`/`"normalModeKeyBindingsNonRecursive"`/`"visualModeKeyBindingsNonRecursive"`
 

--- a/README.md
+++ b/README.md
@@ -245,16 +245,16 @@ Custom remappings are defined on a per-mode basis.
 * Bind `:` to show the command palette:
 
 ```json
-"vim.normalModeKeyBindingsNonRecursive": [
-    {
-        "before": [":"],
-        "commands": [
-            {
-                "command": "workbench.action.showCommands",
-            }
-        ]
-    }
-]
+    "vim.normalModeKeyBindingsNonRecursive": [
+        {
+            "before": [":"],
+            "commands": [
+                {
+                    "command": "workbench.action.showCommands",
+                }
+            ]
+        }
+    ]
 ```
 
 * Bind `<leader>m` to add a bookmark and `<leader>b` to open the list of all bookmarks (using the [Bookmarks](https://github.com/alefragnani/vscode-bookmarks) extension):

--- a/src/configuration/iconfiguration.ts
+++ b/src/configuration/iconfiguration.ts
@@ -12,7 +12,7 @@ export interface IModeSpecificStrings<T> {
 export interface IKeyRemapping {
   before: string[];
   after?: string[];
-  commands?: { command: string; args: any[] }[];
+  commands?: ({ command: string; args: any[] } | string)[];
 }
 
 export interface IDebugConfiguration {

--- a/src/configuration/remapper.ts
+++ b/src/configuration/remapper.ts
@@ -90,7 +90,7 @@ export class Remapper implements IRemapper {
     if (remapping) {
       logger.debug(
         `Remapper: ${this._configKey}. match found. before=${remapping.before}. after=${
-        remapping.after
+          remapping.after
         }. command=${remapping.commands}.`
       );
 
@@ -130,17 +130,28 @@ export class Remapper implements IRemapper {
       if (remapping.commands) {
         for (const command of remapping.commands) {
           // Check if this is a vim command by looking for :
-          if (command.command.slice(0, 1) === ':') {
+          let commandString: string;
+          let commandArgs: string[];
+
+          if (typeof command === 'string') {
+            commandString = command;
+            commandArgs = [];
+          } else {
+            commandString = command.command;
+            commandArgs = command.args;
+          }
+
+          if (commandString.slice(0, 1) === ':') {
             await commandLine.Run(
-              command.command.slice(1, command.command.length),
+              commandString.slice(1, commandString.length),
               modeHandler.vimState
             );
             await modeHandler.updateView(modeHandler.vimState);
           } else {
-            if (command.args) {
-              await vscode.commands.executeCommand(command.command, command.args);
+            if (commandArgs) {
+              await vscode.commands.executeCommand(commandString, commandArgs);
             } else {
-              await vscode.commands.executeCommand(command.command);
+              await vscode.commands.executeCommand(commandString);
             }
           }
         }
@@ -172,14 +183,18 @@ export class Remapper implements IRemapper {
 
       if (remapping.commands) {
         for (const command of remapping.commands) {
-          debugMsg += `command=${command.command}. args=${command.args}.`;
+          if (typeof command === 'string') {
+            debugMsg += `command=${command}. args=.`;
+          } else {
+            debugMsg += `command=${command.command}. args=${command.args}.`;
+          }
         }
       }
 
       if (!remapping.after && !remapping.commands) {
         logger.error(
           `Remapper: ${
-          this._configKey
+            this._configKey
           }. Invalid configuration. Missing 'after' key or 'command'. ${debugMsg}`
         );
         continue;


### PR DESCRIPTION
**What this PR does / why we need it**:
Enables the syntax specified in #2806 to work.

**Which issue(s) this PR fixes**
#2806.

**Notes:**
This simply makes the "command" object in `IKeyRemapping` be either the old object or a string. If it's a string, we then interpret the string as `{ command: str; args: [] }`.