### PR TITLE
fix: esc when closing auto-complete widget will stay in insert mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
       {
         "key": "Escape",
         "command": "extension.vim_escape",
-        "when": "editorTextFocus && vim.active && !inDebugRepl"
+        "when": "editorTextFocus && !suggestWidgetVisible && vim.active && !inDebugRepl"
       },
       {
         "key": "Home",


### PR DESCRIPTION
<!--
Yay! Thanks for sending us a PR! 🎊

Please ensure your PR adheres to:

- [ ] Commit messages has a short & issue references when necessary
- [ ] Each commit does a logical chunk of work.
- [ ] It builds and tests pass (e.g `gulp`)
-->

**What this PR does / why we need it**:

- When an auto-complete widget is visible when in Insert mode, `<Esc>` will close the auto-complete widget, but leave the editor in Insert mode.
- Wasn't able to find a VSCode API to detect if suggest widget was available. 
- Not sure if this will be a contentious change, but I like this new behaviour. Open to comments.

**Which issue(s) this PR fixes**
https://github.com/VSCodeVim/Vim/issues/826, https://github.com/VSCodeVim/Vim/issues/804

<!--
Commits in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)
-->

**Special notes for your reviewer**:

- It is assumed that while the suggestion widget is visible, the user's intention when pressing `<Esc>`, is to close the auto-suggest widget.
