### PR TITLE
Feature/improved jump list

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -8,5 +8,6 @@
 	},
 	"typescript.tsdk": "./node_modules/typescript/lib", // we want to use the TS server from our node_modules folder to control its version
 	"editor.tabSize": 2,
-	"editor.insertSpaces": true
+	"editor.insertSpaces": true,
+	"mocha.enabled": false
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,13 +1,12 @@
 {
 	"files.trimTrailingWhitespace": true,
 	"files.exclude": {
-		"out": false
+		"out": false // set this to true to hide the "out" folder with the compiled JS files
 	},
 	"search.exclude": {
 		"out": true // set this to false to include "out" folder in search results
 	},
 	"typescript.tsdk": "./node_modules/typescript/lib", // we want to use the TS server from our node_modules folder to control its version
 	"editor.tabSize": 2,
-	"editor.insertSpaces": true,
-	"mocha.enabled": false
+	"editor.insertSpaces": true
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,7 @@
 {
 	"files.trimTrailingWhitespace": true,
 	"files.exclude": {
-		"out": false // set this to true to hide the "out" folder with the compiled JS files
+		"out": false
 	},
 	"search.exclude": {
 		"out": true // set this to false to include "out" folder in search results

--- a/extension.ts
+++ b/extension.ts
@@ -13,6 +13,7 @@ import { commandLine } from './src/cmd_line/commandLine';
 import { Position } from './src/common/motion/position';
 import { EditorIdentity } from './src/editorIdentity';
 import { Globals } from './src/globals';
+import { Jump } from './src/jumps/jump';
 import { ModeName } from './src/mode/mode';
 import { ModeHandler } from './src/mode/modeHandler';
 import { Notation } from './src/configuration/notation';
@@ -22,7 +23,6 @@ import { taskQueue } from './src/taskQueue';
 import { ModeHandlerMap } from './src/mode/modeHandlerMap';
 import { logger } from './src/util/logger';
 import { CompositionState } from './src/state/compositionState';
-import { Jump } from './src/state/globalState';
 
 let extensionContext: vscode.ExtensionContext;
 let previousActiveEditorId: EditorIdentity | null = null;
@@ -142,7 +142,7 @@ export async function activate(context: vscode.ExtensionContext) {
       fileName: toHandler.vimState.editor.document.fileName,
       position: toHandler.vimState.cursorPosition,
     });
-    toHandler.vimState.globalState.jumpHistory.jumpFiles(from, to);
+    toHandler.vimState.globalState.jumpTracker.recordFileJump(from, to);
   };
 
   // window events

--- a/extension.ts
+++ b/extension.ts
@@ -155,18 +155,8 @@ export async function activate(context: vscode.ExtensionContext) {
   });
 
   const recordFileJump = (fromHandler: ModeHandler | null, toHandler: ModeHandler) => {
-    const from = fromHandler
-      ? new Jump({
-          editor: fromHandler.vimState.editor,
-          fileName: fromHandler.vimState.editor.document.fileName,
-          position: fromHandler.vimState.cursorPosition,
-        })
-      : null;
-    const to = new Jump({
-      editor: toHandler.vimState.editor,
-      fileName: toHandler.vimState.editor.document.fileName,
-      position: toHandler.vimState.cursorPosition,
-    });
+    const from = fromHandler ? Jump.fromStateNow(fromHandler.vimState) : null;
+    const to = Jump.fromStateNow(toHandler.vimState);
 
     globalState.jumpTracker.recordFileJump(from, to);
   };

--- a/extension.ts
+++ b/extension.ts
@@ -129,18 +129,20 @@ export async function activate(context: vscode.ExtensionContext) {
     }
   });
 
