### PR TITLE
fix log message for 'vim.debug.silent'

### DIFF
--- a/src/util/logger.ts
+++ b/src/util/logger.ts
@@ -51,7 +51,7 @@ class VsCodeMessage extends TransportStream {
     let selectedAction = await showMessage(message, ...this.actionMessages);
     if (selectedAction === 'Suppress Errors') {
       vscode.window.showInformationMessage(
-        'Ignorance is bliss; temporarily suppressing log messages. For more permanence, please configure `vim.debug.suppress`.'
+        'Ignorance is bliss; temporarily suppressing log messages. For more permanence, please configure `vim.debug.silent`.'
       );
       configuration.debug.silent = true;
     }


### PR DESCRIPTION
#3591 changed the config key from 'vim.debug.suppress' to 'vim.debug.silent'.
Unfortunately, the log message still referenced the old config key.
This PR fixes this by printing out the correct config key in the log message.