### PR TITLE
Use command abbreviations

### DIFF
--- a/src/cmd_line/parser.ts
+++ b/src/cmd_line/parser.ts
@@ -3,7 +3,7 @@ import * as node from './node';
 import * as token from './token';
 import { Logger } from '../util/logger';
 import { VimError, ErrorCode } from '../error';
-import { commandParsers } from './subparser';
+import { commandParsers, CommandParserMapping, getParser } from './subparser';
 
 interface IParseFunction {
   (state: ParserState, command: node.CommandLine): IParseFunction | null;
@@ -57,14 +57,14 @@ function parseCommand(state: ParserState, commandLine: node.CommandLine): IParse
     const tok = state.next();
     switch (tok.type) {
       case token.TokenType.CommandName:
-        const commandParser = (commandParsers as any)[tok.content];
+        const commandParser = getParser(tok.content);
         if (!commandParser) {
           throw VimError.fromCode(ErrorCode.E492);
         }
         // TODO: Pass the args, but keep in mind there could be multiple
         // commands, not just one.
         const argsTok = state.next();
-        const args = argsTok.type === token.TokenType.CommandArgs ? argsTok.content : null;
+        const args = argsTok.type === token.TokenType.CommandArgs ? argsTok.content : undefined;
         commandLine.command = commandParser(args);
         return null;
       default:

--- a/src/cmd_line/subparser.ts
+++ b/src/cmd_line/subparser.ts
@@ -18,106 +18,231 @@ import { parseWriteQuitAllCommandArgs } from './subparsers/writequitall';
 import { parseFileInfoCommandArgs } from './subparsers/fileInfo';
 import { parseMarksCommandArgs } from './subparsers/marks';
 import { parseSmileCommandArgs } from './subparsers/smile';
+import { CommandBase } from './node';
 
-// maps command names to parsers for said commands.
-export const commandParsers = {
-  w: parseWriteCommandArgs,
-  write: parseWriteCommandArgs,
+// Associates a name and an abbreviation with a command parser
+export type CommandParserMapping = {
+  /** The shortest abbreviation that will work, such as `:q` */
+  abbrev?: string;
 
-  wa: parseWallCommandArgs,
-  wall: parseWallCommandArgs,
-
-  nohlsearch: parseNohlCommandArgs,
-  noh: parseNohlCommandArgs,
-  nohl: parseNohlCommandArgs,
-
-  close: parseCloseCommandArgs,
-  clo: parseCloseCommandArgs,
-
-  quit: parseQuitCommandArgs,
-  q: parseQuitCommandArgs,
-
-  qa: parseQuitAllCommandArgs,
-  qall: parseQuitAllCommandArgs,
-
-  wq: parseWriteQuitCommandArgs,
-  writequit: parseWriteQuitCommandArgs,
-  x: parseWriteQuitCommandArgs,
-
-  wqa: parseWriteQuitAllCommandArgs,
-  wqall: parseWriteQuitAllCommandArgs,
-  xa: parseWriteQuitAllCommandArgs,
-  xall: parseWriteQuitAllCommandArgs,
-
-  tabn: tabCmd.parseTabNCommandArgs,
-  tabnext: tabCmd.parseTabNCommandArgs,
-
-  tabp: tabCmd.parseTabPCommandArgs,
-  tabprevious: tabCmd.parseTabPCommandArgs,
-  tabN: tabCmd.parseTabPCommandArgs,
-  tabNext: tabCmd.parseTabPCommandArgs,
-
-  tabfirst: tabCmd.parseTabFirstCommandArgs,
-  tabfir: tabCmd.parseTabFirstCommandArgs,
-
-  tablast: tabCmd.parseTabLastCommandArgs,
-  tabl: tabCmd.parseTabLastCommandArgs,
-
-  tabe: tabCmd.parseTabNewCommandArgs,
-  tabedit: tabCmd.parseTabNewCommandArgs,
-  tabnew: tabCmd.parseTabNewCommandArgs,
-
-  tabclose: tabCmd.parseTabCloseCommandArgs,
-  tabc: tabCmd.parseTabCloseCommandArgs,
-
-  tabo: tabCmd.parseTabOnlyCommandArgs,
-  tabonly: tabCmd.parseTabOnlyCommandArgs,
-
-  tabm: tabCmd.parseTabMovementCommandArgs,
-
-  s: parseSubstituteCommandArgs,
-
-  smile: parseSmileCommandArgs,
-
-  e: fileCmd.parseEditFileCommandArgs,
-  edit: fileCmd.parseEditFileCommandArgs,
-  ene: fileCmd.parseEditNewFileCommandArgs,
-  enew: fileCmd.parseEditNewFileCommandArgs,
-
-  sp: fileCmd.parseEditFileInNewHorizontalWindowCommandArgs,
-  split: fileCmd.parseEditFileInNewHorizontalWindowCommandArgs,
-  vs: fileCmd.parseEditFileInNewVerticalWindowCommandArgs,
-  vsp: fileCmd.parseEditFileInNewVerticalWindowCommandArgs,
-  vsplit: fileCmd.parseEditFileInNewVerticalWindowCommandArgs,
-
-  new: fileCmd.parseEditNewFileInNewHorizontalWindowCommandArgs,
-  vne: fileCmd.parseEditNewFileInNewVerticalWindowCommandArgs,
-  vnew: fileCmd.parseEditNewFileInNewVerticalWindowCommandArgs,
-
-  on: parseOnlyCommandArgs,
-  only: parseOnlyCommandArgs,
-
-  set: parseOptionsCommandArgs,
-  se: parseOptionsCommandArgs,
-
-  read: parseReadCommandArgs,
-  r: parseReadCommandArgs,
-
-  reg: parseRegisterCommandArgs,
-
-  dig: parseDigraphCommandArgs,
-  digr: parseDigraphCommandArgs,
-  digraph: parseDigraphCommandArgs,
-  digraphs: parseDigraphCommandArgs,
-
-  d: parseDeleteRangeLinesCommandArgs,
-
-  sort: parseSortCommandArgs,
-
-  f: parseFileInfoCommandArgs,
-  fi: parseFileInfoCommandArgs,
-  fil: parseFileInfoCommandArgs,
-  file: parseFileInfoCommandArgs,
-
-  marks: parseMarksCommandArgs,
+  /** The parser for this command */
+  parser: (args: string) => CommandBase;
 };
+
+export const commandParsers = {
+  write: {
+    abbrev: 'w',
+    parser: parseWriteCommandArgs,
+  },
+
+  wall: {
+    abbrev: 'wa',
+    parser: parseWallCommandArgs,
+  },
+
+  nohlsearch: {
+    abbrev: 'noh',
+    parser: parseNohlCommandArgs,
+  },
+
+  close: {
+    abbrev: 'clo',
+    parser: parseCloseCommandArgs,
+  },
+
+  quit: {
+    abbrev: 'q',
+    parser: parseQuitCommandArgs,
+  },
+
+  qall: {
+    abbrev: 'qa',
+    parser: parseQuitAllCommandArgs,
+  },
+
+  quitall: {
+    abbrev: 'quita',
+    parser: parseQuitAllCommandArgs,
+  },
+
+  wq: {
+    parser: parseWriteQuitCommandArgs,
+  },
+
+  x: {
+    parser: parseWriteQuitCommandArgs,
+  },
+
+  wqall: {
+    abbrev: 'wqa',
+    parser: parseWriteQuitAllCommandArgs,
+  },
+
+  xall: {
+    abbrev: 'xa',
+    parser: parseWriteQuitAllCommandArgs,
+  },
+
+  tabnext: {
+    abbrev: 'tabn',
+    parser: tabCmd.parseTabNCommandArgs,
+  },
+
+  tabprevious: {
+    abbrev: 'tabp',
+    parser: tabCmd.parseTabPCommandArgs,
+  },
+
+  tabNext: {
+    abbrev: 'tabN',
+    parser: tabCmd.parseTabPCommandArgs,
+  },
+
+  tabfirst: {
+    abbrev: 'tabfir',
+    parser: tabCmd.parseTabFirstCommandArgs,
+  },
+
+  tablast: {
+    abbrev: 'tabl',
+    parser: tabCmd.parseTabLastCommandArgs,
+  },
+
+  tabedit: {
+    abbrev: 'tabe',
+    parser: tabCmd.parseTabNewCommandArgs,
+  },
+
+  tabnew: {
+    // TODO: abbrev: "tabn", ?
+    parser: tabCmd.parseTabNewCommandArgs,
+  },
+
+  tabclose: {
+    abbrev: 'tabc',
+    parser: tabCmd.parseTabCloseCommandArgs,
+  },
+
+  tabonly: {
+    abbrev: 'tabo',
+    parser: tabCmd.parseTabOnlyCommandArgs,
+  },
+
+  tabmove: {
+    abbrev: 'tabm',
+    parser: tabCmd.parseTabMovementCommandArgs,
+  },
+
+  substitute: {
+    abbrev: 's',
+    parser: parseSubstituteCommandArgs,
+  },
+
+  smile: {
+    abbrev: '',
+    parser: parseSmileCommandArgs,
+  },
+
+  edit: {
+    abbrev: 'e',
+    parser: fileCmd.parseEditFileCommandArgs,
+  },
+
+  enew: {
+    abbrev: 'ene',
+    parser: fileCmd.parseEditNewFileCommandArgs,
+  },
+
+  split: {
+    abbrev: 'sp',
+    parser: fileCmd.parseEditFileInNewHorizontalWindowCommandArgs,
+  },
+
+  vsplit: {
+    abbrev: 'vs',
+    parser: fileCmd.parseEditFileInNewVerticalWindowCommandArgs,
+  },
+
+  new: {
+    // TODO: abbrev: "?"
+    parser: fileCmd.parseEditNewFileInNewHorizontalWindowCommandArgs,
+  },
+
+  vnew: {
+    abbrev: 'vne',
+    parser: fileCmd.parseEditNewFileInNewVerticalWindowCommandArgs,
+  },
+
+  only: {
+    abbrev: 'on',
+    parser: parseOnlyCommandArgs,
+  },
+
+  set: {
+    abbrev: 'se',
+    parser: parseOptionsCommandArgs,
+  },
+
+  read: {
+    abbrev: 'r',
+    parser: parseReadCommandArgs,
+  },
+
+  registers: {
+    abbrev: 'reg',
+    parser: parseRegisterCommandArgs,
+  },
+
+  display: {
+    abbrev: 'reg',
+    parser: parseRegisterCommandArgs,
+  },
+
+  digraphs: {
+    abbrev: 'dig',
+    parser: parseDigraphCommandArgs,
+  },
+
+  d: {
+    parser: parseDeleteRangeLinesCommandArgs,
+  },
+
+  sort: {
+    parser: parseSortCommandArgs,
+  },
+
+  file: {
+    abbrev: 'f',
+    parser: parseFileInfoCommandArgs,
+  },
+
+  marks: {
+    parser: parseMarksCommandArgs,
+  },
+};
+
+/**
+ * Returns a command parser for the given `input`, if one exists.
+ * Resolves `q`, `qu`, `qui`, and `quit` the same.
+ */
+export function getParser(input: string): ((args?: string) => CommandBase) | undefined {
+  if (input === '') {
+    return undefined;
+  }
+
+  for (const fullName of Object.keys(commandParsers)) {
+    const parserMapping: CommandParserMapping = commandParsers[fullName];
+
+    if (parserMapping.abbrev !== undefined) {
+      if (input.startsWith(parserMapping.abbrev) && fullName.startsWith(input)) {
+        return parserMapping.parser;
+      }
+    } else {
+      if (input === fullName) {
+        return parserMapping.parser;
+      }
+    }
+  }
+
+  return undefined;
+}

--- a/test/cmd_line/subparser.close.test.ts
+++ b/test/cmd_line/subparser.close.test.ts
@@ -3,39 +3,35 @@ import * as assert from 'assert';
 import { commandParsers } from '../../src/cmd_line/subparser';
 
 suite(':close args parser', () => {
-  test('has all aliases', () => {
-    assert.equal(commandParsers.close.name, commandParsers.clo.name);
-  });
-
   test('can parse empty args', () => {
-    const args = commandParsers.close('');
+    const args = commandParsers.close.parser('');
     assert.equal(args.arguments.bang, undefined);
     assert.equal(args.arguments.range, undefined);
   });
 
   test('ignores trailing white space', () => {
-    const args = commandParsers.close('  ');
+    const args = commandParsers.close.parser('  ');
     assert.equal(args.arguments.bang, undefined);
     assert.equal(args.arguments.range, undefined);
   });
 
   test('can parse !', () => {
-    const args = commandParsers.close('!');
+    const args = commandParsers.close.parser('!');
     assert.ok(args.arguments.bang);
     assert.equal(args.arguments.range, undefined);
   });
 
   test('throws if space before !', () => {
-    assert.throws(() => commandParsers.close(' !'));
+    assert.throws(() => commandParsers.close.parser(' !'));
   });
 
   test('ignores space after !', () => {
-    const args = commandParsers.close('! ');
+    const args = commandParsers.close.parser('! ');
     assert.equal(args.arguments.bang, true);
     assert.equal(args.arguments.range, undefined);
   });
 
   test('throws if bad input', () => {
-    assert.throws(() => commandParsers.close('x'));
+    assert.throws(() => commandParsers.close.parser('x'));
   });
 });

--- a/test/cmd_line/subparser.quit.test.ts
+++ b/test/cmd_line/subparser.quit.test.ts
@@ -3,39 +3,35 @@ import * as assert from 'assert';
 import { commandParsers } from '../../src/cmd_line/subparser';
 
 suite(':quit args parser', () => {
-  test('has all aliases', () => {
-    assert.equal(commandParsers.quit.name, commandParsers.q.name);
-  });
-
   test('can parse empty args', () => {
-    const args = commandParsers.quit('');
+    const args = commandParsers.quit.parser('');
     assert.equal(args.arguments.bang, undefined);
     assert.equal(args.arguments.range, undefined);
   });
 
   test('ignores trailing white space', () => {
-    const args = commandParsers.quit('  ');
+    const args = commandParsers.quit.parser('  ');
     assert.equal(args.arguments.bang, undefined);
     assert.equal(args.arguments.range, undefined);
   });
 
   test('can parse !', () => {
-    const args = commandParsers.quit('!');
+    const args = commandParsers.quit.parser('!');
     assert.ok(args.arguments.bang);
     assert.equal(args.arguments.range, undefined);
   });
 
   test('throws if space before !', () => {
-    assert.throws(() => commandParsers.quit(' !'));
+    assert.throws(() => commandParsers.quit.parser(' !'));
   });
 
   test('ignores space after !', () => {
-    const args = commandParsers.quit('! ');
+    const args = commandParsers.quit.parser('! ');
     assert.equal(args.arguments.bang, true);
     assert.equal(args.arguments.range, undefined);
   });
 
   test('throws if bad input', () => {
-    assert.throws(() => commandParsers.quit('x'));
+    assert.throws(() => commandParsers.quit.parser('x'));
   });
 });

--- a/test/cmd_line/subparser.substitute.test.ts
+++ b/test/cmd_line/subparser.substitute.test.ts
@@ -4,32 +4,32 @@ import { commandParsers } from '../../src/cmd_line/subparser';
 
 suite(':substitute args parser', () => {
   test('can parse pattern, replace, and flags', () => {
-    const args = commandParsers.s('/a/b/g');
+    const args = commandParsers.substitute.parser('/a/b/g');
     assert.equal(args.arguments.pattern, 'a');
     assert.equal(args.arguments.replace, 'b');
     assert.equal(args.arguments.flags, 8);
   });
 
   test('can parse count', () => {
-    const args = commandParsers.s('/a/b/g 3');
+    const args = commandParsers.substitute.parser('/a/b/g 3');
     assert.equal(args.arguments.count, 3);
   });
 
   test('can parse custom delimiter', () => {
-    const args = commandParsers.s('#a#b#g');
+    const args = commandParsers.substitute.parser('#a#b#g');
     assert.equal(args.arguments.pattern, 'a');
     assert.equal(args.arguments.replace, 'b');
     assert.equal(args.arguments.flags, 8);
   });
 
   test('can escape delimiter', () => {
-    const args = commandParsers.s('/\\/\\/a/b/');
+    const args = commandParsers.substitute.parser('/\\/\\/a/b/');
     assert.equal(args.arguments.pattern, '//a');
     assert.equal(args.arguments.replace, 'b');
   });
 
   test('can parse flag KeepPreviousFlags', () => {
-    const args = commandParsers.s('/a/b/&');
+    const args = commandParsers.substitute.parser('/a/b/&');
     assert.equal(args.arguments.flags, 1);
   });
 });

--- a/test/cmd_line/subparser.test.ts
+++ b/test/cmd_line/subparser.test.ts
@@ -1,71 +1,119 @@
 import * as assert from 'assert';
 
-import { commandParsers } from '../../src/cmd_line/subparser';
+import { commandParsers, getParser } from '../../src/cmd_line/subparser';
 
-suite(':write args parser', () => {
-  test('has all aliases', () => {
-    assert.equal(commandParsers.write.name, commandParsers.w.name);
+suite('getParser', () => {
+  test('empty', () => {
+    assert.equal(getParser(''), undefined);
   });
 
-  test('can parse empty args', () => {
-    // TODO: perhaps we don't need to export this func at all.
-    // TODO: this func must return args only, not a command?
-    // TODO: the range must be passed separately, not as arg.
-    const args = commandParsers.write('');
-    assert.equal(args.arguments.append, undefined);
-    assert.equal(args.arguments.bang, undefined);
-    assert.equal(args.arguments.cmd, undefined);
-    assert.equal(args.arguments.file, undefined);
-    assert.equal(args.arguments.opt, undefined);
-    assert.equal(args.arguments.optValue, undefined);
-    assert.equal(args.arguments.range, undefined);
+  test(':marks', () => {
+    assert.notEqual(getParser('marks'), undefined);
+    assert.equal(getParser('marksx'), undefined);
   });
 
-  test('can parse ++opt', () => {
-    const args = commandParsers.write('++enc=foo');
-    assert.equal(args.arguments.append, undefined);
-    assert.equal(args.arguments.bang, undefined);
-    assert.equal(args.arguments.cmd, undefined);
-    assert.equal(args.arguments.file, undefined);
-    assert.equal(args.arguments.opt, 'enc');
-    assert.equal(args.arguments.optValue, 'foo');
-    assert.equal(args.arguments.range, undefined);
+  test(':write', () => {
+    const w = getParser('w');
+    assert.notEqual(w, undefined);
+
+    assert.equal(getParser('wr'), w);
+    assert.equal(getParser('wri'), w);
+    assert.equal(getParser('writ'), w);
+    assert.equal(getParser('write'), w);
+
+    assert.equal(getParser('writex'), undefined);
   });
 
-  test('throws if bad ++opt name', () => {
-    assert.throws(() => commandParsers.write('++foo=foo'));
+  test(':nohlsearch', () => {
+    assert.equal(getParser('no'), undefined);
+
+    const noh = getParser('noh');
+    assert.notEqual(noh, undefined);
+
+    assert.equal(getParser('nohl'), noh);
+    assert.equal(getParser('nohls'), noh);
+    assert.equal(getParser('nohlse'), noh);
+    assert.equal(getParser('nohlsea'), noh);
+    assert.equal(getParser('nohlsear'), noh);
+    assert.equal(getParser('nohlsearc'), noh);
+    assert.equal(getParser('nohlsearch'), noh);
+
+    assert.equal(getParser('nohlsearchx'), undefined);
   });
 
-  test('can parse bang', () => {
-    const args = commandParsers.write('!');
-    assert.equal(args.arguments.append, undefined);
-    assert.equal(args.arguments.bang, true);
-    assert.equal(args.arguments.cmd, undefined);
-    assert.equal(args.arguments.file, undefined);
-    assert.equal(args.arguments.opt, undefined);
-    assert.equal(args.arguments.optValue, undefined);
-    assert.equal(args.arguments.range, undefined);
+  test(':quitall', () => {
+    const qa = getParser('qa');
+    assert.notEqual(qa, undefined);
+
+    assert.equal(getParser('qal'), qa);
+    assert.equal(getParser('qall'), qa);
+
+    assert.equal(getParser('quita'), qa);
+    assert.equal(getParser('quital'), qa);
+    assert.equal(getParser('quitall'), qa);
   });
 
-  test("can parse ' !cmd'", () => {
-    const args = commandParsers.write(' !foo');
-    assert.equal(args.arguments.append, undefined);
-    assert.equal(args.arguments.bang, undefined);
-    assert.equal(args.arguments.cmd, 'foo');
-    assert.equal(args.arguments.file, undefined);
-    assert.equal(args.arguments.opt, undefined);
-    assert.equal(args.arguments.optValue, undefined);
-    assert.equal(args.arguments.range, undefined);
-  });
+  suite(':write args parser', () => {
+    test('can parse empty args', () => {
+      // TODO: perhaps we don't need to export this func at all.
+      // TODO: this func must return args only, not a command?
+      // TODO: the range must be passed separately, not as arg.
+      const args = commandParsers.write.parser('');
+      assert.equal(args.arguments.append, undefined);
+      assert.equal(args.arguments.bang, undefined);
+      assert.equal(args.arguments.cmd, undefined);
+      assert.equal(args.arguments.file, undefined);
+      assert.equal(args.arguments.opt, undefined);
+      assert.equal(args.arguments.optValue, undefined);
+      assert.equal(args.arguments.range, undefined);
+    });
 
-  test("can parse ' !cmd' when cmd is empty", () => {
-    const args = commandParsers.write(' !');
-    assert.equal(args.arguments.append, undefined);
-    assert.equal(args.arguments.bang, undefined);
-    assert.equal(args.arguments.cmd, undefined);
-    assert.equal(args.arguments.file, undefined);
-    assert.equal(args.arguments.opt, undefined);
-    assert.equal(args.arguments.optValue, undefined);
-    assert.equal(args.arguments.range, undefined);
+    test('can parse ++opt', () => {
+      const args = commandParsers.write.parser('++enc=foo');
+      assert.equal(args.arguments.append, undefined);
+      assert.equal(args.arguments.bang, undefined);
+      assert.equal(args.arguments.cmd, undefined);
+      assert.equal(args.arguments.file, undefined);
+      assert.equal(args.arguments.opt, 'enc');
+      assert.equal(args.arguments.optValue, 'foo');
+      assert.equal(args.arguments.range, undefined);
+    });
+
+    test('throws if bad ++opt name', () => {
+      assert.throws(() => commandParsers.write.parser('++foo=foo'));
+    });
+
+    test('can parse bang', () => {
+      const args = commandParsers.write.parser('!');
+      assert.equal(args.arguments.append, undefined);
+      assert.equal(args.arguments.bang, true);
+      assert.equal(args.arguments.cmd, undefined);
+      assert.equal(args.arguments.file, undefined);
+      assert.equal(args.arguments.opt, undefined);
+      assert.equal(args.arguments.optValue, undefined);
+      assert.equal(args.arguments.range, undefined);
+    });
+
+    test("can parse ' !cmd'", () => {
+      const args = commandParsers.write.parser(' !foo');
+      assert.equal(args.arguments.append, undefined);
+      assert.equal(args.arguments.bang, undefined);
+      assert.equal(args.arguments.cmd, 'foo');
+      assert.equal(args.arguments.file, undefined);
+      assert.equal(args.arguments.opt, undefined);
+      assert.equal(args.arguments.optValue, undefined);
+      assert.equal(args.arguments.range, undefined);
+    });
+
+    test("can parse ' !cmd' when cmd is empty", () => {
+      const args = commandParsers.write.parser(' !');
+      assert.equal(args.arguments.append, undefined);
+      assert.equal(args.arguments.bang, undefined);
+      assert.equal(args.arguments.cmd, undefined);
+      assert.equal(args.arguments.file, undefined);
+      assert.equal(args.arguments.opt, undefined);
+      assert.equal(args.arguments.optValue, undefined);
+      assert.equal(args.arguments.range, undefined);
+    });
   });
 });


### PR DESCRIPTION
Vim commands are (in nearly all cases) triggered by all strings "between" the command's abbreviation and its full name.
For instance, `:q`, `:qu`, `:qui`, and `:quit` all resolve to the same command.
Only the full command list will autocomplete, however: `:q<tab>` yields `:quit`.
We now handle both these cases correctly by storing both the full name and the shortest abbreviation.