### PR TITLE
Digraphs: Allow input in reverse order (fixes #3599)

### DIFF
--- a/src/actions/commands/insert.ts
+++ b/src/actions/commands/insert.ts
@@ -306,7 +306,14 @@ class CommandInsertDigraph extends BaseCommand {
 
   public async exec(position: Position, vimState: VimState): Promise<VimState> {
     const digraph = this.keysPressed.slice(1, 3).join('');
-    let charCodes = (DefaultDigraphs[digraph] || configuration.digraphs[digraph])[1];
+    const reverseDigraph = digraph
+      .split('')
+      .reverse()
+      .join('');
+    let charCodes = (DefaultDigraphs[digraph] ||
+      DefaultDigraphs[reverseDigraph] ||
+      configuration.digraphs[digraph] ||
+      configuration.digraphs[reverseDigraph])[1];
     if (!(charCodes instanceof Array)) {
       charCodes = [charCodes];
     }
@@ -324,7 +331,16 @@ class CommandInsertDigraph extends BaseCommand {
       return false;
     }
     const chars = keysPressed.slice(1, 3).join('');
-    return chars in configuration.digraphs || chars in DefaultDigraphs;
+    const reverseChars = chars
+      .split('')
+      .reverse()
+      .join('');
+    return (
+      chars in configuration.digraphs ||
+      reverseChars in configuration.digraphs ||
+      chars in DefaultDigraphs ||
+      reverseChars in DefaultDigraphs
+    );
   }
 
   public couldActionApply(vimState: VimState, keysPressed: string[]): boolean {
@@ -332,8 +348,15 @@ class CommandInsertDigraph extends BaseCommand {
       return false;
     }
     const chars = keysPressed.slice(1, keysPressed.length).join('');
+    const reverseChars = chars
+      .split('')
+      .reverse()
+      .join('');
     if (chars.length > 0) {
-      const predicate = (digraph: string) => chars === digraph.substring(0, chars.length);
+      const predicate = (digraph: string) => {
+        const digraphChars = digraph.substring(0, chars.length);
+        return chars === digraphChars || reverseChars === digraphChars;
+      };
       const match =
         Object.keys(configuration.digraphs).find(predicate) ||
         Object.keys(DefaultDigraphs).find(predicate);

--- a/test/mode/modeInsert.test.ts
+++ b/test/mode/modeInsert.test.ts
@@ -347,8 +347,11 @@ suite('Mode Insert', () => {
       'e',
       'x',
       't',
+      '<C-k>',
+      '>',
+      '-',
     ]);
-    assertEqualLines(['text→text']);
+    assertEqualLines(['text→text→']);
   });
 
   test('Can handle custom digraph insert', async () => {
@@ -356,7 +359,7 @@ suite('Mode Insert', () => {
       'R!': ['🚀', [55357, 56960]],
     };
     await reloadConfiguration();
-    await modeHandler.handleMultipleKeyEvents(['i', '<C-k>', 'R', '!']);
-    assertEqualLines(['🚀']);
+    await modeHandler.handleMultipleKeyEvents(['i', '<C-k>', 'R', '!', '<C-k>', '!', 'R']);
+    assertEqualLines(['🚀🚀']);
   });
 });


### PR DESCRIPTION
**What this PR does / why we need it**:

Allows the input of the digraph characters in reverse order. The author was not aware of this short passage in the vim documentation and thus did not implement the feature in the original PR (#3407).

> If a digraph with `{char1}{char2}` does not exist, Vim searches for a digraph `{char2}{char1}`.  This helps when you don't remember which character comes first.
http://vimdoc.sourceforge.net/htmldoc/digraph.html#digraphs-use

**Which issue(s) this PR fixes**:  #3599
