### PR TITLE
Prevent error on loading search history if no active editor on startup

### DIFF
--- a/src/state/searchState.ts
+++ b/src/state/searchState.ts
@@ -58,9 +58,10 @@ export class SearchState {
 
     // checking if the tab that is worked on has changed, or the file version has changed
     const shouldRecalculate =
-      this._cachedDocumentName !== TextEditor.getDocumentName() ||
-      this._cachedDocumentVersion !== TextEditor.getDocumentVersion() ||
-      forceRecalc;
+      TextEditor.isActive &&
+      (this._cachedDocumentName !== TextEditor.getDocumentName() ||
+        this._cachedDocumentVersion !== TextEditor.getDocumentVersion() ||
+        forceRecalc);
 
     if (shouldRecalculate) {
       // Calculate and store all matching ranges

--- a/src/textEditor.ts
+++ b/src/textEditor.ts
@@ -11,6 +11,21 @@ export class TextEditor {
   // TODO: Refactor args
 
   /**
+   * Verify that a tab is even open for the TextEditor to act upon.
+   *
+   * This class was designed assuming there will usually be an active editor
+   * to act upon, which is usually true with editor hotkeys.
+   *
+   * But there are cases where an editor won't be active, such as running
+   * code on VSCodeVim activation, where you might see the error:
+   * > [Extension Host] Here is the error stack:
+   * > TypeError: Cannot read property 'document' of undefined
+   */
+  static get isActive() {
+    return vscode.window.activeTextEditor != null;
+  }
+
+  /**
    * Do not use this method! It has been deprecated. Use InsertTextTransformation
    * (or possibly InsertTextVSCodeTransformation) instead.
    */


### PR DESCRIPTION
**What this PR does / why we need it**:

We were seeing the error on startup with globalState.loadSearchHistory(), related to #3116.

```
TypeError: Cannot read property 'document' of undefined

[Extension Host] Here is the error stack:  TypeError: Cannot read property 'document' of undefined
	at Function.getDocumentName (/Users/shawnaxsom/side-projects/Vim/out/src/textEditor.js:62:47)
	at SearchState._recalculateSearchRanges (/Users/shawnaxsom/side-projects/Vim/out/src/state/searchState.js:52:88)
	at SearchState.set searchString [as searchString] (/Users/shawnaxsom/side-projects/Vim/out/src/state/searchState.js:43:18)
	at new SearchState (/Users/shawnaxsom/side-projects/Vim/out/src/state/searchState.js:25:27)
	at __dirname.loadSearchHistory.GlobalState._searchHistory.get.forEach.val (/Users/shawnaxsom/side-projects/Vim/out/src/state/globalState.js:26:63)
	at Array.forEach (<anonymous>)
	at GlobalState.loadSearchHistory (/Users/shawnaxsom/side-projects/Vim/out/src/state/globalState.js:26:18)
	at /Users/shawnaxsom/side-projects/Vim/out/extension.js:248:21
	at Generator.next (<anonymous>)
	at __awaiter (/Users/shawnaxsom/side-projects/Vim/out/extension.js:7:71)
	at new Promise (<anonymous>)
	at __awaiter (/Users/shawnaxsom/side-projects/Vim/out/extension.js:3:12)
	at activate (/Users/shawnaxsom/side-projects/Vim/out/extension.js:64:12)
[...]
```

When creating a new SearchState in loadSearchHistory, it was calling searchState.set searchString, which calls _recalculateSearchRanges, which tried to access the document that didn't exist.

This happened if the editor loaded with no active tab when initializing VSCodeVim, and resulted in being "stuck in insert mode" when trying to edit when the user did open a tab.

**Which issue(s) this PR fixes**

fixes #3143
fixes #3139

**Special notes for your reviewer**:

I briefly tested #3116, and it seems to work, even if you loaded no tab on startup and then jumped to the last tab you searched on.

`TextEditor.js` maybe should be less assuming that there is an active text editor, not using the `!` symbol. But at that point we wouldn't want to just do nothing in many cases either, so maybe there isn't a good fix (ideally the consumer of TextEditor would check for an active editor, but it is easy to forget to do so).