### PR TITLE
Show search results in the overview ruler

### DIFF
--- a/src/configuration/decoration.ts
+++ b/src/configuration/decoration.ts
@@ -56,6 +56,7 @@ class DecorationImpl {
 
     this.SearchHighlight = vscode.window.createTextEditorDecorationType({
       backgroundColor: configuration.searchHighlightColor,
+      overviewRulerColor: new vscode.ThemeColor('editorOverviewRuler.findMatchForeground'),
     });
 
     this.EasyMotion = vscode.window.createTextEditorDecorationType({


### PR DESCRIPTION


<!--
Yay! Thanks for sending us a PR! 🎊

Please ensure your PR adheres to:

- [ ] Commit messages has a short & issue references when necessary
- [ ] Each commit does a logical chunk of work.
- [ ] It builds and tests pass (e.g `gulp`)
-->

**What this PR does / why we need it**:
When you use VSCode's built-in search, the results show up in the "overview ruler" (the scroll bar). Now our custom search does the same.

**Note:** this works perfectly when `hlsearch` is set. When it's unset, they show up while you're typing, but not once you actually do the search. I'm not sure what better behavior would be, but am open to changing it.

**Which issue(s) this PR fixes**
Fixes #1856
<!--
Commits in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)
-->
