### PR TITLE
support "edit" command

### DIFF
--- a/src/cmd_line/subparser.ts
+++ b/src/cmd_line/subparser.ts
@@ -74,6 +74,7 @@ export const commandParsers = {
   s: parseSubstituteCommandArgs,
 
   e: fileCmd.parseEditFileCommandArgs,
+  edit: fileCmd.parseEditFileCommandArgs,
   ene: fileCmd.parseEditNewFileCommandArgs,
   enew: fileCmd.parseEditNewFileCommandArgs,
 


### PR DESCRIPTION
Just adds "edit" to the list of commands, as currently the shorthand `:e` is supported but the explicit `:edit` is not.
