### PR TITLE
fix #3157: register single onDidChangeTextDocument handler and delegate to appropriate mode handler

### DIFF
--- a/extension.ts
+++ b/extension.ts
@@ -51,7 +51,7 @@ export async function getAndUpdateModeHandler(forceSyncAndUpdate = false): Promi
     !previousActiveEditorId ||
     !previousActiveEditorId.isEqual(activeEditorId)
   ) {
-    curHandler.syncCursors();
+    await curHandler.syncCursors();
     await curHandler.updateView(curHandler.vimState, { drawSelection: false, revealRange: false });
   }
 

--- a/src/mode/modeHandler.ts
+++ b/src/mode/modeHandler.ts
@@ -77,44 +77,6 @@ export class ModeHandler implements vscode.Disposable {
         // For whatever reason, the editor positions aren't updated until after the
         // stack clears, which is why this setTimeout is necessary
         this.syncCursors();
-
-        // Handle scenarios where mouse used to change current position.
-        const onChangeTextEditorSelection = vscode.window.onDidChangeTextEditorSelection(
-          (e: vscode.TextEditorSelectionChangeEvent) => {
-            if (configuration.disableExtension) {
-              return;
-            }
-
-            if (Globals.isTesting) {
-              return;
-            }
-
-            if (e.textEditor !== this.vimState.editor) {
-              return;
-            }
-
-            if (this.vimState.focusChanged) {
-              this.vimState.focusChanged = false;
-              return;
-            }
-
-            if (this.currentMode.name === ModeName.EasyMotionMode) {
-              return;
-            }
-
-            taskQueue.enqueueTask(
-              () => this.handleSelectionChange(e),
-              undefined,
-              /**
-               * We don't want these to become backlogged! If they do, we'll update
-               * the selection to an incorrect value and see a jittering cursor.
-               */
-              true
-            );
-          }
-        );
-
-        this._disposables.push(onChangeTextEditorSelection);
         this._disposables.push(this.vimState);
 
         cb();
@@ -137,7 +99,7 @@ export class ModeHandler implements vscode.Disposable {
    * https://gist.github.com/rebornix/d21d1cc060c009d4430d3904030bd4c1 to
    * perform the manual testing.
    */
-  private async handleSelectionChange(e: vscode.TextEditorSelectionChangeEvent): Promise<void> {
+  public async handleSelectionChange(e: vscode.TextEditorSelectionChangeEvent): Promise<void> {
     let selection = e.selections[0];
     if (
       (e.selections.length !== this.vimState.allCursors.length || this.vimState.isMultiCursor) &&

--- a/src/mode/modeHandler.ts
+++ b/src/mode/modeHandler.ts
@@ -5,7 +5,6 @@ import { Actions, BaseAction, KeypressState } from './../actions/base';
 import { BaseMovement, isIMovement } from './../actions/motion';
 import { CommandInsertInInsertMode, CommandInsertPreviousText } from './../actions/commands/insert';
 import { Decoration } from '../configuration/decoration';
-import { Globals } from '../globals';
 import { Jump } from '../jumps/jump';
 import { Mode, ModeName, VSCodeVimCursorType } from './mode';
 import { PairMatcher } from './../common/matching/matcher';
@@ -22,7 +21,6 @@ import { commandLine } from '../cmd_line/commandLine';
 import { configuration } from '../configuration/configuration';
 import { getCursorsAfterSync } from '../util/util';
 import { logger } from '../util/logger';
-import { taskQueue } from './../taskQueue';
 import {
   BaseCommand,
   CommandQuitRecordMacro,
@@ -45,10 +43,16 @@ export class ModeHandler implements vscode.Disposable {
     return this._modes.find(mode => mode.isActive)!;
   }
 
-  /**
-   * Called back when initialization completes
-   */
-  constructor(cb: (err?: Error) => void) {
+  public static async Create(textEditor = vscode.window.activeTextEditor!): Promise<ModeHandler> {
+    const modeHandler = new ModeHandler(textEditor);
+    await modeHandler.setCurrentMode(
+      configuration.startInInsertMode ? ModeName.Insert : ModeName.Normal
+    );
+    await modeHandler.syncCursors();
+    return modeHandler;
+  }
+
+  private constructor(textEditor: vscode.TextEditor) {
     this._remappers = new Remappers();
     this._modes = [
       new modes.NormalMode(),
@@ -65,23 +69,26 @@ export class ModeHandler implements vscode.Disposable {
       new modes.DisabledMode(),
     ];
 
-    this.vimState = new VimState(vscode.window.activeTextEditor!, configuration.enableNeovim);
-    this.setCurrentMode(configuration.startInInsertMode ? ModeName.Insert : ModeName.Normal)
-      .then(() => {
-        // Sometimes, Visual Studio Code will start the cursor in a position which
-        // is not (0, 0) - e.g., if you previously edited the file and left the
-        // cursor somewhere else when you closed it. This will set our cursor's
-        // position to the position that VSC set it to.
+    this.vimState = new VimState(textEditor, configuration.enableNeovim);
+    this._disposables.push(this.vimState);
+  }
 
-        // This also makes things like gd work.
-        // For whatever reason, the editor positions aren't updated until after the
-        // stack clears, which is why this setTimeout is necessary
-        this.syncCursors();
-        this._disposables.push(this.vimState);
-
-        cb();
-      })
-      .catch(cb);
+  /**
+   * Syncs cursors between vscode representation and vim representation
+   */
+  public async syncCursors() {
+    return require('util').promisify(setTimeout)(() => {
+      if (this.vimState.editor) {
+        this.vimState.cursorStartPosition = Position.FromVSCodePosition(
+          this.vimState.editor.selection.start
+        );
+        this.vimState.cursorPosition = Position.FromVSCodePosition(
+          this.vimState.editor.selection.start
+        );
+        this.vimState.desiredColumn = this.vimState.cursorPosition.character;
+        this.vimState.prevSelection = this.vimState.editor.selection;
+      }
+    }, 0);
   }
 
   /**
@@ -233,14 +240,7 @@ export class ModeHandler implements vscode.Disposable {
     }
   }
 
-  private async setCurrentMode(modeName: ModeName): Promise<void> {
-    await this.vimState.setCurrentMode(modeName);
-    for (let mode of this._modes) {
-      mode.isActive = mode.name === modeName;
-    }
-  }
-
-  async handleKeyEvent(key: string): Promise<Boolean> {
+  public async handleKeyEvent(key: string): Promise<Boolean> {
     const now = Number(new Date());
 
     logger.debug(`ModeHandler: handling key=${key}.`);
@@ -1391,6 +1391,13 @@ export class ModeHandler implements vscode.Disposable {
     await VsCodeContext.Set('vim.mode', ModeName[this.vimState.currentMode]);
   }
 
+  private async setCurrentMode(modeName: ModeName): Promise<void> {
+    await this.vimState.setCurrentMode(modeName);
+    for (let mode of this._modes) {
+      mode.isActive = mode.name === modeName;
+    }
+  }
+
   private _renderStatusBar(): void {
     let text: string[] = [];
 
@@ -1450,23 +1457,6 @@ export class ModeHandler implements vscode.Disposable {
 
   dispose() {
     this._disposables.map(d => d.dispose());
-  }
-
-  // Syncs cursors between vscode representation and vim representation
-  syncCursors() {
-    setTimeout(() => {
-      if (this.vimState.editor) {
-        this.vimState.cursorStartPosition = Position.FromVSCodePosition(
-          this.vimState.editor.selection.start
-        );
-        this.vimState.cursorPosition = Position.FromVSCodePosition(
-          this.vimState.editor.selection.start
-        );
-        this.vimState.desiredColumn = this.vimState.cursorPosition.character;
-
-        this.vimState.prevSelection = this.vimState.editor.selection;
-      }
-    }, 0);
   }
 
   private IsModeWhereCmdVIsOverriden(mode: ModeName): boolean {

--- a/src/mode/modeHandlerMap.ts
+++ b/src/mode/modeHandlerMap.ts
@@ -8,16 +8,7 @@ class ModeHandlerMapImpl {
     let modeHandler = this.modeHandlerMap[key];
     if (!modeHandler) {
       isNew = true;
-      await new Promise((res, rej) => {
-        modeHandler = new ModeHandler(err => {
-          if (err) {
-            rej(err);
-            return;
-          }
-
-          res();
-        });
-      });
+      modeHandler = await ModeHandler.Create();
       this.modeHandlerMap[key] = modeHandler;
     }
     return [modeHandler, isNew];

--- a/test/jumpTracker.test.ts
+++ b/test/jumpTracker.test.ts
@@ -1,19 +1,14 @@
 import * as assert from 'assert';
 import * as vscode from 'vscode';
 
-import { Globals } from '../src/globals';
 import { Jump } from './../src/jumps/jump';
 import { JumpTracker } from '../src/jumps/jumpTracker';
-import { ModeHandler } from '../src/mode/modeHandler';
 import { Position } from '../src/common/motion/position';
-import { TextEditor } from '../src/textEditor';
 import { cleanUpWorkspace, setupWorkspace } from './testUtils';
-import { getAndUpdateModeHandler } from '../extension';
 import { getTestingFunctions } from './testSimplifier';
-import { waitForCursorSync } from '../src/util/util';
 
 suite('Record and navigate jumps', () => {
-  let { newTest, newTestOnly } = getTestingFunctions();
+  let { newTest } = getTestingFunctions();
 
   setup(async () => {
     await setupWorkspace();

--- a/test/mode/modeHandlerMap.test.ts
+++ b/test/mode/modeHandlerMap.test.ts
@@ -1,9 +1,6 @@
 import * as assert from 'assert';
 
-import { getAndUpdateModeHandler } from '../../extension';
-import { ModeName } from '../../src/mode/mode';
 import { ModeHandlerMap } from '../../src/mode/modeHandlerMap';
-import { cleanUpWorkspace, setupWorkspace } from './../testUtils';
 
 suite('Mode Handler Map', () => {
   setup(() => {


### PR DESCRIPTION
<!--
Yay! Thanks for sending us a PR! 🎊

Please ensure your PR adheres to:

- [ ] Commit messages has a short & issue references when necessary
- [ ] Each commit does a logical chunk of work.
- [ ] It builds and tests pass (e.g `gulp`)
-->

**What this PR does / why we need it**:
This seemed to do the trick to fix #3157. Instead of having an event handler for each modehandler (ie. text editor), declared a single event handler and delegated the event to the right mode handler. This should have the added benefit of improving perf.

To be perfectly honest however, I'm not entirely sure how this fixed the issue as the same callback code to update the position was still being called, albeit unnecessarily for all the other open text editors.

This PR also includes a minor refactor to add a wrapper around registering event handlers to ensure that we are disposing the events properly.

**Which issue(s) this PR fixes**

#3157 

<!--
Commits in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)
-->

**Special notes for your reviewer**:
