### PR TITLE
Fix issues with keybindings when changing to an editor in different mode

### DIFF
--- a/extension.ts
+++ b/extension.ts
@@ -187,6 +187,8 @@ export async function activate(context: vscode.ExtensionContext) {
       if (vscode.window.activeTextEditor !== undefined) {
         const mh: ModeHandler = await getAndUpdateModeHandler();
 
+        await mh.updateVimModeForKeybindings(mh.vimState.currentMode);
+
         await mh.updateView(mh.vimState, { drawSelection: false, revealRange: false });
 
         globalState.jumpTracker.handleFileJump(


### PR DESCRIPTION
**What this PR does / why we need it**:

Fix issues with keybindings when changing to an editor in different mode. This resulted in keybindings not working until changing modes again, including seeing `<Tab>` inserted as text in insert mode, if vscode thought we were in normal mode still.

**Which issue(s) this PR fixes**

fixes #3096 
fixes #730 
fixes https://github.com/Microsoft/vscode/issues/59925

**Special notes for your reviewer**:

I'm not exactly sure why we don't have tests between editors. It would be nice to add tests here. I know that in the onDidChangeActiveTextEditor handler we even return automatically if `Globals.isTesting` is true.

Anyway, there are two main changes here:

1. "setContext vim.mode" is called when switching editor windows (previously this wasn't getting called until pressing keys in the new editor window).
2. I also made _previousMode static, since setContext for vim.mode applies across editors (along with renaming to _lastVimModeSetForKeybindings to clarify purpose).