### PR TITLE
Fix statusBarColors linting in vscode user settings.

### DIFF
--- a/package.json
+++ b/package.json
@@ -583,32 +583,32 @@
           "default": false
         },
         "vim.statusBarColors.normal": {
-          "type": "string",
+          "type": ["string", "array"],
           "description": "Status bar color when in Normal mode",
           "default": "#005f5f"
         },
         "vim.statusBarColors.insert": {
-          "type": "string",
+          "type": ["string", "array"],
           "description": "Status bar color when in Insert mode",
           "default": "#5f0000"
         },
         "vim.statusBarColors.visual": {
-          "type": "string",
+          "type": ["string", "array"],
           "description": "Status bar color when in Visual mode",
           "default": "#5f00af"
         },
         "vim.statusBarColors.visualline": {
-          "type": "string",
+          "type": ["string", "array"],
           "description": "Status bar color when in VisualLine mode",
           "default": "#005f5f"
         },
         "vim.statusBarColors.visualblock": {
-          "type": "string",
+          "type": ["string", "array"],
           "description": "Status bar color when in VisualBlock mode",
           "default": "#86592d"
         },
         "vim.statusBarColors.replace": {
-          "type": "string",
+          "type": ["string", "array"],
           "description": "Status bar color when in Replace mode",
           "default": "#00000"
         },


### PR DESCRIPTION
<!--
Yay! Thanks for sending us a PR! 🎊

Please ensure your PR adheres to:

- [ ] Commit messages has a short & issue references when necessary
- [ ] Each commit does a logical chunk of work.
- [ ] It builds and tests pass (e.g `gulp`)
-->

**What this PR does / why we need it**:
User settings linting for `vim.statusBarColors` shows errors when configuring a background and foreground colors. User settings expects a string, but `vim.statusBarColors` supports `string` and `string[]`.

**Which issue(s) this PR fixes**
https://github.com/VSCodeVim/Vim/issues/3607

<!--
Commits in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)
-->
