### PR TITLE
Handle backspace on first character of all-space line correctly

### DIFF
--- a/src/actions/commands/insert.ts
+++ b/src/actions/commands/insert.ts
@@ -252,7 +252,7 @@ export class CommandInsertInInsertMode extends BaseCommand {
         if (
           position.character > 0 &&
           line.length > 0 &&
-          line.match(/^ +$/) &&
+          line.match(/^\s+$/) &&
           configuration.expandtab
         ) {
           // If the line is empty except whitespace and we're not on the first

--- a/src/actions/commands/insert.ts
+++ b/src/actions/commands/insert.ts
@@ -249,9 +249,15 @@ export class CommandInsertInInsertMode extends BaseCommand {
           range: new Range(selection.start as Position, selection.end as Position),
         });
       } else {
-        if (line.length > 0 && line.match(/^ +$/) && configuration.expandtab) {
-          // If the line is empty except whitespace, backspace should return to
-          // the next lowest level of indentation.
+        if (
+          position.character > 0 &&
+          line.length > 0 &&
+          line.match(/^ +$/) &&
+          configuration.expandtab
+        ) {
+          // If the line is empty except whitespace and we're not on the first
+          // character of the line, backspace should return to the next lowest
+          // level of indentation.
 
           const tabSize = vimState.editor.options.tabSize as number;
           const desiredLineLength = Math.floor((position.character - 1) / tabSize) * tabSize;

--- a/test/mode/modeInsert.test.ts
+++ b/test/mode/modeInsert.test.ts
@@ -333,6 +333,14 @@ suite('Mode Insert', () => {
     end: ['fun', 'fun', 'fun', 'fun', 'fu|n', 'foobar'],
   });
 
+  // This corner case caused an issue, see #3915
+  newTest({
+    title: 'Can handle backspace at beginning of line with all spaces',
+    start: ['abc', '|     '],
+    keysPressed: 'i<BS><Esc>',
+    end: ['ab|c     '],
+  });
+
   test('Can handle digraph insert', async () => {
     await modeHandler.handleMultipleKeyEvents([
       'i',


### PR DESCRIPTION
**What this PR does / why we need it**:
On an all-spaces line, you press backspace in insert mode, it'll cause an error. Now this corner case is accounted for.

**Which issue(s) this PR fixes**
Fixes #3915