### PR TITLE
Implement `scrolloff`

### DIFF
--- a/extension.ts
+++ b/extension.ts
@@ -52,7 +52,11 @@ export async function getAndUpdateModeHandler(forceSyncAndUpdate = false): Promi
     !previousActiveEditorId.isEqual(activeEditorId)
   ) {
     curHandler.syncCursors();
-    await curHandler.updateView(curHandler.vimState, { drawSelection: false, revealRange: false });
+    await curHandler.updateView(curHandler.vimState, {
+      drawSelection: false,
+      revealRange: false,
+      mouse: false,
+    });
   }
 
   previousActiveEditorId = activeEditorId;
@@ -237,7 +241,11 @@ export async function activate(context: vscode.ExtensionContext) {
 
           await VsCodeContext.Set('vim.mode', ModeName[mh.vimState.currentMode]);
 
-          await mh.updateView(mh.vimState, { drawSelection: false, revealRange: false });
+          await mh.updateView(mh.vimState, {
+            drawSelection: false,
+            revealRange: false,
+            mouse: false,
+          });
 
           globalState.jumpTracker.handleFileJump(
             lastClosedModeHandler ? Jump.fromStateNow(lastClosedModeHandler.vimState) : null,
@@ -392,7 +400,7 @@ export async function activate(context: vscode.ExtensionContext) {
   if (vscode.window.activeTextEditor) {
     let mh = await getAndUpdateModeHandler();
     // This is called last because getAndUpdateModeHandler() will change cursor
-    mh.updateView(mh.vimState, { drawSelection: false, revealRange: false });
+    mh.updateView(mh.vimState, { drawSelection: false, revealRange: false, mouse: false });
   }
 
   // Disable automatic keyboard navigation in lists, so it doesn't interfere

--- a/package.json
+++ b/package.json
@@ -445,6 +445,11 @@
           "description": "Number of lines to scroll with CTRL-U and CTRL-D commands.",
           "default": 20
         },
+        "vim.scrolloff": {
+          "type": "number",
+          "description": "Minimal number of screen lines to keep above and below the cursor.",
+          "default": 0
+        },
         "vim.showcmd": {
           "type": "boolean",
           "description": "Show the text of any command you are in the middle of writing.",

--- a/src/actions/commands/actions.ts
+++ b/src/actions/commands/actions.ts
@@ -623,7 +623,20 @@ abstract class CommandEditorScroll extends BaseCommand {
   by: EditorScrollByUnit;
 
   public async exec(position: Position, vimState: VimState): Promise<VimState> {
-    let timesToRepeat = vimState.recordedState.count || 1;
+    const timesToRepeat = vimState.recordedState.count || 1;
+    const visibleRange = vimState.editor.visibleRanges[0];
+
+    if (
+      this.to === 'up' &&
+      visibleRange.end.line - vimState.cursors[0].stop.line < configuration.scrolloff + 1
+    ) {
+      vimState.cursors[0] = vimState.cursors[0].getDown(-1);
+    } else if (
+      this.to === 'down' &&
+      vimState.cursors[0].stop.line - visibleRange.start.line < configuration.scrolloff + 1
+    ) {
+      vimState.cursors[0] = vimState.cursors[0].getDown(1);
+    }
 
     vimState.postponedCodeViewChanges.push({
       command: 'editorScroll',
@@ -2308,7 +2321,7 @@ class CommandTopScroll extends BaseCommand {
     vimState.postponedCodeViewChanges.push({
       command: 'revealLine',
       args: {
-        lineNumber: position.line,
+        lineNumber: position.line - configuration.scrolloff,
         at: 'top',
       },
     });
@@ -2362,7 +2375,7 @@ class CommandBottomScroll extends BaseCommand {
     vimState.postponedCodeViewChanges.push({
       command: 'revealLine',
       args: {
-        lineNumber: position.line,
+        lineNumber: position.line + configuration.scrolloff,
         at: 'bottom',
       },
     });

--- a/src/configuration/configuration.ts
+++ b/src/configuration/configuration.ts
@@ -175,6 +175,8 @@ class Configuration implements IConfiguration {
 
   autoindent = true;
 
+  scrolloff = 0;
+
   camelCaseMotion: ICamelCaseMotionConfiguration = {
     enable: true,
   };


### PR DESCRIPTION
**What this PR does / why we need it**:
Implements `scrolloff`, which keeps a buffer between the cursor and the top/bottom of the viewport.

**Which issue(s) this PR fixes**
Fixes #1427

**Special notes for your reviewer**:
As noted on the ticket, this feature is best addressed in VSCode itself, but this at least works more consistently with VSCodeVim's feature set than separate existing extensions.
Known issues:
* It counts lines, not "screen lines", so it does not play nicely with word wrap.
* It does not play nice with, for instance, <C-d>, when smooth scrolling is enabled. This is already buggy due to race conditions relating to scrolling, though, so I'm not worrying about it here.

I'm not sure if this is auto-testable in the existing framework, so I'd encourage the reviewer and anyone just passing by to check this branch out and play around with it yourself.