### PR TITLE
Fix replace character (`r`) behavior with newline

### DIFF
--- a/src/actions/commands/actions.ts
+++ b/src/actions/commands/actions.ts
@@ -3505,6 +3505,16 @@ class ActionReplaceCharacter extends BaseCommand {
         cursorIndex: this.multicursorIndex,
         diff: new PositionDiff(0, -1),
       });
+    } else if (toReplace === '\n') {
+      // A newline replacement always inserts exactly one newline (regardless
+      // of count prefix) and puts the cursor on the next line.
+      vimState.recordedState.transformations.push({
+        type: 'replaceText',
+        text: '\n',
+        start: position,
+        end: endPos,
+        diff: PositionDiff.NewBOLDiff(1),
+      });
     } else {
       vimState.recordedState.transformations.push({
         type: 'replaceText',

--- a/test/mode/normalModeTests/commands.test.ts
+++ b/test/mode/normalModeTests/commands.test.ts
@@ -163,6 +163,21 @@ suite('Mode Normal', () => {
   });
 
   newTest({
+    title: "Can handle 'r\n'",
+    start: ['abc|defg', '12345'],
+    keysPressed: 'r\n',
+    end: ['abc', '|efg', '12345'],
+  });
+
+  // `r` only ever inserts one newline, regardless of count prefix
+  newTest({
+    title: "Can handle '<Count>r\n'",
+    start: ['abc|defg', '12345'],
+    keysPressed: '3r\n',
+    end: ['abc', '|g', '12345'],
+  });
+
+  newTest({
     title: "Can handle 'J' once",
     start: ['one', 'tw|o'],
     keysPressed: 'kJ',


### PR DESCRIPTION
<!--
Yay! Thanks for sending us a PR! 🎊

Please ensure your PR adheres to:

- [ ] Commit messages has a short & issue references when necessary
- [ ] Each commit does a logical chunk of work.
- [ ] It builds and tests pass (e.g `gulp`)
-->

**What this PR does / why we need it**:
Fixes the behavior of `<count>r<enter>`
The cursor now ends up at the beginning of the next line and will only ever insert one newline, regardless of count prefix.

**Which issue(s) this PR fixes**
Fixes #1884
<!--
Commits in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)
-->

**Special notes for your reviewer**:
