### PR TITLE
fix: slightly improve perf by caching vscode context

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -19,6 +19,7 @@ A clear and concise description of what you expected to happen.
 
 **Screenshots**
 If applicable, add screenshots to help explain your problem.
+If remapping-related, please attach log output: https://github.com/VSCodeVim/Vim#debugging-remappings.
 
 **Environment (please complete the following information):**
 

--- a/extension.ts
+++ b/extension.ts
@@ -8,21 +8,22 @@ import './src/actions/include-all';
 import * as _ from 'lodash';
 import * as vscode from 'vscode';
 
-import { configuration } from './src/configuration/configuration';
-import { commandLine } from './src/cmd_line/commandLine';
-import { Position } from './src/common/motion/position';
-import { EditorIdentity } from './src/editorIdentity';
-import { Globals } from './src/globals';
-import { GlobalState } from './src/state/globalState';
-import { Jump } from './src/jumps/jump';
-import { ModeName } from './src/mode/mode';
-import { ModeHandler } from './src/mode/modeHandler';
-import { Notation } from './src/configuration/notation';
-import { StatusBar } from './src/statusBar';
-import { taskQueue } from './src/taskQueue';
-import { ModeHandlerMap } from './src/mode/modeHandlerMap';
-import { logger } from './src/util/logger';
 import { CompositionState } from './src/state/compositionState';
+import { EditorIdentity } from './src/editorIdentity';
+import { GlobalState } from './src/state/globalState';
+import { Globals } from './src/globals';
+import { Jump } from './src/jumps/jump';
+import { ModeHandler } from './src/mode/modeHandler';
+import { ModeHandlerMap } from './src/mode/modeHandlerMap';
+import { ModeName } from './src/mode/mode';
+import { Notation } from './src/configuration/notation';
+import { Position } from './src/common/motion/position';
+import { StatusBar } from './src/statusBar';
+import { VsCodeContext } from './src/util/vscode-context';
+import { commandLine } from './src/cmd_line/commandLine';
+import { configuration } from './src/configuration/configuration';
+import { logger } from './src/util/logger';
+import { taskQueue } from './src/taskQueue';
 
 const globalState = new GlobalState();
 let extensionContext: vscode.ExtensionContext;
@@ -191,7 +192,7 @@ export async function activate(context: vscode.ExtensionContext) {
       if (vscode.window.activeTextEditor !== undefined) {
         const mh: ModeHandler = await getAndUpdateModeHandler(true);
 
-        await mh.updateVimModeForKeybindings(mh.vimState.currentMode);
+        await VsCodeContext.Set('vim.mode', this.vimState.currentMode);
 
         await mh.updateView(mh.vimState, { drawSelection: false, revealRange: false });
 
@@ -324,7 +325,7 @@ export async function activate(context: vscode.ExtensionContext) {
  * @param isDisabled if true, sets VSCodeVim to Disabled mode; else sets to enabled mode
  */
 async function toggleExtension(isDisabled: boolean, compositionState: CompositionState) {
-  await vscode.commands.executeCommand('setContext', 'vim.active', !isDisabled);
+  await VsCodeContext.Set('vim.active', !isDisabled);
   if (!vscode.window.activeTextEditor) {
     // This was happening in unit tests.
     // If activate was called and no editor window is open, we can't properly initialize.

--- a/src/configuration/configuration.ts
+++ b/src/configuration/configuration.ts
@@ -1,8 +1,8 @@
 import * as vscode from 'vscode';
 
 import { Globals } from '../globals';
-import { taskQueue } from '../taskQueue';
 import { Notation } from './notation';
+import { taskQueue } from '../taskQueue';
 import {
   IConfiguration,
   IKeyRemapping,
@@ -10,6 +10,7 @@ import {
   IAutoSwitchInputMethod,
   IDebugConfiguration,
 } from './iconfiguration';
+import { VsCodeContext } from '../util/vscode-context';
 
 const packagejson: {
   contributes: {
@@ -159,15 +160,11 @@ class Configuration implements IConfiguration {
         }
       }
 
-      vscode.commands.executeCommand('setContext', `vim.use${boundKey.key}`, useKey);
+      VsCodeContext.Set(`vim.use${boundKey.key}`, useKey);
     }
 
-    vscode.commands.executeCommand('setContext', 'vim.overrideCopy', this.overrideCopy);
-    vscode.commands.executeCommand(
-      'setContext',
-      'vim.overrideCtrlC',
-      this.overrideCopy || this.useCtrlKeys
-    );
+    VsCodeContext.Set('vim.overrideCopy', this.overrideCopy);
+    VsCodeContext.Set('vim.overrideCtrlC', this.overrideCopy || this.useCtrlKeys);
   }
 
   unproxify(obj: Object): Object {

--- a/src/util/vscode-context.ts
+++ b/src/util/vscode-context.ts
@@ -1,0 +1,19 @@
+import * as vscode from 'vscode';
+
+export class VsCodeContextImpl {
+  contextMap: { [key: string]: any } = {};
+
+  public async Set(key: string, value: any): Promise<void> {
+    const prev = this.Get(key);
+    if (!prev || prev !== value) {
+      this.contextMap[key] = value;
+      return vscode.commands.executeCommand('setContext', key, value);
+    }
+  }
+
+  public Get(key: string): any {
+    return this.contextMap[key];
+  }
+}
+
+export let VsCodeContext = new VsCodeContextImpl();


### PR DESCRIPTION
<!--
Yay! Thanks for sending us a PR! 🎊

Please ensure your PR adheres to:

- [ ] Commit messages has a short & issue references when necessary
- [ ] Each commit does a logical chunk of work.
- [ ] It builds and tests pass (e.g `gulp`)
-->

**What this PR does / why we need it**:

The following operation `vscode.commands.executeCommand('setContext', ...` takes roughly 1s to complete. Cache the value and only update vscode context when value changes.

We had done this for some of the context values. This PR does it for _all_ context values.

**Which issue(s) this PR fixes**

<!--
Commits in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)
-->

**Special notes for your reviewer**:

- sorted imports