### PR TITLE
correct the `G` command description

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -74,7 +74,7 @@ Now follows an exhaustive list of every known Vim command that we could find.
 | :white_check_mark: | :1234: -  | up N lines, on the first non-blank character                                              |
 | :white_check_mark: | :1234: +  | down N lines, on the first non-blank character (also: CTRL-M and CR)                      |
 | :white_check_mark: | :1234: \_ | down N-1 lines, on the first non-blank character                                          |
-| :white_check_mark: | :1234: G  | goto line N (default: last line), on the first non-blank character                        |
+| :white_check_mark: | :1234: G  | goto line N (default: last line), on the first character (maybe blank)                    |
 | :white_check_mark: | :1234: gg | goto line N (default: first line), on the first non-blank character                       |
 | :white_check_mark: | :1234: %  | goto line N percentage down in the file; N must be given, otherwise it is the `%` command |
 | :white_check_mark: | :1234: gk | up N screen lines (differs from "k" when line wraps)                                      |


### PR DESCRIPTION
the 🔢 G command is to goto the first charactor to the line.