### PR TITLE
Reenable change that minimized the calls to setContext

### DIFF
--- a/extension.ts
+++ b/extension.ts
@@ -58,7 +58,11 @@ export async function getAndUpdateModeHandler(): Promise<ModeHandler> {
     }
   } else {
     previousActiveEditorId = activeEditorId;
-    await curHandler.updateView(curHandler.vimState, { drawSelection: false, revealRange: false });
+    await curHandler.updateView(curHandler.vimState, {
+      drawSelection: false,
+      revealRange: false,
+      forceSetContext: false,
+    });
   }
 
   if (prevHandler && curHandler.vimState.focusChanged) {
@@ -238,7 +242,7 @@ export async function activate(context: vscode.ExtensionContext) {
   // Initialize mode handler for current active Text Editor at startup.
   if (vscode.window.activeTextEditor) {
     let mh = await getAndUpdateModeHandler();
-    mh.updateView(mh.vimState, { drawSelection: false, revealRange: false });
+    mh.updateView(mh.vimState, { drawSelection: false, revealRange: false, forceSetContext: true });
   }
 
   // This is called last because getAndUpdateModeHandler() will change cursor
@@ -337,7 +341,11 @@ async function handleActiveEditorChange(): Promise<void> {
     if (vscode.window.activeTextEditor !== undefined) {
       const mh = await getAndUpdateModeHandler();
 
-      mh.updateView(mh.vimState, { drawSelection: false, revealRange: false });
+      mh.updateView(mh.vimState, {
+        drawSelection: false,
+        revealRange: false,
+        forceSetContext: true,
+      });
     }
   });
 }


### PR DESCRIPTION
There was not actually any issue with this that I can detect. I believe the reason I reverted it was that I upgraded VSCodeVim, and did not click Reload, so the contexts were out of sync. Upon restarting vscode, the extension would have worked properly WITH the performance improvements enabled (this PR).