### PR TITLE
Make sure :noh disables hlsearch until the next search is done

### DIFF
--- a/src/actions/commands/actions.ts
+++ b/src/actions/commands/actions.ts
@@ -906,6 +906,8 @@ class CommandInsertInSearchMode extends BaseCommand {
       const nextMatch = searchState.getNextSearchMatchPosition(vimState.cursorStopPosition);
       vimState.cursorStopPosition = nextMatch.pos;
 
+      vimState.globalState.hl = true;
+
       Register.putByKey(searchState.searchString, '/', undefined, true);
 
       ReportSearch(nextMatch.index, searchState.matchRanges.length, vimState);
@@ -1284,8 +1286,6 @@ export class CommandSearchForwards extends BaseCommand {
     // Reset search history index
     vimState.globalState.searchStateIndex = vimState.globalState.searchStatePrevious.length;
 
-    vimState.globalState.hl = true;
-
     return vimState;
   }
 }
@@ -1309,8 +1309,6 @@ export class CommandSearchBackwards extends BaseCommand {
 
     // Reset search history index
     vimState.globalState.searchStateIndex = vimState.globalState.searchStatePrevious.length;
-
-    vimState.globalState.hl = true;
 
     return vimState;
   }

--- a/src/cmd_line/commands/nohl.ts
+++ b/src/cmd_line/commands/nohl.ts
@@ -1,5 +1,6 @@
 import { VimState } from '../../state/vimState';
 import * as node from '../node';
+import { StatusBar } from '../../statusBar';
 
 export class NohlCommand extends node.CommandBase {
   protected _arguments: {};
@@ -17,5 +18,8 @@ export class NohlCommand extends node.CommandBase {
 
   async execute(vimState: VimState): Promise<void> {
     vimState.globalState.hl = false;
+
+    // Clear the `match x of y` message from status bar
+    StatusBar.Set('', vimState.currentMode, vimState.isRecordingMacro, true);
   }
 }


### PR DESCRIPTION


<!--
Yay! Thanks for sending us a PR! 🎊

Please ensure your PR adheres to:

- [ ] Commit messages has a short & issue references when necessary
- [ ] Each commit does a logical chunk of work.
- [ ] It builds and tests pass (e.g `gulp`)
-->

**What this PR does / why we need it**:
`hlsearch` was enabled when a search was initiated (`/`), not when you actually search (`<enter>`). The result is that `:noh` would be undone when a search is cancelled (`/<esc>`).

**Which issue(s) this PR fixes**
Fixes #3748

<!--
Commits in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)
-->