-  const recordFileJump = (prevHandler, mh) => {
-    const from = prevHandler
+  const recordFileJump = (fromHandler: ModeHandler | null, toHandler: ModeHandler) => {
+    const from = fromHandler
       ? new Jump({
-          fileName: prevHandler.vimState.editor.document.fileName,
-          position: prevHandler.vimState.cursorPosition,
+          editor: fromHandler.vimState.editor,
+          fileName: fromHandler.vimState.editor.document.fileName,
+          position: fromHandler.vimState.cursorPosition,
         })
       : null;
     const to = new Jump({
-      fileName: mh.vimState.editor.document.fileName,
-      position: mh.vimState.cursorPosition,
+      editor: toHandler.vimState.editor,
+      fileName: toHandler.vimState.editor.document.fileName,
+      position: toHandler.vimState.cursorPosition,
     });
-    mh.vimState.globalState.jumpHistory.jumpFiles(from, to);
+    toHandler.vimState.globalState.jumpHistory.jumpFiles(from, to);
   };
 
   // window events

--- a/extension.ts
+++ b/extension.ts
@@ -176,7 +176,7 @@ export async function activate(context: vscode.ExtensionContext) {
 
         await mh.updateView(mh.vimState, { drawSelection: false, revealRange: false });
 
-        globalState.jumpTracker.recordFileJump(
+        globalState.jumpTracker.handleFileJump(
           mhPrevious ? Jump.fromStateNow(mhPrevious.vimState) : null,
           Jump.fromStateNow(mh.vimState)
         );

--- a/extension.ts
+++ b/extension.ts
@@ -375,6 +375,4 @@ function handleContentChangedFromDisk(document: vscode.TextDocument): void {
 
 process.on('unhandledRejection', function(reason: any, p: any) {
   logger.error(`Unhandled Rejection at: Promise ${p}. Reason: ${reason}.`);
-  // TODO: remove
-  throw reason;
 });

--- a/extension.ts
+++ b/extension.ts
@@ -87,8 +87,17 @@ export async function activate(context: vscode.ExtensionContext) {
       event.contentChanges[0].text === '' &&
       event.contentChanges[0].range.start.line !== event.contentChanges[0].range.end.line
     ) {
-      // This generally means content was deleted at the range provided.
       globalState.jumpTracker.handleTextDeleted(event.document, event.contentChanges[0].range);
+    } else if (
+      event.contentChanges.length === 1 &&
+      (event.contentChanges[0].text === '\n' || event.contentChanges[0].text === '\r\n') &&
+      event.contentChanges[0].range.start.line === event.contentChanges[0].range.end.line
+    ) {
+      globalState.jumpTracker.handleTextAdded(
+        event.document,
+        event.contentChanges[0].range,
+        event.contentChanges[0].text
+      );
     }
 
     // Change from vscode editor should set document.isDirty to true but they initially don't!

--- a/src/actions/base.ts
+++ b/src/actions/base.ts
@@ -10,6 +10,11 @@ export class BaseAction {
    */
   public isMotion = false;
 
+  /**
+   * If isJump is true, then the action will be added to the jump list on completion.
+   */
+  isJump = true;
+
   public canBeRepeatedWithDot = false;
 
   /**

--- a/src/actions/base.ts
+++ b/src/actions/base.ts
@@ -13,7 +13,7 @@ export class BaseAction {
   /**
    * If isJump is true, then the action will be added to the jump list on completion.
    */
-  isJump = true;
+  public isJump = false;
 
   public canBeRepeatedWithDot = false;
 

--- a/src/actions/base.ts
+++ b/src/actions/base.ts
@@ -11,7 +11,7 @@ export class BaseAction {
   public isMotion = false;
 
   /**
-   * If isJump is true, then the action will be added to the jump list on completion.
+   * If isJump is true, then the cursor position will be added to the jump list on completion.
    */
   public isJump = false;
 

--- a/src/actions/commands/actions.ts
+++ b/src/actions/commands/actions.ts
@@ -158,7 +158,7 @@ export abstract class BaseCommand extends BaseAction {
   isCompleteAction = true;
 
   /**
-   * If isJump is true, then the action will be added to the jump list on completion.
+   * If isJump is true, then the cursor position will be added to the jump list on completion.
    */
   isJump = false;
 

--- a/src/actions/commands/actions.ts
+++ b/src/actions/commands/actions.ts
@@ -2822,16 +2822,18 @@ abstract class ActionNavigateCommand extends BaseCommand {
   async handleFileJump(jump: Jump, vimState: VimState) {
     vimState.globalState.jumpTracker.isJumpingFiles = true;
 
-    // TODO: Check for editor closed also, probably won't work if it is closed
     if (jump.editor) {
+      // Open jump file from stored editor
       await vscode.window.showTextDocument(jump.editor.document);
     } else if (existsSync(jump.fileName)) {
+      // Open jump file from disk
       await new FileCommand({
         name: jump.fileName,
         lineNumber: jump.position.line,
         createFileIfNotExists: false,
       }).execute();
     } else {
+      // Get jump file from visible editors
       const editor: vscode.TextEditor = vscode.window.visibleTextEditors.filter(
         e => e.document.fileName === jump.fileName
       )[0];

--- a/src/actions/commands/actions.ts
+++ b/src/actions/commands/actions.ts
@@ -2884,7 +2884,7 @@ class CommandNavigateBack extends ActionNavigateCommand {
   }
 
   getJumpToNavigate(position: Position, vimState: VimState) {
-    return vimState.globalState.jumpTracker.back(Jump.fromStateNow(vimState));
+    return vimState.globalState.jumpTracker.jumpBack(Jump.fromStateNow(vimState));
   }
 }
 
@@ -2898,7 +2898,7 @@ class CommandNavigateForward extends ActionNavigateCommand {
   }
 
   getJumpToNavigate(position: Position, vimState: VimState) {
-    return vimState.globalState.jumpTracker.forward(Jump.fromStateNow(vimState));
+    return vimState.globalState.jumpTracker.jumpForward(Jump.fromStateNow(vimState));
   }
 }
 

--- a/src/actions/commands/actions.ts
+++ b/src/actions/commands/actions.ts
@@ -2866,7 +2866,13 @@ class CommandNavigateBack extends ActionNavigateCommand {
   }
 
   getJumpToNavigate(position: Position, vimState: VimState) {
-    return vimState.globalState.jumpHistory.back();
+    return vimState.globalState.jumpHistory.back(
+      new Jump({
+        editor: vimState.editor,
+        fileName: vimState.editor.document.fileName,
+        position: vimState.cursorPosition,
+      })
+    );
   }
 }
 
@@ -2880,7 +2886,13 @@ class CommandNavigateForward extends ActionNavigateCommand {
   }
 
   getJumpToNavigate(position: Position, vimState: VimState) {
-    return vimState.globalState.jumpHistory.forward();
+    return vimState.globalState.jumpHistory.forward(
+      new Jump({
+        editor: vimState.editor,
+        fileName: vimState.editor.document.fileName,
+        position: vimState.cursorPosition,
+      })
+    );
   }
 }
 

--- a/src/actions/commands/actions.ts
+++ b/src/actions/commands/actions.ts
@@ -23,8 +23,8 @@ import { RegisterAction } from './../base';
 import { BaseAction } from './../base';
 import { commandLine } from './../../cmd_line/commandLine';
 import * as operator from './../operator';
-import { Jump } from '../../state/globalState';
 import { existsSync } from 'fs';
+import { Jump } from '../../jumps/jump';
 
 export class DocumentContentChangeAction extends BaseAction {
   contentChanges: {
@@ -2828,7 +2828,7 @@ abstract class ActionNavigateCommand extends BaseCommand {
     }
 
     if (jump.fileName !== vimState.editor.document.fileName) {
-      vimState.globalState.jumpHistory.isJumpingFiles = true;
+      vimState.globalState.jumpTracker.isJumpingFiles = true;
 
       // TODO: Check for editor closed also, probably won't work if it is closed
       if (jump.editor) {
@@ -2866,7 +2866,7 @@ class CommandNavigateBack extends ActionNavigateCommand {
   }
 
   getJumpToNavigate(position: Position, vimState: VimState) {
-    return vimState.globalState.jumpHistory.back(
+    return vimState.globalState.jumpTracker.back(
       new Jump({
         editor: vimState.editor,
         fileName: vimState.editor.document.fileName,
@@ -2886,7 +2886,7 @@ class CommandNavigateForward extends ActionNavigateCommand {
   }
 
   getJumpToNavigate(position: Position, vimState: VimState) {
-    return vimState.globalState.jumpHistory.forward(
+    return vimState.globalState.jumpTracker.forward(
       new Jump({
         editor: vimState.editor,
         fileName: vimState.editor.document.fileName,

--- a/src/actions/commands/actions.ts
+++ b/src/actions/commands/actions.ts
@@ -24,6 +24,7 @@ import { BaseAction } from './../base';
 import { commandLine } from './../../cmd_line/commandLine';
 import * as operator from './../operator';
 import { Jump } from '../../state/globalState';
+import { existsSync } from 'fs';
 
 export class DocumentContentChangeAction extends BaseAction {
   contentChanges: {
@@ -2825,15 +2826,21 @@ abstract class ActionNavigateCommand extends BaseCommand {
     }
 
     if (jump.fileName !== vimState.editor.document.fileName) {
-      vimState.globalState.jumpHistory.isJumpingFiles = true;
+      // TODO - what about newly created files?
+      if (existsSync(jump.fileName)) {
+        vimState.globalState.jumpHistory.isJumpingFiles = true;
 
-      const fileCommand = new FileCommand({
-        name: jump.fileName,
-        lineNumber: jump.position.line,
-        createFileIfNotExists: false,
-      });
-      fileCommand.execute();
-      return vimState;
+        const fileCommand = new FileCommand({
+          name: jump.fileName,
+          lineNumber: jump.position.line,
+          createFileIfNotExists: false,
+        });
+        fileCommand.execute();
+        return vimState;
+      } else {
+        // Skip to next jump
+        await this.exec(position, vimState);
+      }
     }
 
     vimState.cursorPosition = jump.position;

--- a/src/actions/commands/actions.ts
+++ b/src/actions/commands/actions.ts
@@ -444,7 +444,6 @@ class CommandExecuteMacro extends BaseCommand {
   keys = ['@', '<character>'];
   runsOnceForEachCountPrefix = true;
   canBeRepeatedWithDot = true;
-  isJump = true;
 
   public async exec(position: Position, vimState: VimState): Promise<VimState> {
     const register = this.keysPressed[1];

--- a/src/actions/commands/actions.ts
+++ b/src/actions/commands/actions.ts
@@ -848,6 +848,8 @@ class CommandReplaceInReplaceMode extends BaseCommand {
 class CommandInsertInSearchMode extends BaseCommand {
   modes = [ModeName.SearchInProgressMode];
   keys = [['<character>'], ['<up>'], ['<down>'], ['<C-h>']];
+  isJump = true;
+
   runsOnceForEveryCursor() {
     return this.keysPressed[0] === '\n';
   }

--- a/src/actions/commands/actions.ts
+++ b/src/actions/commands/actions.ts
@@ -159,7 +159,7 @@ export abstract class BaseCommand extends BaseAction {
   /**
    * If isJump is true, then the action will be added to the jump list on completion.
    */
-  isJump = true;
+  isJump = false;
 
   multicursorIndex: number | undefined = undefined;
 
@@ -286,7 +286,6 @@ export class CommandNumber extends BaseCommand {
   modes = [ModeName.Normal, ModeName.Visual, ModeName.VisualLine, ModeName.VisualBlock];
   keys = ['<number>'];
   isCompleteAction = false;
-  isJump = false;
   runsOnceForEveryCursor() {
     return false;
   }
@@ -444,6 +443,7 @@ class CommandExecuteMacro extends BaseCommand {
   keys = ['@', '<character>'];
   runsOnceForEachCountPrefix = true;
   canBeRepeatedWithDot = true;
+  isJump = true;
 
   public async exec(position: Position, vimState: VimState): Promise<VimState> {
     const register = this.keysPressed[1];
@@ -479,6 +479,7 @@ class CommandExecuteLastMacro extends BaseCommand {
   keys = ['@', '@'];
   runsOnceForEachCountPrefix = true;
   canBeRepeatedWithDot = true;
+  isJump = true;
 
   public async exec(position: Position, vimState: VimState): Promise<VimState> {
     let lastInvokedMacro = vimState.historyTracker.lastInvokedMacro;
@@ -1145,6 +1146,7 @@ class CommandSearchCurrentWordExactForward extends BaseCommand {
   keys = ['*'];
   isMotion = true;
   runsOnceForEachCountPrefix = true;
+  isJump = true;
 
   public async exec(position: Position, vimState: VimState): Promise<VimState> {
     return searchCurrentWord(position, vimState, SearchDirection.Forward, true);
@@ -1157,6 +1159,7 @@ class CommandSearchCurrentWordForward extends BaseCommand {
   keys = ['g', '*'];
   isMotion = true;
   runsOnceForEachCountPrefix = true;
+  isJump = true;
 
   public async exec(position: Position, vimState: VimState): Promise<VimState> {
     return searchCurrentWord(position, vimState, SearchDirection.Forward, false);
@@ -1169,6 +1172,7 @@ class CommandSearchVisualForward extends BaseCommand {
   keys = ['*'];
   isMotion = true;
   runsOnceForEachCountPrefix = true;
+  isJump = true;
 
   public async exec(position: Position, vimState: VimState): Promise<VimState> {
     if (configuration.visualstar) {
@@ -1185,6 +1189,7 @@ class CommandSearchCurrentWordExactBackward extends BaseCommand {
   keys = ['#'];
   isMotion = true;
   runsOnceForEachCountPrefix = true;
+  isJump = true;
 
   public async exec(position: Position, vimState: VimState): Promise<VimState> {
     return searchCurrentWord(position, vimState, SearchDirection.Backward, true);
@@ -1197,6 +1202,7 @@ class CommandSearchCurrentWordBackward extends BaseCommand {
   keys = ['g', '#'];
   isMotion = true;
   runsOnceForEachCountPrefix = true;
+  isJump = true;
 
   public async exec(position: Position, vimState: VimState): Promise<VimState> {
     return searchCurrentWord(position, vimState, SearchDirection.Backward, false);
@@ -1209,6 +1215,7 @@ class CommandSearchVisualBackward extends BaseCommand {
   keys = ['#'];
   isMotion = true;
   runsOnceForEachCountPrefix = true;
+  isJump = true;
 
   public async exec(position: Position, vimState: VimState): Promise<VimState> {
     if (configuration.visualstar) {
@@ -1224,6 +1231,7 @@ export class CommandSearchForwards extends BaseCommand {
   modes = [ModeName.Normal, ModeName.Visual, ModeName.VisualLine, ModeName.VisualBlock];
   keys = ['/'];
   isMotion = true;
+  isJump = true;
 
   public async exec(position: Position, vimState: VimState): Promise<VimState> {
     vimState.globalState.searchState = new SearchState(
@@ -1249,6 +1257,7 @@ export class CommandSearchBackwards extends BaseCommand {
   modes = [ModeName.Normal, ModeName.Visual, ModeName.VisualLine, ModeName.VisualBlock];
   keys = ['?'];
   isMotion = true;
+  isJump = true;
 
   public async exec(position: Position, vimState: VimState): Promise<VimState> {
     vimState.globalState.searchState = new SearchState(
@@ -2193,6 +2202,7 @@ class CommandBottomScrollFirstChar extends BaseCommand {
 class CommandGoToOtherEndOfHighlightedText extends BaseCommand {
   modes = [ModeName.Visual, ModeName.VisualLine, ModeName.VisualBlock];
   keys = ['o'];
+  isJump = true;
 
   public async exec(position: Position, vimState: VimState): Promise<VimState> {
     [vimState.cursorStartPosition, vimState.cursorPosition] = [
@@ -2522,6 +2532,7 @@ class CommandExitVisualLineMode extends BaseCommand {
 class CommandOpenFile extends BaseCommand {
   modes = [ModeName.Normal, ModeName.Visual];
   keys = ['g', 'f'];
+  isJump = true;
 
   public async exec(position: Position, vimState: VimState): Promise<VimState> {
     let fullFilePath: string = '';
@@ -2557,6 +2568,7 @@ class CommandOpenFile extends BaseCommand {
 class CommandGoToDefinition extends BaseCommand {
   modes = [ModeName.Normal];
   keys = [['g', 'd'], ['<C-]>']];
+  isJump = true;
 
   public async exec(position: Position, vimState: VimState): Promise<VimState> {
     const oldActiveEditor = vimState.editor;
@@ -2575,6 +2587,7 @@ class CommandGoToDefinition extends BaseCommand {
 class CommandGoBackInChangelist extends BaseCommand {
   modes = [ModeName.Normal];
   keys = ['g', ';'];
+  isJump = true;
 
   public async exec(position: Position, vimState: VimState): Promise<VimState> {
     const originalIndex = vimState.historyTracker.changelistIndex;
@@ -2596,6 +2609,7 @@ class CommandGoBackInChangelist extends BaseCommand {
 class CommandGoForwardInChangelist extends BaseCommand {
   modes = [ModeName.Normal];
   keys = ['g', ','];
+  isJump = true;
 
   public async exec(position: Position, vimState: VimState): Promise<VimState> {
     const originalIndex = vimState.historyTracker.changelistIndex;
@@ -2617,6 +2631,7 @@ class CommandGoForwardInChangelist extends BaseCommand {
 class CommandGoLastChange extends BaseCommand {
   modes = [ModeName.Normal];
   keys = [['`', '.'], ["'", '.']];
+  isJump = true;
 
   public async exec(position: Position, vimState: VimState): Promise<VimState> {
     const lastPos = vimState.historyTracker.getLastHistoryStartPosition();
@@ -2810,6 +2825,8 @@ abstract class ActionNavigateCommand extends BaseCommand {
     }
 
     if (jump.fileName !== vimState.editor.document.fileName) {
+      vimState.globalState.jumpHistory.isJumpingFiles = true;
+
       const fileCommand = new FileCommand({
         name: jump.fileName,
         lineNumber: jump.position.line,
@@ -2828,7 +2845,6 @@ abstract class ActionNavigateCommand extends BaseCommand {
 class CommandNavigateBack extends ActionNavigateCommand {
   modes = [ModeName.Normal];
   keys = [['<C-o>'], ['<C-t>']];
-  isJump = false;
 
   runsOnceForEveryCursor() {
     return false;
@@ -2843,7 +2859,6 @@ class CommandNavigateBack extends ActionNavigateCommand {
 class CommandNavigateForward extends ActionNavigateCommand {
   modes = [ModeName.Normal];
   keys = ['<C-i>'];
-  isJump = false;
 
   runsOnceForEveryCursor() {
     return false;
@@ -2861,6 +2876,7 @@ class CommandNavigateLast extends BaseCommand {
   runsOnceForEveryCursor() {
     return false;
   }
+  isJump = true;
 
   public async exec(position: Position, vimState: VimState): Promise<VimState> {
     const oldActiveEditor = vimState.editor;
@@ -2882,6 +2898,7 @@ class CommandNavigateLastBOL extends BaseCommand {
   runsOnceForEveryCursor() {
     return false;
   }
+  isJump = true;
 
   public async exec(position: Position, vimState: VimState): Promise<VimState> {
     const oldActiveEditor = vimState.editor;
@@ -2925,6 +2942,7 @@ class CommandOnly extends BaseCommand {
 class MoveToRightPane extends BaseCommand {
   modes = [ModeName.Normal, ModeName.Visual, ModeName.VisualLine];
   keys = [['<C-w>', 'l'], ['<C-w>', '<right>'], ['<C-w l>'], ['<C-w>', '<C-l>']];
+  isJump = true;
 
   public async exec(position: Position, vimState: VimState): Promise<VimState> {
     vimState.postponedCodeViewChanges.push({
@@ -2940,6 +2958,7 @@ class MoveToRightPane extends BaseCommand {
 class MoveToLowerPane extends BaseCommand {
   modes = [ModeName.Normal, ModeName.Visual, ModeName.VisualLine];
   keys = [['<C-w>', 'j'], ['<C-w>', '<down>'], ['<C-w j>'], ['<C-w>', '<C-j>']];
+  isJump = true;
 
   public async exec(position: Position, vimState: VimState): Promise<VimState> {
     vimState.postponedCodeViewChanges.push({
@@ -2955,6 +2974,7 @@ class MoveToLowerPane extends BaseCommand {
 class MoveToUpperPane extends BaseCommand {
   modes = [ModeName.Normal, ModeName.Visual, ModeName.VisualLine];
   keys = [['<C-w>', 'k'], ['<C-w>', '<up>'], ['<C-w k>'], ['<C-w>', '<C-k>']];
+  isJump = true;
 
   public async exec(position: Position, vimState: VimState): Promise<VimState> {
     vimState.postponedCodeViewChanges.push({
@@ -2970,6 +2990,7 @@ class MoveToUpperPane extends BaseCommand {
 class MoveToLeftPane extends BaseCommand {
   modes = [ModeName.Normal, ModeName.Visual, ModeName.VisualLine];
   keys = [['<C-w>', 'h'], ['<C-w>', '<left>'], ['<C-w h>'], ['<C-w>', '<C-h>']];
+  isJump = true;
 
   public async exec(position: Position, vimState: VimState): Promise<VimState> {
     vimState.postponedCodeViewChanges.push({
@@ -2985,6 +3006,7 @@ class MoveToLeftPane extends BaseCommand {
 class CycleThroughPanes extends BaseCommand {
   modes = [ModeName.Normal, ModeName.Visual, ModeName.VisualLine];
   keys = [['<C-w>', '<C-w>'], ['<C-w>', 'w']];
+  isJump = true;
 
   public async exec(position: Position, vimState: VimState): Promise<VimState> {
     vimState.postponedCodeViewChanges.push({

--- a/src/actions/commands/actions.ts
+++ b/src/actions/commands/actions.ts
@@ -2846,7 +2846,16 @@ abstract class ActionNavigateCommand extends BaseCommand {
   }
 
   public async exec(position: Position, vimState: VimState): Promise<VimState> {
-    const jump = this.getJumpToNavigate(position, vimState);
+    let jump = new Jump({
+      editor: vimState.editor,
+      fileName: vimState.editor.document.fileName,
+      position,
+    });
+
+    const iterations = vimState.recordedState.count || 1;
+    for (var i = 0; i < iterations; i++) {
+      jump = this.getJumpToNavigate(position, vimState);
+    }
 
     if (!jump) {
       return vimState;

--- a/src/actions/commands/actions.ts
+++ b/src/actions/commands/actions.ts
@@ -2884,13 +2884,7 @@ class CommandNavigateBack extends ActionNavigateCommand {
   }
 
   getJumpToNavigate(position: Position, vimState: VimState) {
-    return vimState.globalState.jumpTracker.back(
-      new Jump({
-        editor: vimState.editor,
-        fileName: vimState.editor.document.fileName,
-        position: vimState.cursorPosition,
-      })
-    );
+    return vimState.globalState.jumpTracker.back(Jump.fromStateNow(vimState));
   }
 }
 
@@ -2904,13 +2898,7 @@ class CommandNavigateForward extends ActionNavigateCommand {
   }
 
   getJumpToNavigate(position: Position, vimState: VimState) {
-    return vimState.globalState.jumpTracker.forward(
-      new Jump({
-        editor: vimState.editor,
-        fileName: vimState.editor.document.fileName,
-        position: vimState.cursorPosition,
-      })
-    );
+    return vimState.globalState.jumpTracker.forward(Jump.fromStateNow(vimState));
   }
 }
 

--- a/src/actions/motion.ts
+++ b/src/actions/motion.ts
@@ -54,7 +54,7 @@ export abstract class BaseMovement extends BaseAction {
   isMotion = true;
 
   /**
-   * If isJump is true, then the action will be added to the jump list on completion.
+   * If isJump is true, then the cursor position will be added to the jump list on completion.
    *
    * Default to false, as many motions operate on a single line and do not count as a jump.
    */

--- a/src/actions/motion.ts
+++ b/src/actions/motion.ts
@@ -295,6 +295,7 @@ class MoveDownFoldFix extends MoveByScreenLineMaintainDesiredColumn {
 class MoveDown extends BaseMovement {
   keys = ['j'];
   doesntChangeDesiredColumn = true;
+  isJump = false;
 
   public async execAction(position: Position, vimState: VimState): Promise<Position | IMovement> {
     if (configuration.foldfix && vimState.currentMode !== ModeName.VisualBlock) {
@@ -324,6 +325,7 @@ class MoveUpByScreenLineMaintainDesiredColumn extends MoveByScreenLineMaintainDe
 class MoveUp extends BaseMovement {
   keys = ['k'];
   doesntChangeDesiredColumn = true;
+  isJump = false;
 
   public async execAction(position: Position, vimState: VimState): Promise<Position | IMovement> {
     if (configuration.foldfix && vimState.currentMode !== ModeName.VisualBlock) {

--- a/src/actions/motion.ts
+++ b/src/actions/motion.ts
@@ -981,6 +981,7 @@ class MoveScreenToLeftHalf extends MoveByScreenLine {
   movementType: CursorMovePosition = 'left';
   by: CursorMoveByUnit = 'halfLine';
   value = 1;
+  isJump = true;
 
   public doesActionApply(vimState: VimState, keysPressed: string[]): boolean {
     // Don't run if there's an operator because the Sneak plugin uses <operator>z
@@ -996,6 +997,7 @@ class MoveToLineFromViewPortTop extends MoveByScreenLine {
   movementType: CursorMovePosition = 'viewPortTop';
   by: CursorMoveByUnit = 'line';
   value = 1;
+  isJump = true;
 
   public async execActionWithCount(
     position: Position,
@@ -1013,6 +1015,7 @@ class MoveToLineFromViewPortBottom extends MoveByScreenLine {
   movementType: CursorMovePosition = 'viewPortBottom';
   by: CursorMoveByUnit = 'line';
   value = 1;
+  isJump = true;
 
   public async execActionWithCount(
     position: Position,
@@ -1029,6 +1032,7 @@ class MoveToMiddleLineInViewPort extends MoveByScreenLine {
   keys = ['M'];
   movementType: CursorMovePosition = 'viewPortCenter';
   by: CursorMoveByUnit = 'line';
+  isJump = true;
 }
 
 @RegisterAction

--- a/src/actions/motion.ts
+++ b/src/actions/motion.ts
@@ -48,6 +48,13 @@ export abstract class BaseMovement extends BaseAction {
   isMotion = true;
 
   /**
+   * If isJump is true, then the action will be added to the jump list on completion.
+   *
+   * Default to false, as many motions operate on a single line and do not count as a jump.
+   */
+  isJump = false;
+
+  /**
    * If movement can be repeated with semicolon or comma this will be true when
    * running the repetition.
    */
@@ -295,7 +302,6 @@ class MoveDownFoldFix extends MoveByScreenLineMaintainDesiredColumn {
 class MoveDown extends BaseMovement {
   keys = ['j'];
   doesntChangeDesiredColumn = true;
-  isJump = false;
 
   public async execAction(position: Position, vimState: VimState): Promise<Position | IMovement> {
     if (configuration.foldfix && vimState.currentMode !== ModeName.VisualBlock) {
@@ -325,7 +331,6 @@ class MoveUpByScreenLineMaintainDesiredColumn extends MoveByScreenLineMaintainDe
 class MoveUp extends BaseMovement {
   keys = ['k'];
   doesntChangeDesiredColumn = true;
-  isJump = false;
 
   public async execAction(position: Position, vimState: VimState): Promise<Position | IMovement> {
     if (configuration.foldfix && vimState.currentMode !== ModeName.VisualBlock) {
@@ -1238,6 +1243,7 @@ class MoveBeginningFullWord extends BaseMovement {
 @RegisterAction
 class MovePreviousSentenceBegin extends BaseMovement {
   keys = ['('];
+  isJump = true;
 
   public async execAction(position: Position, vimState: VimState): Promise<Position> {
     return position.getSentenceBegin({ forward: false });
@@ -1247,6 +1253,7 @@ class MovePreviousSentenceBegin extends BaseMovement {
 @RegisterAction
 class MoveNextSentenceBegin extends BaseMovement {
   keys = [')'];
+  isJump = true;
 
   public async execAction(position: Position, vimState: VimState): Promise<Position> {
     return position.getSentenceBegin({ forward: true });
@@ -1256,6 +1263,7 @@ class MoveNextSentenceBegin extends BaseMovement {
 @RegisterAction
 class MoveParagraphEnd extends BaseMovement {
   keys = ['}'];
+  isJump = true;
 
   public async execAction(position: Position, vimState: VimState): Promise<Position> {
     const isLineWise =
@@ -1273,6 +1281,7 @@ class MoveParagraphEnd extends BaseMovement {
 @RegisterAction
 class MoveParagraphBegin extends BaseMovement {
   keys = ['{'];
+  isJump = true;
 
   public async execAction(position: Position, vimState: VimState): Promise<Position> {
     return position.getCurrentParagraphBeginning();
@@ -1283,6 +1292,7 @@ abstract class MoveSectionBoundary extends BaseMovement {
   modes = [ModeName.Normal, ModeName.Visual, ModeName.VisualLine];
   boundary: string;
   forward: boolean;
+  isJump = true;
 
   public async execAction(position: Position, vimState: VimState): Promise<Position> {
     return position.getSectionBoundary({
@@ -1323,6 +1333,7 @@ class MovePreviousSectionEnd extends MoveSectionBoundary {
 @RegisterAction
 class MoveToMatchingBracket extends BaseMovement {
   keys = ['%'];
+  isJump = true;
 
   public async execAction(position: Position, vimState: VimState): Promise<Position | IMovement> {
     position = position.getLeftIfEOL();
@@ -1407,6 +1418,7 @@ export abstract class MoveInsideCharacter extends BaseMovement {
   modes = [ModeName.Normal, ModeName.Visual, ModeName.VisualLine, ModeName.VisualBlock];
   protected charToMatch: string;
   protected includeSurrounding = false;
+  isJump = true;
 
   public async execAction(position: Position, vimState: VimState): Promise<IMovement> {
     const failure = { start: position, stop: position, failed: true };
@@ -1610,6 +1622,7 @@ export abstract class MoveQuoteMatch extends BaseMovement {
   modes = [ModeName.Normal, ModeName.Visual, ModeName.VisualBlock];
   protected charToMatch: string;
   protected includeSurrounding = false;
+  isJump = true;
 
   public async execAction(position: Position, vimState: VimState): Promise<IMovement> {
     const text = TextEditor.getLineAt(position).text;
@@ -1803,6 +1816,7 @@ class MoveToUnclosedCurlyBracketForward extends MoveToMatchingBracket {
 abstract class MoveTagMatch extends BaseMovement {
   modes = [ModeName.Normal, ModeName.Visual, ModeName.VisualBlock];
   protected includeTag = false;
+  isJump = true;
 
   public async execAction(position: Position, vimState: VimState): Promise<IMovement> {
     const editorText = TextEditor.getText();

--- a/src/actions/motion.ts
+++ b/src/actions/motion.ts
@@ -428,6 +428,7 @@ class RightArrowInReplaceMode extends ArrowsInReplaceMode {
 @RegisterAction
 class CommandNextSearchMatch extends BaseMovement {
   keys = ['n'];
+  isJump = true;
 
   public async execAction(position: Position, vimState: VimState): Promise<Position> {
     const searchState = vimState.globalState.searchState;
@@ -451,6 +452,7 @@ class CommandNextSearchMatch extends BaseMovement {
 @RegisterAction
 class CommandPreviousSearchMatch extends BaseMovement {
   keys = ['N'];
+  isJump = true;
 
   public async execAction(position: Position, vimState: VimState): Promise<Position> {
     const searchState = vimState.globalState.searchState;

--- a/src/actions/motion.ts
+++ b/src/actions/motion.ts
@@ -471,6 +471,7 @@ class CommandPreviousSearchMatch extends BaseMovement {
 @RegisterAction
 export class MarkMovementBOL extends BaseMovement {
   keys = ["'", '<character>'];
+  isJump = true;
 
   public async execAction(position: Position, vimState: VimState): Promise<Position> {
     const markName = this.keysPressed[1];
@@ -485,6 +486,7 @@ export class MarkMovementBOL extends BaseMovement {
 @RegisterAction
 export class MarkMovement extends BaseMovement {
   keys = ['`', '<character>'];
+  isJump = true;
 
   public async execAction(position: Position, vimState: VimState): Promise<Position> {
     const markName = this.keysPressed[1];

--- a/src/actions/motion.ts
+++ b/src/actions/motion.ts
@@ -1059,6 +1059,7 @@ class MoveNextLineNonBlank extends BaseMovement {
 @RegisterAction
 class MoveNonBlankFirst extends BaseMovement {
   keys = ['g', 'g'];
+  isJump = true;
 
   public async execActionWithCount(
     position: Position,
@@ -1076,6 +1077,7 @@ class MoveNonBlankFirst extends BaseMovement {
 @RegisterAction
 class MoveNonBlankLast extends BaseMovement {
   keys = ['G'];
+  isJump = true;
 
   public async execActionWithCount(
     position: Position,

--- a/src/cmd_line/commands/substitute.ts
+++ b/src/cmd_line/commands/substitute.ts
@@ -133,7 +133,8 @@ export class SubstituteCommand extends node.CommandBase {
               editor: vimState.editor,
               fileName: vimState.editor.document.fileName,
               position: new Position(line, 0),
-            })
+            }),
+            Jump.fromStateNow(vimState)
           );
         }
         matchPos += match.length;
@@ -149,7 +150,8 @@ export class SubstituteCommand extends node.CommandBase {
           editor: vimState.editor,
           fileName: vimState.editor.document.fileName,
           position: new Position(line, 0),
-        })
+        }),
+        Jump.fromStateNow(vimState)
       );
     }
   }

--- a/src/cmd_line/commands/substitute.ts
+++ b/src/cmd_line/commands/substitute.ts
@@ -129,7 +129,6 @@ export class SubstituteCommand extends node.CommandBase {
           );
 
           vimState.globalState.jumpTracker.recordJump(
-            null,
             new Jump({
               editor: vimState.editor,
               fileName: vimState.editor.document.fileName,
@@ -146,7 +145,6 @@ export class SubstituteCommand extends node.CommandBase {
       );
 
       vimState.globalState.jumpTracker.recordJump(
-        null,
         new Jump({
           editor: vimState.editor,
           fileName: vimState.editor.document.fileName,

--- a/src/cmd_line/commands/substitute.ts
+++ b/src/cmd_line/commands/substitute.ts
@@ -8,6 +8,8 @@ import { VimError, ErrorCode } from '../../error';
 import { TextEditor } from '../../textEditor';
 import { configuration } from '../../configuration/configuration';
 import { Decoration } from '../../configuration/decoration';
+import { Jump } from '../../jumps/jump';
+import { Position } from '../../common/motion/position';
 
 export interface ISubstituteCommandArguments extends node.ICommandArgs {
   pattern: string;
@@ -125,6 +127,15 @@ export class SubstituteCommand extends node.CommandBase {
             new vscode.Range(line, 0, line, originalContent.length),
             newContent
           );
+
+          vimState.globalState.jumpTracker.recordJump(
+            null,
+            new Jump({
+              editor: vimState.editor,
+              fileName: vimState.editor.document.fileName,
+              position: new Position(line, 0),
+            })
+          );
         }
         matchPos += match.length;
       }
@@ -132,6 +143,15 @@ export class SubstituteCommand extends node.CommandBase {
       await TextEditor.replace(
         new vscode.Range(line, 0, line, originalContent.length),
         originalContent.replace(regex, this._arguments.replace)
+      );
+
+      vimState.globalState.jumpTracker.recordJump(
+        null,
+        new Jump({
+          editor: vimState.editor,
+          fileName: vimState.editor.document.fileName,
+          position: new Position(line, 0),
+        })
       );
     }
   }

--- a/src/jumps/jump.ts
+++ b/src/jumps/jump.ts
@@ -1,0 +1,53 @@
+import * as vscode from "vscode";
+
+import { Position } from "../common/motion/position";
+
+/**
+ * Represents a Jump in the JumpTracker.
+ * Includes information necessary to determine jump actions, and to
+ * be able to open the related file.
+ */
+export class Jump {
+  public editor: vscode.TextEditor;
+  public fileName: string;
+  public position: Position;
+
+  /**
+   *
+   * @param options
+   * @param options.editor - The editor associated with the jump.
+   * @param options.fileName - The absolute or relative file path.
+   * @param options.position - The line and column number information.
+   */
+  constructor({
+    editor,
+    fileName,
+    position,
+  }: {
+    editor: vscode.TextEditor;
+    fileName: string;
+    position: Position;
+  }) {
+    if (!fileName) {
+      throw new Error("fileName is required for Jumps");
+    }
+    this.editor = editor;
+    // TODO - can we just always require editor and get filename from it?
+    this.fileName = fileName;
+    this.position = position;
+  }
+
+  /**
+   * Determine whether another jump matches the same file path and line number,
+   * regardless of whether the column numbers match.
+   *
+   * @param other - Another Jump to compare against
+   */
+  public onSameLine(other: Jump | null | undefined): boolean {
+    return (
+      !other ||
+      (this.fileName === other.fileName &&
+        this.position.line === other.position.line)
+    );
+  }
+}

--- a/src/jumps/jump.ts
+++ b/src/jumps/jump.ts
@@ -1,6 +1,7 @@
-import * as vscode from "vscode";
+import * as vscode from 'vscode';
 
-import { Position } from "../common/motion/position";
+import { Position } from '../common/motion/position';
+import { VimState } from '../state/vimState';
 
 /**
  * Represents a Jump in the JumpTracker.
@@ -29,12 +30,24 @@ export class Jump {
     position: Position;
   }) {
     if (!fileName) {
-      throw new Error("fileName is required for Jumps");
+      throw new Error('fileName is required for Jumps');
     }
     this.editor = editor;
     // TODO - can we just always require editor and get filename from it?
     this.fileName = fileName;
     this.position = position;
+  }
+
+  /**
+   * Factory method for creating a Jump from a VimState.
+   * @param vimState - State that contains the fileName and position for the jump
+   */
+  static fromState(vimState: VimState) {
+    return new Jump({
+      editor: vimState.editor,
+      fileName: vimState.editor.document.fileName,
+      position: vimState.cursorPosition,
+    });
   }
 
   /**
@@ -45,9 +58,7 @@ export class Jump {
    */
   public onSameLine(other: Jump | null | undefined): boolean {
     return (
-      !other ||
-      (this.fileName === other.fileName &&
-        this.position.line === other.position.line)
+      !other || (this.fileName === other.fileName && this.position.line === other.position.line)
     );
   }
 }

--- a/src/jumps/jump.ts
+++ b/src/jumps/jump.ts
@@ -5,8 +5,8 @@ import { VimState } from '../state/vimState';
 
 /**
  * Represents a Jump in the JumpTracker.
- * Includes information necessary to determine jump actions, and to
- * be able to open the related file.
+ * Includes information necessary to determine jump actions,
+ * and to be able to open the related file.
  */
 export class Jump {
   public editor: vscode.TextEditor | null;

--- a/src/jumps/jump.ts
+++ b/src/jumps/jump.ts
@@ -9,7 +9,7 @@ import { VimState } from '../state/vimState';
  * be able to open the related file.
  */
 export class Jump {
-  public editor: vscode.TextEditor;
+  public editor: vscode.TextEditor | null;
   public fileName: string;
   public position: Position;
 
@@ -25,15 +25,11 @@ export class Jump {
     fileName,
     position,
   }: {
-    editor: vscode.TextEditor;
+    editor: vscode.TextEditor | null;
     fileName: string;
     position: Position;
   }) {
-    if (!fileName) {
-      throw new Error('fileName is required for Jumps');
-    }
     this.editor = editor;
-    // TODO - can we just always require editor and get filename from it?
     this.fileName = fileName;
     this.position = position;
   }

--- a/src/jumps/jump.ts
+++ b/src/jumps/jump.ts
@@ -35,14 +35,27 @@ export class Jump {
   }
 
   /**
-   * Factory method for creating a Jump from a VimState.
+   * Factory method for creating a Jump from a VimState's current cursor position.
    * @param vimState - State that contains the fileName and position for the jump
    */
-  static fromState(vimState: VimState) {
+  static fromStateNow(vimState: VimState) {
     return new Jump({
       editor: vimState.editor,
       fileName: vimState.editor.document.fileName,
       position: vimState.cursorPosition,
+    });
+  }
+
+  /**
+   * Factory method for creating a Jump from a VimState's cursor position,
+   * before any actions or commands were performed.
+   * @param vimState - State that contains the fileName and prior position for the jump
+   */
+  static fromStateBefore(vimState: VimState) {
+    return new Jump({
+      editor: vimState.editor,
+      fileName: vimState.editor.document.fileName,
+      position: vimState.cursorPositionJustBeforeAnythingHappened[0],
     });
   }
 

--- a/src/jumps/jumpTracker.ts
+++ b/src/jumps/jumpTracker.ts
@@ -1,0 +1,149 @@
+import { Jump } from "./jump";
+
+/**
+ * JumpTracker is a handrolled version of vscode's TextEditorState
+ * in relation to the 'workbench.action.navigateBack' command.
+ */
+export class JumpTracker {
+  public isJumpingFiles = false;
+
+  private jumps: Jump[] = [];
+  private currentJumpIndex = 0;
+
+  /**
+   * Record that a jump occurred from one file to another.
+   * This is likely only needed on a handler for
+   * vscode.window.onDidChangeActiveTextEditor
+   *
+   * File jumps have extra checks in place, keeping in mind
+   * whether this plugin initiated the jump, whether the new file is
+   * a legitimate file.
+   *
+   * @param from - File/position jumped from
+   * @param to - File/position jumped to
+   */
+  public recordFileJump(from: Jump | null, to: Jump) {
+    if (this.isJumpingFiles) {
+      this.isJumpingFiles = false;
+      return;
+    }
+
+    if (to.editor.document.isClosed) {
+      // Wallaby.js seemed to be adding an extra file jump, named e.g. extension-output-#4
+      // It was marked closed when jumping to it. Hopefully we can rely on checking isClosed
+      // when extensions get all weird on us.
+      return;
+    }
+
+    if (from && from.fileName === to.fileName) {
+      return;
+    }
+
+    if (this.currentJumpIndex < this.jumps.length - 1) {
+      this.clearJumpsAftercurrentJumpIndex();
+    }
+
+    if (from) {
+      this.jumps.push(from);
+    }
+    this.jumps.push(to);
+
+    this.currentJumpIndex = this.jumps.length - 1;
+  }
+
+  /**
+   * Record that a jump occurred.
+   *
+   * If the current position is back in history,
+   * jumps after this position will be removed.
+   *
+   * @param from - File/position jumped from
+   * @param to - File/position jumped to
+   */
+  public recordJump(from: Jump | null, to: Jump) {
+    const previousJump = this.jumps[this.currentJumpIndex - 1];
+    const currentJump = this.jumps[this.currentJumpIndex];
+    const nextJump = this.jumps[this.currentJumpIndex + 1];
+
+    if (previousJump && previousJump.onSameLine(to)) {
+      this.currentJumpIndex -= 1;
+      return;
+    }
+
+    if (currentJump && currentJump.onSameLine(to)) {
+      this.replaceCurrentJump(to);
+      return;
+    }
+
+    if (nextJump && nextJump.onSameLine(to)) {
+      this.currentJumpIndex += 1;
+      return;
+    }
+
+    if (this.currentJumpIndex < this.jumps.length - 1) {
+      this.clearJumpsAftercurrentJumpIndex();
+    }
+
+    if (from && !from.onSameLine(currentJump) && !from.onSameLine(to)) {
+      this.jumps.push(from);
+    }
+    this.jumps.push(to);
+
+    this.currentJumpIndex = this.jumps.length - 1;
+  }
+
+  /**
+   * Get the previous jump in history.
+   * Continues further back if the current line is on the same line.
+   *
+   * @param from - File/position jumped from
+   */
+  public back(from: Jump): Jump {
+    if (this.currentJumpIndex <= 0) {
+      return this.jumps[0];
+    }
+
+    this.currentJumpIndex = this.currentJumpIndex - 1;
+    const jump = this.jumps[this.currentJumpIndex];
+
+    if (jump && jump.onSameLine(from)) {
+      this.removeCurrentJump();
+      return this.back(from);
+    }
+    return jump;
+  }
+
+  /**
+   * Get the next jump in history.
+   * Continues further ahead if the current line is on the same line.
+   *
+   * @param from - File/position jumped from
+   */
+  public forward(from: Jump): Jump {
+    if (this.currentJumpIndex >= this.jumps.length - 1) {
+      return this.jumps[this.jumps.length - 1];
+    }
+
+    this.currentJumpIndex = Math.min(this.currentJumpIndex + 1, this.jumps.length - 1);
+    const jump = this.jumps[this.currentJumpIndex];
+
+    if (jump && jump.onSameLine(from)) {
+      this.removeCurrentJump();
+      this.currentJumpIndex -= 1;
+      return this.forward(from);
+    }
+    return jump;
+  }
+
+  clearJumpsAftercurrentJumpIndex(): any {
+    this.jumps.splice(this.currentJumpIndex + 1, this.jumps.length);
+  }
+
+  removeCurrentJump(): any {
+    this.jumps.splice(this.currentJumpIndex, 1);
+  }
+
+  replaceCurrentJump(to: Jump): any {
+    this.jumps.splice(this.currentJumpIndex, 1, to);
+  }
+}

--- a/src/jumps/jumpTracker.ts
+++ b/src/jumps/jumpTracker.ts
@@ -174,8 +174,7 @@ export class JumpTracker {
   public handleTextAdded(document: vscode.TextDocument, range: vscode.Range, text: string): void {
     const distance = text.split('').filter(c => c === '\n').length;
 
-    for (let i = this._jumps.length - 1; i >= 0; i--) {
-      const jump = this._jumps[i];
+    this._jumps.forEach((jump, i) => {
       const jumpIsAfterAddedText =
         jump.fileName === document.fileName && jump.position.line > range.start.line;
 
@@ -184,14 +183,13 @@ export class JumpTracker {
 
         this.changePositionForJumpNumber(i, jump, newPosition);
       }
-    }
+    });
   }
 
   public handleTextDeleted(document: vscode.TextDocument, range: vscode.Range): void {
     const distance = range.end.line - range.start.line;
 
-    for (let i = this._jumps.length - 1; i >= 0; i--) {
-      const jump = this._jumps[i];
+    this._jumps.forEach((jump, i) => {
       const jumpIsAfterDeletedText =
         jump.fileName === document.fileName && jump.position.line >= range.start.line;
 
@@ -202,7 +200,7 @@ export class JumpTracker {
 
         this.changePositionForJumpNumber(i, jump, newPosition);
       }
-    }
+    });
 
     this.removeDuplicateJumps();
   }

--- a/src/jumps/jumpTracker.ts
+++ b/src/jumps/jumpTracker.ts
@@ -14,7 +14,7 @@ export class JumpTracker {
    *
    * Either the jump was added, or it was traversing jump history
    * and shouldn't count as a new jump.
-   * */
+   */
   public isJumpingFiles = false;
 
   /**

--- a/src/jumps/jumpTracker.ts
+++ b/src/jumps/jumpTracker.ts
@@ -36,28 +36,28 @@ export class JumpTracker {
   }
 
   /**
-   * Current jump in the list of jumps
+   * Current jump in the list of jumps.
    */
   public get currentJump(): Jump {
     return this._jumps[this._currentJumpNumber] || null;
   }
 
   /**
-   * Current jump in the list of jumps
+   * Current jump in the list of jumps.
    */
   public get hasJumps(): boolean {
     return this._jumps.length > 0;
   }
 
   /**
-   * Last jump in list of jumps
+   * Last jump in list of jumps.
    */
   public get end(): Jump | null {
     return this._jumps[this._jumps.length - 1];
   }
 
   /**
-   * First jump in list of jumps
+   * First jump in list of jumps.
    */
   public get start(): Jump | null {
     return this._jumps[0];
@@ -93,7 +93,7 @@ export class JumpTracker {
   /**
    * Record that a jump occurred from one file to another.
    * This is likely only needed on a handler for
-   * vscode.window.onDidChangeActiveTextEditor
+   * vscode.window.onDidChangeActiveTextEditor.
    *
    * File jumps have extra checks in place, keeping in mind
    * whether this plugin initiated the jump, whether the new file is
@@ -179,6 +179,13 @@ export class JumpTracker {
     return jump;
   }
 
+  /**
+   * Update existing jumps when lines were added to a document.
+   *
+   * @param document - Document that was changed.
+   * @param range - Location where the text was added.
+   * @param text - Text containing one or more newline characters.
+   */
   public handleTextAdded(document: vscode.TextDocument, range: vscode.Range, text: string): void {
     const distance = text.split('').filter(c => c === '\n').length;
 
@@ -194,6 +201,12 @@ export class JumpTracker {
     });
   }
 
+  /**
+   * Update existing jumps when lines were removed from a document.
+   *
+   * @param document - Document that was changed.
+   * @param range - Location where the text was removed.
+   */
   public handleTextDeleted(document: vscode.TextDocument, range: vscode.Range): void {
     const distance = range.end.line - range.start.line;
 
@@ -213,6 +226,14 @@ export class JumpTracker {
     this.removeDuplicateJumps();
   }
 
+  /**
+   * Clear existing jumps and reset jump position.
+   */
+  public clearJumps(): void {
+    this._jumps.splice(0, this._jumps.length);
+    this._currentJumpNumber = 0;
+  }
+
   changePositionForJumpNumber(index: number, jump: Jump, newPosition: Position) {
     this._jumps.splice(
       index,
@@ -225,18 +246,10 @@ export class JumpTracker {
     );
   }
 
-  clearJumps(): void {
-    this._jumps.splice(0, this._jumps.length);
-  }
-
   clearOldJumps(): void {
     if (this._jumps.length > 100) {
       this._jumps.splice(0, this._jumps.length - 100);
     }
-  }
-
-  clearJumpsAfterCurrentJumpIndex(): void {
-    this._jumps.splice(this._currentJumpNumber + 1, this._jumps.length);
   }
 
   clearJumpsOnSameLine(jump: Jump): void {
@@ -248,21 +261,5 @@ export class JumpTracker {
       const jump = this._jumps[i];
       this.clearJumpsOnSameLine(jump);
     }
-  }
-
-  removeJumpNumber(index: number): void {
-    this._jumps.splice(index, 1);
-  }
-
-  removeCurrentJump(): void {
-    this.removeJumpNumber(this._currentJumpNumber);
-  }
-
-  getJumpNumberOfLine(line: number) {
-    return this._jumps.findIndex(j => j.position.line === line);
-  }
-
-  updateCurrentJumpColumn(to: Jump): void {
-    this._jumps.splice(this._currentJumpNumber, 1, to);
   }
 }

--- a/src/jumps/jumpTracker.ts
+++ b/src/jumps/jumpTracker.ts
@@ -128,7 +128,7 @@ export class JumpTracker {
    *
    * @param from - File/position jumped from
    */
-  public back(from: Jump): Jump {
+  public jumpBack(from: Jump): Jump {
     if (!this.hasJumps) {
       return from;
     }
@@ -157,7 +157,7 @@ export class JumpTracker {
    *
    * @param from - File/position jumped from
    */
-  public forward(from: Jump): Jump {
+  public jumpForward(from: Jump): Jump {
     if (!this.hasJumps) {
       return from;
     }

--- a/src/jumps/jumpTracker.ts
+++ b/src/jumps/jumpTracker.ts
@@ -83,6 +83,8 @@ export class JumpTracker {
     }
 
     this._currentJumpIndex = this._jumps.length;
+
+    this.clearOldJumps();
   }
 
   /**
@@ -174,6 +176,12 @@ export class JumpTracker {
 
   clearJumps(): void {
     this._jumps.splice(0, this._jumps.length);
+  }
+
+  clearOldJumps(): void {
+    if (this._jumps.length > 100) {
+      this._jumps.splice(0, this._jumps.length - 100);
+    }
   }
 
   clearJumpsAfterCurrentJumpIndex(): void {

--- a/src/mode/modeHandler.ts
+++ b/src/mode/modeHandler.ts
@@ -971,17 +971,12 @@ export class ModeHandler implements vscode.Disposable {
           if (command.replay === 'contentChange') {
             vimState = await this.runMacro(vimState, recordedMacro);
           } else {
-            this.vimState.recordedState = new RecordedState();
+            let keyStrokes: string[] = [];
             for (let action of recordedMacro.actionsRun) {
-              await this.handleMultipleKeyEvents(action.keysPressed);
-
-              if (action.isJump) {
-                vimState.globalState.jumpTracker.recordJump(
-                  Jump.fromStateBefore(vimState),
-                  Jump.fromStateNow(vimState)
-                );
-              }
+              keyStrokes = keyStrokes.concat(action.keysPressed);
             }
+            this.vimState.recordedState = new RecordedState();
+            await this.handleMultipleKeyEvents(keyStrokes);
           }
 
           vimState.isReplayingMacro = false;

--- a/src/mode/modeHandler.ts
+++ b/src/mode/modeHandler.ts
@@ -115,42 +115,7 @@ export class ModeHandler implements vscode.Disposable {
       }
     );
 
-    // const onDidChangeActiveTextEditor = vscode.window.onDidChangeActiveTextEditor(
-    //   (textEditor: vscode.TextEditor | undefined) => {
-    //     if (configuration.disableExt) {
-    //       return;
-    //     }
-
-    //     if (Globals.isTesting) {
-    //       return;
-    //     }
-
-    //     if (!textEditor) {
-    //       return;
-    //     }
-
-    //     if (textEditor !== this.vimState.editor) {
-    //       return;
-    //     }
-
-    //     if (this.vimState.focusChanged) {
-    //       return;
-    //     }
-
-    //     if (this.currentMode.name === ModeName.EasyMotionMode) {
-    //       return;
-    //     }
-
-    //     this.vimState.globalState.jumpHistory.push({
-    //       fileName: this.vimState.editor.document.fileName,
-    //       position: this.vimState.cursorPosition,
-    //       recordedState: new RecordedState(), // TODO - can we record something meaningful?
-    //     });
-    //   }
-    // );
-
     this._disposables.push(onChangeTextEditorSelection);
-    // this._disposables.push(onDidChangeActiveTextEditor);
     this._disposables.push(this.vimState);
   }
 
@@ -414,6 +379,12 @@ export class ModeHandler implements vscode.Disposable {
 
     let action = result as BaseAction;
     let actionToRecord: BaseAction | undefined = action;
+    let originalLocation = new Jump({
+      editor: this.vimState.editor,
+      fileName: this.vimState.editor.document.fileName,
+      position: vimState.cursorPosition,
+      recordedState,
+    });
 
     if (recordedState.actionsRun.length === 0) {
       recordedState.actionsRun.push(action);
@@ -475,7 +446,9 @@ export class ModeHandler implements vscode.Disposable {
     await this.updateView(vimState);
 
     if (action.isJump) {
-      vimState.globalState.jumpHistory.push(
+      vimState.globalState.jumpHistory.jump(
+        // vimState.globalState.jumpHistory.jumpFiles(
+        originalLocation,
         new Jump({
           editor: this.vimState.editor,
           fileName: this.vimState.editor.document.fileName,

--- a/src/mode/modeHandler.ts
+++ b/src/mode/modeHandler.ts
@@ -78,10 +78,6 @@ export class ModeHandler implements vscode.Disposable {
     // Handle scenarios where mouse used to change current position.
     const onChangeTextEditorSelection = vscode.window.onDidChangeTextEditorSelection(
       (e: vscode.TextEditorSelectionChangeEvent) => {
-        // console.log('CHANGED SELECTION', e.kind);
-        // const editor: vscode.TextEditor = vscode.window.
-        // vscode.
-
         if (configuration.disableExt) {
           return;
         }

--- a/src/mode/modeHandler.ts
+++ b/src/mode/modeHandler.ts
@@ -375,11 +375,7 @@ export class ModeHandler implements vscode.Disposable {
 
     let action = result as BaseAction;
     let actionToRecord: BaseAction | undefined = action;
-    let originalLocation = new Jump({
-      editor: this.vimState.editor,
-      fileName: this.vimState.editor.document.fileName,
-      position: vimState.cursorPosition,
-    });
+    let originalLocation = Jump.fromStateNow(vimState);
 
     if (recordedState.actionsRun.length === 0) {
       recordedState.actionsRun.push(action);
@@ -441,7 +437,10 @@ export class ModeHandler implements vscode.Disposable {
     await this.updateView(vimState);
 
     if (action.isJump) {
-      vimState.globalState.jumpTracker.recordJump(originalLocation, Jump.fromState(vimState));
+      vimState.globalState.jumpTracker.recordJump(
+        Jump.fromStateBefore(vimState),
+        Jump.fromStateNow(vimState)
+      );
     }
 
     return vimState;
@@ -972,18 +971,12 @@ export class ModeHandler implements vscode.Disposable {
           } else {
             this.vimState.recordedState = new RecordedState();
             for (let action of recordedMacro.actionsRun) {
-              let originalLocation = new Jump({
-                editor: this.vimState.editor,
-                fileName: this.vimState.editor.document.fileName,
-                position: vimState.cursorPosition,
-              });
-
               await this.handleMultipleKeyEvents(action.keysPressed);
 
               if (action.isJump) {
                 vimState.globalState.jumpTracker.recordJump(
-                  originalLocation,
-                  Jump.fromState(vimState)
+                  Jump.fromStateBefore(vimState),
+                  Jump.fromStateNow(vimState)
                 );
               }
             }
@@ -1179,11 +1172,7 @@ export class ModeHandler implements vscode.Disposable {
     vimState.isRunningDotCommand = true;
 
     for (let action of actions) {
-      let originalLocation = new Jump({
-        editor: this.vimState.editor,
-        fileName: this.vimState.editor.document.fileName,
-        position: vimState.cursorPosition,
-      });
+      let originalLocation = Jump.fromStateNow(vimState);
 
       recordedState.actionsRun.push(action);
       vimState.keyHistory = vimState.keyHistory.concat(action.keysPressed);
@@ -1203,7 +1192,7 @@ export class ModeHandler implements vscode.Disposable {
       await this.updateView(vimState);
 
       if (action.isJump) {
-        vimState.globalState.jumpTracker.recordJump(originalLocation, Jump.fromState(vimState));
+        vimState.globalState.jumpTracker.recordJump(originalLocation, Jump.fromStateNow(vimState));
       }
     }
 

--- a/src/mode/modeHandler.ts
+++ b/src/mode/modeHandler.ts
@@ -477,6 +477,7 @@ export class ModeHandler implements vscode.Disposable {
     if (action.isJump) {
       vimState.globalState.jumpHistory.push(
         new Jump({
+          editor: this.vimState.editor,
           fileName: this.vimState.editor.document.fileName,
           position: vimState.cursorPosition,
           recordedState,

--- a/src/mode/modeHandler.ts
+++ b/src/mode/modeHandler.ts
@@ -32,7 +32,7 @@ import {
 import { Mode, ModeName, VSCodeVimCursorType } from './mode';
 import { logger } from '../util/logger';
 import { Neovim } from '../neovim/neovim';
-import { Jump } from '../state/globalState';
+import { Jump } from '../jumps/jump';
 
 export class ModeHandler implements vscode.Disposable {
   private _disposables: vscode.Disposable[] = [];
@@ -383,7 +383,6 @@ export class ModeHandler implements vscode.Disposable {
       editor: this.vimState.editor,
       fileName: this.vimState.editor.document.fileName,
       position: vimState.cursorPosition,
-      recordedState,
     });
 
     if (recordedState.actionsRun.length === 0) {
@@ -446,14 +445,12 @@ export class ModeHandler implements vscode.Disposable {
     await this.updateView(vimState);
 
     if (action.isJump) {
-      vimState.globalState.jumpHistory.jump(
-        // vimState.globalState.jumpHistory.jumpFiles(
+      vimState.globalState.jumpTracker.recordJump(
         originalLocation,
         new Jump({
           editor: this.vimState.editor,
           fileName: this.vimState.editor.document.fileName,
           position: vimState.cursorPosition,
-          recordedState,
         })
       );
     }

--- a/src/mode/modeHandler.ts
+++ b/src/mode/modeHandler.ts
@@ -445,14 +445,7 @@ export class ModeHandler implements vscode.Disposable {
     await this.updateView(vimState);
 
     if (action.isJump) {
-      vimState.globalState.jumpTracker.recordJump(
-        originalLocation,
-        new Jump({
-          editor: this.vimState.editor,
-          fileName: this.vimState.editor.document.fileName,
-          position: vimState.cursorPosition,
-        })
-      );
+      vimState.globalState.jumpTracker.recordJump(originalLocation, Jump.fromState(vimState));
     }
 
     return vimState;

--- a/src/state/globalState.ts
+++ b/src/state/globalState.ts
@@ -6,14 +6,9 @@ import { SearchState } from './searchState';
  * State which stores global state (across editors)
  */
 export class GlobalState {
-  private static _jumpTracker: JumpTracker = new JumpTracker();
-
   /**
    * Getters and setters for changing global state
    */
-  public get jumpTracker(): JumpTracker {
-    return GlobalState._jumpTracker;
-  }
 
   /**
    * The keystroke sequence that made up our last complete action (that can be
@@ -40,6 +35,11 @@ export class GlobalState {
    * Used internally for nohl.
    */
   private static _hl = true;
+
+  /**
+   * Track jumps, and traverse jump history
+   */
+  private static _jumpTracker: JumpTracker = new JumpTracker();
 
   /**
    * Getters and setters for changing global state
@@ -82,5 +82,9 @@ export class GlobalState {
 
   public set hl(enabled: boolean) {
     GlobalState._hl = enabled;
+  }
+
+  public get jumpTracker(): JumpTracker {
+    return GlobalState._jumpTracker;
   }
 }

--- a/src/state/globalState.ts
+++ b/src/state/globalState.ts
@@ -1,10 +1,99 @@
+import { Position } from '../common/motion/position';
 import { RecordedState } from './../state/recordedState';
 import { SearchState } from './searchState';
+
+export class Jump {
+  public fileName: string;
+  public position: Position;
+  public recordedState?: RecordedState;
+
+  constructor({
+    fileName,
+    position,
+    recordedState,
+  }: {
+    fileName: string;
+    position: Position;
+    recordedState?: RecordedState;
+  }) {
+    this.fileName = fileName;
+    this.position = position;
+    this.recordedState = recordedState;
+  }
+
+  public equals(other: Jump): boolean {
+    return this.fileName === other.fileName && this.position.isEqual(other.position);
+  }
+}
+
+export class JumpHistory {
+  private jumps: Jump[] = [];
+  private currentPosition = 0;
+
+  public push(jump: Jump) {
+    const previousJump = this.jumps[this.currentPosition - 1];
+    const currentJump = this.jumps[this.currentPosition];
+    const nextJump = this.jumps[this.currentPosition + 1];
+
+    if (previousJump && previousJump.equals(jump)) {
+      this.currentPosition -= 1;
+      console.log('On previous jump', this.currentPosition);
+      return;
+    }
+
+    if (currentJump && currentJump.equals(jump)) {
+      console.log('On current jump', this.currentPosition);
+      return;
+    }
+
+    if (previousJump && previousJump.equals(jump)) {
+      this.currentPosition -= 1;
+      console.log('On previous jump', this.currentPosition);
+      return;
+    }
+
+    if (nextJump && nextJump.equals(jump)) {
+      this.currentPosition += 1;
+      console.log('On next jump', this.currentPosition);
+      return;
+    }
+
+    if (this.currentPosition < this.jumps.length - 1) {
+      this.jumps.splice(this.currentPosition + 1, this.jumps.length);
+      console.log('Removing following jumps');
+    }
+    const last = this.jumps[this.jumps.length - 1];
+    if (!last || !last.position.isEqual(jump.position)) {
+      console.log('Added new jump', jump.fileName, jump.position.line);
+      this.jumps.push(jump);
+    }
+    this.currentPosition = this.jumps.length - 1;
+  }
+
+  public back(): Jump {
+    this.currentPosition = Math.max(this.currentPosition - 1, 0);
+    return this.jumps[this.currentPosition];
+  }
+
+  public forward(): Jump {
+    this.currentPosition = Math.min(this.currentPosition + 1, this.jumps.length - 1);
+    return this.jumps[this.currentPosition];
+  }
+}
 
 /**
  * State which stores global state (across editors)
  */
 export class GlobalState {
+  private static _jumpHistory: JumpHistory = new JumpHistory();
+
+  /**
+   * Getters and setters for changing global state
+   */
+  public get jumpHistory(): JumpHistory {
+    return GlobalState._jumpHistory;
+  }
+
   /**
    * The keystroke sequence that made up our last complete action (that can be
    * repeated with '.').

--- a/src/state/globalState.ts
+++ b/src/state/globalState.ts
@@ -7,10 +7,6 @@ import { SearchState } from './searchState';
  */
 export class GlobalState {
   /**
-   * Getters and setters for changing global state
-   */
-
-  /**
    * The keystroke sequence that made up our last complete action (that can be
    * repeated with '.').
    */

--- a/src/state/globalState.ts
+++ b/src/state/globalState.ts
@@ -46,10 +46,16 @@ export class JumpHistory {
   private currentPosition = 0;
 
   public jumpFiles(from: Jump | null, to: Jump) {
-    console.log('jumpFiles------------');
     const currentJump = this.jumps[this.currentPosition];
     if (this.isJumpingFiles) {
       this.isJumpingFiles = false;
+      return;
+    }
+
+    if (to.editor.document.isClosed) {
+      // Wallaby.js seemed to be adding an extra file jump, named e.g. extension-output-#4
+      // It was marked closed when jumping to it. Hopefully we can rely on checking isClosed
+      // when extensions get all weird on us.
       return;
     }
 
@@ -58,59 +64,39 @@ export class JumpHistory {
     }
 
     if (this.currentPosition < this.jumps.length - 1) {
-      console.log('Removing following jumps jumping files');
       this.jumps.splice(this.currentPosition + 1, this.jumps.length);
     }
 
-    console.log('Jumping to file', to.fileName, to.position.line);
-
     if (from) {
-      if (currentJump && currentJump.equals(from)) {
-        console.log('On from');
-      } else {
-        console.log('Jumped From', from.fileName);
-        this.jumps.push(from);
-      }
+      this.jumps.push(from);
     }
-    if (currentJump && currentJump.equals(to)) {
-      console.log('On to');
-    } else {
-      console.log('Jumped To', to.fileName);
-      this.jumps.push(to);
-    }
+    this.jumps.push(to);
     this.currentPosition = this.jumps.length - 1;
   }
 
   public push(jump: Jump) {
-    console.log('push------------');
-
     const previousJump = this.jumps[this.currentPosition - 1];
     const currentJump = this.jumps[this.currentPosition];
     const nextJump = this.jumps[this.currentPosition + 1];
 
     if (previousJump && previousJump.equals(jump)) {
       this.currentPosition -= 1;
-      console.log('On previous jump', this.currentPosition);
       return;
     }
 
     if (currentJump && currentJump.equals(jump)) {
-      console.log('On current jump', this.currentPosition);
       return;
     }
 
     if (nextJump && nextJump.equals(jump)) {
       this.currentPosition += 1;
-      console.log('On next jump', this.currentPosition);
       return;
     }
 
     if (this.currentPosition < this.jumps.length - 1) {
       this.jumps.splice(this.currentPosition + 1, this.jumps.length);
-      console.log('Removing following jumps');
     }
 
-    console.log('Added new jump', jump.fileName, jump.position.line);
     this.jumps.push(jump);
     this.currentPosition = this.jumps.length - 1;
   }

--- a/src/state/globalState.ts
+++ b/src/state/globalState.ts
@@ -107,22 +107,47 @@ export class JumpHistory {
     this.currentPosition = this.jumps.length - 1;
   }
 
+  public back(from: Jump): Jump {
+    if (this.currentPosition <= 0) {
+      return this.jumps[0];
+    }
+
+    this.currentPosition = this.currentPosition - 1;
+    const jump = this.jumps[this.currentPosition];
+
+    if (jump && jump.onSameLine(from)) {
+      this.removeCurrentJump();
+      return this.back(from);
+    }
+    return jump;
+  }
+
+  public forward(from: Jump): Jump {
+    if (this.currentPosition >= this.jumps.length - 1) {
+      return this.jumps[this.jumps.length - 1];
+    }
+
+    this.currentPosition = Math.min(this.currentPosition + 1, this.jumps.length - 1);
+    const jump = this.jumps[this.currentPosition];
+
+    if (jump && jump.onSameLine(from)) {
+      this.removeCurrentJump();
+      this.currentPosition -= 1;
+      return this.forward(from);
+    }
+    return jump;
+  }
+
   clearJumpsAfterCurrentPosition(): any {
     this.jumps.splice(this.currentPosition + 1, this.jumps.length);
   }
 
+  removeCurrentJump(): any {
+    this.jumps.splice(this.currentPosition, 1);
+  }
+
   replaceCurrentJump(to: Jump): any {
-    this.jumps.splice(this.currentPosition, this.jumps.length, to);
-  }
-
-  public back(): Jump {
-    this.currentPosition = Math.max(this.currentPosition - 1, 0);
-    return this.jumps[this.currentPosition];
-  }
-
-  public forward(): Jump {
-    this.currentPosition = Math.min(this.currentPosition + 1, this.jumps.length - 1);
-    return this.jumps[this.currentPosition];
+    this.jumps.splice(this.currentPosition, 1, to);
   }
 }
 

--- a/src/state/globalState.ts
+++ b/src/state/globalState.ts
@@ -16,21 +16,63 @@ export class Jump {
     position: Position;
     recordedState?: RecordedState;
   }) {
+    if (!fileName) {
+      throw new Error('fileName is required for Jumps');
+    }
+    if (!position) {
+      throw new Error('position is required for Jumps');
+    }
     this.fileName = fileName;
     this.position = position;
     this.recordedState = recordedState;
   }
 
   public equals(other: Jump): boolean {
-    return this.fileName === other.fileName && this.position.isEqual(other.position);
+    return this.fileName === other.fileName && this.position.line === other.position.line;
   }
 }
 
 export class JumpHistory {
+  public isJumpingFiles = false;
+
   private jumps: Jump[] = [];
   private currentPosition = 0;
 
+  public jumpFiles(from: Jump, to: Jump) {
+    console.log('jumpFiles------------');
+    const currentJump = this.jumps[this.currentPosition];
+    if (this.isJumpingFiles) {
+      this.isJumpingFiles = false;
+      return;
+    }
+
+    if (this.currentPosition < this.jumps.length - 1) {
+      console.log('Removing following jumps jumping files');
+      this.jumps.splice(this.currentPosition + 1, this.jumps.length);
+    }
+
+    console.log('Jumping to file', to.fileName, to.position.line);
+
+    if (from) {
+      if (currentJump && currentJump.equals(from)) {
+        console.log('On from');
+      } else {
+        console.log('Jumped From', from.fileName);
+        this.jumps.push(from);
+      }
+    }
+    if (currentJump && currentJump.equals(to)) {
+      console.log('On to');
+    } else {
+      console.log('Jumped To', to.fileName);
+      this.jumps.push(to);
+    }
+    this.currentPosition = this.jumps.length - 1;
+  }
+
   public push(jump: Jump) {
+    console.log('push------------');
+
     const previousJump = this.jumps[this.currentPosition - 1];
     const currentJump = this.jumps[this.currentPosition];
     const nextJump = this.jumps[this.currentPosition + 1];
@@ -46,12 +88,6 @@ export class JumpHistory {
       return;
     }
 
-    if (previousJump && previousJump.equals(jump)) {
-      this.currentPosition -= 1;
-      console.log('On previous jump', this.currentPosition);
-      return;
-    }
-
     if (nextJump && nextJump.equals(jump)) {
       this.currentPosition += 1;
       console.log('On next jump', this.currentPosition);
@@ -62,11 +98,9 @@ export class JumpHistory {
       this.jumps.splice(this.currentPosition + 1, this.jumps.length);
       console.log('Removing following jumps');
     }
-    const last = this.jumps[this.jumps.length - 1];
-    if (!last || !last.position.isEqual(jump.position)) {
-      console.log('Added new jump', jump.fileName, jump.position.line);
-      this.jumps.push(jump);
-    }
+
+    console.log('Added new jump', jump.fileName, jump.position.line);
+    this.jumps.push(jump);
     this.currentPosition = this.jumps.length - 1;
   }
 

--- a/src/state/globalState.ts
+++ b/src/state/globalState.ts
@@ -1,17 +1,22 @@
+import * as vscode from 'vscode';
+
 import { Position } from '../common/motion/position';
 import { RecordedState } from './../state/recordedState';
 import { SearchState } from './searchState';
 
 export class Jump {
+  public editor: vscode.TextEditor;
   public fileName: string;
   public position: Position;
   public recordedState?: RecordedState;
 
   constructor({
+    editor,
     fileName,
     position,
     recordedState,
   }: {
+    editor: vscode.TextEditor;
     fileName: string;
     position: Position;
     recordedState?: RecordedState;
@@ -22,6 +27,8 @@ export class Jump {
     if (!position) {
       throw new Error('position is required for Jumps');
     }
+    this.editor = editor;
+    // TODO - can we just always require editor and get filename from it?
     this.fileName = fileName;
     this.position = position;
     this.recordedState = recordedState;
@@ -38,11 +45,15 @@ export class JumpHistory {
   private jumps: Jump[] = [];
   private currentPosition = 0;
 
-  public jumpFiles(from: Jump, to: Jump) {
+  public jumpFiles(from: Jump | null, to: Jump) {
     console.log('jumpFiles------------');
     const currentJump = this.jumps[this.currentPosition];
     if (this.isJumpingFiles) {
       this.isJumpingFiles = false;
+      return;
+    }
+
+    if (from && from.fileName === to.fileName) {
       return;
     }
 

--- a/test/jumpTracker.test.ts
+++ b/test/jumpTracker.test.ts
@@ -194,6 +194,15 @@ suite('Record and navigate jumps', () => {
       });
     });
 
+    suite('Can track jumps from substitutes', () => {
+      newJumpTest({
+        start: ['|a1', 'a2', 'a3'],
+        keysPressed: ':%s/a/b\n',
+        end: ['|b1', 'b2', 'b3'],
+        jumps: ['b2', 'b3'],
+      });
+    });
+
     suite('Can track jumps from macros', () => {
       newJumpTest({
         start: ['|start', 'a1', 'a2', 'a3', 'a4', 'a5', 'a6', 'a7', 'a8', 'a9', 'end'],

--- a/test/jumpTracker.test.ts
+++ b/test/jumpTracker.test.ts
@@ -1,16 +1,16 @@
-import * as assert from 'assert';
-import * as vscode from 'vscode';
+import * as assert from "assert";
+import * as vscode from "vscode";
 
-import { Jump } from './../src/jumps/jump';
-import { getAndUpdateModeHandler } from '../extension';
-import { ModeHandler } from '../src/mode/modeHandler';
-import { TextEditor } from '../src/textEditor';
-import { cleanUpWorkspace, setupWorkspace } from './testUtils';
-import { JumpTracker } from '../src/jumps/jumpTracker';
-import { Position } from '../src/common/motion/position';
-import { waitForCursorSync } from '../src/util/util';
+import { Jump } from "./../src/jumps/jump";
+import { getAndUpdateModeHandler } from "../extension";
+import { ModeHandler } from "../src/mode/modeHandler";
+import { TextEditor } from "../src/textEditor";
+import { cleanUpWorkspace, setupWorkspace } from "./testUtils";
+import { JumpTracker } from "../src/jumps/jumpTracker";
+import { Position } from "../src/common/motion/position";
+import { waitForCursorSync } from "../src/util/util";
 
-suite('Jump Tracker', () => {
+suite("Jump Tracker", () => {
   let jumpTracker: JumpTracker;
   let modeHandler: ModeHandler;
   let editor: vscode.TextEditor;
@@ -27,8 +27,8 @@ end`;
   const jump = (lineNumber, columnNumber) =>
     new Jump({
       editor,
-      fileName: 'Untitled',
-      position: new Position(lineNumber, columnNumber),
+      fileName: "Untitled",
+      position: new Position(lineNumber, columnNumber)
     });
 
   const start = jump(0, 0);
@@ -52,7 +52,7 @@ end`;
     await waitForCursorSync();
 
     jumpTracker = modeHandler.vimState.globalState.jumpTracker;
-    await modeHandler.handleMultipleKeyEvents(['gg']);
+    await modeHandler.handleMultipleKeyEvents(["gg"]);
     await waitForCursorSync();
     jumpTracker.clearJumps();
   });
@@ -63,10 +63,12 @@ end`;
   });
 
   const fixLineEndings = (t: string): string =>
-    process.platform === 'win32' ? t.replace(/\\n/g, '\\r\\n') : t;
-  const flatten = list => list.reduce((a, b) => a.concat(Array.isArray(b) ? flatten(b) : b), []);
-  const hasPrefix = (t: string): boolean => t.startsWith('<') && t.endsWith('>');
-  const tokenize = (t: string): string[] => (hasPrefix(t) ? [t] : t.split(''));
+    process.platform === "win32" ? t.replace(/\\n/g, "\\r\\n") : t;
+  const flatten = list =>
+    list.reduce((a, b) => a.concat(Array.isArray(b) ? flatten(b) : b), []);
+  const hasPrefix = (t: string): boolean =>
+    t.startsWith("<") && t.endsWith(">");
+  const tokenize = (t: string): string[] => (hasPrefix(t) ? [t] : t.split(""));
   const sendKeys = async (keys: string[]) => {
     for (var i = 0; i < keys.length; i++) {
       const key = keys[i];
@@ -82,35 +84,39 @@ end`;
     assert.deepEqual(
       jumpTracker.jumps.map(line),
       expectedJumps.map(line),
-      'Jumps are not in the correct order or the jumps are for the wrong lines'
+      "Jumps are not in the correct order or the jumps are for the wrong lines"
     );
   };
   const assertCurrentJump = (expectedCurrentJump: Jump) =>
     assert.deepEqual(
       position(jumpTracker.currentJump || jumpTracker.end),
       position(expectedCurrentJump),
-      'Current jump is incorrect'
+      "Current jump is incorrect"
     );
 
-  const testJumps = async (keys: string[], jumps: Jump[], currentJump?: Jump) => {
-    test(`Can record jumps for key events: ${keys.map(k => k.replace('\n', '\\n'))}`, async () => {
+  const testJumps = async (
+    keys: string[],
+    jumps: Jump[],
+    currentJump: Jump
+  ) => {
+    test(`Can record jumps for key events: ${keys.map(k =>
+      k.replace("\n", "\\n")
+    )}`, async () => {
       await sendKeys(flatten(keys.map(fixLineEndings).map(tokenize)));
 
       assertJumps(jumps);
-      assertCurrentJump(currentJump || jumpTracker.jumps[jumpTracker.jumps.length - 1]);
+      assertCurrentJump(currentJump);
     });
   };
 
-  testJumps(['G', 'gg'], [start, end]);
-  testJumps(['G', 'gg', 'G'], [end, start]);
-  testJumps(['G', 'gg', 'G', 'gg'], [start, end]);
-  testJumps(['/b\n', 'n'], [start, b1]);
-  testJumps(['G', '?b\n', 'gg', 'G'], [end, b2, start]);
-  testJumps(['j', '%', '%'], [open, close]);
-
-  testJumps(['j', '%', '%'], [open, close], close);
-  testJumps(['j', '%', '%', '<C-o>'], [close, open], close);
-  testJumps(['j', '%', '%', '<C-o>', '<C-i>'], [close, open], open);
-  testJumps(['j', '%', '%', '<C-o>', '%'], [open, close], close);
-  testJumps(['j', '%', '%', '<C-o>', 'gg'], [open, close], close);
+  testJumps(["G", "gg"], [start, end], end);
+  testJumps(["G", "gg", "G"], [end, start], start);
+  testJumps(["G", "gg", "G", "gg"], [start, end], end);
+  testJumps(["/b\n", "n"], [start, b1], b1);
+  testJumps(["G", "?b\n", "gg", "G"], [end, b2, start], start);
+  testJumps(["j", "%", "%"], [open, close], close);
+  testJumps(["j", "%", "%", "<C-o>"], [close, open], close);
+  testJumps(["j", "%", "%", "<C-o>", "<C-i>"], [close, open], open);
+  testJumps(["j", "%", "%", "<C-o>", "%"], [open, close], close);
+  testJumps(["j", "%", "%", "<C-o>", "gg"], [open, close], close);
 });

--- a/test/jumpTracker.test.ts
+++ b/test/jumpTracker.test.ts
@@ -130,6 +130,14 @@ suite('Record and navigate jumps', () => {
         end: ['|start', '{', 'a1', 'b1', 'a2', 'b2', '}', 'end'],
         jumps: ['start', '{', 'b1', 'a2', 'a1'],
       });
+
+      newJumpTest({
+        title: 'Can enter number to jump back multiple times',
+        start: ['|start', '{', 'a1', 'b1', 'a2', 'b2', '}', 'end'],
+        keysPressed: 'Gggj%2<C-o>',
+        end: ['start', '{', 'a1', 'b1', 'a2', 'b2', '}', '|end'],
+        jumps: ['start', '|end', '{', '}'],
+      });
     });
 
     suite('Can shifts jump lines up after deleting a line', () => {

--- a/test/jumpTracker.test.ts
+++ b/test/jumpTracker.test.ts
@@ -134,31 +134,47 @@ b2
 }
 end`;
 
-    setup(async () => {
-      await setupWorkspace();
-      await setupTestsWithText(text);
+    suite('Can track basic jumps', () => {
+      setup(async () => {
+        await setupWorkspace();
+        await setupTestsWithText(text);
+      });
+
+      teardown(() => {
+        jumpTracker.clearJumps();
+        cleanUpWorkspace();
+      });
+
+      testJumps(['G', 'gg'], [start, end], end);
+      testJumps(['G', 'gg', 'G'], [end, start], start);
+      testJumps(['G', 'gg', 'G', 'gg'], [start, end], end);
+      testJumps(['/b\n', 'n'], [start, b1], b1);
+      testJumps(['G', '?b\n', 'gg', 'G'], [end, b2, start], start);
+      testJumps(['j', '%', '%'], [open, close], close);
     });
 
-    teardown(() => {
-      jumpTracker.clearJumps();
-      cleanUpWorkspace();
-    });
+    suite('Can track jumps with back/forward', () => {
+      setup(async () => {
+        await setupWorkspace();
+        await setupTestsWithText(text);
+      });
 
-    testJumps(['G', 'gg'], [start, end], end);
-    testJumps(['G', 'gg', 'G'], [end, start], start);
-    testJumps(['G', 'gg', 'G', 'gg'], [start, end], end);
-    testJumps(['/b\n', 'n'], [start, b1], b1);
-    testJumps(['G', '?b\n', 'gg', 'G'], [end, b2, start], start);
-    testJumps(['j', '%', '%'], [open, close], close);
-    testJumps(['j', '%', '%', '<C-o>'], [close, open], close);
-    testJumps(['j', '%', '%', '<C-o>', '<C-i>'], [close, open], open);
-    testJumps(['j', '%', '%', '<C-o>', '%'], [open, close], close);
-    testJumps(['j', '%', '%', '<C-o>', 'gg'], [open, close], close);
-    testJumps(['j', '%', '%', '<C-o>', '<C-o>', 'gg'], [open, close], close);
-    testJumps(
-      ['/^\n', 'nnn', '<C-o>', '<C-o>', '<C-o>', '<C-i>', 'gg'],
-      [start, open, b1, a2, a1],
-      a1
-    );
+      teardown(() => {
+        jumpTracker.clearJumps();
+        cleanUpWorkspace();
+      });
+
+      testJumps(['j', '%', '%', '<C-o>'], [close, open], close);
+      testJumps(['j', '%', '%', '<C-o>', '<C-i>'], [close, open], open);
+      testJumps(['j', '%', '%', '<C-o>', '%'], [open, close], close);
+      testJumps(['j', '%', '%', '<C-o>', 'gg'], [open, close], close);
+      testJumps(['j', '%', '%', '<C-o>', '<C-o>', 'gg'], [open, close], close);
+      testJumps(
+        ['/^\n', 'nnn', '<C-o>', '<C-o>', '<C-o>', '<C-i>', 'gg'],
+        [start, open, b1, a2, a1],
+        a1
+      );
+      testJumps(['/^\n', 'nnn', '3', '<C-o>', '<C-i>', 'gg'], [start, open, b1, a2, a1], a1);
+    });
   });
 });

--- a/test/jumpTracker.test.ts
+++ b/test/jumpTracker.test.ts
@@ -1,186 +1,131 @@
 import * as assert from 'assert';
 import * as vscode from 'vscode';
 
+import { Globals } from '../src/globals';
 import { Jump } from './../src/jumps/jump';
-import { getAndUpdateModeHandler } from '../extension';
+import { JumpTracker } from '../src/jumps/jumpTracker';
 import { ModeHandler } from '../src/mode/modeHandler';
+import { Position } from '../src/common/motion/position';
 import { TextEditor } from '../src/textEditor';
 import { cleanUpWorkspace, setupWorkspace } from './testUtils';
-import { JumpTracker } from '../src/jumps/jumpTracker';
-import { Position } from '../src/common/motion/position';
+import { getAndUpdateModeHandler } from '../extension';
+import { getTestingFunctions } from './testSimplifier';
 import { waitForCursorSync } from '../src/util/util';
 
-suite('Jump Tracker', () => {
-  let jumpTracker: JumpTracker;
-  let modeHandler: ModeHandler;
-  let editor: vscode.TextEditor;
+suite('Record and navigate jumps', () => {
+  let { newTest, newTestOnly } = getTestingFunctions();
 
-  const jump = (lineNumber, columnNumber) =>
-    new Jump({
-      editor,
-      fileName: 'Untitled',
-      position: new Position(lineNumber, columnNumber),
-    });
-
-  const range = (n: number) => Array.from(Array(n).keys());
-  const fixLineEndings = (t: string): string =>
-    process.platform === 'win32' ? t.replace(/\\n/g, '\\r\\n') : t;
-  const flatten = list => list.reduce((a, b) => a.concat(Array.isArray(b) ? flatten(b) : b), []);
-  const hasPrefix = (t: string): boolean => t.startsWith('<') && t.endsWith('>');
-  const tokenize = (t: string): string[] => (hasPrefix(t) ? [t] : t.split(''));
-  const sendKeys = async (keys: string[]) => {
-    for (var i = 0; i < keys.length; i++) {
-      const key = keys[i];
-      await modeHandler.handleKeyEvent(key);
-      await waitForCursorSync();
-    }
-  };
-
-  const position = j => [j.position.line, j.position.character];
-  const line = j => j.position.line;
-
-  const assertJumps = (expectedJumps: Jump[]) => {
-    assert.deepEqual(
-      jumpTracker.jumps.map(line),
-      expectedJumps.map(line),
-      'Jumps are not in the correct order or the jumps are for the wrong lines'
-    );
-  };
-  const assertCurrentJump = (expectedCurrentJump: Jump) =>
-    assert.deepEqual(
-      position(jumpTracker.currentJump || jumpTracker.end),
-      position(expectedCurrentJump),
-      'Current jump is incorrect'
-    );
-
-  const setupTestsWithText = async (textEditorText: string) => {
-    modeHandler = await getAndUpdateModeHandler();
-    editor = modeHandler.vimState.editor!;
-
-    modeHandler.vimState.editor = vscode.window.activeTextEditor!;
-    (modeHandler as any).vimState.cursorPosition = new Position(0, 0);
-
-    await TextEditor.insert(textEditorText);
-    await waitForCursorSync();
-
-    jumpTracker = modeHandler.vimState.globalState.jumpTracker;
-    await modeHandler.handleMultipleKeyEvents(['gg']);
-    await waitForCursorSync();
-    jumpTracker.clearJumps();
-  };
-
-  /**
-   * Create a test that checks both recorded jumps and final jump position.
-   *
-   * To get expected results for the tests:
-   * 1) Open vim with vim -u NONE
-   * 2) Paste in the text being tested against (text variable)
-   * 3) :clearjumps
-   * 4) Reproduce the key combinations
-   * 5) :jumps
-   * Read jumps from top to bottom, that should be in the jumps variable.
-   * The arrow (>) will be the currentJump variable.
-   */
-  const testJumps = async (keys: string[], jumps: Jump[], currentJump: Jump) => {
-    test(`Can record jumps for key events: ${keys.map(k => k.replace('\n', '\\n'))}`, async () => {
-      await sendKeys(flatten(keys.map(fixLineEndings).map(tokenize)));
-
-      assertJumps(jumps);
-      assertCurrentJump(currentJump);
-    });
-  };
-
-  suite('Jump Tracker unit tests', () => {
-    setup(async () => {
-      await setupWorkspace();
-      await setupTestsWithText(range(102).join('\n'));
-    });
-
-    teardown(() => {
-      jumpTracker.clearJumps();
-      cleanUpWorkspace();
-    });
-
-    test('Records up to 100 jumps, the fixed length in vanilla Vim', async () => {
-      range(102).forEach((iteration: number) => {
-        jumpTracker.recordJump(jump(iteration, 0), jump(iteration + 1, 0));
-      });
-
-      assert.equal(jumpTracker.jumps.length, 100, 'Jump tracker should cut off jumps at 100');
-      assert.deepEqual(
-        jumpTracker.jumps.map(j => j.position.line),
-        range(102).slice(2, 102),
-        "Jump tracker doesn't contain the expected jumps after removing old jumps"
-      );
-    });
+  setup(async () => {
+    await setupWorkspace();
   });
 
+  teardown(cleanUpWorkspace);
+
+  const newJumpTest = options => {
+    return newTest({
+      title: `Can track jumps for keys: ${options.keysPressed.replace(/\n/g, '<CR>')}`,
+      ...options,
+    });
+  };
+
   suite('Can record jumps for actions the same as vanilla Vim', () => {
-    const text = ['start', '{', 'a1', 'b1', 'a2', 'b2', '}', 'end'].join('\n');
-    const start = jump(0, 0);
-    const open = jump(1, 0);
-    const a1 = jump(2, 0);
-    const b1 = jump(3, 0);
-    const a2 = jump(4, 0);
-    const b2 = jump(5, 0);
-    const close = jump(6, 0);
-    const end = jump(7, 0);
-
     suite('Can track basic jumps', () => {
-      setup(async () => {
-        await setupWorkspace();
-        await setupTestsWithText(text);
+      newJumpTest({
+        start: ['|start', '{', 'a1', 'b1', 'a2', 'b2', '}', 'end'],
+        keysPressed: 'Ggg',
+        end: ['|start', '{', 'a1', 'b1', 'a2', 'b2', '}', 'end'],
+        jumps: ['start', 'end'],
       });
-
-      teardown(() => {
-        jumpTracker.clearJumps();
-        cleanUpWorkspace();
+      newJumpTest({
+        start: ['|start', '{', 'a1', 'b1', 'a2', 'b2', '}', 'end'],
+        keysPressed: 'GggG',
+        end: ['start', '{', 'a1', 'b1', 'a2', 'b2', '}', '|end'],
+        jumps: ['end', 'start'],
       });
-
-      testJumps(['G', 'gg'], [start, end], end);
-      testJumps(['G', 'gg', 'G'], [end, start], start);
-      testJumps(['G', 'gg', 'G', 'gg'], [start, end], end);
-      testJumps(['/b\n', 'n'], [start, b1], b1);
-      testJumps(['G', '?b\n', 'gg', 'G'], [end, b2, start], start);
-      testJumps(['j', '%', '%'], [open, close], close);
+      newJumpTest({
+        start: ['|start', '{', 'a1', 'b1', 'a2', 'b2', '}', 'end'],
+        keysPressed: 'GggGgg',
+        end: ['|start', '{', 'a1', 'b1', 'a2', 'b2', '}', 'end'],
+        jumps: ['start', 'end'],
+      });
+      newJumpTest({
+        start: ['|start', '{', 'a1', 'b1', 'a2', 'b2', '}', 'end'],
+        keysPressed: '/b\nn',
+        end: ['start', '{', 'a1', 'b1', 'a2', '|b2', '}', 'end'],
+        jumps: ['start', 'b1'],
+      });
+      newJumpTest({
+        start: ['|start', '{', 'a1', 'b1', 'a2', 'b2', '}', 'end'],
+        keysPressed: 'G?b\nggG',
+        end: ['start', '{', 'a1', 'b1', 'a2', 'b2', '}', '|end'],
+        jumps: ['end', 'b2', 'start'],
+      });
+      newJumpTest({
+        start: ['|start', '{', 'a1', 'b1', 'a2', 'b2', '}', 'end'],
+        keysPressed: 'j%%',
+        end: ['start', '|{', 'a1', 'b1', 'a2', 'b2', '}', 'end'],
+        jumps: ['{', '}'],
+      });
     });
 
     suite('Can track jumps with back/forward', () => {
-      setup(async () => {
-        await setupWorkspace();
-        await setupTestsWithText(text);
+      newJumpTest({
+        start: ['|start', '{', 'a1', 'b1', 'a2', 'b2', '}', 'end'],
+        keysPressed: 'j%%<C-o>',
+        end: ['start', '{', 'a1', 'b1', 'a2', 'b2', '|}', 'end'],
+        jumps: ['|}', '{'],
       });
-
-      teardown(() => {
-        jumpTracker.clearJumps();
-        cleanUpWorkspace();
+      newJumpTest({
+        start: ['|start', '{', 'a1', 'b1', 'a2', 'b2', '}', 'end'],
+        keysPressed: 'j%%<C-o><C-i>',
+        end: ['start', '|{', 'a1', 'b1', 'a2', 'b2', '}', 'end'],
+        jumps: ['}', '|{'],
       });
-
-      testJumps(['j', '%', '%', '<C-o>'], [close, open], close);
-      testJumps(['j', '%', '%', '<C-o>', '<C-i>'], [close, open], open);
-      testJumps(['j', '%', '%', '<C-o>', '%'], [open, close], close);
-      testJumps(['j', '%', '%', '<C-o>', 'gg'], [open, close], close);
-      testJumps(['j', '%', '%', '<C-o>', '<C-o>', 'gg'], [open, close], close);
-      testJumps(
-        ['/^\n', 'nnn', '<C-o>', '<C-o>', '<C-o>', '<C-i>', 'gg'],
-        [start, open, b1, a2, a1],
-        a1
-      );
+      newJumpTest({
+        start: ['|start', '{', 'a1', 'b1', 'a2', 'b2', '}', 'end'],
+        keysPressed: 'j%%<C-o>%',
+        end: ['start', '|{', 'a1', 'b1', 'a2', 'b2', '}', 'end'],
+        jumps: ['{', '}'],
+      });
+      newJumpTest({
+        start: ['|start', '{', 'a1', 'b1', 'a2', 'b2', '}', 'end'],
+        keysPressed: 'j%%<C-o>gg',
+        end: ['|start', '{', 'a1', 'b1', 'a2', 'b2', '}', 'end'],
+        jumps: ['{', '}'],
+      });
+      newJumpTest({
+        start: ['|start', '{', 'a1', 'b1', 'a2', 'b2', '}', 'end'],
+        keysPressed: 'j%%<C-o><C-o>gg',
+        end: ['|start', '{', 'a1', 'b1', 'a2', 'b2', '}', 'end'],
+        jumps: ['{', '}'],
+      });
+      newJumpTest({
+        start: ['|start', '{', 'a1', 'b1', 'a2', 'b2', '}', 'end'],
+        keysPressed: '/^\nnnn<C-o><C-o><C-o><C-i>gg',
+        end: ['|start', '{', 'a1', 'b1', 'a2', 'b2', '}', 'end'],
+        jumps: ['start', '{', 'b1', 'a2', 'a1'],
+      });
     });
 
-    suite('Can handle count prefixes when jumping back and forward', () => {
-      setup(async () => {
-        await setupWorkspace();
-        await setupTestsWithText(text);
+    suite('Can handle deleted lines', () => {
+      newJumpTest({
+        start: ['|start', 'a1', 'a2', 'a3', 'a4', 'a5', 'end'],
+        keysPressed: '/^\nnnnkkdd',
+        end: ['start', 'a1', '|a3', 'a4', 'a5', 'end'],
+        jumps: ['start', 'a1', 'a3'],
       });
-
-      teardown(() => {
-        jumpTracker.clearJumps();
-        cleanUpWorkspace();
+      newJumpTest({
+        start: ['|start', 'a1', 'a2', 'a3', 'a4', 'a5', 'end'],
+        keysPressed: '/^\nnnnkdd',
+        end: ['start', 'a1', 'a2', '|a4', 'a5', 'end'],
+        jumps: ['start', 'a1', 'a2', 'a4'],
       });
-
-      testJumps(['/^\n', 'nnn', '3', '<C-o>', '<C-i>', 'gg'], [start, open, b1, a2, a1], a1);
-      testJumps(['/^\n', 'nnnn', '3', '<C-o>', '2', '<C-i>'], [start, open, a1, b1, a2, b2], a2);
+      newJumpTest({
+        start: ['|start', 'a1', 'a2', 'a3', 'a4', 'a5', 'end'],
+        keysPressed: '/a4\n/a5\nkkkdd',
+        end: ['start', 'a1', '|a3', 'a4', 'a5', 'end'],
+        jumps: ['start', 'a4'],
+      });
     });
   });
 });

--- a/test/jumpTracker.test.ts
+++ b/test/jumpTracker.test.ts
@@ -1,16 +1,16 @@
-import * as assert from "assert";
-import * as vscode from "vscode";
+import * as assert from 'assert';
+import * as vscode from 'vscode';
 
-import { Jump } from "./../src/jumps/jump";
-import { getAndUpdateModeHandler } from "../extension";
-import { ModeHandler } from "../src/mode/modeHandler";
-import { TextEditor } from "../src/textEditor";
-import { cleanUpWorkspace, setupWorkspace } from "./testUtils";
-import { JumpTracker } from "../src/jumps/jumpTracker";
-import { Position } from "../src/common/motion/position";
-import { waitForCursorSync } from "../src/util/util";
+import { Jump } from './../src/jumps/jump';
+import { getAndUpdateModeHandler } from '../extension';
+import { ModeHandler } from '../src/mode/modeHandler';
+import { TextEditor } from '../src/textEditor';
+import { cleanUpWorkspace, setupWorkspace } from './testUtils';
+import { JumpTracker } from '../src/jumps/jumpTracker';
+import { Position } from '../src/common/motion/position';
+import { waitForCursorSync } from '../src/util/util';
 
-suite("Jump Tracker", () => {
+suite('Jump Tracker', () => {
   let jumpTracker: JumpTracker;
   let modeHandler: ModeHandler;
   let editor: vscode.TextEditor;
@@ -27,8 +27,8 @@ end`;
   const jump = (lineNumber, columnNumber) =>
     new Jump({
       editor,
-      fileName: "Untitled",
-      position: new Position(lineNumber, columnNumber)
+      fileName: 'Untitled',
+      position: new Position(lineNumber, columnNumber),
     });
 
   const start = jump(0, 0);
@@ -52,7 +52,7 @@ end`;
     await waitForCursorSync();
 
     jumpTracker = modeHandler.vimState.globalState.jumpTracker;
-    await modeHandler.handleMultipleKeyEvents(["gg"]);
+    await modeHandler.handleMultipleKeyEvents(['gg']);
     await waitForCursorSync();
     jumpTracker.clearJumps();
   });
@@ -63,12 +63,10 @@ end`;
   });
 
   const fixLineEndings = (t: string): string =>
-    process.platform === "win32" ? t.replace(/\\n/g, "\\r\\n") : t;
-  const flatten = list =>
-    list.reduce((a, b) => a.concat(Array.isArray(b) ? flatten(b) : b), []);
-  const hasPrefix = (t: string): boolean =>
-    t.startsWith("<") && t.endsWith(">");
-  const tokenize = (t: string): string[] => (hasPrefix(t) ? [t] : t.split(""));
+    process.platform === 'win32' ? t.replace(/\\n/g, '\\r\\n') : t;
+  const flatten = list => list.reduce((a, b) => a.concat(Array.isArray(b) ? flatten(b) : b), []);
+  const hasPrefix = (t: string): boolean => t.startsWith('<') && t.endsWith('>');
+  const tokenize = (t: string): string[] => (hasPrefix(t) ? [t] : t.split(''));
   const sendKeys = async (keys: string[]) => {
     for (var i = 0; i < keys.length; i++) {
       const key = keys[i];
@@ -84,24 +82,30 @@ end`;
     assert.deepEqual(
       jumpTracker.jumps.map(line),
       expectedJumps.map(line),
-      "Jumps are not in the correct order or the jumps are for the wrong lines"
+      'Jumps are not in the correct order or the jumps are for the wrong lines'
     );
   };
   const assertCurrentJump = (expectedCurrentJump: Jump) =>
     assert.deepEqual(
       position(jumpTracker.currentJump || jumpTracker.end),
       position(expectedCurrentJump),
-      "Current jump is incorrect"
+      'Current jump is incorrect'
     );
 
-  const testJumps = async (
-    keys: string[],
-    jumps: Jump[],
-    currentJump: Jump
-  ) => {
-    test(`Can record jumps for key events: ${keys.map(k =>
-      k.replace("\n", "\\n")
-    )}`, async () => {
+  /**
+   * Create a test that checks both recorded jumps and final jump position.
+   *
+   * To get expected results for the tests:
+   * 1) Open vim with vim -u NONE
+   * 2) Paste in the text being tested against (text variable)
+   * 3) :clearjumps
+   * 4) Reproduce the key combinations
+   * 5) :jumps
+   * Read jumps from top to bottom, that should be in the jumps variable.
+   * The arrow (>) will be the currentJump variable.
+   */
+  const testJumps = async (keys: string[], jumps: Jump[], currentJump: Jump) => {
+    test(`Can record jumps for key events: ${keys.map(k => k.replace('\n', '\\n'))}`, async () => {
       await sendKeys(flatten(keys.map(fixLineEndings).map(tokenize)));
 
       assertJumps(jumps);
@@ -109,14 +113,20 @@ end`;
     });
   };
 
-  testJumps(["G", "gg"], [start, end], end);
-  testJumps(["G", "gg", "G"], [end, start], start);
-  testJumps(["G", "gg", "G", "gg"], [start, end], end);
-  testJumps(["/b\n", "n"], [start, b1], b1);
-  testJumps(["G", "?b\n", "gg", "G"], [end, b2, start], start);
-  testJumps(["j", "%", "%"], [open, close], close);
-  testJumps(["j", "%", "%", "<C-o>"], [close, open], close);
-  testJumps(["j", "%", "%", "<C-o>", "<C-i>"], [close, open], open);
-  testJumps(["j", "%", "%", "<C-o>", "%"], [open, close], close);
-  testJumps(["j", "%", "%", "<C-o>", "gg"], [open, close], close);
+  testJumps(['G', 'gg'], [start, end], end);
+  testJumps(['G', 'gg', 'G'], [end, start], start);
+  testJumps(['G', 'gg', 'G', 'gg'], [start, end], end);
+  testJumps(['/b\n', 'n'], [start, b1], b1);
+  testJumps(['G', '?b\n', 'gg', 'G'], [end, b2, start], start);
+  testJumps(['j', '%', '%'], [open, close], close);
+  testJumps(['j', '%', '%', '<C-o>'], [close, open], close);
+  testJumps(['j', '%', '%', '<C-o>', '<C-i>'], [close, open], open);
+  testJumps(['j', '%', '%', '<C-o>', '%'], [open, close], close);
+  testJumps(['j', '%', '%', '<C-o>', 'gg'], [open, close], close);
+  testJumps(['j', '%', '%', '<C-o>', '<C-o>', 'gg'], [open, close], close);
+  testJumps(
+    ['/^\n', 'nnn', '<C-o>', '<C-o>', '<C-o>', '<C-i>', 'gg'],
+    [start, open, b1, a2, a1],
+    a1
+  );
 });

--- a/test/jumpTracker.test.ts
+++ b/test/jumpTracker.test.ts
@@ -22,15 +22,6 @@ suite('Jump Tracker', () => {
       position: new Position(lineNumber, columnNumber),
     });
 
-  const start = jump(0, 0);
-  const open = jump(1, 0);
-  const a1 = jump(2, 0);
-  const b1 = jump(3, 0);
-  const a2 = jump(4, 0);
-  const b2 = jump(5, 0);
-  const close = jump(6, 0);
-  const end = jump(7, 0);
-
   const range = (n: number) => Array.from(Array(n).keys());
   const fixLineEndings = (t: string): string =>
     process.platform === 'win32' ? t.replace(/\\n/g, '\\r\\n') : t;
@@ -133,6 +124,14 @@ a2
 b2
 }
 end`;
+    const start = jump(0, 0);
+    const open = jump(1, 0);
+    const a1 = jump(2, 0);
+    const b1 = jump(3, 0);
+    const a2 = jump(4, 0);
+    const b2 = jump(5, 0);
+    const close = jump(6, 0);
+    const end = jump(7, 0);
 
     suite('Can track basic jumps', () => {
       setup(async () => {
@@ -174,7 +173,21 @@ end`;
         [start, open, b1, a2, a1],
         a1
       );
+    });
+
+    suite('Can handle count prefixes when jumping back and forward', () => {
+      setup(async () => {
+        await setupWorkspace();
+        await setupTestsWithText(text);
+      });
+
+      teardown(() => {
+        jumpTracker.clearJumps();
+        cleanUpWorkspace();
+      });
+
       testJumps(['/^\n', 'nnn', '3', '<C-o>', '<C-i>', 'gg'], [start, open, b1, a2, a1], a1);
+      testJumps(['/^\n', 'nnnn', '3', '<C-o>', '2', '<C-i>'], [start, open, a1, b1, a2, b2], a2);
     });
   });
 });

--- a/test/jumpTracker.test.ts
+++ b/test/jumpTracker.test.ts
@@ -193,5 +193,14 @@ suite('Record and navigate jumps', () => {
         jumps: ['start', 'a4'],
       });
     });
+
+    suite('Can track jumps from macros', () => {
+      newJumpTest({
+        start: ['|start', 'a1', 'a2', 'a3', 'a4', 'a5', 'a6', 'a7', 'a8', 'a9', 'end'],
+        keysPressed: 'qq/^\nnq@q@q<C-o><C-o>',
+        end: ['start', 'a1', 'a2', 'a3', '|a4', 'a5', 'a6', 'a7', 'a8', 'a9', 'end'],
+        jumps: ['start', 'a1', 'a2', 'a3', '|a4', 'a5', 'a6'],
+      });
+    });
   });
 });

--- a/test/jumpTracker.test.ts
+++ b/test/jumpTracker.test.ts
@@ -1,0 +1,85 @@
+import * as assert from 'assert';
+import * as vscode from 'vscode';
+
+import { Jump } from './../src/jumps/jump';
+import { getAndUpdateModeHandler } from '../extension';
+import { ModeHandler } from '../src/mode/modeHandler';
+import { TextEditor } from '../src/textEditor';
+import { cleanUpWorkspace, setupWorkspace } from './testUtils';
+import { JumpTracker } from '../src/jumps/jumpTracker';
+import { Position } from '../src/common/motion/position';
+import { waitForCursorSync } from '../src/util/util';
+
+suite('Jump Tracker', () => {
+  let jumpTracker: JumpTracker;
+  let modeHandler: ModeHandler;
+  let editor: vscode.TextEditor;
+
+  const text = `start
+a1
+b1
+c1
+b2
+d1
+b3
+e1
+end`;
+
+  const jump = (line, character) => new Jump({
+    editor,
+    fileName: 'Untitled',
+    position: new Position(line, character),
+  });
+
+  const start = jump(0, 0);
+  const b1 = jump(2, 0);
+  const b3 = jump(6, 0);
+  const end = jump(8, 0);
+
+
+  setup(async () => {
+    await setupWorkspace();
+    modeHandler = await getAndUpdateModeHandler();
+    editor = modeHandler.vimState.editor!;
+
+    modeHandler.vimState.editor = vscode.window.activeTextEditor!;
+    (modeHandler as any).vimState.cursorPosition = new Position(0, 0);
+
+    await TextEditor.insert(text);
+    await waitForCursorSync();
+
+    jumpTracker = modeHandler.vimState.globalState.jumpTracker;
+    jumpTracker.clearJumps();
+  });
+
+  teardown(() => {
+    jumpTracker.clearJumps();
+    cleanUpWorkspace();
+  });
+
+  const assertJumpsEqual = (leftJumps, rightJumps) => {
+    const position = j => ([j.position.line, j.position.character]);
+
+    assert.deepEqual(
+      leftJumps.map(position),
+      rightJumps.map(position),
+    );
+  };
+
+  const testJumps = async (keys, jumps) => {
+    test(`jumpTracker records: ${keys.join('').replace('\n', '<CR>')}`, async () => {
+      for (var i = 0; i < keys.length; i++) {
+        const key = keys[i];
+        await modeHandler.handleKeyEvent(key);
+        await waitForCursorSync();
+      }
+      assertJumpsEqual(jumpTracker.jumps, jumps);
+    });
+  };
+
+  testJumps(['G', 'g', 'g'], [start, end]);
+  testJumps(['G', 'g', 'g', 'G'], [end, start]);
+  testJumps(['G', 'g', 'g', 'G', 'g', 'g'], [start, end]);
+  testJumps(['/', 'b', '\n', 'n'], [start, b1]);
+  testJumps(['G', '?', 'b', '\n', 'g', 'g', 'G'], [end, b3, start]);
+});

--- a/test/jumpTracker.test.ts
+++ b/test/jumpTracker.test.ts
@@ -116,14 +116,7 @@ suite('Jump Tracker', () => {
   });
 
   suite('Can record jumps for actions the same as vanilla Vim', () => {
-    const text = `start
-{
-a1
-b1
-a2
-b2
-}
-end`;
+    const text = ['start', '{', 'a1', 'b1', 'a2', 'b2', '}', 'end'].join('\n');
     const start = jump(0, 0);
     const open = jump(1, 0);
     const a1 = jump(2, 0);

--- a/test/jumpTracker.test.ts
+++ b/test/jumpTracker.test.ts
@@ -69,7 +69,7 @@ suite('Record and navigate jumps', () => {
 
       assert.deepEqual(
         jumpTracker.jumps.map(j => j.fileName),
-        ['file1', 'file3', 'file2'],
+        ['file1', 'file2', 'file3', 'file2'],
         'Unexpected jumps found'
       );
       assert.equal(jumpTracker.currentJump, null, 'Unexpected current jump found');

--- a/test/jumpTracker.test.ts
+++ b/test/jumpTracker.test.ts
@@ -202,5 +202,14 @@ suite('Record and navigate jumps', () => {
         jumps: ['start', 'a1', 'a2', 'a3', '|a4', 'a5', 'a6'],
       });
     });
+
+    suite('Can track jumps from marks', () => {
+      newJumpTest({
+        start: ['|start', 'a1', 'a2', 'a3', 'end'],
+        keysPressed: 'maG`a',
+        end: ['|start', 'a1', 'a2', 'a3', 'end'],
+        jumps: ['start', 'end'],
+      });
+    });
   });
 });

--- a/test/jumpTracker.test.ts
+++ b/test/jumpTracker.test.ts
@@ -259,7 +259,7 @@ suite('Record and navigate jumps', () => {
       });
     });
 
-    suite('Can shifts jump lines up after deleting a line', () => {
+    suite('Can shifts jump lines up after deleting a line with Visual Line Mode', () => {
       newJumpTest({
         start: ['|start', 'a1', 'a2', 'a3', 'a4', 'a5', 'end'],
         keysPressed: '/^\nnnnkkdd',
@@ -283,6 +283,15 @@ suite('Record and navigate jumps', () => {
         keysPressed: '/a4\n/a5\nkkkdd',
         end: ['start', 'a1', '|a3', 'a4', 'a5', 'end'],
         jumps: ['start', 'a4'],
+      });
+    });
+
+    suite('Can shifts jump lines up after deleting a line with Visual Mode', () => {
+      newJumpTest({
+        start: ['|start', 'a1', 'a2', 'a3', 'a4', 'a5', 'end'],
+        keysPressed: '/^\nnnnkklvjjhx',
+        end: ['start', 'a1', 'a|4', 'a5', 'end'],
+        jumps: ['start', 'a1', 'a4'],
       });
     });
 

--- a/test/jumpTracker.test.ts
+++ b/test/jumpTracker.test.ts
@@ -28,6 +28,31 @@ suite('Record and navigate jumps', () => {
     });
   };
 
+  suite('Jump Tracker unit tests', () => {
+    test('Records up to 100 jumps, the fixed length in vanilla Vim', async () => {
+      const jumpTracker = new JumpTracker();
+
+      const range = (n: number) => Array.from(Array(n).keys());
+      const jump = (lineNumber, columnNumber) =>
+        new Jump({
+          editor: null,
+          fileName: 'Untitled',
+          position: new Position(lineNumber, columnNumber),
+        });
+
+      range(102).forEach((iteration: number) => {
+        jumpTracker.recordJump(jump(iteration, 0), jump(iteration + 1, 0));
+      });
+
+      assert.equal(jumpTracker.jumps.length, 100, 'Jump tracker should cut off jumps at 100');
+      assert.deepEqual(
+        jumpTracker.jumps.map(j => j.position.line),
+        range(102).slice(2, 102),
+        "Jump tracker doesn't contain the expected jumps after removing old jumps"
+      );
+    });
+  });
+
   suite('Can record jumps for actions the same as vanilla Vim', () => {
     suite('Can track basic jumps', () => {
       newJumpTest({

--- a/test/jumpTracker.test.ts
+++ b/test/jumpTracker.test.ts
@@ -132,7 +132,7 @@ suite('Record and navigate jumps', () => {
       });
     });
 
-    suite('Can handle deleted lines', () => {
+    suite('Can shifts jump lines up after deleting a line', () => {
       newJumpTest({
         start: ['|start', 'a1', 'a2', 'a3', 'a4', 'a5', 'end'],
         keysPressed: '/^\nnnnkkdd',
@@ -147,8 +147,41 @@ suite('Record and navigate jumps', () => {
       });
       newJumpTest({
         start: ['|start', 'a1', 'a2', 'a3', 'a4', 'a5', 'end'],
+        keysPressed: '/^\nnnnnn<C-o><C-o><C-o><C-o>dd',
+        end: ['start', 'a1', '|a3', 'a4', 'a5', 'end'],
+        jumps: ['start', 'a1', '|a3', 'a4', 'a5', 'end'],
+      });
+      newJumpTest({
+        start: ['|start', 'a1', 'a2', 'a3', 'a4', 'a5', 'end'],
         keysPressed: '/a4\n/a5\nkkkdd',
         end: ['start', 'a1', '|a3', 'a4', 'a5', 'end'],
+        jumps: ['start', 'a4'],
+      });
+    });
+
+    suite('Can shift jump lines down after inserting a line', () => {
+      newJumpTest({
+        start: ['|start', 'a1', 'a2', 'a3', 'a4', 'a5', 'end'],
+        keysPressed: '/^\nnnnkkoINSERTED<Esc>0',
+        end: ['start', 'a1', 'a2', '|INSERTED', 'a3', 'a4', 'a5', 'end'],
+        jumps: ['start', 'a1', 'a2', 'a3'],
+      });
+      newJumpTest({
+        start: ['|start', 'a1', 'a2', 'a3', 'a4', 'a5', 'end'],
+        keysPressed: '/^\nnnnkoINSERTED<Esc>0',
+        end: ['start', 'a1', 'a2', 'a3', '|INSERTED', 'a4', 'a5', 'end'],
+        jumps: ['start', 'a1', 'a2', 'a3'],
+      });
+      newJumpTest({
+        start: ['|start', 'a1', 'a2', 'a3', 'a4', 'a5', 'end'],
+        keysPressed: '/^\nnnnkOINSERTED<Esc>0',
+        end: ['start', 'a1', 'a2', '|INSERTED', 'a3', 'a4', 'a5', 'end'],
+        jumps: ['start', 'a1', 'a2', 'a3'],
+      });
+      newJumpTest({
+        start: ['|start', 'a1', 'a2', 'a3', 'a4', 'a5', 'end'],
+        keysPressed: '/a4\n/a5\nkkkoINSERTED<Esc>0',
+        end: ['start', 'a1', 'a2', '|INSERTED', 'a3', 'a4', 'a5', 'end'],
         jumps: ['start', 'a4'],
       });
     });

--- a/test/testSimplifier.ts
+++ b/test/testSimplifier.ts
@@ -61,6 +61,7 @@ interface ITestObject {
   keysPressed: string;
   end: string[];
   endMode?: ModeName;
+  jumps?: string[];
 }
 
 class TestObjectHelper {
@@ -211,66 +212,95 @@ function tokenizeKeySequence(sequence: string): string[] {
 }
 
 async function testIt(modeHandler: ModeHandler, testObj: ITestObject): Promise<void> {
-  modeHandler.vimState.editor = vscode.window.activeTextEditor!;
+  try {
+    modeHandler.vimState.editor = vscode.window.activeTextEditor!;
 
-  let helper = new TestObjectHelper(testObj);
+    let helper = new TestObjectHelper(testObj);
+    const jumpTracker = modeHandler.vimState.globalState.jumpTracker;
 
-  // Don't try this at home, kids.
-  (modeHandler as any).vimState.cursorPosition = new Position(0, 0);
+    // Don't try this at home, kids.
+    (modeHandler as any).vimState.cursorPosition = new Position(0, 0);
 
-  await modeHandler.handleKeyEvent('<Esc>');
+    await modeHandler.handleKeyEvent('<Esc>');
 
-  // Insert all the text as a single action.
-  await modeHandler.vimState.editor.edit(builder => {
-    builder.insert(new Position(0, 0), testObj.start.join('\n').replace('|', ''));
-  });
+    // Insert all the text as a single action.
+    await modeHandler.vimState.editor.edit(builder => {
+      builder.insert(new Position(0, 0), testObj.start.join('\n').replace('|', ''));
+    });
 
-  await modeHandler.handleMultipleKeyEvents(['<Esc>', 'g', 'g']);
+    await modeHandler.handleMultipleKeyEvents(['<Esc>', 'g', 'g']);
 
-  await waitForCursorSync();
+    await waitForCursorSync();
 
-  // Since we bypassed VSCodeVim to add text,
-  // we need to tell the history tracker that we added it.
-  modeHandler.vimState.historyTracker.addChange();
-  modeHandler.vimState.historyTracker.finishCurrentStep();
+    // Since we bypassed VSCodeVim to add text,
+    // we need to tell the history tracker that we added it.
+    modeHandler.vimState.historyTracker.addChange();
+    modeHandler.vimState.historyTracker.finishCurrentStep();
 
-  // move cursor to start position using 'hjkl'
-  await modeHandler.handleMultipleKeyEvents(helper.getKeyPressesToMoveToStartPosition());
+    // move cursor to start position using 'hjkl'
+    await modeHandler.handleMultipleKeyEvents(helper.getKeyPressesToMoveToStartPosition());
 
-  await waitForCursorSync();
+    await waitForCursorSync();
 
-  Globals.mockModeHandler = modeHandler;
+    Globals.mockModeHandler = modeHandler;
 
-  let keysPressed = testObj.keysPressed;
-  if (process.platform === 'win32') {
-    keysPressed = keysPressed.replace(/\\n/g, '\\r\\n');
-  }
+    let keysPressed = testObj.keysPressed;
+    if (process.platform === 'win32') {
+      keysPressed = keysPressed.replace(/\\n/g, '\\r\\n');
+    }
 
-  // assumes key presses are single characters for nowkA
-  await modeHandler.handleMultipleKeyEvents(tokenizeKeySequence(keysPressed));
+    jumpTracker.clearJumps();
 
-  // Check valid test object input
-  assert(helper.isValid, "Missing '|' in test object.");
+    // assumes key presses are single characters for nowkA
+    await modeHandler.handleMultipleKeyEvents(tokenizeKeySequence(keysPressed));
 
-  // end: check given end output is correct
-  //
-  assertEqualLines(helper.asVimOutputText());
-  // Check final cursor position
-  //
-  let actualPosition = Position.FromVSCodePosition(TextEditor.getSelection().start);
-  let expectedPosition = helper.endPosition;
-  assert.equal(actualPosition.line, expectedPosition.line, 'Cursor LINE position is wrong.');
-  assert.equal(
-    actualPosition.character,
-    expectedPosition.character,
-    'Cursor CHARACTER position is wrong.'
-  );
+    // Check valid test object input
+    assert(helper.isValid, "Missing '|' in test object.");
 
-  // endMode: check end mode is correct if given
-  if (typeof testObj.endMode !== 'undefined') {
-    let actualMode = ModeName[modeHandler.currentMode.name].toUpperCase();
-    let expectedMode = ModeName[testObj.endMode].toUpperCase();
-    assert.equal(actualMode, expectedMode, "Didn't enter correct mode.");
+    // end: check given end output is correct
+    //
+    const lines = helper.asVimOutputText();
+    assertEqualLines(lines);
+    // Check final cursor position
+    //
+    let actualPosition = Position.FromVSCodePosition(TextEditor.getSelection().start);
+    let expectedPosition = helper.endPosition;
+    assert.equal(actualPosition.line, expectedPosition.line, 'Cursor LINE position is wrong.');
+    assert.equal(
+      actualPosition.character,
+      expectedPosition.character,
+      'Cursor CHARACTER position is wrong.'
+    );
+
+    // endMode: check end mode is correct if given
+    if (typeof testObj.endMode !== 'undefined') {
+      let actualMode = ModeName[modeHandler.currentMode.name].toUpperCase();
+      let expectedMode = ModeName[testObj.endMode].toUpperCase();
+      assert.equal(actualMode, expectedMode, "Didn't enter correct mode.");
+    }
+
+    // jumps: check jumps are correct if given
+    if (typeof testObj.jumps !== 'undefined') {
+      assert.deepEqual(
+        jumpTracker.jumps.map(j => lines[j.position.line] || '<MISSING>'),
+        testObj.jumps.map(t => t.replace('|', '')),
+        'Incorrect jumps found'
+      );
+
+      const stripBar = text => (text ? text.replace('|', '') : text);
+      const actualJumpPosition =
+        (jumpTracker.currentJump && lines[jumpTracker.currentJump.position.line]) || '<FRONT>';
+      const expectedJumpPosition = stripBar(testObj.jumps.find(t => t.includes('|'))) || '<FRONT>';
+
+      assert.deepEqual(
+        actualJumpPosition.toString(),
+        expectedJumpPosition.toString(),
+        'Incorrect jump position found'
+      );
+    }
+  } catch (err) {
+    console.error(err);
+    throw err;
   }
 }
 

--- a/test/testUtils.ts
+++ b/test/testUtils.ts
@@ -4,10 +4,11 @@ import * as os from 'os';
 import { join } from 'path';
 import * as vscode from 'vscode';
 
-import { IConfiguration } from '../src/configuration/iconfiguration';
-import { Globals } from '../src/globals';
-import { TextEditor } from '../src/textEditor';
 import { Configuration } from './testConfiguration';
+import { Globals } from '../src/globals';
+import { IConfiguration } from '../src/configuration/iconfiguration';
+import { TextEditor } from '../src/textEditor';
+import { getAndUpdateModeHandler } from '../extension';
 
 function rndName() {
   return Math.random()
@@ -89,6 +90,15 @@ export async function setupWorkspace(
 
   activeTextEditor!.options.tabSize = config.tabstop;
   activeTextEditor!.options.insertSpaces = config.expandtab;
+
+  if (!vscode.window.activeTextEditor) {
+    console.warn('Unable to enable extension. Active Text Editor was not found');
+    return;
+  }
+  await vscode.commands.executeCommand('setContext', 'vim.active', true);
+  const mh = await getAndUpdateModeHandler();
+  Globals.mockModeHandler = mh;
+  await mh.handleKeyEvent('<ExtensionEnable>');
 }
 
 export async function cleanUpWorkspace(): Promise<any> {

--- a/test/testUtils.ts
+++ b/test/testUtils.ts
@@ -91,6 +91,10 @@ export async function setupWorkspace(
   activeTextEditor!.options.tabSize = config.tabstop;
   activeTextEditor!.options.insertSpaces = config.expandtab;
 
+  mockAndEnable();
+}
+
+const mockAndEnable = async () => {
   if (!vscode.window.activeTextEditor) {
     console.warn('Unable to enable extension. Active Text Editor was not found');
     return;
@@ -99,7 +103,7 @@ export async function setupWorkspace(
   const mh = await getAndUpdateModeHandler();
   Globals.mockModeHandler = mh;
   await mh.handleKeyEvent('<ExtensionEnable>');
-}
+};
 
 export async function cleanUpWorkspace(): Promise<any> {
   return new Promise((c, e) => {

--- a/test/testUtils.ts
+++ b/test/testUtils.ts
@@ -91,14 +91,10 @@ export async function setupWorkspace(
   activeTextEditor!.options.tabSize = config.tabstop;
   activeTextEditor!.options.insertSpaces = config.expandtab;
 
-  mockAndEnable();
+  await mockAndEnable();
 }
 
 const mockAndEnable = async () => {
-  if (!vscode.window.activeTextEditor) {
-    console.warn('Unable to enable extension. Active Text Editor was not found');
-    return;
-  }
   await vscode.commands.executeCommand('setContext', 'vim.active', true);
   const mh = await getAndUpdateModeHandler();
   Globals.mockModeHandler = mh;


### PR DESCRIPTION
**What this PR does / why we need it**:

There have been several issues opened in the past that discuss the limitations of the current `<C-o>` and `<C-i>` jump list implementation, which relies on vscode internals.

The largest criticism is that small movements (such as j and k) are registered as jumps (vscode has an internal "jump" tracker, a history service, that is hard-coded with constant EDITOR_SELECTION_THRESHOLD to register a jump after moving 10 lines). The history was also limited. A common use case is to jump to definition in another file, navigate around that file to learn about how it works, and then to jump back. The user would have to jump back many times more than in vanilla Vim, and often would hit the start of history as old entries are truncated off.

This PR therefore implements our own jump list (or "Jump Tracker", in vein of the name of our "History Tracker" that is used for undo/redo). This gives us much more control of jump history, and I have also matched it with vanilla Vim behavior.

Motions and actions can now set an `isJump` flag to mark that they should be tracked as a jump. I have updated all of the existing motions and jumps to match vanilla Vim. Substitutes and some commands will also count jumps.

For testing, I enhanced `testSimplifier` to allow tracking jump position and jump entries. In the tests I wrote, I made sure to compare to vanilla Vim, matching the `:jumps` command in the expected jump results.

**Which issue(s) this PR fixes**

fixes #1933
fixes #2461

**Special notes for your reviewer**:

I ran into some issues trying to unit test, that I believe is unrelated to this PR. I tried to fix a few of the issues. I am still seeing this one:

```error: ModeHandler: error handling key=d. err=TypeError: Cannot read property 'document' of undefined.```

That seems to happen for the first test in the list if I run an individual test suite like this:

```MOCHA_GREP='Can record jumps for actions the same as vanilla Vim' npm test```


Anyway, here are some future enhancement ideas / limitations:

* Add `:jumps` and `:clearjumps` commands, matching Vim's built-in commands
* Neovim-based commands aren't tracked granularly, such as `:substitute`.
* Jumps where files were deleted may show a benign error `Unable to open...File not found...`. Behavior works fine, and you can continue to jump to previous entries. I wonder if there is a way to detect the error and remove the jump after the fact in case they jump to that point again.
* Split panes share the jump list. This seems similar to how vscode itself works with the built-in back functionality. I'm storing the JumpTracker in `GlobalState`. I don't know that we have per-pane state, so if we wanted to make it per-pane it would take a little more work.