### PR TITLE
Fix quickpick commandline

### DIFF
--- a/extension.ts
+++ b/extension.ts
@@ -197,10 +197,8 @@ export async function activate(context: vscode.ExtensionContext) {
 
   // register extension commands
   registerCommand(context, 'vim.showQuickpickCmdLine', async () => {
-    let [modeHandler] = await ModeHandlerMap.getOrCreate(
-      new EditorIdentity(vscode.window.activeTextEditor).toString()
-    );
-    commandLine.PromptAndRun('', modeHandler.vimState);
+    const modeHandler = await getAndUpdateModeHandler();
+    await commandLine.PromptAndRun('', modeHandler.vimState);
     modeHandler.updateView(modeHandler.vimState);
   });
 


### PR DESCRIPTION
The missing await was not ideal here when doing commands where the cursor changes location

```:2``` and ```:40``` etc