### PR TITLE
Fix regression with setContext in modeHandler

### DIFF
--- a/extension.ts
+++ b/extension.ts
@@ -58,11 +58,7 @@ export async function getAndUpdateModeHandler(): Promise<ModeHandler> {
     }
   } else {
     previousActiveEditorId = activeEditorId;
-    await curHandler.updateView(curHandler.vimState, {
-      drawSelection: false,
-      revealRange: false,
-      forceSetContext: false,
-    });
+    await curHandler.updateView(curHandler.vimState, { drawSelection: false, revealRange: false });
   }
 
   if (prevHandler && curHandler.vimState.focusChanged) {
@@ -242,7 +238,7 @@ export async function activate(context: vscode.ExtensionContext) {
   // Initialize mode handler for current active Text Editor at startup.
   if (vscode.window.activeTextEditor) {
     let mh = await getAndUpdateModeHandler();
-    mh.updateView(mh.vimState, { drawSelection: false, revealRange: false, forceSetContext: true });
+    mh.updateView(mh.vimState, { drawSelection: false, revealRange: false });
   }
 
   // This is called last because getAndUpdateModeHandler() will change cursor
@@ -341,11 +337,7 @@ async function handleActiveEditorChange(): Promise<void> {
     if (vscode.window.activeTextEditor !== undefined) {
       const mh = await getAndUpdateModeHandler();
 
-      mh.updateView(mh.vimState, {
-        drawSelection: false,
-        revealRange: false,
-        forceSetContext: true,
-      });
+      mh.updateView(mh.vimState, { drawSelection: false, revealRange: false });
     }
   });
 }

--- a/src/mode/modeHandler.ts
+++ b/src/mode/modeHandler.ts
@@ -36,7 +36,6 @@ export class ModeHandler implements vscode.Disposable {
   private _disposables: vscode.Disposable[] = [];
   private _modes: Mode[];
   private _remappers: Remappers;
-  private _prevMode: ModeName;
 
   public vimState: VimState;
 
@@ -257,11 +256,7 @@ export class ModeHandler implements vscode.Disposable {
         }
       }
 
-      await this.updateView(this.vimState, {
-        drawSelection: toDraw,
-        revealRange: true,
-        forceSetContext: false,
-      });
+      await this.updateView(this.vimState, { drawSelection: toDraw, revealRange: true });
     }
   }
 
@@ -1184,10 +1179,9 @@ export class ModeHandler implements vscode.Disposable {
 
   public async updateView(
     vimState: VimState,
-    args: { drawSelection: boolean; revealRange: boolean; forceSetContext: boolean } = {
+    args: { drawSelection: boolean; revealRange: boolean } = {
       drawSelection: true,
       revealRange: true,
-      forceSetContext: false,
     }
   ): Promise<void> {
     // Draw selection (or cursor)
@@ -1402,15 +1396,11 @@ export class ModeHandler implements vscode.Disposable {
 
     this._renderStatusBar();
 
-    // Only update the context if the mode has changed for performance reasons
-    if (args.forceSetContext || this._prevMode !== this.vimState.currentMode) {
-      this._prevMode = this.vimState.currentMode;
-      await vscode.commands.executeCommand(
-        'setContext',
-        'vim.mode',
-        ModeName[this.vimState.currentMode]
-      );
-    }
+    await vscode.commands.executeCommand(
+      'setContext',
+      'vim.mode',
+      ModeName[this.vimState.currentMode]
+    );
   }
 
   private _renderStatusBar(): void {


### PR DESCRIPTION
Reverts VSCodeVim/Vim#2861

Causes some really bad things to happen, the easiest one is when you do ```:``` or search with ```/```