### PR TITLE
fix: use ferrarimarco's image instead of my fork to generate changelog

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -76,7 +76,7 @@ function validateArgs(done) {
 }
 
 function createChangelog(done) {
-  const imageName = 'jpoon/github-changelog-generator';
+  const imageName = 'ferrarimarco/github-changelog-generator';
   const version = require('./package.json').version;
 
   const options = minimist(process.argv.slice(2), releaseOptions);


### PR DESCRIPTION
<!--
Yay! Thanks for sending us a PR! 🎊

Please ensure your PR adheres to:

- [ ] Commit messages has a short & issue references when necessary
- [ ] Each commit does a logical chunk of work.
- [ ] It builds and tests pass (e.g `gulp`)
-->

**What this PR does / why we need it**:

I initially created a fork of the image as I wanted `1.15.0` of the changelog generator. Now that ferrarimaro has pushed it up that version up, using ferrarimaro's image as it's more official than my fork. 

https://hub.docker.com/r/ferrarimarco/github-changelog-generator/tags/

**Which issue(s) this PR fixes**

<!--
Commits in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)
-->

**Special notes for your reviewer**: