### PR TITLE
fix: log warning if remapped command does not exist. closes #3307

### DIFF
--- a/extension.ts
+++ b/extension.ts
@@ -260,7 +260,7 @@ export async function activate(context: vscode.ExtensionContext) {
       if (mh.vimState.currentMode !== ModeName.Insert) {
         let text = compositionState.composingText;
         compositionState.reset();
-        await mh.handleMultipleKeyEvents(text.split(''));
+        mh.handleMultipleKeyEvents(text.split(''));
       }
     });
   });
@@ -287,9 +287,9 @@ export async function activate(context: vscode.ExtensionContext) {
           // Check if this is a vim command by looking for :
           if (command.command.slice(0, 1) === ':') {
             await commandLine.Run(command.command.slice(1, command.command.length), mh.vimState);
-            await mh.updateView(mh.vimState);
+            mh.updateView(mh.vimState);
           } else {
-            await vscode.commands.executeCommand(command.command, command.args);
+            vscode.commands.executeCommand(command.command, command.args);
           }
         }
       }
@@ -311,12 +311,13 @@ export async function activate(context: vscode.ExtensionContext) {
     mh.updateView(mh.vimState, { drawSelection: false, revealRange: false });
   }
 
-  await commandLine.load();
-  await globalState.loadSearchHistory();
-  await configurationValidator.initialize();
-
-  // This is called last because getAndUpdateModeHandler() will change cursor
-  toggleExtension(configuration.disableExt, compositionState);
+  await Promise.all([
+    commandLine.load(),
+    globalState.load(),
+    configurationValidator.initialize(),
+    // This is called last because getAndUpdateModeHandler() will change cursor
+    toggleExtension(configuration.disableExt, compositionState),
+  ]);
 }
 
 /**

--- a/src/cmd_line/commandLine.ts
+++ b/src/cmd_line/commandLine.ts
@@ -35,7 +35,7 @@ class CommandLine {
     this._history = new CommandLineHistory();
   }
 
-  public load(): Promise<void> {
+  public async load(): Promise<void> {
     return this._history.load();
   }
 
@@ -56,7 +56,7 @@ class CommandLine {
       const useNeovim = configuration.enableNeovim && cmd.command && cmd.command.neovimCapable;
 
       if (useNeovim) {
-        var statusBarText = await vimState.nvim.run(vimState, command);
+        const statusBarText = await vimState.nvim.run(vimState, command);
         StatusBar.Set(statusBarText, vimState.currentMode, vimState.isRecordingMacro, true);
       } else {
         await cmd.execute(vimState.editor, vimState);
@@ -74,7 +74,7 @@ class CommandLine {
           );
         }
       } else {
-        logger.error(`commandLine : error executing cmd=${command}. err=${e}.`);
+        logger.error(`commandLine: error executing cmd=${command}. err=${e}.`);
         Message.ShowError(e.toString());
       }
     }

--- a/src/cmd_line/commands/write.ts
+++ b/src/cmd_line/commands/write.ts
@@ -49,7 +49,7 @@ export class WriteCommand extends node.CommandBase {
       Message.ShowError('Not implemented.');
       return;
     }
-    
+
     // defer saving the file to vscode if file is new (to present file explorer) or if file is a remote file
     if (vimState.editor.document.isUntitled || vimState.editor.document.uri.scheme !== 'file') {
       await vscode.commands.executeCommand('workbench.action.files.save');

--- a/src/history/historyFile.ts
+++ b/src/history/historyFile.ts
@@ -102,7 +102,7 @@ export class HistoryFile {
     try {
       let parsedData = JSON.parse(data);
       if (!Array.isArray(parsedData)) {
-        throw Error('Expected JSON');
+        throw Error('Unexpected format in history file. Expected JSON.');
       }
       this._history = parsedData;
     } catch (e) {

--- a/src/state/globalState.ts
+++ b/src/state/globalState.ts
@@ -1,10 +1,10 @@
 import { JumpTracker } from '../jumps/jumpTracker';
-import { RecordedState } from './../state/recordedState';
-import { SubstituteState } from './substituteState';
-import { SearchState, SearchDirection } from './searchState';
-import { SearchHistory } from '../history/historyFile';
-import { Position } from '../common/motion/position';
 import { ModeName } from '../mode/mode';
+import { Position } from '../common/motion/position';
+import { RecordedState } from './../state/recordedState';
+import { SearchHistory } from '../history/historyFile';
+import { SearchState, SearchDirection } from './searchState';
+import { SubstituteState } from './substituteState';
 
 /**
  * State which stores global state (across editors)
@@ -47,6 +47,11 @@ export class GlobalState {
   private static _jumpTracker: JumpTracker = new JumpTracker();
 
   /**
+   * Tracks search history
+   */
+  private static _searchHistory: SearchHistory | undefined;
+
+  /**
    * Getters and setters for changing global state
    */
   public get searchStatePrevious(): SearchState[] {
@@ -57,8 +62,7 @@ export class GlobalState {
     GlobalState._searchStatePrevious = GlobalState._searchStatePrevious.concat(states);
   }
 
-  private static _searchHistory: SearchHistory | undefined;
-  public async loadSearchHistory() {
+  public async load() {
     if (GlobalState._searchHistory === undefined) {
       GlobalState._searchHistory = new SearchHistory();
       await GlobalState._searchHistory.load();

--- a/src/util/logger.ts
+++ b/src/util/logger.ts
@@ -1,6 +1,6 @@
-import { configuration } from '../configuration/configuration';
 import * as winston from 'winston';
 import { ConsoleForElectron } from 'winston-console-for-electron';
+import { configuration } from '../configuration/configuration';
 
 export const logger = winston.createLogger({
   level: configuration.debug.loggingLevel,

--- a/src/util/util.ts
+++ b/src/util/util.ts
@@ -30,7 +30,9 @@ export async function getCursorsAfterSync(timeoutInMilliseconds: number = 0): Pr
   try {
     await waitForCursorSync(timeoutInMilliseconds, true);
   } catch (e) {
-    logger.warn(`getCursorsAfterSync: selection not updated within ${timeoutInMilliseconds}ms. error=${e}.`);
+    logger.warn(
+      `getCursorsAfterSync: selection not updated within ${timeoutInMilliseconds}ms. error=${e}.`
+    );
   }
 
   return vscode.window.activeTextEditor!.selections.map(

--- a/test/configuration/remapper.test.ts
+++ b/test/configuration/remapper.test.ts
@@ -77,13 +77,13 @@ suite('Remapper', () => {
       inputtedKeys: string[],
       currentMode: ModeName
     ) {
-      return TestRemapper._findMatchingRemap(userDefinedRemappings, inputtedKeys, currentMode);
+      return TestRemapper.findMatchingRemap(userDefinedRemappings, inputtedKeys, currentMode);
     }
 
     public getRemappedKeySequenceLengthRange(remappings: {
       [key: string]: IKeyRemapping;
     }): [number, number] {
-      return TestRemapper._getRemappedKeysLengthRange(remappings);
+      return TestRemapper.getRemappedKeysLengthRange(remappings);
     }
   }
 


### PR DESCRIPTION
<!--
Yay! Thanks for sending us a PR! 🎊

Please ensure your PR adheres to:

- [ ] Commit messages has a short & issue references when necessary
- [ ] Each commit does a logical chunk of work.
- [ ] It builds and tests pass (e.g `gulp`)
-->

**What this PR does / why we need it**:
* As there are cases where the command has not yet been registered by VS Code (ie. when an extension has not yet been activated), we can't ignore these remapped commands, so instead we'll log a warning
* Properly fixes #3295, but not awaiting the `executeCommand` and allowing the task queue to catch the error. 

**Which issue(s) this PR fixes**
#3295, #3307 

<!--
Commits in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)
-->

**Special notes for your reviewer**:
@xconverge this is likely going to conflict with your async PR