### PR TITLE
Workaround surround bug

### DIFF
--- a/src/actions/plugins/surround.ts
+++ b/src/actions/plugins/surround.ts
@@ -347,6 +347,10 @@ export class CommandSurroundAddToReplacement extends BaseCommand {
       vimState.recordedState.surroundKeys.push(vimState.keyHistory[i]);
     }
 
+    // When deleting surroundings, handled == false. This workaround
+    // resets the command list anyway.
+    vimState.recordedState.resetCommandList();
+
     return false;
   }
 

--- a/src/actions/plugins/surround.ts
+++ b/src/actions/plugins/surround.ts
@@ -85,7 +85,9 @@ class CommandSurroundAddTarget extends BaseCommand {
     }
 
     // It's possible we're already done, e.g. dst
-    await CommandSurroundAddToReplacement.TryToExecuteSurround(vimState, position);
+    if (await CommandSurroundAddToReplacement.TryToExecuteSurround(vimState, position)) {
+      this.isCompleteAction = true;
+    }
 
     return vimState;
   }
@@ -326,7 +328,9 @@ export class CommandSurroundAddToReplacement extends BaseCommand {
 
     vimState.surround.replacement += stringToAdd;
 
-    await CommandSurroundAddToReplacement.TryToExecuteSurround(vimState, position);
+    if (await CommandSurroundAddToReplacement.TryToExecuteSurround(vimState, position)) {
+      this.isCompleteAction = true;
+    }
 
     return vimState;
   }
@@ -347,11 +351,7 @@ export class CommandSurroundAddToReplacement extends BaseCommand {
       vimState.recordedState.surroundKeys.push(vimState.keyHistory[i]);
     }
 
-    // When deleting surroundings, handled == false. This workaround
-    // resets the command list anyway.
-    vimState.recordedState.resetCommandList();
-
-    return false;
+    return true;
   }
 
   // we assume that we start directly on the characters we're operating over


### PR DESCRIPTION
**What this PR does / why we need it**:
When deleting surroundings using <kbd>ds</kbd>, this plugin doesn't recognize it as being handled, so the command list remains what it was before surround.ts handled it. This pull request fixes this by clearing the command list when a surround command finishes.

![screencast](https://user-images.githubusercontent.com/23725670/42546927-9bb710a0-848d-11e8-89bc-c78bee761ffc.gif)

**Which issue(s) this PR fixes**
N/A

**Special notes for your reviewer**:
A better way to fix this bug would be to somehow have [this line of code](https://github.com/VSCodeVim/Vim/blob/e12c6f35edb35d777e5f2f8f1770057cb1e83ce1/src/mode/modeHandler.ts#L330) executed. However, I wasn't able to figure out how, so I came up with this workaround.