### PR TITLE
Refactor <C-u> and <C-d>

### DIFF
--- a/package.json
+++ b/package.json
@@ -464,9 +464,9 @@
         },
         "vim.scroll": {
           "type": "number",
-          "markdownDescription": "Number of lines to scroll with `Ctrl-U` and `Ctrl-D` commands.",
-          "default": 20,
-          "minimum": 1
+          "markdownDescription": "Number of lines to scroll with `Ctrl-U` and `Ctrl-D` commands. Set to 0 to use a half page scroll.",
+          "default": 0,
+          "minimum": 0
         },
         "vim.showcmd": {
           "type": "boolean",

--- a/src/configuration/configuration.ts
+++ b/src/configuration/configuration.ts
@@ -312,6 +312,13 @@ class Configuration implements IConfiguration {
   report = 2;
   wrapscan = true;
 
+  scroll = 0;
+  getScrollLines(visibleRanges: vscode.Range[]): number {
+    return this.scroll === 0
+      ? Math.ceil((visibleRanges[0].end.line - visibleRanges[0].start.line) / 2)
+      : this.scroll;
+  }
+
   cursorStylePerMode: IModeSpecificStrings<string> = {
     normal: undefined,
     insert: undefined,

--- a/src/configuration/iconfiguration.ts
+++ b/src/configuration/iconfiguration.ts
@@ -330,4 +330,9 @@ export interface IConfiguration {
    * Searches wrap around the end of the file.
    */
   wrapscan: boolean;
+
+  /**
+   * Number of lines to scroll with CTRL-U and CTRL-D commands. Set to 0 to use a half page scroll.
+   */
+  scroll: number;
 }

--- a/test/testConfiguration.ts
+++ b/test/testConfiguration.ts
@@ -107,4 +107,5 @@ export class Configuration implements IConfiguration {
   report = 2;
   digraphs: {};
   wrapscan = true;
+  scroll = 20;
 }


### PR DESCRIPTION
Our implementation of `<C-u>` and `<C-d>` has never quite been right - currently, `<C-d>` gets stuck and `<C-u>` jumps to the top as soon as it's visible. We also stopped paying any attention to the `vim.scroll` option at some point.

This commit fixes all of the above and simplifies the logic.