### PR TITLE
Correct intentation when replacing space with newline

### DIFF
--- a/src/actions/commands/insert.ts
+++ b/src/actions/commands/insert.ts
@@ -282,6 +282,14 @@ export class CommandInsertInInsertMode extends BaseCommand {
           position: vimState.cursorPosition,
         });
       } else {
+        if (char === '\n') {
+          // Remove whitespace to the right of cursor before inserting newline
+          const whitespace = line.substring(position.character).search(/\S|$/);
+          if (whitespace > 0) {
+            await TextEditor.delete(new vscode.Range(position, position.getRight(whitespace)));
+          }
+        }
+
         vimState.recordedState.transformations.push({
           type: 'insertTextVSCode',
           text: char,


### PR DESCRIPTION


<!--
Yay! Thanks for sending us a PR! 🎊

Please ensure your PR adheres to:

- [ ] Commit messages has a short & issue references when necessary
- [ ] Each commit does a logical chunk of work.
- [ ] It builds and tests pass (e.g `gulp`)
-->

**What this PR does / why we need it**:

Changes the behavior of inserting a newline in the middle of a line, by removing whitespace to the right of the cursor on the original line. The result is that the new line is correctly indented.

The resulting behavior is consistent with real vim.

**Which issue(s) this PR fixes**

Fixes issue #2791
<!--
Commits in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)
-->

**Special notes for your reviewer**:

I first tried to implement this behavior by registering a new command for the return key. This resulted in exceptions, because there is some special handling of the `CommandInsertInInsertMode` inside `modeHandler.ts`. While it would be possible to handle my new command in the same way, it seemed simpler just to amend the existing command.