### PR TITLE
Assign activeTextEditor to local variable first.

### DIFF
--- a/extension.ts
+++ b/extension.ts
@@ -36,14 +36,15 @@ interface ICodeKeybinding {
 }
 
 export async function getAndUpdateModeHandler(forceSyncAndUpdate = false): Promise<ModeHandler> {
-  const activeEditorId = new EditorIdentity(vscode.window.activeTextEditor);
+  const activeTextEditor = vscode.window.activeTextEditor;
+  const activeEditorId = new EditorIdentity(activeTextEditor);
 
   let [curHandler, isNew] = await ModeHandlerMap.getOrCreate(activeEditorId.toString());
   if (isNew) {
     extensionContext.subscriptions.push(curHandler);
   }
 
-  curHandler.vimState.editor = vscode.window.activeTextEditor!;
+  curHandler.vimState.editor = activeTextEditor!;
 
   if (
     forceSyncAndUpdate ||

--- a/src/actions/commands/actions.ts
+++ b/src/actions/commands/actions.ts
@@ -2765,14 +2765,12 @@ class CommandGoToDefinition extends BaseCommand {
   isJump = true;
 
   public async exec(position: Position, vimState: VimState): Promise<VimState> {
-    const oldActiveEditor = vimState.editor;
-
     await vscode.commands.executeCommand('editor.action.goToDeclaration');
     // `executeCommand` returns immediately before cursor is updated
     // wait for the editor to update before updating the vim state
     // https://github.com/VSCodeVim/Vim/issues/3277
     await waitForCursorSync(1000);
-    if (oldActiveEditor === vimState.editor) {
+    if (vimState.editor === vscode.window.activeTextEditor) {
       vimState.cursorStopPosition = Position.FromVSCodePosition(vimState.editor.selection.start);
     }
 

--- a/src/actions/commands/actions.ts
+++ b/src/actions/commands/actions.ts
@@ -2766,10 +2766,7 @@ class CommandGoToDefinition extends BaseCommand {
 
   public async exec(position: Position, vimState: VimState): Promise<VimState> {
     await vscode.commands.executeCommand('editor.action.goToDeclaration');
-    // `executeCommand` returns immediately before cursor is updated
-    // wait for the editor to update before updating the vim state
-    // https://github.com/VSCodeVim/Vim/issues/3277
-    await waitForCursorSync(1000);
+
     if (vimState.editor === vscode.window.activeTextEditor) {
       vimState.cursorStopPosition = Position.FromVSCodePosition(vimState.editor.selection.start);
     }


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix GoToDefinition bug when use C# extension.

**Which issue(s) this PR fixes**
#3865
