### PR TITLE
Make `C` work with registers

### DIFF
--- a/src/actions/commands/actions.ts
+++ b/src/actions/commands/actions.ts
@@ -2524,10 +2524,9 @@ class CommandChangeToLineEnd extends BaseCommand {
   modes = [ModeName.Normal];
   keys = ['C'];
   runsOnceForEachCountPrefix = false;
-  mustBeFirstKey = true;
 
   public async exec(position: Position, vimState: VimState): Promise<VimState> {
-    let count = vimState.recordedState.count || 1;
+    const count = vimState.recordedState.count || 1;
 
     return new operator.ChangeOperator().run(
       vimState,

--- a/test/mode/normalModeTests/commands.test.ts
+++ b/test/mode/normalModeTests/commands.test.ts
@@ -135,6 +135,14 @@ suite('Mode Normal', () => {
   });
 
   newTest({
+    title: "Can handle 'NC' and put",
+    start: ['tex|t', 'one', 'two'],
+    keysPressed: '"a2C<C-r>a',
+    end: ['text', 'one|', 'two'],
+    endMode: ModeName.Insert,
+  });
+
+  newTest({
     title: "Can handle 'r'",
     start: ['tex|t'],
     keysPressed: 'hrs',


### PR DESCRIPTION
Things like `"aC` did nothing because mustBeFirstKey = true.
I'm not 100% sure that there wasn't a reason why mustBeFirstKey was true, but I can't see what it would be.
Fixes #2504