### PR TITLE
Move prettier configuration to .prettierrc

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,5 @@
+{
+  "printWidth": 100,
+  "singleQuote": true,
+  "trailingComma": "es5"
+}

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -40,15 +40,12 @@ function runPrettier(command, done) {
     }
 
     const prettierPath = path.normalize('./node_modules/.bin/prettier');
-    exec(
-      `${prettierPath} --write --print-width 100 --single-quote --trailing-comma es5 ${files}`,
-      function(err) {
-        if (err) {
-          return done(new PluginError('runPrettier', { message: err }));
-        }
-        return done();
+    exec(`${prettierPath} --write ${files}`, function(err) {
+      if (err) {
+        return done(new PluginError('runPrettier', { message: err }));
       }
-    );
+      return done();
+    });
   });
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Move prettier configuration to `.prettierrc` (see https://prettier.io/docs/en/configuration.html)

This means that people can develop with the intended prettier configuration in their local editor (as will look for a `.prettierrc` by default) while maintaining the `forceprettier` functionality (and keeps the configuration in one place)

**Which issue(s) this PR fixes**

None that I could find

**Special notes for your reviewer**:

- The `prettier` cli will pick up this file during the gulp `forceprettier` step

- Hopefully the intent of this makes sense (eg. I personally run prettier in its default mode so need to update my config depending on the repo I'm working on, unless there's some config for my editor to pick up)

- The configuration could be moved to within the `package.json` (as per the link above) if that felt like a better home (I'm personally quite used to `.rc` files, but perhaps others aren't)

- Funnily enough, prettier reformatted `gulpfile.js` once the line length of the cli command was reduced