### PR TITLE
Roadmap doc fix for visual mode case switching

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -352,7 +352,7 @@ Status | Command | Description
 :white_check_mark:  | :1234:  s		| change N characters
 :white_check_mark:  | {visual}c	| in Visual block mode: Change each of the selected lines with the entered text
 :white_check_mark:  |    {visual}C	| in Visual block mode: Change each of the selected lines until end-of-line with the entered text
-:white_check_mark:	| switch case for highlighted text
+:white_check_mark:	| {visual}~ | switch case for highlighted text
 :white_check_mark:  |    {visual}u	| make highlighted text lowercase
 :white_check_mark:  |    {visual}U	| make highlighted text uppercase
 :white_check_mark:  |    g~{motion}     | switch case for the text that is moved over with {motion}


### PR DESCRIPTION
<!--
Yay! Thanks for sending us a PR! 🎊

Please ensure your PR adheres to:

- [ ] Commit messages has a short & issue references when necessary
- [ ] Each commit does a logical chunk of work.
- [ ] It builds and tests pass (e.g `gulp`)
-->

**What this PR does / why we need it**:

Adds an undocumented shortcut to the roadmap docs.

**Which issue(s) this PR fixes**

n/a

<!--
Commits in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)
-->

**Special notes for your reviewer**:

`~` works for case switching in visual mode, so I've assumed that the docs just aren't up to date.

It looks like the description text fell into the keyboard shortcut column... and the keyboard shortcut wasn't yet provided.