### PR TITLE
Remove unnecessary allocation every tick

### DIFF
--- a/src/actions/base.ts
+++ b/src/actions/base.ts
@@ -198,9 +198,8 @@ export class Actions {
       const { type, action } = possibleAction!;
 
       if (action.doesActionApply(vimState, keysPressed)) {
-        const result = new type();
-        result.keysPressed = vimState.recordedState.actionKeys.slice(0);
-        return result;
+        action.keysPressed = vimState.recordedState.actionKeys.slice(0);
+        return action;
       }
 
       if (action.couldActionApply(vimState, keysPressed)) {


### PR DESCRIPTION
I am not sure of the repercussions of this but it makes sense to me. We have a map of actions already allocated so lets use them! This function is called every tick for single key actions so it makes sense to me to minimize time spent allocating