### PR TITLE
Implement `q/` and `q?`

### DIFF
--- a/src/mode/modeHandler.ts
+++ b/src/mode/modeHandler.ts
@@ -32,6 +32,8 @@ import {
   isTextTransformation,
   TextTransformations,
 } from './../transformations/transformations';
+import { globalState } from '../state/globalState';
+import { ReportSearch } from '../util/statusBarTextUtils';
 
 export class ModeHandler implements vscode.Disposable {
   private _disposables: vscode.Disposable[] = [];
@@ -906,6 +908,21 @@ export class ModeHandler implements vscode.Disposable {
           if (cmd && cmd.length !== 0) {
             await commandLine.Run(cmd, this.vimState);
             this.updateView(this.vimState);
+          }
+          break;
+
+        case 'showSearchHistory':
+          const searchState = await globalState.showSearchHistory();
+          if (searchState) {
+            globalState.searchState = searchState;
+            const nextMatch = searchState.getNextSearchMatchPosition(
+              vimState.cursorStartPosition,
+              command.direction
+            );
+
+            vimState.cursorStopPosition = nextMatch.pos;
+            this.updateView(this.vimState);
+            ReportSearch(nextMatch.index, searchState.matchRanges.length, vimState);
           }
           break;
 

--- a/src/state/globalState.ts
+++ b/src/state/globalState.ts
@@ -1,3 +1,4 @@
+import * as vscode from 'vscode';
 import { JumpTracker } from '../jumps/jumpTracker';
 import { ModeName } from '../mode/mode';
 import { Position } from '../common/motion/position';
@@ -6,6 +7,7 @@ import { SearchHistory } from '../history/historyFile';
 import { SearchState, SearchDirection } from './searchState';
 import { SubstituteState } from './substituteState';
 import { configuration } from '../configuration/configuration';
+import { VimState } from './vimState';
 
 /**
  * State which stores global state (across editors)
@@ -100,6 +102,29 @@ class GlobalState {
 
     // Update the index to the end of the search history
     this.searchStateIndex = this.searchStatePrevious.length - 1;
+  }
+
+  public async showSearchHistory(): Promise<SearchState | undefined> {
+    if (!vscode.window.activeTextEditor) {
+      return undefined;
+    }
+
+    const items = this._searchStatePrevious
+      .slice()
+      .reverse()
+      .map(searchState => {
+        return {
+          label: searchState.searchString,
+          searchState: searchState,
+        };
+      });
+
+    const item = await vscode.window.showQuickPick(items, {
+      placeHolder: 'Vim search history',
+      ignoreFocusOut: false,
+    });
+
+    return item ? item.searchState : undefined;
   }
 
   public get jumpTracker(): JumpTracker {

--- a/src/transformations/transformations.ts
+++ b/src/transformations/transformations.ts
@@ -188,6 +188,11 @@ export interface ShowCommandHistory {
   type: 'showCommandHistory';
 }
 
+export interface ShowSearchHistory {
+  type: 'showSearchHistory';
+  direction: number;
+}
+
 /**
  * Represents pressing '.'
  */
@@ -247,6 +252,7 @@ export type Transformation =
   | DeleteTextTransformation
   | MoveCursorTransformation
   | ShowCommandHistory
+  | ShowSearchHistory
   | Dot
   | Macro
   | ContentChangeTransformation


### PR DESCRIPTION
These show your search history via a QuickPick, allowing you to search through and re-do these.
Also implemented an alias for these, which is `<C-f>` while typing a search.
Refs #3949