### PR TITLE
Fix f/F/t/T with <tab>

### DIFF
--- a/src/actions/motion.ts
+++ b/src/actions/motion.ts
@@ -666,7 +666,7 @@ class MoveFindForward extends BaseMovement {
     count: number
   ): Promise<Position | IMovement> {
     count = count || 1;
-    const toFind = this.keysPressed[1];
+    const toFind = this.keysPressed[1] === '<tab>' ? '\t' : this.keysPressed[1];
     let result = position.findForwards(toFind, count);
 
     if (!result) {
@@ -699,7 +699,7 @@ class MoveFindBackward extends BaseMovement {
     count: number
   ): Promise<Position | IMovement> {
     count = count || 1;
-    const toFind = this.keysPressed[1];
+    const toFind = this.keysPressed[1] === '<tab>' ? '\t' : this.keysPressed[1];
     let result = position.findBackwards(toFind, count);
 
     if (!result) {
@@ -728,7 +728,7 @@ class MoveTilForward extends BaseMovement {
     count: number
   ): Promise<Position | IMovement> {
     count = count || 1;
-    const toFind = this.keysPressed[1];
+    const toFind = this.keysPressed[1] === '<tab>' ? '\t' : this.keysPressed[1];
     let result = position.tilForwards(toFind, count);
 
     // For t<character> vim executes ; as 2; and , as 2,
@@ -766,7 +766,7 @@ class MoveTilBackward extends BaseMovement {
     count: number
   ): Promise<Position | IMovement> {
     count = count || 1;
-    const toFind = this.keysPressed[1];
+    const toFind = this.keysPressed[1] === '<tab>' ? '\t' : this.keysPressed[1];
     let result = position.tilBackwards(toFind, count);
 
     // For T<character> vim executes ; as 2; and , as 2,

--- a/src/actions/motion.ts
+++ b/src/actions/motion.ts
@@ -17,6 +17,7 @@ import { configuration } from './../configuration/configuration';
 import { shouldWrapKey } from './wrapping';
 import { VimError, ErrorCode } from '../error';
 import { ReportSearch } from '../util/statusBarTextUtils';
+import { Notation } from '../configuration/notation';
 
 export function isIMovement(o: IMovement | Position): o is IMovement {
   return (o as IMovement).start !== undefined && (o as IMovement).stop !== undefined;
@@ -666,7 +667,7 @@ class MoveFindForward extends BaseMovement {
     count: number
   ): Promise<Position | IMovement> {
     count = count || 1;
-    const toFind = this.keysPressed[1] === '<tab>' ? '\t' : this.keysPressed[1];
+    const toFind = Notation.ToControlCharacter(this.keysPressed[1]);
     let result = position.findForwards(toFind, count);
 
     if (!result) {
@@ -699,7 +700,7 @@ class MoveFindBackward extends BaseMovement {
     count: number
   ): Promise<Position | IMovement> {
     count = count || 1;
-    const toFind = this.keysPressed[1] === '<tab>' ? '\t' : this.keysPressed[1];
+    const toFind = Notation.ToControlCharacter(this.keysPressed[1]);
     let result = position.findBackwards(toFind, count);
 
     if (!result) {
@@ -728,7 +729,7 @@ class MoveTilForward extends BaseMovement {
     count: number
   ): Promise<Position | IMovement> {
     count = count || 1;
-    const toFind = this.keysPressed[1] === '<tab>' ? '\t' : this.keysPressed[1];
+    const toFind = Notation.ToControlCharacter(this.keysPressed[1]);
     let result = position.tilForwards(toFind, count);
 
     // For t<character> vim executes ; as 2; and , as 2,
@@ -766,7 +767,7 @@ class MoveTilBackward extends BaseMovement {
     count: number
   ): Promise<Position | IMovement> {
     count = count || 1;
-    const toFind = this.keysPressed[1] === '<tab>' ? '\t' : this.keysPressed[1];
+    const toFind = Notation.ToControlCharacter(this.keysPressed[1]);
     let result = position.tilBackwards(toFind, count);
 
     // For T<character> vim executes ; as 2; and , as 2,

--- a/src/configuration/notation.ts
+++ b/src/configuration/notation.ts
@@ -1,7 +1,7 @@
 import * as _ from 'lodash';
 
 export class Notation {
-  // Mapping from the nomalized string to regex strings that could match it.
+  // Mapping from the normalized string to regex strings that could match it.
   private static _notationMap: { [key: string]: string[] } = {
     'C-': ['ctrl\\+', 'c\\-'],
     'D-': ['cmd\\+', 'd\\-'],
@@ -14,6 +14,15 @@ export class Notation {
     ' ': ['<space>'],
     '\n': ['<cr>', '<enter>'],
   };
+
+  // Converts keystroke like <tab> to a single control character like \t
+  public static ToControlCharacter(key: string) {
+    if (key === "<tab>") {
+      return '\t';
+    }
+
+    return key;
+  }
 
   public static IsControlKey(key: string): boolean {
     key = key.toLocaleUpperCase();

--- a/test/mode/normalModeTests/motions.test.ts
+++ b/test/mode/normalModeTests/motions.test.ts
@@ -215,6 +215,13 @@ suite('Motions in Normal Mode', () => {
   });
 
   newTest({
+    title: "Can handle 'f' with <tab>",
+    start: ['|text\tttext'],
+    keysPressed: 'f<tab>',
+    end: ['text|\tttext'],
+  });
+
+  newTest({
     title: "Can handle 'F'",
     start: ['text tex|t'],
     keysPressed: '$Ft',


### PR DESCRIPTION
**What this PR does / why we need it**:
`f`/`F`/`t`/`T` didn't work with <tab>. Now they do.

**Which issue(s) this PR fixes**
Fixes #2510