### PR TITLE
Added common example for key remapping for £

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,16 @@ Custom remappings are defined on a per-mode basis.
     ]
 ```
 
+- Bind `£` to goto previous whole word under cursor
+```json
+    "vim.normalModeKeyBindings": [
+        {
+            "before": ["£"],
+            "after": ["#"]
+        }
+    ]
+```
+
 - Bind `:` to show the command palette:
 
 ```json

--- a/README.md
+++ b/README.md
@@ -170,6 +170,7 @@ Custom remappings are defined on a per-mode basis.
 ```
 
 - Bind `£` to goto previous whole word under cursor
+
 ```json
     "vim.normalModeKeyBindings": [
         {


### PR DESCRIPTION
<!--
Yay! Thanks for sending us a PR! 🎊

Please ensure your PR adheres to:

- [x] Commit messages has a short & issue references when necessary
- [x] Each commit does a logical chunk of work.
- [x] It builds and tests pass (e.g `gulp`)
-->

**What this PR does / why we need it**:
Since UK keyboard has `shift+3` to be `£` instead of `#`. The command for going to the previous word under cursor wouldn't work. I have been searching online and couldn't find any documentation about this. So I thought would be nice to include at README here.
