### PR TITLE
Make `%` skip over characters such as '>'

### DIFF
--- a/test/mode/normalModeTests/matchingBracket.test.ts
+++ b/test/mode/normalModeTests/matchingBracket.test.ts
@@ -58,4 +58,18 @@ suite('Matching Bracket (%)', () => {
     keysPressed: '%',
     end: ['|[(( }}} ))]'],
   });
+
+  newTest({
+    title: 'parentheses after >',
+    start: ['|foo->bar(baz);'],
+    keysPressed: '%',
+    end: ['foo->bar(baz|);'],
+  });
+
+  newTest({
+    title: 'parentheses after "',
+    start: ['|test "in quotes" [(in brackets)]'],
+    keysPressed: '%',
+    end: ['test "in quotes" [(in brackets)|]'],
+  });
 });


### PR DESCRIPTION
**What this PR does / why we need it**:
These have matches, but are not compatible with the `%` motion (matchesWithPercentageMotion=false). We should skip over them to find one that is compatible.

**Which issue(s) this PR fixes**
Fixes #3807