### PR TITLE
Fix typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -607,7 +607,7 @@ Once active, type `gr` (say "go replace") followed by a motion to describe the t
 
 ## 🎩 VSCodeVim tricks!
 
-Vim has a lot of nifty tricks and we try to preserve some of them:
+VSCode has a lot of nifty tricks and we try to preserve some of them:
 
 - `gd` - jump to definition.
 - `gq` - on a visual selection reflow and wordwrap blocks of text, preserving commenting style. Great for formatting documentation comments.


### PR DESCRIPTION
In the README, a number of nifty tricks are referenced, however, the text incorrectly refers to these features as being Vim features. This patch fixes this, by correctly referring to these features as belonging to VSCode, making the README clearer and more accurate.