### PR TITLE
Globalmarks

### DIFF
--- a/src/actions/motion.ts
+++ b/src/actions/motion.ts
@@ -458,7 +458,7 @@ export class MarkMovementBOL extends BaseMovement {
     }
 
     if (mark.isUppercaseMark && mark.editor !== undefined) {
-      ensureEditorIsActive(mark.editor);
+      await ensureEditorIsActive(mark.editor);
     }
 
     return mark.position;

--- a/src/actions/motion.ts
+++ b/src/actions/motion.ts
@@ -1,10 +1,10 @@
 import * as vscode from 'vscode';
 
-import { ChangeOperator, DeleteOperator, YankOperator, BaseOperator } from './operator';
+import { ChangeOperator, DeleteOperator, YankOperator } from './operator';
 import { CursorMoveByUnit, CursorMovePosition, TextEditor } from './../textEditor';
 import { Mode } from './../mode/mode';
 import { PairMatcher } from './../common/matching/matcher';
-import { Position, PositionDiff } from './../common/motion/position';
+import { Position } from './../common/motion/position';
 import { QuoteMatcher } from './../common/matching/quoteMatcher';
 import { RegisterAction } from './base';
 import { RegisterMode } from './../register/register';
@@ -19,9 +19,6 @@ import { globalState } from '../state/globalState';
 import { reportSearch } from '../util/statusBarTextUtils';
 import { SneakForward, SneakBackward } from './plugins/sneak';
 import { Notation } from '../configuration/notation';
-import { globalState } from '../state/globalState';
-import { BaseMovement, IMovement, isIMovement, SelectionType } from './baseMotion';
-import { SneakForward, SneakBackward } from './plugins/sneak';
 import { SearchDirection } from '../state/searchState';
 
 /**

--- a/src/actions/motion.ts
+++ b/src/actions/motion.ts
@@ -461,7 +461,7 @@ export class MarkMovementBOL extends BaseMovement {
       await ensureEditorIsActive(mark.editor);
     }
 
-    return mark.position;
+    return mark.position.getFirstLineNonBlankChar();
   }
 }
 

--- a/src/actions/motion.ts
+++ b/src/actions/motion.ts
@@ -14,7 +14,7 @@ import { VimState } from './../state/vimState';
 import { configuration } from './../configuration/configuration';
 import { shouldWrapKey } from './wrapping';
 import { VimError, ErrorCode } from '../error';
-import { BaseMovement } from './baseMotion';
+import { BaseMovement, SelectionType, IMovement, isIMovement } from './baseMotion';
 import { globalState } from '../state/globalState';
 import { reportSearch } from '../util/statusBarTextUtils';
 import { SneakForward, SneakBackward } from './plugins/sneak';
@@ -23,35 +23,6 @@ import { globalState } from '../state/globalState';
 import { BaseMovement, IMovement, isIMovement, SelectionType } from './baseMotion';
 import { SneakForward, SneakBackward } from './plugins/sneak';
 import { SearchDirection } from '../state/searchState';
-
-export function isIMovement(o: IMovement | Position): o is IMovement {
-  return (o as IMovement).start !== undefined && (o as IMovement).stop !== undefined;
-}
-
-/**
- * The result of a (more sophisticated) Movement.
- */
-export interface IMovement {
-  start: Position;
-  stop: Position;
-
-  /**
-   * Whether this motion succeeded. Some commands, like fx when 'x' can't be found,
-   * will not move the cursor. Furthermore, dfx won't delete *anything*, even though
-   * deleting to the current character would generally delete 1 character.
-   */
-  failed?: boolean;
-
-  diff?: PositionDiff;
-
-  // It /so/ annoys me that I have to put this here.
-  registerMode?: RegisterMode;
-}
-
-enum SelectionType {
-  Concatenating, // selections that concatenate repeated movements
-  Expanding, // selections that expand the start and end of the previous selection
-}
 
 /**
  * A movement is something like 'h', 'k', 'w', 'b', 'gg', etc.

--- a/src/actions/motion.ts
+++ b/src/actions/motion.ts
@@ -465,12 +465,6 @@ export class MarkMovementBOL extends BaseMovement {
   }
 }
 
-async function ensureEditorIsActive(editor: vscode.TextEditor) {
-  if (editor !== vscode.window.activeTextEditor) {
-    await vscode.window.showTextDocument(editor.document);
-  }
-}
-
 @RegisterAction
 export class MarkMovement extends BaseMovement {
   keys = ['`', '<character>'];
@@ -485,10 +479,16 @@ export class MarkMovement extends BaseMovement {
     }
 
     if (mark.isUppercaseMark && mark.editor !== undefined) {
-      ensureEditorIsActive(mark.editor);
+      await ensureEditorIsActive(mark.editor);
     }
 
     return mark.position;
+  }
+}
+
+async function ensureEditorIsActive(editor: vscode.TextEditor) {
+  if (editor !== vscode.window.activeTextEditor) {
+    await vscode.window.showTextDocument(editor.document);
   }
 }
 

--- a/src/history/historyTracker.ts
+++ b/src/history/historyTracker.ts
@@ -82,6 +82,7 @@ export interface IMark {
   name: string;
   position: Position;
   isUppercaseMark: boolean;
+  editor?: vscode.TextEditor; // only required when using global marks (isUppercaseMark is true)
 }
 
 class HistoryStep {
@@ -115,6 +116,11 @@ class HistoryStep {
    * The position of every mark at the start of this history step.
    */
   marks: IMark[] = [];
