### PR TITLE
Put'ing text ending in newline should behave like LineWise

### DIFF
--- a/src/actions/commands/actions.ts
+++ b/src/actions/commands/actions.ts
@@ -1422,7 +1422,7 @@ export class PutCommand extends BaseCommand {
     const noPrevLine = vimState.cursorStartPosition.isAtDocumentBegin();
     const noNextLine = vimState.cursorStopPosition.isAtDocumentEnd();
 
-    if (register.registerMode === RegisterMode.CharacterWise) {
+    if (register.registerMode === RegisterMode.CharacterWise && text[text.length - 1] !== '\n') {
       textToAdd = text;
       whereToAddText = dest;
     } else if (
@@ -1468,6 +1468,15 @@ export class PutCommand extends BaseCommand {
           whereToAddText = dest.getLineBegin();
         } else {
           textToAdd = '\n' + text;
+          whereToAddText = dest.getLineEnd();
+        }
+      } else if (text[text.length - 1] === '\n') {
+        // Text yanked with a trailing newline behaves just like linewise.
+        if (after) {
+          textToAdd = text;
+          whereToAddText = dest.getLineBegin();
+        } else {
+          textToAdd = '\n' + text.substring(0, text.length - 1);
           whereToAddText = dest.getLineEnd();
         }
       } else {


### PR DESCRIPTION
Given the block:

      1234567
    1.def foo
    2.  a
    3.  b
    4.end

Putting the cursor inside and running `2yy` to copy two lines will put "a\n  b" into the register and set LineWise mode.

Alternatively with the cursor on r2c1, pressing `vj$` will fill the buffer with `  a\n  b\n` in CharacterWise mode.

In vim, Put'ing either of these has the same effect. That is, given:

      1234567
    1.// word
    2.// etc.

Putting the cursor at r1c1 and running `p` results, in *either* case, in:

      1234567
    1.// word
    2.  a
    3.  b
    4.// etc.

In VSCode, however, the latter case -- the CharacterWise case with a trailing newline -- we get:

      1234567
    1./  a
    2.  b
    3./ word
    4.// etc.

Vim seems to use the presence of a trailing newline as an indication of whether a Put should be considered LineWise, as does this PR.
