### PR TITLE
Make the write command non-blocking on remote files

### DIFF
--- a/src/cmd_line/commands/write.ts
+++ b/src/cmd_line/commands/write.ts
@@ -52,7 +52,7 @@ export class WriteCommand extends node.CommandBase {
 
     // defer saving the file to vscode if file is new (to present file explorer) or if file is a remote file
     if (vimState.editor.document.isUntitled || vimState.editor.document.uri.scheme !== 'file') {
-      await vscode.commands.executeCommand('workbench.action.files.save');
+      vscode.commands.executeCommand('workbench.action.files.save');
       return;
     }
 


### PR DESCRIPTION
As title. Saving a remote file can be slow, and we don't want to block
the vim state it. We're not doing anything with the result anyway, so it
should(?) be okay to remove this await.

**What this PR does / why we need it**:
Fixes #3777, more context is there

