### PR TITLE
Disallow all forms of :help

### DIFF
--- a/src/cmd_line/commandLine.ts
+++ b/src/cmd_line/commandLine.ts
@@ -67,7 +67,7 @@ class CommandLine {
       command = command.slice(1);
     }
 
-    if (command === 'help') {
+    if ('help'.startsWith(command.split(/\s/)[0])) {
       StatusBar.Set(`:help Not supported.`, vimState.currentMode, vimState.isRecordingMacro, true);
       return;
     }


### PR DESCRIPTION
With neovim enabled, :h will replace your file with the output of help. While supporting :help by putting it into a new buffer at some point could be cool, this is...not good.