### PR TITLE
When the `c` (confirm) flag is used in a `:s` command, don't use neovim

### DIFF
--- a/src/cmd_line/commandLine.ts
+++ b/src/cmd_line/commandLine.ts
@@ -84,7 +84,7 @@ class CommandLine {
 
     try {
       const cmd = parser.parse(command);
-      const useNeovim = configuration.enableNeovim && cmd.command && cmd.command.neovimCapable;
+      const useNeovim = configuration.enableNeovim && cmd.command && cmd.command.neovimCapable();
 
       if (useNeovim) {
         const statusBarText = await vimState.nvim.run(vimState, command);

--- a/src/cmd_line/commands/deleteRange.ts
+++ b/src/cmd_line/commands/deleteRange.ts
@@ -12,7 +12,6 @@ export interface IDeleteRangeCommandArguments extends node.ICommandArgs {
 }
 
 export class DeleteRangeCommand extends node.CommandBase {
-  neovimCapable = true;
   protected _arguments: IDeleteRangeCommandArguments;
 
   constructor(args: IDeleteRangeCommandArguments) {
@@ -23,6 +22,10 @@ export class DeleteRangeCommand extends node.CommandBase {
 
   get arguments(): IDeleteRangeCommandArguments {
     return this._arguments;
+  }
+
+  public neovimCapable(): boolean {
+    return true;
   }
 
   async deleteRange(start: Position, end: Position, vimState: VimState): Promise<string> {

--- a/src/cmd_line/commands/read.ts
+++ b/src/cmd_line/commands/read.ts
@@ -15,7 +15,6 @@ export interface IReadCommandArguments extends node.ICommandArgs {
 //  http://vimdoc.sourceforge.net/htmldoc/insert.html#:read!
 //
 export class ReadCommand extends node.CommandBase {
-  neovimCapable = true;
   protected _arguments: IReadCommandArguments;
 
   constructor(args: IReadCommandArguments) {
@@ -26,6 +25,10 @@ export class ReadCommand extends node.CommandBase {
 
   get arguments(): IReadCommandArguments {
     return this._arguments;
+  }
+
+  public neovimCapable(): boolean {
+    return true;
   }
 
   async execute(): Promise<void> {

--- a/src/cmd_line/commands/sort.ts
+++ b/src/cmd_line/commands/sort.ts
@@ -11,7 +11,6 @@ export interface ISortCommandArguments extends node.ICommandArgs {
 }
 
 export class SortCommand extends node.CommandBase {
-  neovimCapable = true;
   protected _arguments: ISortCommandArguments;
 
   constructor(args: ISortCommandArguments) {
@@ -21,6 +20,10 @@ export class SortCommand extends node.CommandBase {
 
   get arguments(): ISortCommandArguments {
     return this._arguments;
+  }
+
+  public neovimCapable(): boolean {
+    return true;
   }
 
   async execute(vimState: VimState): Promise<void> {

--- a/src/cmd_line/commands/substitute.ts
+++ b/src/cmd_line/commands/substitute.ts
@@ -84,7 +84,6 @@ export enum SubstituteFlags {
  *   - update search state too!
  */
 export class SubstituteCommand extends node.CommandBase {
-  neovimCapable = true;
   protected _arguments: ISubstituteCommandArguments;
   protected _abort: boolean;
   constructor(args: ISubstituteCommandArguments) {
@@ -96,6 +95,11 @@ export class SubstituteCommand extends node.CommandBase {
 
   get arguments(): ISubstituteCommandArguments {
     return this._arguments;
+  }
+
+  public neovimCapable(): boolean {
+    // We need to use VSCode's quickpick capabilities to do confirmation
+    return (this._arguments.flags & SubstituteFlags.ConfirmEach) === 0;
   }
 
   getRegex(args: ISubstituteCommandArguments, vimState: VimState) {

--- a/src/cmd_line/node.ts
+++ b/src/cmd_line/node.ts
@@ -227,7 +227,6 @@ export interface ICommandArgs {
 }
 
 export abstract class CommandBase {
-  public neovimCapable = false;
   protected get activeTextEditor() {
     return vscode.window.activeTextEditor;
   }
@@ -241,6 +240,10 @@ export abstract class CommandBase {
     return this._arguments;
   }
   protected _arguments: ICommandArgs;
+
+  public neovimCapable(): boolean {
+    return false;
+  }
 
   abstract execute(vimState: VimState): Promise<void>;
 


### PR DESCRIPTION
We need to use VSCode's quickpick capabilities to do confirmation.
Fixes #3371