### PR TITLE
Feature/fix black hole operator mappings

### DIFF
--- a/src/actions/commands/actions.ts
+++ b/src/actions/commands/actions.ts
@@ -1872,7 +1872,7 @@ class CommandInsertInCommandline extends BaseCommand {
 @RegisterAction
 class CommandEscInCommandline extends BaseCommand {
   modes = [ModeName.CommandlineInProgress];
-  keys = [['<Esc>'], ['<C-c>'], ['<C-[>']];;
+  keys = [['<Esc>'], ['<C-c>'], ['<C-[>']];
   runsOnceForEveryCursor() {
     return this.keysPressed[0] === '\n';
   }

--- a/src/mode/modeHandler.ts
+++ b/src/mode/modeHandler.ts
@@ -321,6 +321,7 @@ export class ModeHandler implements vscode.Disposable {
        */
       if (
         !this.vimState.isCurrentlyPerformingRemapping &&
+        !this.vimState.recordedState.operator &&
         (withinTimeout || this.vimState.recordedState.commandList.length === 1)
       ) {
         handled = await this._remappers.sendKey(

--- a/test/configuration/remapper.test.ts
+++ b/test/configuration/remapper.test.ts
@@ -305,6 +305,24 @@ suite('Remapper', () => {
     actual = await Register.get(vimState);
     assert.equal(actual.text, expected);
   });
+
+  test('d -> black hole register delete in normal mode through modehandler', async () => {
+    assert.equal(modeHandler.currentMode.name, ModeName.Normal);
+
+    await modeHandler.handleMultipleKeyEvents(['<Esc>', 'g', 'g']);
+    await modeHandler.handleMultipleKeyEvents(['i', 'word1 word2', '<Esc>', '0']);
+
+    const expected = 'text-to-put-on-register';
+    let actual: IRegisterContent;
+    Register.put(expected, modeHandler.vimState);
+    actual = await Register.get(vimState);
+    assert.equal(actual.text, expected);
+
+    await modeHandler.handleMultipleKeyEvents(['d', 'w']);
+
+    actual = await Register.get(vimState);
+    assert.equal(actual.text, expected);
+  });
 });
 
 /* tslint:enable:no-string-literal */

--- a/test/configuration/remapper.test.ts
+++ b/test/configuration/remapper.test.ts
@@ -46,6 +46,14 @@ suite('Remapper', () => {
       before: ['d'],
       after: ['"', '_', 'd'],
     },
+    {
+      before: ['y', 'y'],
+      after: ['y', 'l'],
+    },
+    {
+      before: ['e'],
+      after: ['$'],
+    },
   ];
   const visualModeKeyBindings: IKeyRemapping[] = [
     {
@@ -284,7 +292,7 @@ suite('Remapper', () => {
     assert.equal(modeHandler.currentMode.name, ModeName.Normal);
 
     await modeHandler.handleMultipleKeyEvents(['<Esc>', 'g', 'g']);
-    await modeHandler.handleMultipleKeyEvents(['i', 'line1', '<Esc>']);
+    await modeHandler.handleMultipleKeyEvents(['i', 'line1', '<Esc>', '0']);
 
     const expected = 'text-to-put-on-register';
     let actual: IRegisterContent;

--- a/test/configuration/remapper.test.ts
+++ b/test/configuration/remapper.test.ts
@@ -7,12 +7,15 @@ import { ModeHandler } from '../../src/mode/modeHandler';
 import { Configuration } from '../testConfiguration';
 import { assertEqual, setupWorkspace, cleanUpWorkspace } from '../testUtils';
 import { IKeyRemapping } from '../../src/configuration/iconfiguration';
+import { IRegisterContent, Register } from '../../src/register/register';
 import { getAndUpdateModeHandler } from '../../extension';
+import { VimState } from '../../src/state/vimState';
 
 /* tslint:disable:no-string-literal */
 
 suite('Remapper', () => {
   let modeHandler: ModeHandler;
+  let vimState: VimState;
   const leaderKey = '\\';
   const insertModeKeyBindings: IKeyRemapping[] = [
     {
@@ -38,6 +41,10 @@ suite('Remapper', () => {
           args: [],
         },
       ],
+    },
+    {
+      before: ['d'],
+      after: ['"', '_', 'd'],
     },
   ];
   const visualModeKeyBindings: IKeyRemapping[] = [
@@ -81,6 +88,7 @@ suite('Remapper', () => {
 
     await setupWorkspace(configuration);
     modeHandler = await getAndUpdateModeHandler();
+    vimState = modeHandler.vimState;
   });
 
   teardown(cleanUpWorkspace);
@@ -270,6 +278,24 @@ suite('Remapper', () => {
     // assert
     assert.equal(actual, true);
     assert.equal(vscode.window.visibleTextEditors.length, 0);
+  });
+
+  test('d -> black hole register delete in normal mode through modehandler', async () => {
+    assert.equal(modeHandler.currentMode.name, ModeName.Normal);
+
+    await modeHandler.handleMultipleKeyEvents(['<Esc>', 'g', 'g']);
+    await modeHandler.handleMultipleKeyEvents(['i', 'line1', '<Esc>']);
+
+    const expected = 'text-to-put-on-register';
+    let actual: IRegisterContent;
+    Register.put(expected, modeHandler.vimState);
+    actual = await Register.get(vimState);
+    assert.equal(actual.text, expected);
+
+    await modeHandler.handleMultipleKeyEvents(['d', 'd']);
+
+    actual = await Register.get(vimState);
+    assert.equal(actual.text, expected);
   });
 });
 


### PR DESCRIPTION
**What this PR does / why we need it**:

It is somewhat common in Vim to remap keys to copy to the black hole register, when the user doesn't want to modify the default register. In our current remapping system, this wasn't supported with operators when the operator was a repeated key press (e.g. `dd` with `"_d` mapped).

Vanilla Vim seems to disregard key mappings if an operator is in progress. `dd` with `"_d` mapped should result in `"_dd`, not `"_d"_d`. So this change seems in line with vanilla as far as that goes.

Therefore, with this PR, the following vscode setting should allow e.g. `dd` and `dw` to become `"_dd` and `"_dw`, thereby yanking to the black hole register and not overwriting the default register or the system clipboard.

```
{
     "vim.normalModeKeyBindingsNonRecursive": [
        {
            "before": ["d"],
            "after": [ "\"", "_", "d" ]
        }
    ]
}
```

**Which issue(s) this PR fixes**

fixes #2672

**Special notes for your reviewer**:

Note that there are still issues with mapping, such as if you want to map both `d` and `dd`. But those don't appear to be regressions. Vanilla Vim handles the following scenarios:

```Mapping "d" should change the first "d" in "dw"
Mapping "w" does NOT affect the "w" in "dw"
Mapping "dd" should change "dd"
Mapping "d" and "dd", it uses "dd" remap if "dd" is pressed, otherwise it waits for a timeout to do "d" remap
Mapping just "d", it realizes there are no mappings that involve additional keystrokes, so it applies "d" remap immediately
```

It seems we would need to e.g. revamp how the remapper timeouts work in ModeHandler if we wanted to handle these. I could open a separate GitHub issue to tackle that.