### PR TITLE
Fix: Missing bindings to exit CommandMode. closes #3035

### DIFF
--- a/src/actions/commands/actions.ts
+++ b/src/actions/commands/actions.ts
@@ -1856,7 +1856,7 @@ class CommandInsertInCommandline extends BaseCommand {
 @RegisterAction
 class CommandEscInCommandline extends BaseCommand {
   modes = [ModeName.CommandlineInProgress];
-  keys = ['<Esc>'];
+  keys = [['<Esc>'], ['<C-c>'], ['<C-[>']];;
   runsOnceForEveryCursor() {
     return this.keysPressed[0] === '\n';
   }


### PR DESCRIPTION
This fixes #3035, adding the missing key bindings to exit CommandMode:
* <C-[>  which is the same as <Esc>
* <C-c>
