### PR TITLE
fix: sync editor.wordSeparators and vim.iskeyword. closes #3166

### DIFF
--- a/package.json
+++ b/package.json
@@ -422,8 +422,7 @@
         },
         "vim.iskeyword": {
           "type": "string",
-          "description": "keywords contain alphanumeric characters and '_'",
-          "default": "/\\()\"':,.;<>~!@#$%^&*|+=[]{}`?-"
+          "description": "keywords contain alphanumeric characters and '_'. If not configured `editor.wordSeparators` is used."
         },
         "vim.ignorecase": {
           "type": "boolean",

--- a/src/configuration/configuration.ts
+++ b/src/configuration/configuration.ts
@@ -50,10 +50,9 @@ interface IKeyBinding {
  *
  * Vim option override sequence.
  * 1. `:set {option}` on the fly
- * 2. TODO .vimrc.
- * 3. `vim.{option}`
- * 4. VS Code configuration
- * 5. VSCodeVim flavored Vim option default values
+ * 2. `vim.{option}`
+ * 3. VS Code configuration
+ * 4. VSCodeVim flavored Vim option default values
  *
  */
 class Configuration implements IConfiguration {
@@ -295,7 +294,11 @@ class Configuration implements IConfiguration {
   })
   relativenumber: boolean;
 
-  iskeyword: string = '/\\()"\':,.;<>~!@#$%^&*|+=[]{}`?-';
+  @overlapSetting({
+    settingName: 'wordSeparators',
+    defaultValue: '/\\()"\':,.;<>~!@#$%^&*|+=[]{}`?-',
+  })
+  iskeyword: string;
 
   boundKeyCombinations: IKeyBinding[] = [];
 
@@ -364,11 +367,16 @@ function overlapSetting(args: {
   return function(target: any, propertyKey: string) {
     Object.defineProperty(target, propertyKey, {
       get: function() {
-        if (this['_' + propertyKey] !== undefined) {
-          return this['_' + propertyKey];
+        // retrieve value from vim configuration
+        // if the value is not defined or empty
+        // look at the equivalent `editor` setting
+        // if that is not defined then defer to the default value
+        let val = this['_' + propertyKey];
+        if (val !== undefined && val !== '') {
+          return val;
         }
 
-        let val = this.getConfiguration('editor').get(args.settingName, args.defaultValue);
+        val = this.getConfiguration('editor').get(args.settingName, args.defaultValue);
         if (args.map && val !== undefined) {
           val = args.map.get(val);
         }
@@ -376,9 +384,10 @@ function overlapSetting(args: {
         return val;
       },
       set: function(value) {
+        // synchronize the vim setting with the `editor` equivalent
         this['_' + propertyKey] = value;
 
-        if (value === undefined || Globals.isTesting) {
+        if (value === undefined || value === '' || Globals.isTesting) {
           return;
         }
 


### PR DESCRIPTION
<!--
Yay! Thanks for sending us a PR! 🎊

Please ensure your PR adheres to:

- [ ] Commit messages has a short & issue references when necessary
- [ ] Each commit does a logical chunk of work.
- [ ] It builds and tests pass (e.g `gulp`)
-->

**What this PR does / why we need it**:

* Adds `iskeyword` as an overlap setting to `editor.wordSeparators`. As a result, the following will take precedence:

1. vim.iskeyword
2. if (1) is undefined, editor.wordSeparators
3. if (2) is undefined, then default value of `@,48-57,_,128-167,224-235` is used

* This change removes the default value for `iskeyword` so unless users have explicitly configured this value, `editor.wordSeparators` will be used. 

So in the standard use case where users were using the default values for `iskeyword` those folks will be moving from using this:
```
/\()\"':,.;<>~!@#$%^&*|+=[]{}`?-
``` 
to vscode's default for `editor.wordSeparators`

```
`~!@#$%^&*()-=+[{]}\|;:'",.<>/?
```

The two are the same set, but in different order so there should *not* be a change in behaviour. Note that if `vim.iskeyword` is set, it will override the value of `editor.wordSeparators`.

**Which issue(s) this PR fixes**
#3166 

<!--
Commits in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)
-->

**Special notes for your reviewer**:
