### PR TITLE
When backspace is hit on an empty search, cancel the search

### DIFF
--- a/src/actions/commands/actions.ts
+++ b/src/actions/commands/actions.ts
@@ -874,6 +874,9 @@ class CommandInsertInSearchMode extends BaseCommand {
 
     // handle special keys first
     if (key === '<BS>' || key === '<shift+BS>' || key === '<C-h>') {
+      if (searchState.searchString.length === 0) {
+        return new CommandEscInSearchMode().exec(position, vimState);
+      }
       searchState.searchString = searchState.searchString.slice(0, -1);
     } else if (key === '\n') {
       await vimState.setCurrentMode(vimState.globalState.searchState!.previousMode);

--- a/test/mode/normalModeTests/motions.test.ts
+++ b/test/mode/normalModeTests/motions.test.ts
@@ -1,5 +1,6 @@
 import { getTestingFunctions } from '../../testSimplifier';
 import { cleanUpWorkspace, setupWorkspace } from './../../testUtils';
+import { ModeName } from '../../../src/mode/mode';
 
 suite('Motions in Normal Mode', () => {
   let { newTest, newTestOnly } = getTestingFunctions();
@@ -379,6 +380,14 @@ suite('Motions in Normal Mode', () => {
   //     end: ['three four |two one'],
   //   });
   // });
+
+  newTest({
+    title: 'Backspace on empty search cancels',
+    start: ['|one two three'],
+    keysPressed: '/tw<BS><BS><BS>',
+    end: ['|one two three'],
+    endMode: ModeName.Normal,
+  });
 
   newTest({
     title: 'maintains column position correctly',


### PR DESCRIPTION
**What this PR does / why we need it**:
Allows you to cancel a search with backspace after deleting search term.

**Which issue(s) this PR fixes**
Fixes #3619