### PR TITLE
Fix gq to handle tab indentation

### DIFF
--- a/src/actions/operator.ts
+++ b/src/actions/operator.ts
@@ -841,22 +841,27 @@ class ActionVisualReflowParagraph extends BaseOperator {
     { singleLine: true, start: '' },
   ];
 
-  public getIndentationLevel(s: string): number {
+  public getIndentation(s: string): string {
+    // Use the indentation of the first non-whitespace line, if any such line is
+    // selected.
     for (const line of s.split('\n')) {
       const result = line.match(/^\s+/g);
-      const indentLevel = result ? result[0].length : 0;
+      const indent = result ? result[0] : '';
 
-      if (indentLevel !== line.length) {
-        return indentLevel;
+      if (indent !== line) {
+        return indent;
       }
     }
 
-    return 0;
+    return '';
   }
 
-  public reflowParagraph(s: string, indentLevel: number): string {
+  public reflowParagraph(s: string, indent: string): string {
+    let indentLevel = 0;
+    for (const char of indent) {
+      indentLevel += char === '\t' ? configuration.tabstop : 1;
+    }
     const maximumLineLength = configuration.textwidth - indentLevel - 2;
-    const indent = Array(indentLevel + 1).join(' ');
 
     // Chunk the lines by commenting style.
 
@@ -1033,9 +1038,9 @@ class ActionVisualReflowParagraph extends BaseOperator {
     end = Position.LaterOf(start, end);
 
     let textToReflow = TextEditor.getText(new vscode.Range(start, end));
-    let indentLevel = this.getIndentationLevel(textToReflow);
+    let indent = this.getIndentation(textToReflow);
 
-    textToReflow = this.reflowParagraph(textToReflow, indentLevel);
+    textToReflow = this.reflowParagraph(textToReflow, indent);
 
     vimState.recordedState.transformations.push({
       type: 'replaceText',

--- a/test/mode/modeNormal.test.ts
+++ b/test/mode/modeNormal.test.ts
@@ -1330,34 +1330,41 @@ suite('Mode Normal', () => {
     end: ['testtest', 'testtest', 'testtes|t'],
   });
 
-  //  These tests run poorly on Travis for w.e. reason
-  // newTest({
-  //   title: "gq handles spaces after single line comments correctly",
-  //   start: ['//    We choose to write a vim extension, not because it is easy, but because it is hard|.'],
-  //   keysPressed: 'Vgq',
-  //   end: [ '//    We choose to write a vim extension, not because it is easy, but because it is',
-  //         '|//    hard.'],
-  // });
+  newTest({
+    title: 'gq handles spaces after single line comments correctly',
+    start: [
+      '//    We choose to write a vim extension, not because it is easy, but because it is hard|.',
+    ],
+    keysPressed: 'Vgq',
+    end: [
+      '//    We choose to write a vim extension, not because it is easy, but because it is',
+      '|//    hard.',
+    ],
+  });
 
-  // newTest({
-  //   title: "gq handles spaces before single line comments correctly",
-  //   start: ['    // We choose to write a vim extension, not because it is easy, but because it is hard|.'],
-  //   keysPressed: 'Vgq',
-  //   end: [ '    // We choose to write a vim extension, not because it is easy, but because',
-  //         '|    // it is hard.']
-  // });
+  newTest({
+    title: 'gq handles spaces before single line comments correctly',
+    start: [
+      '    // We choose to write a vim extension, not because it is easy, but because it is hard|.',
+    ],
+    keysPressed: 'Vgq',
+    end: [
+      '    // We choose to write a vim extension, not because it is easy, but because',
+      '|    // it is hard.',
+    ],
+  });
 
-  // newTest({
-  //   title: 'gq handles tabs before single line comments correctly',
-  //   start: [
-  //     '\t\t// We choose to write a vim extension, not because it is easy, but because it is hard|.',
-  //   ],
-  //   keysPressed: 'Vgq',
-  //   end: [
-  //     '\t\t// We choose to write a vim extension, not because it is easy, but',
-  //     '|\t\t// because it is hard.',
-  //   ],
-  // });
+  newTest({
+    title: 'gq handles tabs before single line comments correctly',
+    start: [
+      '\t\t// We choose to write a vim extension, not because it is easy, but because it is hard|.',
+    ],
+    keysPressed: 'Vgq',
+    end: [
+      '\t\t// We choose to write a vim extension, not because it is easy, but',
+      '|\t\t// because it is hard.',
+    ],
+  });
 
   newTest({
     title: 'Can handle space',

--- a/test/mode/modeNormal.test.ts
+++ b/test/mode/modeNormal.test.ts
@@ -1347,6 +1347,18 @@ suite('Mode Normal', () => {
   //         '|    // it is hard.']
   // });
 
+  // newTest({
+  //   title: 'gq handles tabs before single line comments correctly',
+  //   start: [
+  //     '\t\t// We choose to write a vim extension, not because it is easy, but because it is hard|.',
+  //   ],
+  //   keysPressed: 'Vgq',
+  //   end: [
+  //     '\t\t// We choose to write a vim extension, not because it is easy, but',
+  //     '|\t\t// because it is hard.',
+  //   ],
+  // });
+
   newTest({
     title: 'Can handle space',
     start: ['|abc', 'def'],


### PR DESCRIPTION
**What this PR does / why we need it**: The `gq` command to "reflow" selected text in visual line mode didn't properly handle tabs, replacing them with spaces.

**Which issue(s) this PR fixes**: (none, I can create one if needed)

**Special notes for your reviewer**: I added another commented-out `gq` test case under the assumption that it would also "run poorly on Travis". It passes locally though (along with the two old commented-out `gq` tests).
