### PR TITLE
fix: closes #3157

### DIFF
--- a/extension.ts
+++ b/extension.ts
@@ -215,7 +215,7 @@ export async function activate(context: vscode.ExtensionContext) {
     context,
     vscode.window.onDidChangeTextEditorSelection,
     async (e: vscode.TextEditorSelectionChangeEvent) => {
-      const mh = await getAndUpdateModeHandler(true);
+      const mh = await getAndUpdateModeHandler();
 
       if (mh.vimState.focusChanged) {
         mh.vimState.focusChanged = false;

--- a/src/state/vimState.ts
+++ b/src/state/vimState.ts
@@ -177,6 +177,7 @@ export class VimState implements vscode.Disposable {
    */
   public lastVisualSelectionStart: Position;
   public lastVisualSelectionEnd: Position;
+
   /**
    * Was the previous mouse click past EOL
    */
@@ -220,13 +221,6 @@ export class VimState implements vscode.Disposable {
   public recordedState = new RecordedState();
 
   public recordedMacro = new RecordedState();
-
-  /**
-   * Programmatically triggering an edit will unfortunately ALSO trigger our mouse update
-   * function. We use this variable to determine if the update function was triggered
-   * by us or by a mouse action.
-   */
-  public prevSelection: vscode.Selection;
 
   public nvim: NeovimWrapper;
 


### PR DESCRIPTION
<!--
Yay! Thanks for sending us a PR! 🎊

Please ensure your PR adheres to:

- [ ] Commit messages has a short & issue references when necessary
- [ ] Each commit does a logical chunk of work.
- [ ] It builds and tests pass (e.g `gulp`)
-->

**What this PR does / why we need it**:
Continuation of https://github.com/VSCodeVim/Vim/pull/3408 where this PR actually addresses #3157.
On the mouse event, the `handleSelection` callback was returning early as `prevSelection` had already been updated. We already have code that checks to determine if it is a mouse vs internal event so removing this check entirely. 

**Which issue(s) this PR fixes**
#3157 

<!--
Commits in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)
-->

**Special notes for your reviewer**:
