### PR TITLE
Fix emulated plugins link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ VSCodeVim is automatically enabled following [installation](https://marketplace.
 
 ### Vim Compatibility
 
-Vimscript is _not_ supported, therefore we are _not_ able to load your `.vimrc` or use `.vim` plugins. You have to replicate these using our [Settings](#settings) and [Emulated plugins](#emulated-plugins).
+Vimscript is _not_ supported, therefore we are _not_ able to load your `.vimrc` or use `.vim` plugins. You have to replicate these using our [Settings](#settings) and [Emulated plugins](#-emulated-plugins).
 
 ### Mac Setup
 


### PR DESCRIPTION
Just need a dash due to the emoji:`#-emulated-plugins` 