### PR TITLE
docs: update slackin link

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 This document offers a set of guidelines for contributing to VSCodeVim.
 These are just guidelines, not rules; use your best judgment and feel free to propose changes to this document.
-If you need help, drop by on [Slack](https://vscodevim-slackin.azurewebsites.net/).
+If you need help, drop by on [Slack](https://vscodevim.herokuapp.com/).
 
 Thanks for helping us in making VSCodeVim better! :clap:
 

--- a/README.md
+++ b/README.md
@@ -4,13 +4,13 @@
 [![http://aka.ms/vscodevim](https://vsmarketplacebadge.apphb.com/version/vscodevim.vim.svg)](http://aka.ms/vscodevim)
 [![](https://vsmarketplacebadge.apphb.com/installs-short/vscodevim.vim.svg)](https://marketplace.visualstudio.com/items?itemName=vscodevim.vim)
 [![https://travis-ci.org/VSCodeVim/Vim](https://travis-ci.org/VSCodeVim/Vim.svg?branch=master)](https://travis-ci.org/VSCodeVim/Vim)
-[![http://vscodevim.herokuapp.com/](https://img.shields.io/badge/vscodevim-slack-blue.svg?logo=slack)](http://vscodevim.herokuapp.com/)
+[![https://vscodevim.herokuapp.com/](https://img.shields.io/badge/vscodevim-slack-blue.svg?logo=slack)](https://vscodevim.herokuapp.com/)
 
 VSCodeVim is a Vim emulator for [Visual Studio Code](https://code.visualstudio.com/).
 
 - 🚚 For a full list of supported Vim features, please refer to our [roadmap](ROADMAP.md).
 - 📃 Our [change log](CHANGELOG.md) outlines the breaking/major/minor updates between releases.
-- ❓ If you need to ask any questions, join us on [Slack](https://vscodevim-slackin.azurewebsites.net)
+- ❓ If you need to ask any questions, join us on [Slack](https://vscodevim.herokuapp.com/)
 - Report missing features/bugs on [GitHub](https://github.com/VSCodeVim/Vim/issues).
 
 <details>

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "*",
     "onCommand:type"
   ],
-  "qna": "https://vscodevim-slackin.azurewebsites.net/",
+  "qna": "https://vscodevim.herokuapp.com/",
   "main": "./out/extension",
   "contributes": {
     "commands": [


### PR DESCRIPTION
Change to https for existing links and convert to heroku for azure ones

**What this PR does / why we need it**: Slack has moved to heroku apps but some of them still has the old azure link, also some heroku one has http instead of https

**Which issue(s) this PR fixes**: This doesn't start a fix for a particular issue but rather finish the fix for #3370 
