### PR TITLE
Fix `gf` showing error for files which exist

### DIFF
--- a/src/cmd_line/commands/file.ts
+++ b/src/cmd_line/commands/file.ts
@@ -112,11 +112,13 @@ export class FileCommand extends node.CommandBase {
     }
 
     // create file
-    if (this.arguments.createFileIfNotExists) {
-      fs.closeSync(fs.openSync(filePath, 'w'));
-    } else {
-      Message.ShowError('The file ' + filePath + ' does not exist.');
-      return;
+    if (!fs.existsSync(filePath)) {
+      if (this.arguments.createFileIfNotExists) {
+        fs.closeSync(fs.openSync(filePath, 'w'));
+      } else {
+        Message.ShowError('The file ' + filePath + ' does not exist.');
+        return;
+      }
     }
 
     let folder = vscode.Uri.file(filePath);


### PR DESCRIPTION
https://github.com/VSCodeVim/Vim/issues/2966

**What this PR does / why we need it**:
This PR makes `gf` work as-expected. (Currently, `gf` just shows an error message.)

**Which issue(s) this PR fixes**
Fixes #2966 

**Special notes for your reviewer**:
None.