### PR TITLE
Not quite working - Reset the command list in ModeHandler.runAction if in insert mode

### DIFF
--- a/src/mode/modeHandler.ts
+++ b/src/mode/modeHandler.ts
@@ -578,7 +578,7 @@ export class ModeHandler implements vscode.Disposable {
       }
     }
 
-    if (ranAction && vimState.currentMode !== ModeName.Insert) {
+    if (ranAction) {
       vimState.recordedState.resetCommandList();
     }
 


### PR DESCRIPTION
Line 382 was checking if there was an action ran AND if the current
state was not insert mode. This caused a bug which left the commandList
with a lingering `i` which broke remapped bindings for the following
key. Remove this check so that the command list is clear upon entering
insert mode.

**What this PR does / why we need it**:
* Define a `insertModeRemapping` e.g. `"<c-e>"` -> `["<c-o>","x"]`
* Press `i` to enter insert mode.
* Press `<c-e>`

Nothing happens. This is because the `vimState.recordedState.commandList` length is 2 and the `withinTimeout` variable is `false`. Thus no attempt to remap and the keymapping lookup fails to find anything. 

HOWEVER, this causes the `jj` -> `esc` map test to fail and does indeed invalidate such bindings in insert mode. 

I can't say I know what to look for at this point because how you guys handle this state is spread out throughout these classes. So if somebody could check this out and find the proper way to amend this diff then I'd be very pleased. 

**Which issue(s) this PR fixes**
https://github.com/VSCodeVim/Vim/issues/3252