### PR TITLE
add possible count for IndentObjectMatch

### DIFF
--- a/test/mode/modeNormal.test.ts
+++ b/test/mode/modeNormal.test.ts
@@ -1940,6 +1940,20 @@ suite('Mode Normal', () => {
   });
 
   newTest({
+    title: 'Can do 2cai',
+    start: [
+      'if foo > 3:',
+      '    if foo < 20:',
+      '        log("foo is avarage")|',
+      '    foo = 3',
+      'do_something_else()',
+    ],
+    keysPressed: '2cai',
+    end: ['|', 'do_something_else()'],
+    endMode: ModeName.Insert,
+  });
+
+  newTest({
     title: 'Can do cii',
     start: ['if foo > 3:', '\tlog("foo is big")', '\tfoo = 3', '|', 'do_something_else()'],
     keysPressed: 'cii',


### PR DESCRIPTION
<!--
Yay! Thanks for sending us a PR! 🎊

Please ensure your PR adheres to:

- [x] Commit messages has a short & issue references when necessary
- [x] Each commit does a logical chunk of work.
- [x] It builds and tests pass (e.g `gulp`)
-->

**What this PR does / why we need it**:
This PR extends the 'vim-indent-object' support by adding the possibility to do '2dii' and delete 2 blocks of indented code. 

**Which issue(s) this PR fixes**

<!--
Commits in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)
-->

**Special notes for your reviewer**:
