### PR TITLE
fix (simpler) - cursor whenever changing editors - closes #2688

### DIFF
--- a/extension.ts
+++ b/extension.ts
@@ -34,7 +34,7 @@ interface ICodeKeybinding {
   commands?: { command: string; args: any[] }[];
 }
 
-export async function getAndUpdateModeHandler(): Promise<ModeHandler> {
+export async function getAndUpdateModeHandler(forceSyncAndUpdate = false): Promise<ModeHandler> {
   const activeEditorId = new EditorIdentity(vscode.window.activeTextEditor);
 
   let [curHandler, isNew] = await ModeHandlerMap.getOrCreate(activeEditorId.toString());
@@ -44,7 +44,11 @@ export async function getAndUpdateModeHandler(): Promise<ModeHandler> {
 
   curHandler.vimState.editor = vscode.window.activeTextEditor!;
 
-  if (!previousActiveEditorId || !previousActiveEditorId.isEqual(activeEditorId)) {
+  if (
+    forceSyncAndUpdate ||
+    !previousActiveEditorId ||
+    !previousActiveEditorId.isEqual(activeEditorId)
+  ) {
     curHandler.syncCursors();
     await curHandler.updateView(curHandler.vimState, { drawSelection: false, revealRange: false });
   }
@@ -185,7 +189,7 @@ export async function activate(context: vscode.ExtensionContext) {
 
     taskQueue.enqueueTask(async () => {
       if (vscode.window.activeTextEditor !== undefined) {
-        const mh: ModeHandler = await getAndUpdateModeHandler();
+        const mh: ModeHandler = await getAndUpdateModeHandler(true);
 
         await mh.updateView(mh.vimState, { drawSelection: false, revealRange: false });
 


### PR DESCRIPTION
<!--
Yay! Thanks for sending us a PR! 🎊

Please ensure your PR adheres to:

- [x] Commit messages has a short & issue references when necessary
- [x] Each commit does a logical chunk of work.
- [x] It builds and tests pass (e.g `gulp`)
-->

**What this PR does / why we need it**:
ModeHandler.syncCursors() and updateView() stopped being called on active editor changes after the bugfix to EditorIdentity because a window change wasn't being detected as a window change when the filename-only identity is identical :D.

getAndUpdateModeHandler() is called in a ton of places, so this PR adds a force-sync option, and has the ActiveEditorChange handler use it.

**Which issue(s) this PR fixes**
#2688

<!--
Commits in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)
-->

**Special notes for your reviewer**:

This PR restores the behavior to how it was before.

I took a wrong turn on another PR, but because of that, I noticed that there's some differences between selection change handling and editor switches.  It's pretty clear from just the length of it ;), but for example, EOL-checking seems to behave slightly different when switching editors than when staying in the same editor.  It's probably outside the scope of this issue, but I thought I'd mention it.


