### PR TITLE
fix: revert back to previous non-async code when syncing cursor

### DIFF
--- a/src/mode/modeHandler.ts
+++ b/src/mode/modeHandler.ts
@@ -49,7 +49,7 @@ export class ModeHandler implements vscode.Disposable {
     await modeHandler.setCurrentMode(
       configuration.startInInsertMode ? ModeName.Insert : ModeName.Normal
     );
-    await modeHandler.syncCursors();
+    modeHandler.syncCursors();
     return modeHandler;
   }
 
@@ -77,8 +77,8 @@ export class ModeHandler implements vscode.Disposable {
   /**
    * Syncs cursors between vscode representation and vim representation
    */
-  public async syncCursors() {
-    return require('util').promisify(setTimeout)(() => {
+  public syncCursors() {
+    setImmediate(() => {
       if (this.vimState.editor) {
         this.vimState.cursorStartPosition = Position.FromVSCodePosition(
           this.vimState.editor.selection.start


### PR DESCRIPTION


<!--
Yay! Thanks for sending us a PR! 🎊

Please ensure your PR adheres to:

- [ ] Commit messages has a short & issue references when necessary
- [ ] Each commit does a logical chunk of work.
- [ ] It builds and tests pass (e.g `gulp`)
-->

**What this PR does / why we need it**:
Reverting back to old non-async `syncCursors` resolves. Don't know why yet. Looking it later after fixing.

**Which issue(s) this PR fixes**
#3431

<!--
Commits in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)
-->

**Special notes for your reviewer**:
