### PR TITLE
Add flag to replace `f` with a single-character sneak

### DIFF
--- a/package.json
+++ b/package.json
@@ -566,6 +566,11 @@
           "markdownDescription": "Case sensitivity is determined by `ignorecase` and `smartcase`.",
           "default": false
         },
+        "vim.sneakReplacesF": {
+          "type": "boolean",
+          "markdownDescription": "Use single-character [Sneak](https://github.com/justinmk/vim-sneak) instead of Vim's native `f`.",
+          "default": false
+        },
         "vim.surround": {
           "type": "boolean",
           "markdownDescription": "Enable the [Surround](https://github.com/tpope/vim-surround) plugin for Vim.",

--- a/src/actions/baseMotion.ts
+++ b/src/actions/baseMotion.ts
@@ -1,0 +1,174 @@
+import { PositionDiff, Position } from '../common/motion/position';
+import { RegisterMode } from '../register/register';
+import { BaseAction } from './base';
+import { ModeName } from '../mode/mode';
+import { VimState } from '../state/vimState';
+import { RecordedState } from '../state/recordedState';
+
+export function isIMovement(o: IMovement | Position): o is IMovement {
+  return (o as IMovement).start !== undefined && (o as IMovement).stop !== undefined;
+}
+
+export enum SelectionType {
+  Concatenating, // Selections that concatenate repeated movements
+  Expanding, // Selections that expand the start and end of the previous selection
+}
+
+/**
+ * The result of a (more sophisticated) Movement.
+ */
+export interface IMovement {
+  start: Position;
+  stop: Position;
+
+  /**
+   * Whether this motion succeeded. Some commands, like fx when 'x' can't be found,
+   * will not move the cursor. Furthermore, dfx won't delete *anything*, even though
+   * deleting to the current character would generally delete 1 character.
+   */
+  failed?: boolean;
+
+  diff?: PositionDiff;
+
+  // It /so/ annoys me that I have to put this here.
+  registerMode?: RegisterMode;
+}
+
+export abstract class BaseMovement extends BaseAction {
+  modes = [ModeName.Normal, ModeName.Visual, ModeName.VisualLine, ModeName.VisualBlock];
+
+  isMotion = true;
+
+  /**
+   * If isJump is true, then the cursor position will be added to the jump list on completion.
+   *
+   * Default to false, as many motions operate on a single line and do not count as a jump.
+   */
+  isJump = false;
+
+  /**
+   * If movement can be repeated with semicolon or comma this will be true when
+   * running the repetition.
+   */
+  isRepeat = false;
+
+  /**
+   * Whether we should change desiredColumn in VimState.
+   */
+  public doesntChangeDesiredColumn = false;
+
+  /**
+   * This is for commands like $ which force the desired column to be at
+   * the end of even the longest line.
+   */
+  public setsDesiredColumnToEOL = false;
+
+  protected minCount = 1;
+  protected maxCount = 99999;
+  protected selectionType = SelectionType.Concatenating;
+
+  constructor(keysPressed?: string[], isRepeat?: boolean) {
+    super();
+
+    if (keysPressed) {
+      this.keysPressed = keysPressed;
+    }
+
+    if (isRepeat) {
+      this.isRepeat = isRepeat;
+    }
+  }
+
+  /**
+   * Run the movement a single time.
+   *
+   * Generally returns a new Position. If necessary, it can return an IMovement instead.
+   * Note: If returning an IMovement, make sure that repeated actions on a
+   * visual selection work. For example, V}}
+   */
+  public async execAction(position: Position, vimState: VimState): Promise<Position | IMovement> {
+    throw new Error('Not implemented!');
+  }
+
+  /**
+   * Run the movement in an operator context a single time.
+   *
+   * Some movements operate over different ranges when used for operators.
+   */
+  public async execActionForOperator(
+    position: Position,
+    vimState: VimState
+  ): Promise<Position | IMovement> {
+    return this.execAction(position, vimState);
+  }
+
+  /**
+   * Run a movement count times.
+   *
+   * count: the number prefix the user entered, or 0 if they didn't enter one.
+   */
+  public async execActionWithCount(
+    position: Position,
+    vimState: VimState,
+    count: number
+  ): Promise<Position | IMovement> {
+    let recordedState = vimState.recordedState;
+    let result: Position | IMovement = new Position(0, 0); // bogus init to satisfy typechecker
+    let prevResult: IMovement | undefined = undefined;
+    let firstMovementStart: Position = new Position(position.line, position.character);
+
+    count = this.clampCount(count);
+
+    for (let i = 0; i < count; i++) {
+      const firstIteration = i === 0;
+      const lastIteration = i === count - 1;
+      result = await this.createMovementResult(position, vimState, recordedState, lastIteration);
+
+      if (result instanceof Position) {
+        position = result;
+      } else if (isIMovement(result)) {
+        if (prevResult && result.failed) {
+          return prevResult;
+        }
+
+        if (firstIteration) {
+          firstMovementStart = new Position(result.start.line, result.start.character);
+        }
+
+        position = this.adjustPosition(position, result, lastIteration);
+        prevResult = result;
+      }
+    }
+
+    if (this.selectionType === SelectionType.Concatenating && isIMovement(result)) {
+      result.start = firstMovementStart;
+    }
+
+    return result;
+  }
+
+  protected clampCount(count: number) {
+    count = Math.max(count, this.minCount);
+    count = Math.min(count, this.maxCount);
+    return count;
+  }
+
+  protected async createMovementResult(
+    position: Position,
+    vimState: VimState,
+    recordedState: RecordedState,
+    lastIteration: boolean
+  ): Promise<Position | IMovement> {
+    const result =
+      recordedState.operator && lastIteration
+        ? await this.execActionForOperator(position, vimState)
+        : await this.execAction(position, vimState);
+    return result;
+  }
+  protected adjustPosition(position: Position, result: IMovement, lastIteration: boolean) {
+    if (!lastIteration) {
+      position = result.stop.getRightThroughLineBreaks();
+    }
+    return position;
+  }
+}

--- a/src/actions/motion.ts
+++ b/src/actions/motion.ts
@@ -19,177 +19,12 @@ import { VimError, ErrorCode } from '../error';
 import { ReportSearch } from '../util/statusBarTextUtils';
 import { Notation } from '../configuration/notation';
 import { globalState } from '../state/globalState';
-
-export function isIMovement(o: IMovement | Position): o is IMovement {
-  return (o as IMovement).start !== undefined && (o as IMovement).stop !== undefined;
-}
-
-/**
- * The result of a (more sophisticated) Movement.
- */
-export interface IMovement {
-  start: Position;
-  stop: Position;
-
-  /**
-   * Whether this motion succeeded. Some commands, like fx when 'x' can't be found,
-   * will not move the cursor. Furthermore, dfx won't delete *anything*, even though
-   * deleting to the current character would generally delete 1 character.
-   */
-  failed?: boolean;
-
-  diff?: PositionDiff;
-
-  // It /so/ annoys me that I have to put this here.
-  registerMode?: RegisterMode;
-}
-
-enum SelectionType {
-  Concatenating, // selections that concatenate repeated movements
-  Expanding, // selections that expand the start and end of the previous selection
-}
+import { BaseMovement, IMovement, isIMovement, SelectionType } from './baseMotion';
+import { SneakForward, SneakBackward } from './plugins/sneak';
 
 /**
  * A movement is something like 'h', 'k', 'w', 'b', 'gg', etc.
  */
-export abstract class BaseMovement extends BaseAction {
-  modes = [ModeName.Normal, ModeName.Visual, ModeName.VisualLine, ModeName.VisualBlock];
-
-  isMotion = true;
-
-  /**
-   * If isJump is true, then the cursor position will be added to the jump list on completion.
-   *
-   * Default to false, as many motions operate on a single line and do not count as a jump.
-   */
-  isJump = false;
-
-  /**
-   * If movement can be repeated with semicolon or comma this will be true when
-   * running the repetition.
-   */
-  isRepeat = false;
-
-  /**
-   * Whether we should change desiredColumn in VimState.
-   */
-  public doesntChangeDesiredColumn = false;
-
-  /**
-   * This is for commands like $ which force the desired column to be at
-   * the end of even the longest line.
-   */
-  public setsDesiredColumnToEOL = false;
-
-  protected minCount = 1;
-  protected maxCount = 99999;
-  protected selectionType = SelectionType.Concatenating;
-
-  constructor(keysPressed?: string[], isRepeat?: boolean) {
-    super();
-
-    if (keysPressed) {
-      this.keysPressed = keysPressed;
-    }
-
-    if (isRepeat) {
-      this.isRepeat = isRepeat;
-    }
-  }
-
-  /**
-   * Run the movement a single time.
-   *
-   * Generally returns a new Position. If necessary, it can return an IMovement instead.
-   * Note: If returning an IMovement, make sure that repeated actions on a
-   * visual selection work. For example, V}}
-   */
-  public async execAction(position: Position, vimState: VimState): Promise<Position | IMovement> {
-    throw new Error('Not implemented!');
-  }
-
-  /**
-   * Run the movement in an operator context a single time.
-   *
-   * Some movements operate over different ranges when used for operators.
-   */
-  public async execActionForOperator(
-    position: Position,
-    vimState: VimState
-  ): Promise<Position | IMovement> {
-    return this.execAction(position, vimState);
-  }
-
-  /**
-   * Run a movement count times.
-   *
-   * count: the number prefix the user entered, or 0 if they didn't enter one.
-   */
-  public async execActionWithCount(
-    position: Position,
-    vimState: VimState,
-    count: number
-  ): Promise<Position | IMovement> {
-    let recordedState = vimState.recordedState;
-    let result: Position | IMovement = new Position(0, 0); // bogus init to satisfy typechecker
-    let prevResult: IMovement | undefined = undefined;
-    let firstMovementStart: Position = new Position(position.line, position.character);
-
-    count = this.clampCount(count);
-
-    for (let i = 0; i < count; i++) {
-      const firstIteration = i === 0;
-      const lastIteration = i === count - 1;
-      result = await this.createMovementResult(position, vimState, recordedState, lastIteration);
-
-      if (result instanceof Position) {
-        position = result;
-      } else if (isIMovement(result)) {
-        if (prevResult && result.failed) {
-          return prevResult;
-        }
-
-        if (firstIteration) {
-          firstMovementStart = new Position(result.start.line, result.start.character);
-        }
-
-        position = this.adjustPosition(position, result, lastIteration);
-        prevResult = result;
-      }
-    }
-
-    if (this.selectionType === SelectionType.Concatenating && isIMovement(result)) {
-      result.start = firstMovementStart;
-    }
-
-    return result;
-  }
-
-  protected clampCount(count: number) {
-    count = Math.max(count, this.minCount);
-    count = Math.min(count, this.maxCount);
-    return count;
-  }
-
-  protected async createMovementResult(
-    position: Position,
-    vimState: VimState,
-    recordedState: RecordedState,
-    lastIteration: boolean
-  ): Promise<Position | IMovement> {
-    const result =
-      recordedState.operator && lastIteration
-        ? await this.execActionForOperator(position, vimState)
-        : await this.execAction(position, vimState);
-    return result;
-  }
-  protected adjustPosition(position: Position, result: IMovement, lastIteration: boolean) {
-    if (!lastIteration) {
-      position = result.stop.getRightThroughLineBreaks();
-    }
-    return position;
-  }
-}
 
 export abstract class ExpandingSelection extends BaseMovement {
   protected selectionType = SelectionType.Expanding;
@@ -667,6 +502,14 @@ class MoveFindForward extends BaseMovement {
     vimState: VimState,
     count: number
   ): Promise<Position | IMovement> {
+    if (configuration.sneakReplacesF) {
+      return new SneakForward(this.keysPressed.concat('\n'), this.isRepeat).execActionWithCount(
+        position,
+        vimState,
+        count
+      );
+    }
+
     count = count || 1;
     const toFind = Notation.ToControlCharacter(this.keysPressed[1]);
     let result = position.findForwards(toFind, count);
@@ -700,6 +543,14 @@ class MoveFindBackward extends BaseMovement {
     vimState: VimState,
     count: number
   ): Promise<Position | IMovement> {
+    if (configuration.sneakReplacesF) {
+      return new SneakBackward(this.keysPressed.concat('\n'), this.isRepeat).execActionWithCount(
+        position,
+        vimState,
+        count
+      );
+    }
+
     count = count || 1;
     const toFind = Notation.ToControlCharacter(this.keysPressed[1]);
     let result = position.findBackwards(toFind, count);

--- a/src/actions/plugins/camelCaseMotion.ts
+++ b/src/actions/plugins/camelCaseMotion.ts
@@ -3,7 +3,7 @@ import { RegisterAction } from '../base';
 import { ModeName } from '../../mode/mode';
 import { Position } from '../../common/motion/position';
 import { VimState } from '../../state/vimState';
-import { IMovement, BaseMovement } from '../motion';
+import { IMovement, BaseMovement } from '../baseMotion';
 import { TextEditor } from '../../textEditor';
 import { configuration } from '../../configuration/configuration';
 import { ChangeOperator } from '../operator';

--- a/src/actions/plugins/sneak.ts
+++ b/src/actions/plugins/sneak.ts
@@ -3,10 +3,10 @@ import { VimState } from '../../state/vimState';
 import { configuration } from './../../configuration/configuration';
 import { RegisterAction } from './../base';
 import { Position } from '../../common/motion/position';
-import { IMovement, BaseMovement } from '../motion';
+import { BaseMovement, IMovement } from '../baseMotion';
 
 @RegisterAction
-class SneakForward extends BaseMovement {
+export class SneakForward extends BaseMovement {
   keys = [['s', '<character>', '<character>'], ['z', '<character>', '<character>']];
 
   public couldActionApply(vimState: VimState, keysPressed: string[]): boolean {
@@ -67,7 +67,7 @@ class SneakForward extends BaseMovement {
 }
 
 @RegisterAction
-class SneakBackward extends BaseMovement {
+export class SneakBackward extends BaseMovement {
   keys = [['S', '<character>', '<character>'], ['Z', '<character>', '<character>']];
 
   public couldActionApply(vimState: VimState, keysPressed: string[]): boolean {

--- a/src/actions/plugins/surround.ts
+++ b/src/actions/plugins/surround.ts
@@ -7,9 +7,8 @@ import { ModeName } from './../../mode/mode';
 import { TextEditor } from './../../textEditor';
 import { RegisterAction } from './../base';
 import { BaseCommand } from './../commands/actions';
-import { BaseMovement } from './../motion';
+import { BaseMovement, IMovement } from '../baseMotion';
 import {
-  IMovement,
   MoveABacktick,
   MoveACaret,
   MoveACurlyBrace,
@@ -21,7 +20,7 @@ import {
   MoveInsideCharacter,
   MoveInsideTag,
   MoveQuoteMatch,
-} from './../motion';
+} from '../motion';
 import { ChangeOperator, DeleteOperator, YankOperator } from './../operator';
 import {
   SelectInnerBigWord,

--- a/src/actions/textobject.ts
+++ b/src/actions/textobject.ts
@@ -5,9 +5,8 @@ import { RegisterMode } from './../register/register';
 import { VimState } from './../state/vimState';
 import { TextEditor } from './../textEditor';
 import { RegisterAction } from './base';
+import { BaseMovement, IMovement } from './baseMotion';
 import {
-  BaseMovement,
-  IMovement,
   MoveAClosingCurlyBrace,
   MoveADoubleQuotes,
   MoveAParentheses,

--- a/src/common/motion/range.ts
+++ b/src/common/motion/range.ts
@@ -1,6 +1,6 @@
 import * as vscode from 'vscode';
 
-import { IMovement } from './../../actions/motion';
+import { IMovement } from '../../actions/baseMotion';
 import { Position, PositionDiff } from './position';
 
 export class Range {

--- a/src/configuration/configuration.ts
+++ b/src/configuration/configuration.ts
@@ -183,6 +183,7 @@ class Configuration implements IConfiguration {
 
   sneak = false;
   sneakUseIgnorecaseAndSmartcase = false;
+  sneakReplacesF = false;
 
   surround = true;
 

--- a/src/configuration/iconfiguration.ts
+++ b/src/configuration/iconfiguration.ts
@@ -134,6 +134,11 @@ export interface IConfiguration {
   sneakUseIgnorecaseAndSmartcase: boolean;
 
   /**
+   * Use single-character `sneak` instead of Vim's native `f`"
+   */
+  sneakReplacesF: boolean;
+
+  /**
    * Use surround plugin?
    */
   surround: boolean;

--- a/src/mode/modeHandler.ts
+++ b/src/mode/modeHandler.ts
@@ -2,7 +2,7 @@ import * as vscode from 'vscode';
 import * as modes from './modes';
 
 import { Actions, BaseAction, KeypressState } from './../actions/base';
-import { BaseMovement, isIMovement } from './../actions/motion';
+import { BaseMovement, isIMovement } from '../actions/baseMotion';
 import { CommandInsertInInsertMode, CommandInsertPreviousText } from './../actions/commands/insert';
 import { Jump } from '../jumps/jump';
 import { Logger } from '../util/logger';

--- a/src/state/vimState.ts
+++ b/src/state/vimState.ts
@@ -1,6 +1,6 @@
 import * as vscode from 'vscode';
 
-import { BaseMovement } from '../actions/motion';
+import { BaseMovement } from '../actions/baseMotion';
 import { EasyMotion } from './../actions/plugins/easymotion/easymotion';
 import { EditorIdentity } from './../editorIdentity';
 import { HistoryTracker } from './../history/historyTracker';

--- a/test/testConfiguration.ts
+++ b/test/testConfiguration.ts
@@ -21,6 +21,7 @@ export class Configuration implements IConfiguration {
   replaceWithRegister = false;
   sneak = false;
   sneakUseIgnorecaseAndSmartcase = false;
+  sneakReplacesF = false;
   surround = true;
   easymotion = false;
   easymotionMarkerBackgroundColor = '';


### PR DESCRIPTION
It's called `sneakReplacesF` and is nice because it basically makes `f` work across newlines.

I had to pull a few interfaces and a base class out from motion.ts to avoid a circular import.

Closes #4012