### PR TITLE
Add missing `to` in CONTRIBUTING.md

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -119,4 +119,4 @@ $ rm -rf .vscode-test/
 
 ## Styleguide
 
-Please try your best to adhere our [style guidelines](https://github.com/VSCodeVim/Vim/blob/master/STYLE.md).
+Please try your best to adhere to our [style guidelines](https://github.com/VSCodeVim/Vim/blob/master/STYLE.md).


### PR DESCRIPTION
**What this PR does / why we need it**:

Seems like the contributing markdown file was missing a `to` at the end when asking potential contributors to do their best to adhere to the style guidelines.