### PR TITLE
Bump minimum VSCode version to 1.31.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "url": "https://github.com/VSCodeVim/Vim/issues"
   },
   "engines": {
-    "vscode": "^1.30.0"
+    "vscode": "^1.31.0"
   },
   "categories": [
     "Other",


### PR DESCRIPTION
**What this PR does / why we need it**:
As an alternative to https://github.com/VSCodeVim/Vim/pull/3525, we should at least specify that you need VSCode 1.31.0 or newer in order for the extension to run correctly. (In all reality, I should've done this with the [original CamelCaseMotion PR](https://github.com/VSCodeVim/Vim/pull/3483), but unfortunately overlooked that it was a possibility.)

This sadly won't help people who are having trouble with 1.1.0. Ideally we could unpublish that one release and the release 1.1.1 with this change included. But not sure if that's possible.