### PR TITLE
Add shift+tab support for cmd line

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,6 +89,11 @@
         "when": "editorFocus && vim.active && vim.mode != 'Insert' && !inDebugRepl"
       },
       {
+        "key": "shift+tab",
+        "command": "extension.vim_shift+tab",
+        "when": "editorFocus && vim.active && vim.mode != 'Insert' && !inDebugRepl"
+      },
+      {
         "key": "left",
         "command": "extension.vim_left",
         "when": "editorTextFocus && vim.active && !inDebugRepl"

--- a/test/cmd_line/tabCompletion.test.ts
+++ b/test/cmd_line/tabCompletion.test.ts
@@ -27,6 +27,21 @@ suite('cmd_line tabComplete', () => {
     assert.equal(statusBarAfterTab.trim(), ':edit|', 'Command Tab Completion Failed');
   });
 
+  test('command line command shift+tab', async () => {
+    await modeHandler.handleMultipleKeyEvents([':', 'e', '<tab>']);
+    const firstTab = StatusBar.Get();
+
+    await modeHandler.handleKeyEvent('<tab>');
+    const secondTab = StatusBar.Get();
+
+    await modeHandler.handleKeyEvent('<shift+tab>');
+    const actual = StatusBar.Get();
+
+    await modeHandler.handleKeyEvent('<Esc>');
+    assert.notEqual(firstTab, secondTab);
+    assert.equal(actual, firstTab, "Command can't go back with shift+tab");
+  });
+
   test('command line file tab completion with no base path', async () => {
     await modeHandler.handleKeyEvent(':');
     const statusBarBeforeTab = StatusBar.Get();


### PR DESCRIPTION
**What this PR does / why we need it**:
Add shift+tab to go back on autocompletion on cmd line

**Which issue(s) this PR fixes**
This is related to
#4032