### PR TITLE
Fix <C-d> getting stuck when current column doesn't exist in destination

### DIFF
--- a/src/actions/commands/actions.ts
+++ b/src/actions/commands/actions.ts
@@ -684,11 +684,15 @@ class CommandMoveHalfPageDown extends CommandEditorScroll {
     });
 
     const newFirstLine = editor.visibleRanges[0].start.line;
-    let newPosition = new Position(newFirstLine + lineOffset, startColumn);
+    const newPositionLine = newFirstLine + lineOffset;
+    let newPosition;
 
     const maxLineValue = TextEditor.getLineCount() - 1;
-    if (newPosition.line > maxLineValue) {
+    if (newPositionLine > maxLineValue) {
       newPosition = new Position(0, 0).getDocumentEnd();
+    } else {
+      const newPositionColumn = Math.min(startColumn, TextEditor.getLineMaxColumn(newPositionLine));
+      newPosition = new Position(newPositionLine, newPositionColumn);
     }
 
     if (newPosition.isValid()) {


### PR DESCRIPTION
**What this PR does / why we need it**:

- Fix issue where half page down `<C-d>` gets stuck when on a column that doesn't exist in the destination line.

**Which issue(s) this PR fixes**

fixes #3376
relevant to #3345, which was fixed but fix may have caused this regression (haven't confirmed)

**Special notes for your reviewer**:

- `<C-u>`, `<C-f>`, `<C-b>` all seem fine without modification.