### PR TITLE
fix saving remote file  error

### DIFF
--- a/src/cmd_line/commands/write.ts
+++ b/src/cmd_line/commands/write.ts
@@ -49,7 +49,8 @@ export class WriteCommand extends node.CommandBase {
       Message.ShowError('Not implemented.');
       return;
     }
-
+    
+    // defer saving the file to vscode if file is new (to present file explorer) or if file is a remote file
     if (vimState.editor.document.isUntitled || vimState.editor.document.uri.scheme !== 'file') {
       await vscode.commands.executeCommand('workbench.action.files.save');
       return;

--- a/src/cmd_line/commands/write.ts
+++ b/src/cmd_line/commands/write.ts
@@ -50,7 +50,7 @@ export class WriteCommand extends node.CommandBase {
       return;
     }
 
-    if (vimState.editor.document.isUntitled) {
+    if (vimState.editor.document.isUntitled || vimState.editor.document.uri.scheme !== 'file') {
       await vscode.commands.executeCommand('workbench.action.files.save');
       return;
     }


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes the error when saving remote files (via ssh or others)

**Which issue(s) this PR fixes**
fixes #2956
 
**Special notes for your reviewer**:
scheme value in document's uri is "file" for disk files.
for remote files, the scheme value may be different.
To use the workbench's save function can work on saving remove files.