### PR TITLE
fix ds" with nested quotes and add some tests - fixes #3415

### DIFF
--- a/src/actions/motion.ts
+++ b/src/actions/motion.ts
@@ -1685,8 +1685,15 @@ export abstract class MoveQuoteMatch extends BaseMovement {
   public async execAction(position: Position, vimState: VimState): Promise<IMovement> {
     const text = TextEditor.getLineAt(position).text;
     const quoteMatcher = new QuoteMatcher(this.charToMatch, text);
-    const start = quoteMatcher.findOpening(position.character);
-    const end = quoteMatcher.findClosing(start + 1);
+    let start = quoteMatcher.findOpening(position.character);
+    let end = quoteMatcher.findClosing(start + 1);
+
+    if (end < start && start === position.character) {
+      // start character is a match and no forward match found
+      // search backwards instead
+      end = start;
+      start = quoteMatcher.findOpening(end - 1);
+    }
 
     if (start === -1 || end === -1 || end === start || end < position.character) {
       return {

--- a/src/common/matching/quoteMatcher.ts
+++ b/src/common/matching/quoteMatcher.ts
@@ -30,7 +30,7 @@ export class QuoteMatcher {
   findOpening(start: number): number {
     // First, search backwards to see if we could be inside a quote
     for (let i = start; i >= 0; i--) {
-      if (this.quoteMap[i] === QuoteMatch.Opening) {
+      if (this.quoteMap[i]) {
         return i;
       }
     }

--- a/test/plugins/surround.test.ts
+++ b/test/plugins/surround.test.ts
@@ -94,6 +94,20 @@ suite('surround plugin', () => {
   });
 
   newTest({
+    title: 'change surround with two pairs of quotes',
+    start: ["first ''li|ne'' test"],
+    keysPressed: "cs')",
+    end: ["first '(li|ne)' test"],
+  });
+
+  newTest({
+    title: 'change surround with two pairs of parens',
+    start: ['first ((li|ne)) test'],
+    keysPressed: "cs)'",
+    end: ["first ('li|ne') test"],
+  });
+
+  newTest({
     title: 'change surround with alias',
     start: ['first (li|ne) test'],
     keysPressed: 'csb]',
@@ -112,6 +126,69 @@ suite('surround plugin', () => {
     start: ["first 'li|ne' test"],
     keysPressed: "ds'",
     end: ['first li|ne test'],
+  });
+
+  newTest({
+    title: 'delete surround with quotes',
+    start: ['first "li|ne" test'],
+    keysPressed: 'ds"',
+    end: ['first li|ne test'],
+  });
+
+  newTest({
+    title: 'delete surround with nested of quotes',
+    start: ['first ""li|ne"" test'],
+    keysPressed: 'ds"',
+    end: ['first "li|ne" test'],
+  });
+
+  newTest({
+    title: 'delete surround with inconsistent quotes',
+    start: ['first ""li|ne" test'],
+    keysPressed: 'ds"',
+    end: ['first "li|ne test'],
+  });
+
+  newTest({
+    title: 'delete surround with mixed quotes',
+    start: ['first "\'li|ne"\' test'],
+    keysPressed: 'ds"',
+    end: ["first 'li|ne' test"],
+  });
+
+  newTest({
+    title: 'delete surround with empty quotes cursor at start',
+    start: ['first |"" test'],
+    keysPressed: 'ds"',
+    end: ['first | test'],
+  });
+
+  newTest({
+    title: 'delete surround with empty quotes cursor at end',
+    start: ['first "|" test'],
+    keysPressed: 'ds"',
+    end: ['first | test'],
+  });
+
+  newTest({
+    title: "don't delete surround if cursor is after closing match",
+    start: ['first "line"| test'],
+    keysPressed: 'ds"',
+    end: ['first "line"| test'],
+  });
+
+  newTest({
+    title: 'delete surround if cursor is before opening match',
+    start: ['first | "line" test'],
+    keysPressed: 'ds"',
+    end: ['first  |line test'],
+  });
+
+  newTest({
+    title: 'delete surround with two pairs of parens',
+    start: ['first ((li|ne)) test'],
+    keysPressed: 'ds)',
+    end: ['first (li|ne) test'],
   });
 
   newTest({


### PR DESCRIPTION
- [x] Commit messages has a short & issue references when necessary
- [x] Each commit does a logical chunk of work.
- [x] It builds and tests pass (e.g `gulp`)

**What this PR does / why we need it**:
Fixes `ds"` with nested quotes e.g. `""te|st""` should become `"te|st"`.
Fixes `ds"` with cursor on close quote e.g. `"test|"` should become `test|`

**Which issue(s) this PR fixes**
#3415 

<!--
Commits in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)
-->

**Special notes for your reviewer**:
