### PR TITLE
Fixes $ and % commands

### DIFF
--- a/src/cmd_line/node.ts
+++ b/src/cmd_line/node.ts
@@ -61,7 +61,7 @@ export class LineRange {
     switch (first.type) {
       case token.TokenType.Dollar:
       case token.TokenType.Percent:
-        return new vscode.Position(doc.document.lineCount, 0);
+        return new vscode.Position(doc.document.lineCount - 1, 0);
       case token.TokenType.Dot:
         return new vscode.Position(doc.selection.active.line, 0);
       case token.TokenType.LineNumber:


### PR DESCRIPTION
fixes #2858

I believe that when this was in the quickpick, it was still an error scenario yet, was "caught", ignored, and then updateView was explicitly called so it worked "ok". Now it doesn't error and goes to a valid line.

This used to be logged every time you ran a :$ or :% command
```
error: ModeHandler: error handling key=
. err=Error: Illegal value for `line`.
```