### PR TITLE
Do not treat easymotion input as regex unless it's a letter

### DIFF
--- a/src/actions/plugins/easymotion/easymotion.cmd.ts
+++ b/src/actions/plugins/easymotion/easymotion.cmd.ts
@@ -117,6 +117,12 @@ function getMatchesForString(
       return vimState.easyMotion.sortedSearch(position, new RegExp(' {1,}', 'g'), options);
     default:
       // Search all occurences of the character pressed
+
+      // If the input is not a letter, treating it as regex can cause issues
+      if (!/[a-zA-Z]/.test(searchString)) {
+        return vimState.easyMotion.sortedSearch(position, searchString, options);
+      }
+
       const ignorecase =
         configuration.ignorecase && !(configuration.smartcase && /[A-Z]/.test(searchString));
       const regexFlags = ignorecase ? 'gi' : 'g';

--- a/test/plugins/easymotion.test.ts
+++ b/test/plugins/easymotion.test.ts
@@ -210,4 +210,25 @@ suite('easymotion plugin', () => {
     keysPressed: easymotionCommand({ key: 'h', leaderCount: 2 }, '', 'h'),
     end: ['abcDef|Ghi'],
   });
+
+  newTest({
+    title: 'Can handle searching for backslash (\\)',
+    start: ['|https:\\\\www.google.com'],
+    keysPressed: easymotionCommand({ key: 'f' }, '\\', 'k'),
+    end: ['https:\\|\\www.google.com'],
+  });
+
+  newTest({
+    title: 'Can handle searching for carat (^)',
+    start: ['|<^_^>'],
+    keysPressed: easymotionCommand({ key: 'f' }, '^', 'h'),
+    end: ['<|^_^>'],
+  });
+
+  newTest({
+    title: 'Can handle searching for dot (.)',
+    start: ['|https:\\\\www.google.com'],
+    keysPressed: easymotionCommand({ key: 'f' }, '.', 'k'),
+    end: ['https:\\\\www.google|.com'],
+  });
 });


### PR DESCRIPTION
**What this PR does / why we need it**:
Easymotion used regex to handle case-(in)sensitivity, which caused problems when searching for certain characters (among them `.`, `\`, and `^`). To fix this, I've changed it so that non-letter characters do not use the regex.

**Which issue(s) this PR fixes**
Fixes #3844