### PR TITLE
Move commandline history to XDG_CACHE_HOME or %APPDATA%

### DIFF
--- a/package.json
+++ b/package.json
@@ -604,6 +604,7 @@
     "clipboardy": "1.2.3",
     "diff-match-patch": "1.0.1",
     "lodash": "4.17.10",
+    "mkdirp": "0.5.1",
     "neovim-client": "2.1.0",
     "promised-neovim-client": "2.0.2",
     "untildify": "3.0.3",

--- a/package.json
+++ b/package.json
@@ -600,6 +600,7 @@
     "postinstall": "node ./node_modules/vscode/bin/install"
   },
   "dependencies": {
+    "appdirectory": "0.1.0",
     "clipboardy": "1.2.3",
     "diff-match-patch": "1.0.1",
     "lodash": "4.17.10",

--- a/src/cmd_line/commandLineHistory.ts
+++ b/src/cmd_line/commandLineHistory.ts
@@ -3,6 +3,8 @@ import * as path from 'path';
 import { configuration } from '../configuration/configuration';
 import { logger } from '../util/logger';
 
+const mkdirp = require('mkdirp');
+
 export class CommandLineHistory {
   private static readonly _historyFileName = '.cmdline_history';
   private _historyDir: string;
@@ -59,7 +61,7 @@ export class CommandLineHistory {
     return new Promise<void>((resolve, reject) => {
       try {
         if (!fs.existsSync(this._historyDir)) {
-          fs.mkdirSync(this._historyDir, 0o775);
+          mkdirp.sync(this._historyDir, 0o775);
         }
       } catch (err) {
         logger.error(

--- a/src/util/util.ts
+++ b/src/util/util.ts
@@ -41,6 +41,7 @@ export async function getCursorsAfterSync(timeout: number = 0): Promise<Range[]>
 
 export function getExtensionDirPath(): string {
   const dirs = new AppDirectory('VSCodeVim');
+  logger.debug("VSCodeVim Cache Directory: " + dirs.userCache());
 
   return dirs.userCache();
 }

--- a/src/util/util.ts
+++ b/src/util/util.ts
@@ -38,5 +38,18 @@ export async function getCursorsAfterSync(timeout: number = 0): Promise<Range[]>
 }
 
 export function getExtensionDirPath(): string {
-  return path.join(os.homedir(), '.VSCodeVim');
+  let homeVar = 'XDG_CACHE_HOME';
+  if (process.platform === 'win32') {
+    homeVar = 'LOCALAPPDATA';
+  }
+
+  // Try to find the directory path
+  let newPath = process.env[homeVar];
+
+  // If path is not found, fallback to homedir
+  if (newPath === undefined || newPath === '') {
+    newPath = os.homedir();
+  }
+
+  return path.join(newPath, '.vscodevim');
 }

--- a/src/util/util.ts
+++ b/src/util/util.ts
@@ -5,6 +5,8 @@ import { Position } from '../common/motion/position';
 import { Range } from '../common/motion/range';
 import { logger } from './logger';
 
+const AppDirectory = require('appdirectory');
+
 /**
  * This is certainly quite janky! The problem we're trying to solve
  * is that writing editor.selection = new Position() won't immediately
@@ -38,18 +40,7 @@ export async function getCursorsAfterSync(timeout: number = 0): Promise<Range[]>
 }
 
 export function getExtensionDirPath(): string {
-  let homeVar = 'XDG_CACHE_HOME';
-  if (process.platform === 'win32') {
-    homeVar = 'LOCALAPPDATA';
-  }
+  const dirs = new AppDirectory('VSCodeVim');
 
-  // Try to find the directory path
-  let newPath = process.env[homeVar];
-
-  // If path is not found, fallback to homedir
-  if (newPath === undefined || newPath === '') {
-    newPath = os.homedir();
-  }
-
-  return path.join(newPath, '.vscodevim');
+  return dirs.userCache();
 }


### PR DESCRIPTION
Fixes #2799 

Just tested on 3 platforms

Windows:
```C:\Users\xxxxx\AppData\Local\VSCodeVim\VSCodeVim\Cache```

MacOS:
```/Users/xxxxx/Library/Caches/VSCodeVim```

Linux:
```/home/xxxxx/.cache/VSCodeVim```