### PR TITLE
Multiline yank writes to 0 register; fixes #1214

### DIFF
--- a/src/register/register.ts
+++ b/src/register/register.ts
@@ -302,9 +302,7 @@ export class Register {
    */
   private static processNumberedRegister(content: RegisterContent, vimState: VimState): void {
     // Find the BaseOperator of the current actions
-    const baseOperator = vimState.recordedState.actionsRun.find(value => {
-      return value instanceof BaseOperator || value instanceof BaseCommand;
-    });
+    const baseOperator = vimState.recordedState.operator || vimState.recordedState.command;
 
     if (baseOperator instanceof YankOperator || baseOperator instanceof CommandYankFullLine) {
       // 'yank' to 0 only if no register was specified

--- a/src/state/recordedState.ts
+++ b/src/state/recordedState.ts
@@ -126,7 +126,7 @@ export class RecordedState {
    * The command (e.g. i, ., R, /) the user wants to run, if there is one.
    */
   public get command(): BaseCommand {
-    const list = _.filter(this.actionsRun, a => a instanceof BaseCommand);
+    const list = _.filter(this.actionsRun, a => a instanceof BaseCommand).reverse();
 
     // TODO - disregard <Esc>, then assert this is of length 1.
 

--- a/test/register/register.test.ts
+++ b/test/register/register.test.ts
@@ -105,6 +105,49 @@ suite('register', () => {
     assertEqualLines(['test2', 'test2', 'test3']);
   });
 
+  test("Multiline yank (`[count]yy`) stores text in Register '0'", async () => {
+    modeHandler.vimState.editor = vscode.window.activeTextEditor!;
+
+    await modeHandler.handleMultipleKeyEvents('itest1\ntest2\ntest3'.split(''));
+
+    await modeHandler.handleMultipleKeyEvents([
+      '<Esc>',
+      'g',
+      'g',
+      '2',
+      'y',
+      'y',
+      'd',
+      'd',
+      '"',
+      '0',
+      'P',
+    ]);
+
+    assertEqualLines(['test1', 'test2', 'test2', 'test3']);
+  });
+
+  test("Multiline yank (`[count]Y`) stores text in Register '0'", async () => {
+    modeHandler.vimState.editor = vscode.window.activeTextEditor!;
+
+    await modeHandler.handleMultipleKeyEvents('itest1\ntest2\ntest3'.split(''));
+
+    await modeHandler.handleMultipleKeyEvents([
+      '<Esc>',
+      'g',
+      'g',
+      '2',
+      'Y',
+      'd',
+      'd',
+      '"',
+      '0',
+      'P',
+    ]);
+
+    assertEqualLines(['test1', 'test2', 'test2', 'test3']);
+  });
+
   test("Register '1'-'9' stores delete content", async () => {
     modeHandler.vimState.editor = vscode.window.activeTextEditor!;
 


### PR DESCRIPTION
<!--
Yay! Thanks for sending us a PR! 🎊

Please ensure your PR adheres to:

- [ ] Commit messages has a short & issue references when necessary
- [ ] Each commit does a logical chunk of work.
- [ ] It builds and tests pass (e.g `gulp`)
-->

**What this PR does / why we need it**:
Makes sure that multiline yank commands (`5yy`, `5Y`, `V%y`) write to the `0` register.

**Which issue(s) this PR fixes**
#1214

**Special notes for your reviewer**:
See inline comment below for more explanation of this change