### PR TITLE
Implement `stickyCursor`

### DIFF
--- a/extension.ts
+++ b/extension.ts
@@ -288,6 +288,26 @@ export async function activate(context: vscode.ExtensionContext) {
     true
   );
 
+  registerEventListener(context, vscode.window.onDidChangeTextEditorVisibleRanges, async event => {
+    if (configuration.stickyCursor) {
+      taskQueue.enqueueTask(async () => {
+        const viewPort = event.visibleRanges[0];
+        const mh = await getAndUpdateModeHandler();
+        if (viewPort.start.line > mh.vimState.cursorStopPosition.line) {
+          await vscode.commands.executeCommand('cursorMove', {
+            to: 'viewPortTop',
+          });
+          mh.syncCursors();
+        } else if (mh.vimState.cursorStopPosition.line > viewPort.end.line) {
+          await vscode.commands.executeCommand('cursorMove', {
+            to: 'viewPortBottom',
+          });
+          mh.syncCursors();
+        }
+      });
+    }
+  });
+
   const compositionState = new CompositionState();
 
   // override vscode commands

--- a/package.json
+++ b/package.json
@@ -733,6 +733,11 @@
           "type": "object",
           "description": "Custom digraph shortcuts for inserting special characters, expressed as UTF16 code points",
           "default": {}
+        },
+        "vim.stickyCursor": {
+          "type": "boolean",
+          "description": "If true, the cursor will always be kept within the viewport.",
+          "default": false
         }
       }
     }

--- a/src/configuration/configuration.ts
+++ b/src/configuration/configuration.ts
@@ -184,6 +184,8 @@ class Configuration implements IConfiguration {
   sneak = false;
   sneakUseIgnorecaseAndSmartcase = false;
 
+  stickyCursor = false;
+
   surround = true;
 
   easymotion = false;


### PR DESCRIPTION
**What this PR does / why we need it**:
This new setting emulates vim's limitation (or feature, depending on how you look at it) which kept the cursor within the viewport, even when scrolling with the mouse.

**Which issue(s) this PR fixes**
Fixes #873, #3846

**Special notes for your reviewer**:
This is a simple change, but not a particularly auto-testable one, so I'd appreciate some manual testing. A known issue is that the column position of the cursor isn't guaranteed to stay consistent. I may address that in the future, but I'd say this is good enough for now.