### PR TITLE
:w write in background

### DIFF
--- a/src/cmd_line/subparsers/write.ts
+++ b/src/cmd_line/subparsers/write.ts
@@ -3,9 +3,9 @@ import { Scanner } from '../scanner';
 
 export function parseWriteCommandArgs(args: string): WriteCommand {
   if (!args) {
-    return new WriteCommand({});
+    return new WriteCommand({ bgWrite: true });
   }
-  const scannedArgs: IWriteCommandArguments = {};
+  const scannedArgs: IWriteCommandArguments = { bgWrite: true };
   const scanner = new Scanner(args);
   while (true) {
     scanner.skipWhiteSpace();


### PR DESCRIPTION
This changes the :w behavior to write in background to unfreeze the VS Code UI when the user is using VS Code Remote while allowing operation like wq and wa to work in VS Code

**What this PR does / why we need it**:
This fix the regression caused by https://github.com/VSCodeVim/Vim/pull/3998

**Which issue(s) this PR fixes**
https://github.com/VSCodeVim/Vim/pull/3998
https://github.com/VSCodeVim/Vim/issues/3922
https://github.com/VSCodeVim/Vim/issues/3777