### PR TITLE
Make indent-object LineWise:

### DIFF
--- a/src/actions/textobject.ts
+++ b/src/actions/textobject.ts
@@ -523,6 +523,8 @@ abstract class IndentObjectMatch extends TextObjectMovement {
     const firstValidLine = TextEditor.getLineAt(new Position(firstValidLineNumber, 0));
     const cursorIndent = firstValidLine.firstNonWhitespaceCharacterIndex;
 
+    vimState.currentRegisterMode = RegisterMode.LineWise;
+
     // let startLineNumber = findRangeStart(firstValidLineNumber, cursorIndent);
     let startLineNumber = IndentObjectMatch.findRangeStartOrEnd(
       firstValidLineNumber,
@@ -560,19 +562,9 @@ abstract class IndentObjectMatch extends TextObjectMovement {
       startCharacter = TextEditor.getLineAt(new Position(startLineNumber, 0))
         .firstNonWhitespaceCharacterIndex;
     }
-    // TextEditor.getLineMaxColumn throws when given line 0, which we don't
-    // care about here since it just means this text object wouldn't work on a
-    // single-line document.
-    let endCharacter;
-    if (
-      endLineNumber === TextEditor.getLineCount() - 1 ||
-      vimState.currentMode === ModeName.Visual
-    ) {
-      endCharacter = TextEditor.getLineMaxColumn(endLineNumber);
-    } else {
-      endCharacter = 0;
-      endLineNumber++;
-    }
+
+    let endCharacter = TextEditor.getLineMaxColumn(endLineNumber);
+
     return {
       start: new Position(startLineNumber, startCharacter),
       stop: new Position(endLineNumber, endCharacter),


### PR DESCRIPTION
Given the block:

      1234567
    1.def foo
    2.  a
    3.  b
    4.end

putting the cursor at r2c1 and running `yii` should copy the content at the current indentation level -- lines 2 and 3. Currently, the region is copied in CharacterWise mode as "  a\n  b", meaning that when it's pasted, it's inserted into the current line; that is, given:

      1234567
    1.//word
    4.//etc.

Running `p` at r1c1 gives:

      12345678
    1./  a
    2.  b/word
    3.//etc.

While what we want is:

      12345678
    1.//word
    2.  a
    3.  b
    4.//etc.

I can't think of any situation where indent-object wouldn't make sense as LineWise, but I don't have any context on this codebase so maybe I'm way off here.
