### PR TITLE
fix: ignore remappings with non-existent commands. fixes #3295

### DIFF
--- a/extension.ts
+++ b/extension.ts
@@ -22,6 +22,7 @@ import { StatusBar } from './src/statusBar';
 import { VsCodeContext } from './src/util/vscode-context';
 import { commandLine } from './src/cmd_line/commandLine';
 import { configuration } from './src/configuration/configuration';
+import { configurationValidator } from './src/configuration/configurationValidator';
 import { logger } from './src/util/logger';
 import { taskQueue } from './src/taskQueue';
 
@@ -311,8 +312,8 @@ export async function activate(context: vscode.ExtensionContext) {
   }
 
   await commandLine.load();
-  // Initialize the search history
   await globalState.loadSearchHistory();
+  await configurationValidator.initialize();
 
   // This is called last because getAndUpdateModeHandler() will change cursor
   toggleExtension(configuration.disableExt, compositionState);

--- a/src/configuration/configurationValidator.ts
+++ b/src/configuration/configurationValidator.ts
@@ -1,0 +1,21 @@
+import * as vscode from 'vscode';
+
+class ConfigurationValidator {
+  private map: Map<string, boolean>;
+
+  public async initialize(): Promise<void> {
+    this.map = new Map(
+      (await vscode.commands.getCommands(true)).map(x => [x, true] as [string, boolean])
+    );
+  }
+
+  public isCommandValid(command: string): boolean {
+    if (command.startsWith(':')) {
+      return true;
+    }
+
+    return this.map.get(command) || false;
+  }
+}
+
+export let configurationValidator = new ConfigurationValidator();


### PR DESCRIPTION
<!--
Yay! Thanks for sending us a PR! 🎊

Please ensure your PR adheres to:

- [ ] Commit messages has a short & issue references when necessary
- [ ] Each commit does a logical chunk of work.
- [ ] It builds and tests pass (e.g `gulp`)
-->

**What this PR does / why we need it**:
As we parse through the remapped keys, if a remapping uses a non-existent command, it is ignored. More information on our readme: https://github.com/VSCodeVim/Vim#debugging-remappings

**Which issue(s) this PR fixes**
https://github.com/VSCodeVim/Vim/issues/3295

<!--
Commits in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)
-->

**Special notes for your reviewer**:
~~the new class `commandValidator` is not a true singleton. as the `getCommand` is async, the map can be initialized multiple times.~~ fixed this.