### PR TITLE
Fix `gC` in visual mode

### DIFF
--- a/src/actions/operator.ts
+++ b/src/actions/operator.ts
@@ -782,8 +782,12 @@ export class CommentBlockOperator extends BaseOperator {
   public modes = [ModeName.Normal, ModeName.Visual, ModeName.VisualLine];
 
   public async run(vimState: VimState, start: Position, end: Position): Promise<VimState> {
-    const endPosition = vimState.currentMode === ModeName.Normal ? end.getRight() : end;
-    vimState.editor.selection = new vscode.Selection(start, endPosition);
+    if (vimState.currentMode === ModeName.Normal) {
+      // If we're in normal mode, we need to construct a selection for the
+      // command to operate on. If we're not, we've already got it.
+      const endPosition = end.getRight();
+      vimState.editor.selection = new vscode.Selection(start, endPosition);
+    }
     await vscode.commands.executeCommand('editor.action.blockComment');
 
     vimState.cursorStopPosition = start;

--- a/test/operator/comment.test.ts
+++ b/test/operator/comment.test.ts
@@ -35,7 +35,7 @@ suite('comment operator', () => {
   newTest({
     title: 'block comment in Visual Mode',
     start: ['blah |blah blah'],
-    keysPressed: 'vllllgC',
+    keysPressed: 'vlllgC',
     end: ['blah |/* blah */ blah'],
     endMode: ModeName.Normal,
   });


### PR DESCRIPTION
**What this PR does / why we need it**:
`gC`, which does a block comment, does one fewer than the selected characters in visual mode. I don't have the real commentary vim extension installed, but I don't think this is the correct behavior.

**Which issue(s) this PR fixes**
Fixes #2448