### PR TITLE
Fix reverse selecting in normal mode.

### DIFF
--- a/src/actions/commands/actions.ts
+++ b/src/actions/commands/actions.ts
@@ -1027,7 +1027,7 @@ class CommandOverrideCopy extends BaseCommand {
   public async exec(position: Position, vimState: VimState): Promise<VimState> {
     let text = '';
 
-    if (vimState.currentMode === ModeName.Visual || vimState.currentMode === ModeName.Normal) {
+    if (vimState.currentMode === ModeName.Visual) {
       text = vimState.cursors
         .map(range => {
           const start = Position.EarlierOf(range.start, range.stop);
@@ -1050,7 +1050,10 @@ class CommandOverrideCopy extends BaseCommand {
       for (const { line } of Position.IterateLine(vimState)) {
         text += line + '\n';
       }
-    } else if (vimState.currentMode === ModeName.Insert) {
+    } else if (
+      vimState.currentMode === ModeName.Insert ||
+      vimState.currentMode === ModeName.Normal
+    ) {
       text = vimState.editor.selections
         .map(selection => {
           return vimState.editor.document.getText(new vscode.Range(selection.start, selection.end));


### PR DESCRIPTION
<!--
Yay! Thanks for sending us a PR! 🎊

Please ensure your PR adheres to:

- [x] Commit messages has a short & issue references when necessary
- [x] Each commit does a logical chunk of work.
- [x] It builds and tests pass (e.g `gulp`)
-->

**What this PR does / why we need it**:
This fixes #1951 in normal mode.

**Which issue(s) this PR fixes**
#1951

<!--
Commits in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)
-->

**Special notes for your reviewer**:
I realized that a range object from reverse selecting in insert or normal mode is not corresponding to the user's selection. 
In the PR #2062, native selections are used instead of ranges in insert mode.

I think there are two options to solve #1951.
1. Fix the problem between ranges and user's selections.
2. Use native selections instead of ranges in normal mode just like #2062.

This PR is based on option 2.