### PR TITLE
Document display line movement best practices

### DIFF
--- a/README.md
+++ b/README.md
@@ -617,7 +617,7 @@ Vim has a lot of nifty tricks and we try to preserve some of them:
 
 - How can I use the commandline when in Zen mode or when the status bar is disabled?
 
-  This extension exposes a remappable command to show a vscode style quick-pick, limited functionality, version of the commandline. This can be remapped as follows in visual studio keybindings.json settings file.
+  This extension exposes a remappable command to show a vscode style quick-pick, limited functionality, version of the commandline. This can be remapped as follows in VS Code's keybindings.json settings file.
 
   ```json
   {
@@ -636,6 +636,34 @@ Vim has a lot of nifty tricks and we try to preserve some of them:
     "when": "inZenMode && vim.mode != 'Insert'"
   }
   ```
+
+- How can I move the cursor by each display line with word wrapping?
+
+  If you have word wrap on and would like the cursor to enter each wrapped line when using <kbd>j</kbd>, <kbd>k</kbd>, <kbd>↓</kbd> or <kbd>↑</kbd>, set the following in VS Code's keybindings.json settings file ([other options exist](https://github.com/VSCodeVim/Vim/issues/2924#issuecomment-476121848) but they are slow):
+
+  ```json
+  {
+    "key": "up",
+    "command": "cursorUp",
+    "when": "editorTextFocus && vim.active && !inDebugRepl && !suggestWidgetMultipleSuggestions && !suggestWidgetVisible"
+  },
+  {
+    "key": "down",
+    "command": "cursorDown",
+    "when": "editorTextFocus && vim.active && !inDebugRepl && !suggestWidgetMultipleSuggestions && !suggestWidgetVisible"
+  },
+  {
+    "key": "k",
+    "command": "cursorUp",
+    "when": "editorTextFocus && vim.active && !inDebugRepl && vim.mode == 'Normal' && !suggestWidgetMultipleSuggestions && !suggestWidgetVisible"
+  },
+  {
+    "key": "j",
+    "command": "cursorDown",
+    "when": "editorTextFocus && vim.active && !inDebugRepl && vim.mode == 'Normal' && !suggestWidgetMultipleSuggestions && !suggestWidgetVisible"
+  }
+  ```
+
 
 ## ❤️ Contributing
 

--- a/README.md
+++ b/README.md
@@ -664,7 +664,6 @@ Vim has a lot of nifty tricks and we try to preserve some of them:
   }
   ```
 
-
 ## ❤️ Contributing
 
 This project is maintained by a group of awesome [people](https://github.com/VSCodeVim/Vim/graphs/contributors) and contributions are extremely welcome :heart:. For a quick tutorial on how you can help, see our [contributing guide](/.github/CONTRIBUTING.md).

--- a/README.md
+++ b/README.md
@@ -641,6 +641,7 @@ Vim has a lot of nifty tricks and we try to preserve some of them:
 
   If you have word wrap on and would like the cursor to enter each wrapped line when using <kbd>j</kbd>, <kbd>k</kbd>, <kbd>↓</kbd> or <kbd>↑</kbd>, set the following in VS Code's keybindings.json settings file ([other options exist](https://github.com/VSCodeVim/Vim/issues/2924#issuecomment-476121848) but they are slow):
 
+  <!-- prettier-ignore -->
   ```json
   {
     "key": "up",


### PR DESCRIPTION
Thanks for this project! It's really great to be able to use most common things from Vim in VS Code!

**What this PR does / why we need it**:

Best practices are not documented for how to vertically move to wrapped lines when word wrap is on.

Ref: https://github.com/VSCodeVim/Vim/issues/2403#issuecomment-456365357
Ref: https://github.com/VSCodeVim/Vim/issues/2924#issuecomment-476121848

**Which issue(s) this PR fixes**

This documents the movements in a FAQ item:

- How can I move the cursor by display line with word wrapping?

  If you have word wrap on and would like the cursor to enter each wrapped line when using <kbd>j</kbd>, <kbd>k</kbd>, <kbd>↓</kbd> or <kbd>↑</kbd>, set the following in VS Code's keybindings.json settings file ([other options exist](https://github.com/VSCodeVim/Vim/issues/2924#issuecomment-476121848) but they are slow):

  ```json
  {
    "key": "up",
    "command": "cursorUp",
    "when": "editorTextFocus && vim.active && !inDebugRepl && !suggestWidgetMultipleSuggestions && !suggestWidgetVisible"
  },
  {
    "key": "down",
    "command": "cursorDown",
    "when": "editorTextFocus && vim.active && !inDebugRepl && !suggestWidgetMultipleSuggestions && !suggestWidgetVisible"
  },
  {
    "key": "k",
    "command": "cursorUp",
    "when": "editorTextFocus && vim.active && !inDebugRepl && vim.mode == 'Normal' && !suggestWidgetMultipleSuggestions && !suggestWidgetVisible"
  },
  {
    "key": "j",
    "command": "cursorDown",
    "when": "editorTextFocus && vim.active && !inDebugRepl && vim.mode == 'Normal' && !suggestWidgetMultipleSuggestions && !suggestWidgetVisible"
  }
  ```

**Special notes for your reviewer**:

In case I've missed some case in which rebinding <kbd>j</kbd> and <kbd>k</kbd> in `Normal` mode and <kbd>↓</kbd> and <kbd>↑</kbd> in all modes to the VS Code default would cause a problem, please let me know and we can change this.