### PR TITLE
fix: cursor jumps when selection changes to output window

### DIFF
--- a/extension.ts
+++ b/extension.ts
@@ -233,6 +233,15 @@ export async function activate(context: vscode.ExtensionContext) {
     context,
     vscode.window.onDidChangeTextEditorSelection,
     async (e: vscode.TextEditorSelectionChangeEvent) => {
+      if (
+        vscode.window.activeTextEditor === undefined ||
+        e.textEditor.document !== vscode.window.activeTextEditor.document
+      ) {
+        // we don't care if there is no active editor
+        // or user selection changed in a paneled window (e.g debug console/terminal)
+        return;
+      }
+
       const mh = await getAndUpdateModeHandler();
 
       if (mh.vimState.focusChanged) {

--- a/test/configuration/validators/remappingValidator.test.ts
+++ b/test/configuration/validators/remappingValidator.test.ts
@@ -38,7 +38,8 @@ suite('Remapping Validator', () => {
       {
         before: ['j', 'j'],
         after: ['<Esc>'],
-      }];
+      },
+    ];
     configuration.insertModeKeyBindingsNonRecursive = [];
     configuration.normalModeKeyBindings = [];
     configuration.normalModeKeyBindingsNonRecursive = [];
@@ -62,7 +63,10 @@ suite('Remapping Validator', () => {
     assert.equal(configuration.visualModeKeyBindingsMap.size, 0);
     assert.equal(configuration.visualModeKeyBindingsNonRecursiveMap.size, 0);
 
-    assert.equal(configuration.insertModeKeyBindingsMap.get("jj"), configuration.insertModeKeyBindings[0]);
+    assert.equal(
+      configuration.insertModeKeyBindingsMap.get('jj'),
+      configuration.insertModeKeyBindings[0]
+    );
   });
 
   test('remapping missing after and command', async () => {
@@ -70,8 +74,9 @@ suite('Remapping Validator', () => {
     let configuration = new Configuration();
     configuration.insertModeKeyBindings = [
       {
-        before: ['j', 'j']
-      }];
+        before: ['j', 'j'],
+      },
+    ];
     configuration.insertModeKeyBindingsNonRecursive = [];
     configuration.normalModeKeyBindings = [];
     configuration.normalModeKeyBindingsNonRecursive = [];
@@ -109,8 +114,8 @@ suite('Remapping Validator', () => {
       {
         before: ['c', 'o', 'p', 'y'],
         after: ['c', 'o', 'p', 'y'],
-      }
-    ]
+      },
+    ];
     configuration.normalModeKeyBindingsNonRecursive = [];
     configuration.visualModeKeyBindings = [];
     configuration.visualModeKeyBindingsNonRecursive = [];


### PR DESCRIPTION
<!--
Yay! Thanks for sending us a PR! 🎊

Please ensure your PR adheres to:

- [ ] Commit messages has a short & issue references when necessary
- [ ] Each commit does a logical chunk of work.
- [ ] It builds and tests pass (e.g `gulp`)
-->

**What this PR does / why we need it**:
I still don't understand how this was a regression from 1.0.2 -> 1.0.3 (https://github.com/VSCodeVim/Vim/issues/3444#issuecomment-460254564). 

In any case, if selection changed to a paneled window (e.g. output window), we shouldn't be updating the cursors for the text editor. 

I repro-d the go-lang issue mentioned https://github.com/VSCodeVim/Vim/issues/3444 and confirmed that this is fixed. Was never able to get a wallaby repro as mentioned in #3459, but I'm going to hope for the best and presume that this fix resolves that as well.

**Which issue(s) this PR fixes**
https://github.com/VSCodeVim/Vim/issues/3444, https://github.com/VSCodeVim/Vim/issues/3459

<!--
Commits in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)
-->

**Special notes for your reviewer**:
