### PR TITLE
Format operator fixes and tests

### DIFF
--- a/src/actions/operator.ts
+++ b/src/actions/operator.ts
@@ -343,6 +343,9 @@ export class FormatOperator extends BaseOperator {
   public modes = [ModeName.Normal, ModeName.Visual, ModeName.VisualLine, ModeName.VisualBlock];
 
   public async run(vimState: VimState, start: Position, end: Position): Promise<VimState> {
+    // = operates on complete lines
+    start = new Position(start.line, 0);
+    end = end.getLineEnd();
     vimState.editor.selection = new vscode.Selection(start, end);
     await vscode.commands.executeCommand('editor.action.formatSelection');
     let line = vimState.cursorStartPosition.line;
@@ -351,7 +354,7 @@ export class FormatOperator extends BaseOperator {
       line = vimState.cursorPosition.line;
     }
 
-    let newCursorPosition = new Position(line, 0);
+    let newCursorPosition = new Position(line, 0).getFirstLineNonBlankChar();
     vimState.cursorPosition = newCursorPosition;
     vimState.cursorStartPosition = newCursorPosition;
     await vimState.setCurrentMode(ModeName.Normal);

--- a/test/operator/format.test.ts
+++ b/test/operator/format.test.ts
@@ -1,0 +1,69 @@
+import { ModeName } from '../../src/mode/mode';
+import { getTestingFunctions, ITestObject } from '../testSimplifier';
+import { cleanUpWorkspace, setupWorkspace } from './../testUtils';
+
+suite('format operator', () => {
+  let { newTest, newTestOnly } = getTestingFunctions();
+
+  setup(async () => {
+    await setupWorkspace(undefined, '.ts');
+  });
+
+  teardown(cleanUpWorkspace);
+
+  newTest({
+    title: '== formats current line',
+    start: [' |let a;', '  let b;'],
+    keysPressed: '==',
+    end: ['|let a;', '  let b;'],
+  });
+
+  newTest({
+    title: '=$ formats entire line',
+    start: [' function f() {|let a;', 'let b;', '}'],
+    keysPressed: '=$',
+    end: ['|function f() {', '  let a;', 'let b;', '}'],
+  });
+
+  newTest({
+    title: '=j formats two lines',
+    start: [' |let a;', '  let b;', '  let c;'],
+    keysPressed: '=j',
+    end: ['|let a;', 'let b;', '  let c;'],
+  });
+
+  newTest({
+    title: '3=k formats three lines',
+    start: [' let a;', '  let b;', '|  let c;'],
+    keysPressed: '3=k',
+    end: ['|let a;', 'let b;', 'let c;'],
+  });
+
+  newTest({
+    title: '=gg formats to top of file',
+    start: [' let a;', '  let b;', '|  let c;'],
+    keysPressed: '=gg',
+    end: ['|let a;', 'let b;', 'let c;'],
+  });
+
+  newTest({
+    title: '=G formats to bottom of file',
+    start: ['|  let a;', '  let b;', '  let c;'],
+    keysPressed: '=G',
+    end: ['|let a;', 'let b;', 'let c;'],
+  });
+
+  newTest({
+    title: '=ip formats paragraph',
+    start: ['  function f() {', '|let a;', '  }', '', '  let b;'],
+    keysPressed: '=ip',
+    end: ['|function f() {', '  let a;', '}', '', '  let b;'],
+  });
+
+  newTest({
+    title: 'format in visual mode',
+    start: ['  function f() {', 'let a;', '|  }', '', '  let b;'],
+    keysPressed: 'vkk=',
+    end: ['|function f() {', '  let a;', '}', '', '  let b;'],
+  });
+});


### PR DESCRIPTION
Make format operator (=) consistent with Vim8/NeoVim.
- Format operator now operates on complete lines.
- Cursor ends on first non-blank character instead of column 0.

<!--
Yay! Thanks for sending us a PR! 🎊

Please ensure your PR adheres to:

- [x] Commit messages has a short & issue references when necessary
- [x] Each commit does a logical chunk of work.
- [x] It builds and tests pass (e.g `gulp`)
-->

**What this PR does / why we need it**:

Formatting behavior was inconsistent with Vim8/NeoVim. For example `=G` would not format the current line if the cursor was in the middle.

**Which issue(s) this PR fixes**
Fix #1574 and other behavior described in the tests.

<!--
Commits in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)
-->

**Special notes for your reviewer**:
Thanks for VSCodeVim! I would have never considered using VSCode without it.

Also, the declarative test functions from testSimplifier are awesome.