### PR TITLE
switch to visual mode when shift selection

### DIFF
--- a/package.json
+++ b/package.json
@@ -629,7 +629,7 @@
         },
         "vim.mouseSelectionGoesIntoVisualMode": {
           "type": "boolean",
-          "description": "Does dragging with the mouse put you into visual mode",
+          "description": "Does dragging with the mouse or shft with motion (arrow, Home, End) put you into visual mode",
           "default": true
         },
         "vim.disableExtension": {

--- a/package.json
+++ b/package.json
@@ -627,6 +627,11 @@
           "description": "Uses a hack to move around folds properly",
           "default": false
         },
+        "vim.mswinbehave": {
+          "type": "boolean",
+          "description": "Does mouse/shift selection behave as mswin",
+          "default": true
+        },
         "vim.mouseSelectionGoesIntoVisualMode": {
           "type": "boolean",
           "description": "Does dragging with the mouse or shft with motion (arrow, Home, End) put you into visual mode",

--- a/src/configuration/configuration.ts
+++ b/src/configuration/configuration.ts
@@ -287,6 +287,8 @@ class Configuration implements IConfiguration {
 
   visualstar = false;
 
+  mswinbehave = true;
+
   mouseSelectionGoesIntoVisualMode = true;
 
   changeWordIncludesWhitespace = false;

--- a/src/configuration/iconfiguration.ts
+++ b/src/configuration/iconfiguration.ts
@@ -244,7 +244,8 @@ export interface IConfiguration {
   visualstar: boolean;
 
   /**
-   * Does dragging with the mouse put you into visual mode
+   * Does dragging with the mouse or shift with motion (arrow, Home, End)
+   * put you into visual mode
    */
   mouseSelectionGoesIntoVisualMode: boolean;
 

--- a/src/configuration/iconfiguration.ts
+++ b/src/configuration/iconfiguration.ts
@@ -244,6 +244,12 @@ export interface IConfiguration {
   visualstar: boolean;
 
   /**
+   * After mode change to visual by mouse dragging or shift selection
+   * Does back to normal mode as mswin behave if mouse/shift is no longer hold
+   */
+  mswinbehave: boolean;
+
+  /**
    * Does dragging with the mouse or shift with motion (arrow, Home, End)
    * put you into visual mode
    */

--- a/src/mode/modeHandler.ts
+++ b/src/mode/modeHandler.ts
@@ -131,7 +131,10 @@ export class ModeHandler implements vscode.Disposable {
      * We only trigger our view updating process if it's a mouse selection.
      * Otherwise we only update our internal cursor positions accordingly.
      */
-    if (e.kind !== vscode.TextEditorSelectionChangeKind.Mouse) {
+    if (
+      e.kind !== vscode.TextEditorSelectionChangeKind.Mouse &&
+      e.kind !== vscode.TextEditorSelectionChangeKind.Keyboard
+    ) {
       if (selection) {
         if (this.currentMode.isVisualMode) {
           /**

--- a/src/mode/modeHandler.ts
+++ b/src/mode/modeHandler.ts
@@ -142,6 +142,22 @@ export class ModeHandler implements vscode.Disposable {
            * `start`, `end` and `anchor` information in a selection.
            * See `Fake block cursor with text decoration` section of `updateView` method.
            */
+
+          /**
+           * When mouse dragging or shift+arrow selection, mode change to visual,
+           * back to noraml mode as mswin behave if mouse/shift is no longer hold
+           */
+          if (
+            configuration.mswinbehave &&
+            e.kind === vscode.TextEditorSelectionChangeKind.Command &&
+            this.vimState.startVisualByMouseOrShift
+          ) {
+            this.vimState.cursorStopPosition = Position.FromVSCodePosition(selection.active);
+            this.vimState.cursorStartPosition = Position.FromVSCodePosition(selection.active);
+
+            this.vimState.setCurrentMode(ModeName.Normal);
+            await this.updateView(this.vimState);
+          }
           return;
         }
 
@@ -149,6 +165,8 @@ export class ModeHandler implements vscode.Disposable {
         this.vimState.cursorStartPosition = Position.FromVSCodePosition(selection.start);
       }
       return;
+    } else {
+      this.vimState.startVisualByMouseOrShift = true;
     }
 
     if (this.vimState.isMultiCursor && e.selections.length === 1) {

--- a/src/state/vimState.ts
+++ b/src/state/vimState.ts
@@ -25,6 +25,9 @@ import { globalState } from './../state/globalState';
 export class VimState implements vscode.Disposable {
   private readonly logger = Logger.get('VimState');
 
+  // ture when selection cause by Mouse dragging or shift + arrow
+  public startVisualByMouseOrShift = false;
+
   /**
    * The column the cursor wants to be at, or Number.POSITIVE_INFINITY if it should always
    * be the rightmost column.
@@ -209,6 +212,10 @@ export class VimState implements vscode.Disposable {
 
   private _inputMethodSwitcher: InputMethodSwitcher;
   public async setCurrentMode(value: number): Promise<void> {
+    if (value === ModeName.Normal) {
+      this.startVisualByMouseOrShift = false;
+    }
+
     await this._inputMethodSwitcher.switchInputMethod(this._currentMode, value);
     this._currentMode = value;
   }

--- a/test/testConfiguration.ts
+++ b/test/testConfiguration.ts
@@ -73,6 +73,7 @@ export class Configuration implements IConfiguration {
   iskeyword = '/\\()"\':,.;<>~!@#$%^&*|+=[]{}`?-';
   visualstar = false;
   mouseSelectionGoesIntoVisualMode = true;
+  mswinbehave = true;
   changeWordIncludesWhitespace = false;
   foldfix = false;
   disableExtension = false;


### PR DESCRIPTION
<!--
Yay! Thanks for sending us a PR! 🎊

Please ensure your PR adheres to:

- [ ] Commit messages has a short & issue references when necessary
- [ ] Each commit does a logical chunk of work.
- [ ] It builds and tests pass (e.g `gulp`)
-->

**What this PR does / why we need it**:
For windows developer, it is quite often to make selection with shift + arrow, shift + Home, shift + End., switch to visual mode will be convenient for replace within selection, etc.

**Which issue(s) this PR fixes**
#2457

<!--
Commits in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)
-->

**Special notes for your reviewer**:
