### PR TITLE
Possible fix for #3455: Compare EditorIdentity when handling window.onDidChangeTextEditorSelection.

### DIFF
--- a/extension.ts
+++ b/extension.ts
@@ -254,9 +254,11 @@ export async function activate(context: vscode.ExtensionContext) {
     context,
     vscode.window.onDidChangeTextEditorSelection,
     async (e: vscode.TextEditorSelectionChangeEvent) => {
+      const eventEditorIdentity = new EditorIdentity(e.textEditor);
+      const activeEditorId = new EditorIdentity(vscode.window.activeTextEditor);
       if (
         vscode.window.activeTextEditor === undefined ||
-        e.textEditor.document !== vscode.window.activeTextEditor.document
+        !eventEditorIdentity.isEqual(activeEditorId)
       ) {
         // we don't care if there is no active editor
         // or user selection changed in a paneled window (e.g debug console/terminal)

--- a/src/editorIdentity.ts
+++ b/src/editorIdentity.ts
@@ -2,20 +2,30 @@ import * as vscode from 'vscode';
 
 export class EditorIdentity {
   private _fileName: string;
+  private _viewColumn: number;
 
   constructor(textEditor?: vscode.TextEditor) {
     this._fileName = (textEditor && textEditor.document && textEditor.document.fileName) || '';
+    this._viewColumn = (textEditor && textEditor.viewColumn) || vscode.ViewColumn.One;
   }
 
   get fileName() {
     return this._fileName;
   }
 
+  get viewColumn() {
+    return this._viewColumn;
+  }
+
+  get identifier() {
+    return this.fileName + this.viewColumn;
+  }
+
   public isEqual(other: EditorIdentity): boolean {
-    return this.fileName === other.fileName;
+    return this.identifier === other.identifier;
   }
 
   public toString() {
-    return this.fileName;
+    return this.identifier;
   }
 }


### PR DESCRIPTION
<!--
Yay! Thanks for sending us a PR! 🎊

Please ensure your PR adheres to:

- [ ] Commit messages has a short & issue references when necessary
- [ ] Each commit does a logical chunk of work.
- [ ] It builds and tests pass (e.g `gulp`)
-->

**What this PR does / why we need it**:

This PR changes two things:
* Alters EditorIdentity such that it uses the `ViewColumn` of the editor for differentiating between multiple editors open to the same file using changes long ago proposed by @lukaszb (thanks for posting a patch!).
* Updates our handler for `vscode.window.onDidChangeTextEditorSelection` such that it uses that EditorIdentity when deciding whether to handle an incoming event instead of simply comparing documents.

**Which issue(s) this PR fixes**

#3455 

<!--
Commits in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)
-->

**Special notes for your reviewer**:
