### PR TITLE
fix :wq in remote

### DIFF
--- a/src/cmd_line/commands/write.ts
+++ b/src/cmd_line/commands/write.ts
@@ -52,7 +52,7 @@ export class WriteCommand extends node.CommandBase {
 
     // defer saving the file to vscode if file is new (to present file explorer) or if file is a remote file
     if (vimState.editor.document.isUntitled || vimState.editor.document.uri.scheme !== 'file') {
-      vscode.commands.executeCommand('workbench.action.files.save');
+      await vscode.commands.executeCommand('workbench.action.files.save');
       return;
     }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix the issue where `:wq` can't close a file in vscode remote

**Which issue(s) this PR fixes**
https://github.com/VSCodeVim/Vim/issues/3922