### PR TITLE
Support for line completion (<C-x><C-l>)

### DIFF
--- a/extension.ts
+++ b/extension.ts
@@ -10,7 +10,6 @@ import * as vscode from 'vscode';
 
 import { configuration } from './src/configuration/configuration';
 import { commandLine } from './src/cmd_line/commandLine';
-import { lineCompletionProvider } from './src/completion/lineCompletionProvider';
 import { Position } from './src/common/motion/position';
 import { EditorIdentity } from './src/editorIdentity';
 import { Globals } from './src/globals';
@@ -286,12 +285,6 @@ export async function activate(context: vscode.ExtensionContext) {
     mh.updateView(mh.vimState, { drawSelection: false, revealRange: false });
   }
 
-  vscode.languages.registerCompletionItemProvider(
-    [{ pattern: '**/*' }],
-    lineCompletionProvider,
-    ...['.']
-  );
-
   // This is called last because getAndUpdateModeHandler() will change cursor
   toggleExtension(configuration.disableExt, compositionState);
 }
@@ -379,6 +372,6 @@ function handleContentChangedFromDisk(document: vscode.TextDocument): void {
   });
 }
 
-process.on('unhandledRejection', function(reason: any, p: any) {
+process.on('unhandledRejection', function (reason: any, p: any) {
   logger.error(`Unhandled Rejection at: Promise ${p}. Reason: ${reason}.`);
 });

--- a/extension.ts
+++ b/extension.ts
@@ -10,6 +10,7 @@ import * as vscode from 'vscode';
 
 import { configuration } from './src/configuration/configuration';
 import { commandLine } from './src/cmd_line/commandLine';
+import { lineCompletionProvider } from './src/completion/lineCompletionProvider';
 import { Position } from './src/common/motion/position';
 import { EditorIdentity } from './src/editorIdentity';
 import { Globals } from './src/globals';
@@ -284,6 +285,12 @@ export async function activate(context: vscode.ExtensionContext) {
     let mh = await getAndUpdateModeHandler();
     mh.updateView(mh.vimState, { drawSelection: false, revealRange: false });
   }
+
+  vscode.languages.registerCompletionItemProvider(
+    [{ pattern: '**/*' }],
+    lineCompletionProvider,
+    ...['.']
+  );
 
   // This is called last because getAndUpdateModeHandler() will change cursor
   toggleExtension(configuration.disableExt, compositionState);

--- a/extension.ts
+++ b/extension.ts
@@ -372,6 +372,6 @@ function handleContentChangedFromDisk(document: vscode.TextDocument): void {
   });
 }
 
-process.on('unhandledRejection', function (reason: any, p: any) {
+process.on('unhandledRejection', function(reason: any, p: any) {
   logger.error(`Unhandled Rejection at: Promise ${p}. Reason: ${reason}.`);
 });

--- a/src/actions/commands/insert.ts
+++ b/src/actions/commands/insert.ts
@@ -1,4 +1,3 @@
-import { InputBoxOptions } from './../../../.vscode-test/stable/Visual Studio Code.app/Contents/Resources/app/out/vs/vscode.d';
 import * as vscode from 'vscode';
 
 import { lineCompletionProvider } from '../../completion/lineCompletionProvider';
@@ -530,9 +529,12 @@ class CommandCtrlVInInsertMode extends BaseCommand {
 class CommandShowLineAutocomplete extends BaseCommand {
   modes = [ModeName.Insert];
   keys = ['<C-x>', '<C-l>'];
+  runsOnceForEveryCursor() {
+    return false;
+  }
 
   public async exec(position: Position, vimState: VimState): Promise<VimState> {
-    await lineCompletionProvider.showLineCompletions();
+    await lineCompletionProvider.showLineCompletionsQuickPick(position, vimState);
     return vimState;
   }
 }

--- a/src/actions/commands/insert.ts
+++ b/src/actions/commands/insert.ts
@@ -1,5 +1,7 @@
+import { InputBoxOptions } from './../../../.vscode-test/stable/Visual Studio Code.app/Contents/Resources/app/out/vs/vscode.d';
 import * as vscode from 'vscode';
 
+import { lineCompletionProvider } from '../../completion/lineCompletionProvider';
 import { RecordedState } from '../../state/recordedState';
 import { VimState } from '../../state/vimState';
 import { Position, PositionDiff } from './../../common/motion/position';
@@ -520,6 +522,17 @@ class CommandCtrlVInInsertMode extends BaseCommand {
       });
     }
 
+    return vimState;
+  }
+}
+
+@RegisterAction
+class CommandShowLineAutocomplete extends BaseCommand {
+  modes = [ModeName.Insert];
+  keys = ['<C-x>', '<C-l>'];
+
+  public async exec(position: Position, vimState: VimState): Promise<VimState> {
+    await lineCompletionProvider.showLineCompletions();
     return vimState;
   }
 }