+
+  /**
+   * "global" file marks. (when IMark.name is uppercase)
+   */
+  static fileMarks: IMark[] = [];
 
   constructor(init: {
     changes?: DocumentChange[];
@@ -303,16 +309,12 @@ export class HistoryTracker {
    * text that was marked.
    */
   private updateAndReturnMarks(): IMark[] {
-    const previousMarks = this.currentHistoryStep.marks;
+    const previousMarks = this.getAllCurrentDocumentMarks();
     let newMarks: IMark[] = [];
 
     // clone old marks into new marks
     for (const mark of previousMarks) {
-      newMarks.push({
-        name: mark.name,
-        position: mark.position,
-        isUppercaseMark: mark.isUppercaseMark,
-      });
+      newMarks.push({ ...mark });
     }
 
     for (const change of this.currentHistoryStep.changes) {
@@ -396,28 +398,71 @@ export class HistoryTracker {
   }
 
   /**
+   * Updates all marks affecting the active text editor.
+   * Since all currentHistoryStep's marks are affected, just update the
+   * array.  File marks might not be from the active editor, so the
+   * filemark collection is mutated with the new element in place.
+   */
+  private updateMarks(): void {
+    const newMarks = this.updateAndReturnMarks();
+    this.currentHistoryStep.marks = newMarks.filter(mark => !mark.isUppercaseMark);
+
+    newMarks.filter(mark => mark.isUppercaseMark).forEach(this.putMarkInList.bind);
+  }
+
+  /**
+   * Returns the most a shared static list if isFileMark is true,
+   * otherwise returns the currentHistoryStep.marks.
+   */
+  private getMarkList(isFileMark: boolean): IMark[] {
+    return isFileMark ? HistoryStep.fileMarks : this.currentHistoryStep.marks;
+  }
+
+  /**
+   * Gets all local marks, and file marks targeting the current editor.
+   */
+  private getAllCurrentDocumentMarks(): IMark[] {
+    const fileMarks = HistoryStep.fileMarks.filter(
+      mark => mark.editor === vscode.window.activeTextEditor
+    );
+    return [...this.currentHistoryStep.marks, ...fileMarks];
+  }
+
+  /**
    * Adds a mark.
    */
   public addMark(position: Position, markName: string): void {
+    const isUppercaseMark = markName.toUpperCase() === markName;
     const newMark: IMark = {
       position,
       name: markName,
-      isUppercaseMark: markName === markName.toUpperCase(),
+      isUppercaseMark: isUppercaseMark,
+      editor: isUppercaseMark ? vscode.window.activeTextEditor : undefined,
     };
-    const previousIndex = this.currentHistoryStep.marks.findIndex(mark => mark.name === markName);
+    this.putMarkInList(newMark);
+  }
 
+  /**
+   * Puts the mark either the static or local marks array depending on
+   * mark.isUppercaseMark.
+   */
+  private putMarkInList(mark: IMark): void {
+    const marks = this.getMarkList(mark.isUppercaseMark);
+    const previousIndex = marks.findIndex(existingMark => existingMark.name === mark.name);
     if (previousIndex !== -1) {
-      this.currentHistoryStep.marks[previousIndex] = newMark;
+      marks[previousIndex] = mark;
     } else {
-      this.currentHistoryStep.marks.push(newMark);
+      marks.push(mark);
     }
   }
 
   /**
-   * Retrieves a mark.
+   * Retrieves a mark from either the static or local array depending on
+   * mark.isUppercaseMark.
    */
   public getMark(markName: string): IMark {
-    return <IMark>this.currentHistoryStep.marks.find(mark => mark.name === markName);
+    const marks = this.getMarkList(markName.toUpperCase() === markName);
+    return <IMark>marks.find(mark => mark.name === markName);
   }
 
   public getMarks(): IMark[] {

--- a/src/history/historyTracker.ts
+++ b/src/history/historyTracker.ts
@@ -411,7 +411,7 @@ export class HistoryTracker {
   }
 
   /**
-   * Returns the most a shared static list if isFileMark is true,
+   * Returns the shared static list if isFileMark is true,
    * otherwise returns the currentHistoryStep.marks.
    */
   private getMarkList(isFileMark: boolean): IMark[] {
@@ -419,7 +419,7 @@ export class HistoryTracker {
   }
 
   /**
-   * Gets all local marks, and file marks targeting the current editor.
+   * Gets all local and file marks targeting the current editor.
    */
   private getAllCurrentDocumentMarks(): IMark[] {
     const fileMarks = HistoryStep.fileMarks.filter(

--- a/src/history/historyTracker.ts
+++ b/src/history/historyTracker.ts
@@ -465,8 +465,19 @@ export class HistoryTracker {
     return <IMark>marks.find(mark => mark.name === markName);
   }
 
-  public getMarks(): IMark[] {
-    return this.currentHistoryStep.marks;
+  /**
+   * Gets all local marks.  I.e., marks that are specific for the current
+   * editor.
+   */
+  public getLocalMarks(): IMark[] {
+    return [...this.currentHistoryStep.marks];
+  }
+
+  /**
+   * Gets all file marks.  I.e., marks that are shared among all editors.
+   */
+  public getFileMarks(): IMark[] {
+    return [...HistoryStep.fileMarks];
   }
 
   /**

--- a/src/history/historyTracker.ts
+++ b/src/history/historyTracker.ts
@@ -118,9 +118,9 @@ class HistoryStep {
   marks: IMark[] = [];
 
   /**
-   * "global" file marks. (when IMark.name is uppercase)
+   * "global" marks which operate across files. (when IMark.name is uppercase)
    */
-  static fileMarks: IMark[] = [];
+  static globalMarks: IMark[] = [];
 
   constructor(init: {
     changes?: DocumentChange[];
@@ -415,17 +415,17 @@ export class HistoryTracker {
    * otherwise returns the currentHistoryStep.marks.
    */
   private getMarkList(isFileMark: boolean): IMark[] {
-    return isFileMark ? HistoryStep.fileMarks : this.currentHistoryStep.marks;
+    return isFileMark ? HistoryStep.globalMarks : this.currentHistoryStep.marks;
   }
 
   /**
    * Gets all local and file marks targeting the current editor.
    */
   private getAllCurrentDocumentMarks(): IMark[] {
-    const fileMarks = HistoryStep.fileMarks.filter(
+    const globalMarks = HistoryStep.globalMarks.filter(
       mark => mark.editor === vscode.window.activeTextEditor
     );
-    return [...this.currentHistoryStep.marks, ...fileMarks];
+    return [...this.currentHistoryStep.marks, ...globalMarks];
   }
 
   /**
@@ -476,8 +476,12 @@ export class HistoryTracker {
   /**
    * Gets all file marks.  I.e., marks that are shared among all editors.
    */
-  public getFileMarks(): IMark[] {
-    return [...HistoryStep.fileMarks];
+  public getGlobalMarks(): IMark[] {
+    return [...HistoryStep.globalMarks];
+  }
+
+  public getMarks(): IMark[] {
+    return [...this.currentHistoryStep.marks, ...HistoryStep.globalMarks];
   }
 
   /**

--- a/src/history/historyTracker.ts
+++ b/src/history/historyTracker.ts
@@ -400,8 +400,8 @@ export class HistoryTracker {
   /**
    * Updates all marks affecting the active text editor.
    * Since all currentHistoryStep's marks are affected, just update the
-   * array.  File marks might not be from the active editor, so the
-   * filemark collection is mutated with the new element in place.
+   * array.  Global marks might not be from the active editor, so the
+   * global mark collection is mutated with the new element in place.
    */
   private updateMarks(): void {
     const newMarks = this.updateAndReturnMarks();
@@ -419,7 +419,7 @@ export class HistoryTracker {
   }
 
   /**
-   * Gets all local and file marks targeting the current editor.
+   * Gets all local and global marks targeting the current editor.
    */
   private getAllCurrentDocumentMarks(): IMark[] {
     const globalMarks = HistoryStep.globalMarks.filter(
@@ -443,7 +443,7 @@ export class HistoryTracker {
   }
 
   /**
-   * Puts the mark either the static or local marks array depending on
+   * Puts the mark into either the global or local marks array depending on
    * mark.isUppercaseMark.
    */
   private putMarkInList(mark: IMark): void {
@@ -457,7 +457,7 @@ export class HistoryTracker {
   }
 
   /**
-   * Retrieves a mark from either the static or local array depending on
+   * Retrieves a mark from either the global or local array depending on
    * mark.isUppercaseMark.
    */
   public getMark(markName: string): IMark {
@@ -474,7 +474,7 @@ export class HistoryTracker {
   }
 
   /**
-   * Gets all file marks.  I.e., marks that are shared among all editors.
+   * Gets all global marks.  I.e., marks that are shared among all editors.
    */
   public getGlobalMarks(): IMark[] {
     return [...HistoryStep.globalMarks];

--- a/src/neovim/neovim.ts
+++ b/src/neovim/neovim.ts
@@ -127,7 +127,7 @@ export class NeovimWrapper implements vscode.Disposable {
       "'>",
       [0, rangeEnd.line + 1, rangeEnd.character, false],
     ]);
-    for (const mark of vimState.historyTracker.getMarks()) {
+    for (const mark of vimState.historyTracker.getLocalMarks()) {
       await this.nvim.callFunction('setpos', [
         `'${mark.name}`,
         [0, mark.position.line + 1, mark.position.character, false],

--- a/test/historyTracker.test.ts
+++ b/test/historyTracker.test.ts
@@ -5,12 +5,11 @@ import * as vscode from 'vscode';
 import { HistoryTracker, IMark } from '../src/history/historyTracker';
 import { VimState } from '../src/state/vimState';
 import { Position } from '../src/common/motion/position';
-import { TextEditor } from '../src/textEditor';
 
 suite('historyTracker unit tests', () => {
   let sandbox: sinon.SinonSandbox;
   let historyTracker: HistoryTracker;
-  let activeTextEditor: TextEditor;
+  let activeTextEditor: vscode.TextEditor;
 
   const retrieveLocalMark = (markName: string): IMark | undefined =>
     historyTracker.getLocalMarks().find(mark => mark.name === markName);
@@ -23,7 +22,7 @@ suite('historyTracker unit tests', () => {
   const setupHistoryTracker = (vimState = setupVimState()) => new HistoryTracker(vimState);
 
   const setupVSCode = () => {
-    activeTextEditor = sandbox.createStubInstance<TextEditor>(TextEditor);
+    activeTextEditor = sandbox.createStubInstance<vscode.TextEditor>(TextEditorStub);
     sandbox.stub(vscode, 'window').value({ activeTextEditor });
   };
 
@@ -91,3 +90,39 @@ suite('historyTracker unit tests', () => {
     });
   });
 });
+
+// tslint:disable: no-empty
+class TextEditorStub implements vscode.TextEditor {
+  readonly document: vscode.TextDocument;
+  selection: vscode.Selection;
+  selections: vscode.Selection[];
+  readonly visibleRanges: vscode.Range[];
+  options: vscode.TextEditorOptions;
+  viewColumn?: vscode.ViewColumn;
+
+  constructor() {}
+  async edit(
+    callback: (editBuilder: vscode.TextEditorEdit) => void,
+    options?: { undoStopBefore: boolean; undoStopAfter: boolean }
+  ) {
+    return true;
+  }
+  async insertSnippet(
+    snippet: vscode.SnippetString,
+    location?:
+      | vscode.Position
+      | vscode.Range
+      | ReadonlyArray<Position>
+      | ReadonlyArray<vscode.Range>,
+    options?: { undoStopBefore: boolean; undoStopAfter: boolean }
+  ) {
+    return true;
+  }
+  setDecorations(
+    decorationType: vscode.TextEditorDecorationType,
+    rangesOrOptions: vscode.Range[] | vscode.DecorationOptions[]
+  ) {}
+  revealRange(range: vscode.Range, revealType?: vscode.TextEditorRevealType) {}
+  show(column?: vscode.ViewColumn) {}
+  hide() {}
+}

--- a/test/historyTracker.test.ts
+++ b/test/historyTracker.test.ts
@@ -16,7 +16,7 @@ suite('historyTracker unit tests', () => {
     historyTracker.getLocalMarks().find(mark => mark.name === markName);
 
   const retrieveFileMark = (markName: string): IMark | undefined =>
-    historyTracker.getFileMarks().find(mark => mark.name === markName);
+    historyTracker.getGlobalMarks().find(mark => mark.name === markName);
 
   const setupVimState = () => <VimState>(<any>sandbox.createStubInstance(VimState));
 

--- a/test/historyTracker.test.ts
+++ b/test/historyTracker.test.ts
@@ -1,0 +1,99 @@
+import * as assert from 'assert';
+import * as sinon from 'sinon';
+
+import * as vscode from 'vscode';
+import { HistoryTracker, IMark } from '../src/history/historyTracker';
+import { VimState } from '../src/state/vimState';
+import { Position } from '../src/common/motion/position';
+import { TextEditor } from '../src/textEditor';
+
+
+suite('historyTracker unit tests', () => {
+  let sandbox: sinon.SinonSandbox;
+  let historyTracker: HistoryTracker;
+  let activeTextEditor: TextEditor;
+
+  const retrieveLocalMark = (markName: string): IMark | undefined => (
+    historyTracker.getLocalMarks()
+      .find(mark => mark.name === markName));
+
+  const retrieveFileMark = (markName: string): IMark | undefined => (
+    historyTracker.getFileMarks()
+      .find(mark => mark.name === markName));
+
+  const setupVimState = () => (
+    <VimState><any>sandbox.createStubInstance(VimState));
+
+  const setupHistoryTracker = (vimState = setupVimState()) => (
+    new HistoryTracker(vimState));
+
+  const setupVsCode = () => {
+    activeTextEditor = sandbox.createStubInstance<TextEditor>(TextEditor);
+    sandbox.stub(vscode, 'window').value({ activeTextEditor });
+  };
+
+  const buildMockPosition = (): Position => (
+    <any>sandbox.createStubInstance(Position));
+
+  setup(() => {
+    sandbox = sinon.createSandbox();
+  });
+
+  teardown(() => {
+    sandbox.restore();
+  });
+
+  suite('addMark', () => {
+    setup(() => {
+      setupVsCode();
+      historyTracker = setupHistoryTracker();
+    });
+
+    test('can create lowercase mark', () => {
+      const position = buildMockPosition();
+      historyTracker.addMark(position, 'a');
+      const mark = retrieveLocalMark('a');
+      assert.notStrictEqual(mark, undefined, 'failed to store lowercase mark');
+      if (mark !== undefined) {
+        assert.strictEqual(mark.position, position);
+        assert.strictEqual(mark.isUppercaseMark, false);
+        assert.strictEqual(mark.editor, undefined);
+      }
+    });
+
+    test('can create uppercase mark', () => {
+      const position = buildMockPosition();
+      historyTracker.addMark(position, 'A');
+      const mark = retrieveFileMark('A');
+      assert.notStrictEqual(mark, undefined, 'failed to store file mark');
+      if (mark !== undefined) {
+        assert.strictEqual(mark.position, position);
+        assert.strictEqual(mark.isUppercaseMark, true);
+        assert.strictEqual(mark.editor, activeTextEditor);
+      }
+    });
+
+    test('shares uppercase marks between editor instances', () => {
+      const position = buildMockPosition();
+      const firstHistoryTrackerInstance = historyTracker;
+      const otherHistoryTrackerInstance = setupHistoryTracker(setupVimState());
+      assert.notStrictEqual(firstHistoryTrackerInstance, otherHistoryTrackerInstance);
+      otherHistoryTrackerInstance.addMark(position, 'A');
+      const mark = retrieveFileMark('A');
+      assert.notStrictEqual(mark, undefined);
+      if (mark !== undefined) {
+        assert.strictEqual(position, mark.position);
+      }
+    });
+
+    test('does not share lower marks between editor instances', () => {
+      const position = buildMockPosition();
+      const firstHistoryTrackerInstance = historyTracker;
+      const otherHistoryTrackerInstance = setupHistoryTracker(setupVimState());
+      assert.notStrictEqual(firstHistoryTrackerInstance, otherHistoryTrackerInstance);
+      otherHistoryTrackerInstance.addMark(position, 'a');
+      const mark = retrieveLocalMark('a');
+      assert.strictEqual(mark, undefined);
+    });
+  });
+});

--- a/test/historyTracker.test.ts
+++ b/test/historyTracker.test.ts
@@ -7,33 +7,27 @@ import { VimState } from '../src/state/vimState';
 import { Position } from '../src/common/motion/position';
 import { TextEditor } from '../src/textEditor';
 
-
 suite('historyTracker unit tests', () => {
   let sandbox: sinon.SinonSandbox;
   let historyTracker: HistoryTracker;
   let activeTextEditor: TextEditor;
 
-  const retrieveLocalMark = (markName: string): IMark | undefined => (
-    historyTracker.getLocalMarks()
-      .find(mark => mark.name === markName));
+  const retrieveLocalMark = (markName: string): IMark | undefined =>
+    historyTracker.getLocalMarks().find(mark => mark.name === markName);
 
-  const retrieveFileMark = (markName: string): IMark | undefined => (
-    historyTracker.getFileMarks()
-      .find(mark => mark.name === markName));
+  const retrieveFileMark = (markName: string): IMark | undefined =>
+    historyTracker.getFileMarks().find(mark => mark.name === markName);
 
-  const setupVimState = () => (
-    <VimState><any>sandbox.createStubInstance(VimState));
+  const setupVimState = () => <VimState>(<any>sandbox.createStubInstance(VimState));
 
-  const setupHistoryTracker = (vimState = setupVimState()) => (
-    new HistoryTracker(vimState));
+  const setupHistoryTracker = (vimState = setupVimState()) => new HistoryTracker(vimState);
 
   const setupVsCode = () => {
     activeTextEditor = sandbox.createStubInstance<TextEditor>(TextEditor);
     sandbox.stub(vscode, 'window').value({ activeTextEditor });
   };
 
-  const buildMockPosition = (): Position => (
-    <any>sandbox.createStubInstance(Position));
+  const buildMockPosition = (): Position => <any>sandbox.createStubInstance(Position);
 
   setup(() => {
     sandbox = sinon.createSandbox();

--- a/test/historyTracker.test.ts
+++ b/test/historyTracker.test.ts
@@ -1,7 +1,7 @@
 import * as assert from 'assert';
 import * as sinon from 'sinon';
-
 import * as vscode from 'vscode';
+
 import { HistoryTracker, IMark } from '../src/history/historyTracker';
 import { VimState } from '../src/state/vimState';
 import { Position } from '../src/common/motion/position';
@@ -22,7 +22,7 @@ suite('historyTracker unit tests', () => {
 
   const setupHistoryTracker = (vimState = setupVimState()) => new HistoryTracker(vimState);
 
-  const setupVsCode = () => {
+  const setupVSCode = () => {
     activeTextEditor = sandbox.createStubInstance<TextEditor>(TextEditor);
     sandbox.stub(vscode, 'window').value({ activeTextEditor });
   };
@@ -39,7 +39,7 @@ suite('historyTracker unit tests', () => {
 
   suite('addMark', () => {
     setup(() => {
-      setupVsCode();
+      setupVSCode();
       historyTracker = setupHistoryTracker();
     });
 

--- a/test/mode/modeNormal.test.ts
+++ b/test/mode/modeNormal.test.ts
@@ -1,15 +1,11 @@
 import * as assert from 'assert';
-import * as vscode from 'vscode';
 import { getAndUpdateModeHandler } from '../../extension';
 import { Mode } from '../../src/mode/mode';
 import { ModeHandler } from '../../src/mode/modeHandler';
 import { TextEditor } from '../../src/textEditor';
 import { Configuration } from '../testConfiguration';
 import { getTestingFunctions } from '../testSimplifier';
-import {
-  cleanUpWorkspace,
-  setupWorkspace,
-} from './../testUtils';
+import { cleanUpWorkspace, setupWorkspace } from './../testUtils';
 
 suite('Mode Normal', () => {
   let modeHandler: ModeHandler;

--- a/test/mode/modeNormal.test.ts
+++ b/test/mode/modeNormal.test.ts
@@ -2550,7 +2550,7 @@ suite('Mode Normal', () => {
     newTest({
       title: `can jump to lowercase mark`,
       start: ['|hello world and mars'],
-      keysPressed: `wma2w'a`,
+      keysPressed: 'wma2w`a',
       end: ['hello |world and mars'],
       endMode: Mode.Normal,
     });


### PR DESCRIPTION

**What this PR does / why we need it**:
Supports file marks.  I.e., just like normal marks, except when the mark is uppercase it should jump across files in addition to the cursor position.

**Which issue(s) this PR fixes**
Fixes #1692
Burrows heavily from #564 

**Special notes for your reviewer**:
This is my first pull request on this repo, so I'm not sure if I've missed something.  I was going to add tests, but I couldn't see any existing tests for marks, so I decided not to.
