### PR TITLE
When a search is cancelled, revert to previous search state

### DIFF
--- a/src/actions/commands/actions.ts
+++ b/src/actions/commands/actions.ts
@@ -956,11 +956,9 @@ class CommandEscInSearchMode extends BaseCommand {
     vimState.cursorStopPosition = searchState.searchCursorStartPosition;
 
     const prevSearchList = vimState.globalState.searchStatePrevious;
-    if (prevSearchList) {
-      vimState.globalState.searchState = prevSearchList[prevSearchList.length - 1];
-    } else {
-      vimState.globalState.searchState = undefined;
-    }
+    vimState.globalState.searchState = prevSearchList
+      ? prevSearchList[prevSearchList.length - 1]
+      : undefined;
 
     await vimState.setCurrentMode(searchState.previousMode);
 

--- a/test/mode/normalModeTests/motions.test.ts
+++ b/test/mode/normalModeTests/motions.test.ts
@@ -381,6 +381,13 @@ suite('Motions in Normal Mode', () => {
   // });
 
   newTest({
+    title: 'cancelled search reverts to previous search state',
+    start: ['|one', 'two two', 'three three three'],
+    keysPressed: '/two\n/three<Esc>n',
+    end: ['one', 'two |two', 'three three three'],
+  });
+
+  newTest({
     title: 'maintains column position correctly',
     start: ['|one one one', 'two', 'three'],
     keysPressed: 'lllljj',


### PR DESCRIPTION
<!--
Yay! Thanks for sending us a PR! 🎊

Please ensure your PR adheres to:

- [ ] Commit messages has a short & issue references when necessary
- [ ] Each commit does a logical chunk of work.
- [ ] It builds and tests pass (e.g `gulp`)
-->

**What this PR does / why we need it**:
When a search is cancelled (`<Esc>` after `/`), the search state should revert to the previous state, rather than being overwritten. This means the previous search should still be highlighted if `hlsearch` is enabled and `n` should go to the next instance of that search.

**Which issue(s) this PR fixes**
Fixes #3616
<!--
Commits in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)
-->