### PR TITLE
Fix Emulated Plugins TOC link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ VSCodeVim is a Vim emulator for [Visual Studio Code](https://code.visualstudio.c
   - [Key remapping](#key-remapping)
   - [Vim settings](#vim-settings)
 - [Multi-Cursor mode](#-multi-cursor-mode)
-- [Emulated plugins](#emulated-plugins)
+- [Emulated plugins](#-emulated-plugins)
   - [vim-airline](#vim-airline)
   - [vim-easymotion](#vim-easymotion)
   - [vim-surround](#vim-surround)


### PR DESCRIPTION
Currently the TOC points to `#emulated-plugins` but the actual anchor is `#-emulated-plugins`

<!--
Yay! Thanks for sending us a PR! 🎊

Please ensure your PR adheres to:

- [ ] Commit messages has a short & issue references when necessary
- [ ] Each commit does a logical chunk of work.
- [ ] It builds and tests pass (e.g `gulp`)
-->

**What this PR does / why we need it**:
Fixes the Emulated Plugins link in the README TOC

**Which issue(s) this PR fixes**
None, thought it was simpler to just submit a PR
<!--
Commits in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)
-->

**Special notes for your reviewer**:
I hope you're having a lovely day :)
