### PR TITLE
Fix duplicated command added in c542b42

### DIFF
--- a/package.json
+++ b/package.json
@@ -211,17 +211,7 @@
       {
         "key": "ctrl+n",
         "command": "extension.vim_ctrl+n",
-        "when": "editorTextFocus && vim.active && vim.use<C-n> && !inDebugRepl"
-      },
-      {
-        "key": "ctrl+n",
-        "command": "extension.vim_ctrl+n",
-        "when": "vim.mode == 'SearchInProgressMode' && vim.active && vim.use<C-n> && !inDebugRepl"
-      },
-      {
-        "key": "ctrl+n",
-        "command": "extension.vim_ctrl+n",
-        "when": "vim.mode == 'CommandlineInProgress' && vim.active && vim.use<C-n> && !inDebugRepl"
+        "when": "(editorTextFocus || vim.mode == 'SearchInProgressMode' || vim.mode == 'CommandlineInProgress') && vim.active && vim.use<C-n> && !inDebugRepl"
       },
       {
         "key": "ctrl+o",
@@ -231,17 +221,7 @@
       {
         "key": "ctrl+p",
         "command": "extension.vim_ctrl+p",
-        "when": "suggestWidgetVisible && vim.active && vim.use<C-p> && !inDebugRepl"
-      },
-      {
-        "key": "ctrl+p",
-        "command": "extension.vim_ctrl+p",
-        "when": "vim.mode == 'SearchInProgressMode' && vim.active && vim.use<C-p> && !inDebugRepl"
-      },
-      {
-        "key": "ctrl+p",
-        "command": "extension.vim_ctrl+p",
-        "when": "vim.mode == 'CommandlineInProgress' && vim.active && vim.use<C-p> && !inDebugRepl"
+        "when": "(suggestWidgetVisible || vim.mode == 'SearchInProgressMode || vim.mode == 'CommandlineInProgress') && vim.active && vim.use<C-p> && !inDebugRepl"
       },
       {
         "key": "ctrl+q",

--- a/package.json
+++ b/package.json
@@ -221,7 +221,7 @@
       {
         "key": "ctrl+p",
         "command": "extension.vim_ctrl+p",
-        "when": "(suggestWidgetVisible || vim.mode == 'SearchInProgressMode || vim.mode == 'CommandlineInProgress') && vim.active && vim.use<C-p> && !inDebugRepl"
+        "when": "(suggestWidgetVisible || vim.mode == 'SearchInProgressMode' || vim.mode == 'CommandlineInProgress') && vim.active && vim.use<C-p> && !inDebugRepl"
       },
       {
         "key": "ctrl+q",


### PR DESCRIPTION
<!--
Yay! Thanks for sending us a PR! 🎊

Please ensure your PR adheres to:

- [ ] Commit messages has a short & issue references when necessary
- [ ] Each commit does a logical chunk of work.
- [ ] It builds and tests pass (e.g `gulp`)
-->

**What this PR does / why we need it**:

Fix duplicated command added in c542b42, which cause the extension fail to load.

error message:
```
Activating extension `vscodevim.vim` failed:  command 'extension.vim_ctrl+n' already exists
```

**Which issue(s) this PR fixes**

<!--
Commits in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)
-->

**Special notes for your reviewer**:
