### PR TITLE
WIP: Implement :marks command

### DIFF
--- a/src/cmd_line/commands/marks.ts
+++ b/src/cmd_line/commands/marks.ts
@@ -1,0 +1,43 @@
+import { VimState } from '../../state/vimState';
+import * as node from '../node';
+import { window, QuickPickItem } from 'vscode';
+import { TextEditor } from '../../textEditor';
+import { IMark } from '../../history/historyTracker';
+
+
+class MarkQuickPickItem implements QuickPickItem {
+  mark: IMark;
+
+  label: string;
+  description: string;
+  detail: string;
+  picked = false;
+  alwaysShow = false;
+
+  constructor(mark: IMark) {
+    this.mark = mark;
+    this.label = mark.name;
+    this.description = TextEditor.getLineAt(mark.position).text.trim();
+    this.detail = `line ${mark.position.line} col ${ mark.position.character }`;
+  }
+}
+
+export class MarksCommand extends node.CommandBase {
+  async execute(vimState: VimState): Promise<void> {
+    const quickPickItems: MarkQuickPickItem[] = vimState.historyTracker
+      .getMarks()
+      .map(mark => new MarkQuickPickItem(mark));
+
+    if (quickPickItems.length > 0) {
+      window.showQuickPick(quickPickItems, {
+       canPickMany: false,
+      }).then(async item => {
+        if (item) {
+          // TODO: move to item.mark.position
+        }
+      });
+    } else {
+      window.showInformationMessage('No marks set');
+    }
+  }
+}

--- a/src/cmd_line/subparser.ts
+++ b/src/cmd_line/subparser.ts
@@ -15,6 +15,7 @@ import { parseWallCommandArgs } from './subparsers/wall';
 import { parseWriteCommandArgs } from './subparsers/write';
 import { parseWriteQuitCommandArgs } from './subparsers/writequit';
 import { parseWriteQuitAllCommandArgs } from './subparsers/writequitall';
+import { parseMarksCommandArgs } from './subparsers/marks';
 
 // maps command names to parsers for said commands.
 export const commandParsers = {
@@ -108,4 +109,6 @@ export const commandParsers = {
   d: parseDeleteRangeLinesCommandArgs,
 
   sort: parseSortCommandArgs,
+
+  marks: parseMarksCommandArgs,
 };

--- a/src/cmd_line/subparsers/marks.ts
+++ b/src/cmd_line/subparsers/marks.ts
@@ -1,0 +1,5 @@
+import { MarksCommand } from '../commands/marks';
+
+export function parseMarksCommandArgs(args: string): MarksCommand {
+  return new MarksCommand();
+}

--- a/src/history/historyTracker.ts
+++ b/src/history/historyTracker.ts
@@ -59,7 +59,7 @@ class DocumentChange {
   }
 }
 
-interface IMark {
+export interface IMark {
   name: string;
   position: Position;
   isUppercaseMark: boolean;


### PR DESCRIPTION
**What this PR does / why we need it**:
Implements the `:marks` command, which shows all active marks (in a QuickPick). I'd like it to jump to the chosen mark, but not sure how to get a movement action to execute from within MarksCommand.execute(). Advice would be appreciated.

**Which issue(s) this PR fixes**
Fixes #2563