--- a/src/completion/lineCompletionProvider.ts
+++ b/src/completion/lineCompletionProvider.ts
@@ -1,8 +1,13 @@
 import * as vscode from 'vscode';
 
+import { configuration } from '../configuration/configuration';
 import { getAndUpdateModeHandler } from '../../extension';
 import { ModeHandler } from '../mode/modeHandler';
+import { ModeName } from '../mode/mode';
+import { Position, PositionDiff } from '../common/motion/position';
 import { TextEditor } from './../textEditor';
+import { VimState } from '../state/vimState';
+import { Range } from '../common/motion/range';
 
 const documents = v => {
   return v.workspace.textDocuments;
@@ -10,13 +15,19 @@ const documents = v => {
 const lines = document => {
   return document.getText().split('\n');
 };
-const getMatchingText = (text: string): string[] | null => {
+const getCompletionsForText = (text: string): string[] | null => {
   const matchedLines: string[] = [];
 
   for (const document of documents(vscode)) {
     for (const line of lines(document)) {
-      if (line && line.startsWith(text) && line !== text) {
-        matchedLines.push(line);
+      const lineWithoutPadding = line.replace(/^[ \t]/, '');
+      if (
+        matchedLines.indexOf(line) === -1 &&
+        lineWithoutPadding &&
+        lineWithoutPadding.startsWith(text) &&
+        lineWithoutPadding !== text
+      ) {
+        matchedLines.push(lineWithoutPadding);
       }
     }
   }
@@ -24,10 +35,81 @@ const getMatchingText = (text: string): string[] | null => {
   return matchedLines;
 };
 
+const getCompletionsForCurrentLine = (position: Position, vimState: VimState): string[] | null => {
+  const currentLineText = TextEditor.getText(
+    new vscode.Range(position.getFirstLineNonBlankChar(), vimState.cursorPosition)
+  );
+
+  return getCompletionsForText(currentLineText);
+};
+
 export const lineCompletionProvider = {
   _enabled: false,
 
-  showLineCompletions: async (): Promise<void> => {
+  showLineCompletionsQuickPick: async (
+    position: Position,
+    vimState: VimState
+  ): Promise<VimState> => {
+    this._enabled = true;
+
+    const completions = getCompletionsForCurrentLine(position, vimState);
+
+    if (!completions) {
+      return vimState;
+    }
+
+    const selectedCompletion = await vscode.window.showQuickPick(completions);
+
+    if (!selectedCompletion) {
+      return vimState;
+    }
+
+    const originalText = TextEditor.getLineAt(position).text;
+    const indentationWidth = TextEditor.getIndentationLevel(originalText);
+    const tabSize = configuration.tabstop || Number(vimState.editor.options.tabSize);
+    const newIndentationWidth = (indentationWidth / tabSize + 1) * tabSize;
+
+    // await TextEditor.replaceText(
+    //   vimState,
+    //   selectedCompletion,
+    //   position.getLineBegin(),
+    //   position.getLineEnd(),
+    //   new PositionDiff(0, newIndentationWidth - indentationWidth)
+    // );
+
+    vimState.recordedState.transformations.push({
+      type: 'deleteRange',
+      range: new Range(position.getFirstLineNonBlankChar(), position.getLineEnd()),
+    });
+
+    vimState.recordedState.transformations.push({
+      type: 'insertTextVSCode',
+      text: selectedCompletion,
+    });
+
+    // vimState.recordedState.transformations.push({
+    //   type: 'replaceText',
+    //   text: selectedCompletion,
+    //   start: position.getLineBegin(),
+    //   end: position,
+    // });
+
+    // vimState.recordedState.transformations.push({
+    //   type: 'moveCursor',
+    //   diff: new PositionDiff(0, selectedCompletion.length - originalText.length),
+    // });
+
+    // vimState.currentMode = ModeName.Insert;
+    // vimState.cursorStartPosition = new Position(position.line, selectedCompletion.length);
+    // vimState.cursorPosition = vimState.cursorStartPosition;
+
+    return vimState;
+  },
+
+  showLineCompletionsDropdown: async (): Promise<void> => {
+    // TODO: Delete me, if QuickPick works better.
+    //       Using standard completion ends up having too many
+    //       extra completions in the list.
     this._enabled = true;
 
     await vscode.commands.executeCommand('editor.action.triggerSuggest');
@@ -45,21 +127,13 @@ export const lineCompletionProvider = {
       }
 
       const mh: ModeHandler = await getAndUpdateModeHandler();
+      const completions = getCompletionsForCurrentLine(mh.vimState.cursorPosition, mh.vimState);
 
-      const currentLineText = TextEditor.getText(
-        new vscode.Range(
-          new vscode.Position(mh.vimState.cursorPosition.line, 0),
-          mh.vimState.cursorPosition
-        )
-      );
-
-      const matchingText: string[] | null = getMatchingText(currentLineText);
-
-      if (!matchingText) {
+      if (!completions) {
         return reject({ items: [] });
       }
 
-      const completionItems: vscode.CompletionItem[] = matchingText.map(text => {
+      const completionItems: vscode.CompletionItem[] = completions.map(text => {
         let completionItem = new vscode.CompletionItem(text);
         const description = text.replace(/^[ ]*/, '');
         completionItem.detail = description;

--- a/src/completion/lineCompletionProvider.ts
+++ b/src/completion/lineCompletionProvider.ts
@@ -9,25 +9,80 @@ import { TextEditor } from './../textEditor';
 import { VimState } from '../state/vimState';
 import { Range } from '../common/motion/range';
 
-const documents = v => {
-  return v.workspace.textDocuments;
+const documentsStartingWith = (startingFileName, v) => {
+  return v.workspace.textDocuments.sort((a, b) => {
+    if (a.fileName === startingFileName) {
+      return -1;
+    } else if (b.fileName === startingFileName) {
+      return 1;
+    }
+    return 0;
+  });
 };
-const lines = document => {
-  return document.getText().split('\n');
+
+const linesWithoutPadding = (
+  document: vscode.TextDocument,
+  startLine: number,
+  reverse: boolean
+) => {
+  const distanceFromStartLine = (line: number) => {
+    let distance = reverse ? startLine - line : line - startLine;
+    if (distance < 0) {
+      // We prioritized any items in the main direction searched,
+      // but now find closest items in opposite direction.
+      distance = startLine + Math.abs(distance);
+    }
+
+    return distance;
+  };
+
+  return document
+    .getText()
+    .split('\n')
+    .map((text, line) => ({
+      distance: distanceFromStartLine(line),
+      text: text.replace(/^[ \t]*/, ''),
+    }))
+    .sort((a, b) => (a.distance > b.distance ? 1 : -1));
 };
-const getCompletionsForText = (text: string): string[] | null => {
+
+/**
+ * Get all completions that match given text within open documents.
+ *
+ * Results are sorted in a few ways:
+ * 1) The current document is prioritized over other open documents.
+ * 2) For the current document, lines above the current cursor are always prioritized over lines below it.
+ * 3) For the current document, lines are also prioritized based on distance from cursor.
+ * 4) For other documents, lines are prioritized based on distance from the top.
+ *
+ * @param text - Text to partially match. Indentation is stripped.
+ * @param currentFileName - Current file, which is prioritized in sorting.
+ * @param currentPosition - Current position, which is prioritized when sorting for current file.
+ */
+const getCompletionsForText = (
+  text: string,
+  currentFileName: string,
+  currentPosition: Position
+): string[] | null => {
   const matchedLines: string[] = [];
 
-  for (const document of documents(vscode)) {
-    for (const line of lines(document)) {
-      const lineWithoutPadding = line.replace(/^[ \t]/, '');
+  for (const document of documentsStartingWith(currentFileName, vscode)) {
+    let startLine = 0;
+    let reverse = false;
+
+    if (document.fileName === currentFileName) {
+      startLine = currentPosition.line;
+      reverse = true;
+    }
+
+    for (const line of linesWithoutPadding(document, startLine, reverse)) {
       if (
-        matchedLines.indexOf(line) === -1 &&
-        lineWithoutPadding &&
-        lineWithoutPadding.startsWith(text) &&
-        lineWithoutPadding !== text
+        matchedLines.indexOf(line.text) === -1 &&
+        line.text &&
+        line.text.startsWith(text) &&
+        line.text !== text
       ) {
-        matchedLines.push(lineWithoutPadding);
+        matchedLines.push(line.text);
       }
     }
   }
@@ -40,7 +95,7 @@ const getCompletionsForCurrentLine = (position: Position, vimState: VimState): s
     new vscode.Range(position.getFirstLineNonBlankChar(), vimState.cursorPosition)
   );
 
-  return getCompletionsForText(currentLineText);
+  return getCompletionsForText(currentLineText, vimState.editor.document.fileName, position);
 };
 
 export const lineCompletionProvider = {

--- a/src/completion/lineCompletionProvider.ts
+++ b/src/completion/lineCompletionProvider.ts
@@ -1,10 +1,14 @@
 import * as vscode from 'vscode';
 
-import { Position, PositionDiff } from '../common/motion/position';
+import { Position } from '../common/motion/position';
 import { TextEditor } from './../textEditor';
 import { VimState } from '../state/vimState';
 import { Range } from '../common/motion/range';
 
+/**
+ * Return open text documents, with a given file at the top of the list.
+ * @param startingFileName File that will be first in the array, typically current file
+ */
 const documentsStartingWith = startingFileName => {
   return vscode.workspace.textDocuments.sort((a, b) => {
     if (a.fileName === startingFileName) {
@@ -16,44 +20,51 @@ const documentsStartingWith = startingFileName => {
   });
 };
 
-const linesWithoutPadding = (
+/**
+ * Get lines, with leading tabs or whitespace stripped.
+ * @param document Document to get lines from.
+ * @param lineToStartScanFrom Where to start looking for matches first. Closest matches are sorted first.
+ * @param scanAboveFirst Whether to start scan above or below cursor. Other direction is scanned last.
+ * @returns
+ */
+const linesWithoutIndentation = (
   document: vscode.TextDocument,
-  startLine: number,
-  reverse: boolean
-) => {
+  lineToStartScanFrom: number,
+  scanAboveFirst: boolean
+): { sortPriority: number; text: string }[] => {
   const distanceFromStartLine = (line: number) => {
-    let distance = reverse ? startLine - line : line - startLine;
-    if (distance < 0) {
+    let sortPriority = scanAboveFirst ? lineToStartScanFrom - line : line - lineToStartScanFrom;
+    if (sortPriority < 0) {
       // We prioritized any items in the main direction searched,
       // but now find closest items in opposite direction.
-      distance = startLine + Math.abs(distance);
+      sortPriority = lineToStartScanFrom + Math.abs(sortPriority);
     }
 
-    return distance;
+    return sortPriority;
   };
 
   return document
     .getText()
     .split('\n')
     .map((text, line) => ({
-      distance: distanceFromStartLine(line),
+      sortPriority: distanceFromStartLine(line),
       text: text.replace(/^[ \t]*/, ''),
     }))
-    .sort((a, b) => (a.distance > b.distance ? 1 : -1));
+    .sort((a, b) => (a.sortPriority > b.sortPriority ? 1 : -1));
 };
 
 /**
  * Get all completions that match given text within open documents.
- *
- * Results are sorted in a few ways:
- * 1) The current document is prioritized over other open documents.
- * 2) For the current document, lines above the current cursor are always prioritized over lines below it.
- * 3) For the current document, lines are also prioritized based on distance from cursor.
- * 4) For other documents, lines are prioritized based on distance from the top.
- *
- * @param text - Text to partially match. Indentation is stripped.
- * @param currentFileName - Current file, which is prioritized in sorting.
- * @param currentPosition - Current position, which is prioritized when sorting for current file.
+ * @example
+ * a1
+ * a2
+ * a| // <--- Perform line completion here
+ * a3
+ * a4
+ * // Returns: ['a2', 'a1', 'a3', 'a4']
+ * @param text Text to partially match. Indentation is stripped.
+ * @param currentFileName Current file, which is prioritized in sorting.
+ * @param currentPosition Current position, which is prioritized when sorting for current file.
  */
 const getCompletionsForText = (
   text: string,
@@ -63,15 +74,15 @@ const getCompletionsForText = (
   const matchedLines: string[] = [];
 
   for (const document of documentsStartingWith(currentFileName)) {
-    let startLine = 0;
-    let reverse = false;
+    let lineToStartScanFrom = 0;
+    let scanAboveFirst = false;
 
     if (document.fileName === currentFileName) {
-      startLine = currentPosition.line;
-      reverse = true;
+      lineToStartScanFrom = currentPosition.line;
+      scanAboveFirst = true;
     }
 
-    for (const line of linesWithoutPadding(document, startLine, reverse)) {
+    for (const line of linesWithoutIndentation(document, lineToStartScanFrom, scanAboveFirst)) {
       if (
         matchedLines.indexOf(line.text) === -1 &&
         line.text &&
@@ -86,32 +97,59 @@ const getCompletionsForText = (
   return matchedLines;
 };
 
+/**
+ * Get all completions that match given text within open documents.
+ * Results are sorted in a few ways:
+ * 1) The current document is prioritized over other open documents.
+ * 2) For the current document, lines above the current cursor are always prioritized over lines below it.
+ * 3) For the current document, lines are also prioritized based on distance from cursor.
+ * 4) For other documents, lines are prioritized based on distance from the top.
+ * @example
+ * a1
+ * a2
+ * a| // <--- Perform line completion here
+ * a3
+ * a4
+ * // Returns: ['a2', 'a1', 'a3', 'a4']
+ * @param position Position to start scan from
+ * @param document Document to start scanning from, starting at the position (other open documents are scanned from top)
+ */
 export const getCompletionsForCurrentLine = (
   position: Position,
-  vimState: VimState
+  document: vscode.TextDocument
 ): string[] | null => {
   const currentLineText = TextEditor.getText(
-    new vscode.Range(position.getFirstLineNonBlankChar(), vimState.cursorPosition)
+    new vscode.Range(position.getFirstLineNonBlankChar(), position)
   );
 
-  return getCompletionsForText(currentLineText, vimState.editor.document.fileName, position);
+  return getCompletionsForText(currentLineText, document.fileName, position);
 };
 
 export const lineCompletionProvider = {
   /**
+   * Get all completions that match given text within open documents.
+   * Results are sorted by priority.
+   * @see getCompletionsForCurrentLine
+   *
+   * Any trailing characters are stripped. Trailing characters are often
+   * from auto-close, such as when importing in JavaScript ES6 and typing a
+   * curly brace. So the trailing characters are removed on purpose.
+   *
+   * Modifies vimState, adding transformations that replaces the
+   * current line's text with the chosen completion, with proper indentation.
+   *
    * Here we use Quick Pick, instead of registerCompletionItemProvider
    * Originally I looked at using a standard completion dropdown using that method,
    * but it doesn't allow you to limit completions, and it became overwhelming
    * when e.g. trying to do a line completion when the cursor is positioned after
    * a space character (such that it shows almost any symbol in the list).
-   *
-   * Quick Pick also allows for searching, which is kind of a nice bonus.
+   * Quick Pick also allows for searching, which is a nice bonus.
    */
   showLineCompletionsQuickPick: async (
     position: Position,
     vimState: VimState
   ): Promise<VimState> => {
-    const completions = getCompletionsForCurrentLine(position, vimState);
+    const completions = getCompletionsForCurrentLine(position, vimState.editor.document);
 
     if (!completions) {
       return vimState;

--- a/src/completion/lineCompletionProvider.ts
+++ b/src/completion/lineCompletionProvider.ts
@@ -1,14 +1,14 @@
-import * as vscode from "vscode";
+import * as vscode from 'vscode';
 
-import { getAndUpdateModeHandler } from "../../extension";
-import { ModeHandler } from "../mode/modeHandler";
-import { TextEditor } from "./../textEditor";
+import { getAndUpdateModeHandler } from '../../extension';
+import { ModeHandler } from '../mode/modeHandler';
+import { TextEditor } from './../textEditor';
 
 const documents = v => {
   return v.workspace.textDocuments;
 };
 const lines = document => {
-  return document.getText().split("\n");
+  return document.getText().split('\n');
 };
 const getMatchingText = (text: string): string[] | null => {
   const matchedLines: string[] = [];
@@ -29,7 +29,7 @@ export const lineCompletionProvider = {
     document,
     position,
     token,
-    myContext,
+    myContext
   ): Thenable<vscode.CompletionItem[] | vscode.CompletionList> => {
     return new Promise(async (resolve, reject) => {
       const mh: ModeHandler = await getAndUpdateModeHandler();
@@ -37,8 +37,8 @@ export const lineCompletionProvider = {
       const currentLineText = TextEditor.getText(
         new vscode.Range(
           new vscode.Position(mh.vimState.cursorPosition.line, 0),
-          mh.vimState.cursorPosition,
-        ),
+          mh.vimState.cursorPosition
+        )
       );
 
       const matchingText: string[] | null = getMatchingText(currentLineText);
@@ -47,18 +47,17 @@ export const lineCompletionProvider = {
         return reject({ items: [] });
       }
 
-      const completionItems: vscode.CompletionItem[] = matchingText.map(
-        text => {
-          let completionItem = new vscode.CompletionItem(text);
-          completionItem.detail = text;
-          completionItem.documentation = text;
-          completionItem.filterText = text;
-          completionItem.insertText = text.replace(/^[ ]*/, '');
-          completionItem.label = text;
-          completionItem.kind = vscode.CompletionItemKind.Text;
-          return completionItem;
-        },
-      );
+      const completionItems: vscode.CompletionItem[] = matchingText.map(text => {
+        let completionItem = new vscode.CompletionItem(text);
+        const description = text.replace(/^[ ]*/, '');
+        completionItem.detail = description;
+        completionItem.documentation = description;
+        completionItem.filterText = text;
+        completionItem.insertText = text.replace(currentLineText, '');
+        completionItem.label = description;
+        completionItem.kind = vscode.CompletionItemKind.Text;
+        return completionItem;
+      });
 
       return resolve({ items: completionItems });
     });

--- a/src/completion/lineCompletionProvider.ts
+++ b/src/completion/lineCompletionProvider.ts
@@ -1,0 +1,66 @@
+import * as vscode from "vscode";
+
+import { getAndUpdateModeHandler } from "../../extension";
+import { ModeHandler } from "../mode/modeHandler";
+import { TextEditor } from "./../textEditor";
+
+const documents = v => {
+  return v.workspace.textDocuments;
+};
+const lines = document => {
+  return document.getText().split("\n");
+};
+const getMatchingText = (text: string): string[] | null => {
+  const matchedLines: string[] = [];
+
+  for (const document of documents(vscode)) {
+    for (const line of lines(document)) {
+      if (line && line.startsWith(text) && line !== text) {
+        matchedLines.push(line);
+      }
+    }
+  }
+
+  return matchedLines;
+};
+
+export const lineCompletionProvider = {
+  provideCompletionItems: (
+    document,
+    position,
+    token,
+    myContext,
+  ): Thenable<vscode.CompletionItem[] | vscode.CompletionList> => {
+    return new Promise(async (resolve, reject) => {
+      const mh: ModeHandler = await getAndUpdateModeHandler();
+
+      const currentLineText = TextEditor.getText(
+        new vscode.Range(
+          new vscode.Position(mh.vimState.cursorPosition.line, 0),
+          mh.vimState.cursorPosition,
+        ),
+      );
+
+      const matchingText: string[] | null = getMatchingText(currentLineText);
+
+      if (!matchingText) {
+        return reject({ items: [] });
+      }
+
+      const completionItems: vscode.CompletionItem[] = matchingText.map(
+        text => {
+          let completionItem = new vscode.CompletionItem(text);
+          completionItem.detail = text;
+          completionItem.documentation = text;
+          completionItem.filterText = text;
+          completionItem.insertText = text.replace(/^[ ]*/, '');
+          completionItem.label = text;
+          completionItem.kind = vscode.CompletionItemKind.Text;
+          return completionItem;
+        },
+      );
+
+      return resolve({ items: completionItems });
+    });
+  },
+};

--- a/src/completion/lineCompletionProvider.ts
+++ b/src/completion/lineCompletionProvider.ts
@@ -5,7 +5,7 @@ import { TextEditor } from './../textEditor';
 import { VimState } from '../state/vimState';
 import { Range } from '../common/motion/range';
 
-const documentsStartingWith = (startingFileName) => {
+const documentsStartingWith = startingFileName => {
   return vscode.workspace.textDocuments.sort((a, b) => {
     if (a.fileName === startingFileName) {
       return -1;
@@ -86,7 +86,10 @@ const getCompletionsForText = (
   return matchedLines;
 };
 
-const getCompletionsForCurrentLine = (position: Position, vimState: VimState): string[] | null => {
+export const getCompletionsForCurrentLine = (
+  position: Position,
+  vimState: VimState
+): string[] | null => {
   const currentLineText = TextEditor.getText(
     new vscode.Range(position.getFirstLineNonBlankChar(), vimState.cursorPosition)
   );

--- a/test/completion/lineCompletion.test.ts
+++ b/test/completion/lineCompletion.test.ts
@@ -1,0 +1,64 @@
+import * as assert from 'assert';
+import * as vscode from 'vscode';
+
+import { getAndUpdateModeHandler } from "../../extension";
+import { getCompletionsForCurrentLine } from '../../src/completion/lineCompletionProvider';
+import { ModeHandler } from "../../src/mode/modeHandler";
+import { Position } from '../../src/common/motion/position';
+import { cleanUpWorkspace, setupWorkspace } from '../testUtils';
+import { VimState } from '../../src/state/vimState';
+import { waitForCursorSync } from '../../src/util/util';
+
+suite('Provide line completions', () => {
+  let modeHandler: ModeHandler;
+  let vimState: VimState;
+
+  setup(async () => {
+    await setupWorkspace();
+    modeHandler = await getAndUpdateModeHandler();
+    vimState = modeHandler.vimState;
+  });
+
+  teardown(cleanUpWorkspace);
+
+  const setupTestWithLines = async (lines) => {
+    vimState.cursorPosition = new Position(0, 0);
+
+    await modeHandler.handleKeyEvent('<Esc>');
+    await vimState.editor.edit(builder => {
+      builder.insert(new Position(0, 0), lines.join('\n'));
+    });
+    await modeHandler.handleMultipleKeyEvents(['<Esc>', 'g', 'g', 'j', 'j', 'A']);
+
+    await waitForCursorSync();
+  };
+
+  suite('Line Completion Provider unit tests', () => {
+    test('Can complete lines in file, prioritizing above cursor, near cursor', async () => {
+      const lines = ['a1', 'a2', 'a', 'a3', 'b1', 'a4'];
+      await setupTestWithLines(lines);
+      const expectedCompletions = ['a2', 'a1', 'a3', 'a4'];
+      const topCompletions = getCompletionsForCurrentLine(vimState.cursorPosition, vimState)!.slice(0, expectedCompletions.length);
+
+      assert.deepEqual(topCompletions, expectedCompletions, 'Unexpected completions found');
+    });
+
+    test('Can complete lines in file with different indentation', async () => {
+      const lines = ['a1', '   a 2', 'a', 'a3  ', 'b1', 'a4'];
+      await setupTestWithLines(lines);
+      const expectedCompletions = ['a 2', 'a1', 'a3  ', 'a4'];
+      const topCompletions = getCompletionsForCurrentLine(vimState.cursorPosition, vimState)!.slice(0, expectedCompletions.length);
+
+      assert.deepEqual(topCompletions, expectedCompletions, 'Unexpected completions found');
+    });
+
+    test('Returns no completions for unmatched line', async () => {
+      const lines = ['a1', '   a2', 'azzzzzzzzzzzzzzzzzzzzzzzz', 'a3  ', 'b1', 'a4'];
+      await setupTestWithLines(lines);
+      const expectedCompletions = [];
+      const completions = getCompletionsForCurrentLine(vimState.cursorPosition, vimState)!.slice(0, expectedCompletions.length);
+
+      assert.equal(completions.length, 0, 'Completions found, but none were expected');
+    });
+  });
+});

--- a/test/completion/lineCompletion.test.ts
+++ b/test/completion/lineCompletion.test.ts
@@ -1,9 +1,8 @@
 import * as assert from 'assert';
-import * as vscode from 'vscode';
 
-import { getAndUpdateModeHandler } from "../../extension";
+import { getAndUpdateModeHandler } from '../../extension';
 import { getCompletionsForCurrentLine } from '../../src/completion/lineCompletionProvider';
-import { ModeHandler } from "../../src/mode/modeHandler";
+import { ModeHandler } from '../../src/mode/modeHandler';
 import { Position } from '../../src/common/motion/position';
 import { cleanUpWorkspace, setupWorkspace } from '../testUtils';
 import { VimState } from '../../src/state/vimState';
@@ -21,7 +20,7 @@ suite('Provide line completions', () => {
 
   teardown(cleanUpWorkspace);
 
-  const setupTestWithLines = async (lines) => {
+  const setupTestWithLines = async lines => {
     vimState.cursorPosition = new Position(0, 0);
 
     await modeHandler.handleKeyEvent('<Esc>');
@@ -38,7 +37,10 @@ suite('Provide line completions', () => {
       const lines = ['a1', 'a2', 'a', 'a3', 'b1', 'a4'];
       await setupTestWithLines(lines);
       const expectedCompletions = ['a2', 'a1', 'a3', 'a4'];
-      const topCompletions = getCompletionsForCurrentLine(vimState.cursorPosition, vimState)!.slice(0, expectedCompletions.length);
+      const topCompletions = getCompletionsForCurrentLine(
+        vimState.cursorPosition,
+        vimState.editor.document
+      )!.slice(0, expectedCompletions.length);
 
       assert.deepEqual(topCompletions, expectedCompletions, 'Unexpected completions found');
     });
@@ -47,7 +49,10 @@ suite('Provide line completions', () => {
       const lines = ['a1', '   a 2', 'a', 'a3  ', 'b1', 'a4'];
       await setupTestWithLines(lines);
       const expectedCompletions = ['a 2', 'a1', 'a3  ', 'a4'];
-      const topCompletions = getCompletionsForCurrentLine(vimState.cursorPosition, vimState)!.slice(0, expectedCompletions.length);
+      const topCompletions = getCompletionsForCurrentLine(
+        vimState.cursorPosition,
+        vimState.editor.document
+      )!.slice(0, expectedCompletions.length);
 
       assert.deepEqual(topCompletions, expectedCompletions, 'Unexpected completions found');
     });
@@ -56,7 +61,10 @@ suite('Provide line completions', () => {
       const lines = ['a1', '   a2', 'azzzzzzzzzzzzzzzzzzzzzzzz', 'a3  ', 'b1', 'a4'];
       await setupTestWithLines(lines);
       const expectedCompletions = [];
-      const completions = getCompletionsForCurrentLine(vimState.cursorPosition, vimState)!.slice(0, expectedCompletions.length);
+      const completions = getCompletionsForCurrentLine(
+        vimState.cursorPosition,
+        vimState.editor.document
+      )!.slice(0, expectedCompletions.length);
 
       assert.equal(completions.length, 0, 'Completions found, but none were expected');
     });


### PR DESCRIPTION
**What this PR does / why we need it**:

This adds support for Vim's line completion mode:

* http://vimdoc.sourceforge.net/htmldoc/insert.html#i_CTRL-X_CTRL-L

The line completion hotkey `<C-x><C-l>` opens up a Quick Pick menu. Standard autocompletion wasn't used because extensions like ours can't limit the suggestions to just our own. I tried implementing it that way at first, and results were overwhelming. Quick Pick has the added benefit of being able to do additional searching within the list, so I actually prefer it for this use case.

Completions come from vscode's open editors list. The current file is prioritized, and search starts from the cursor position.

See a video here:

* https://cl.ly/f32a1aa9871e

**Which issue(s) this PR fixes**

#2141 - Just the line completion aspect.

**Special notes for your reviewer**:

I realized in testing it is slightly different than vanilla Vim, as results closest to the cursor are prioritized, but I'm leaving it as is and am happy to hear feedback. Usually I'd change it to mirror Vim, though in this case I think that is a worse experience (I'd be more likely to use a completion just below the cursor than at bottom of the file).