### PR TITLE
Fix MoveHalfPageUp (<C-u>) when first line is visible.

### DIFF
--- a/src/actions/commands/actions.ts
+++ b/src/actions/commands/actions.ts
@@ -738,7 +738,7 @@ class CommandMoveHalfPageUp extends CommandEditorScroll {
 
     let firstLine = editor.visibleRanges[0].start.line;
     let currentSelectionLine = vimState.cursorStopPosition.line;
-    lineOffset = currentSelectionLine - firstLine;
+    lineOffset = firstLine === 0 ? 0 : currentSelectionLine - firstLine;
 
     let timesToRepeat = vimState.recordedState.count || 1;
     await vscode.commands.executeCommand('editorScroll', {

--- a/src/actions/commands/actions.ts
+++ b/src/actions/commands/actions.ts
@@ -734,13 +734,12 @@ class CommandMoveHalfPageUp extends CommandEditorScroll {
     const smoothScrolling = vscode.workspace.getConfiguration('editor').smoothScrolling;
     let lineOffset = 0;
     let editor = vscode.window.activeTextEditor!;
-    let startColumn = vimState.cursorStartPosition.character;
 
     let firstLine = editor.visibleRanges[0].start.line;
     let currentSelectionLine = vimState.cursorStopPosition.line;
-    lineOffset = firstLine === 0 ? 0 : currentSelectionLine - firstLine;
-
     let timesToRepeat = vimState.recordedState.count || 1;
+    lineOffset = firstLine === 0 ? 0 : (currentSelectionLine - firstLine);
+
     await vscode.commands.executeCommand('editorScroll', {
       to: this.to,
       by: this.by,
@@ -757,7 +756,7 @@ class CommandMoveHalfPageUp extends CommandEditorScroll {
       newPosition = new Position(editor.selection.active.line, editor.selection.active.character);
     } else {
       let newFirstLine = editor.visibleRanges[0].start.line;
-      newPosition = new Position(newFirstLine + lineOffset, startColumn);
+      newPosition = new Position(newFirstLine + lineOffset, 0);
     }
     vimState.cursorStopPosition = newPosition;
     return vimState;

--- a/test/mode/modeNormal.test.ts
+++ b/test/mode/modeNormal.test.ts
@@ -2310,4 +2310,25 @@ suite('Mode Normal', () => {
       endMode: ModeName.Insert,
     });
   });
+
+  newTest({
+    title: 'can handle <C-u> when first line is visible and starting column is at the beginning',
+    start: ['hello world', 'hello', 'hi hello', '|foo'],
+    keysPressed: '<C-u>',
+    end: ['|hello world', 'hello', 'hi hello', 'foo'],
+  });
+
+  newTest({
+    title: 'can handle <C-u> when first line is visible and starting column is at the end',
+    start: ['hello world', 'hello', 'hi hello', 'very long line at the bottom|'],
+    keysPressed: '<C-u>',
+    end: ['|hello world', 'hello', 'hi hello', 'very long line at the bottom'],
+  });
+
+  newTest({
+    title: 'can handle <C-u> when first line is visible and starting column is in the middle',
+    start: ['hello world', 'hello', 'hi hello', 'very long line |at the bottom'],
+    keysPressed: '<C-u>',
+    end: ['|hello world', 'hello', 'hi hello', 'very long line at the bottom'],
+  });
 });


### PR DESCRIPTION
<!--
Yay! Thanks for sending us a PR! 🎊

Please ensure your PR adheres to:

- [ ] Commit messages has a short & issue references when necessary
- [ ] Each commit does a logical chunk of work.
- [ ] It builds and tests pass (e.g `gulp`)
-->

**What this PR does / why we need it**:
The behavior of `<c-u>` to move up half a page was inconsistent with vim/neovim when the first line is visible. With this PR `<c-u>` will jump to the first line when it is visible.

**Which issue(s) this PR fixes**
https://github.com/VSCodeVim/Vim/issues/3648
https://github.com/VSCodeVim/Vim/issues/3083

<!--
Commits in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)
-->

**Special notes for your reviewer**:
Note that I had changes the startColumn to 0 to match vim/neovim functionality. When a MoveUpHalfPage, we do not preserve the starting column and go the beginning of the line.

Also, the behavior of <C-b> when the first line is visible does not need to change. vim/neovim keeps the cursor where it is at when MoveUpFullPage is invoked and the first line is visible.
