### PR TITLE
WIP: Add support for <C-a> and g<C-a> in visual modes

### DIFF
--- a/src/common/number/numericString.ts
+++ b/src/common/number/numericString.ts
@@ -11,33 +11,33 @@ export class NumericString {
     { regex: /\d/, base: 10, prefix: '' },
   ];
 
+  // Regex to determine if this number has letters around it,
+  // if it doesn't then that is easy and no prefix or suffix is needed
+  private static findNondigits = /[^\d-+]+/g;
+
+  // Regex to find any leading characters before the number
+  private static findPrefix = /^[^\d-+]+(?=[0-9]+)/g;
+
+  // Regex to find any trailing characters after the number
+  private static findSuffix = /[^\d]*[\d]*(.*)/g;
+
   static parse(input: string): NumericString | null {
     for (const { regex, base, prefix } of NumericString.matchings) {
-      const match = regex.exec(input);
-      if (match == null) {
+      if (!regex.test(input)) {
         continue;
       }
 
-      // Regex to determine if this number has letters around it,
-      // if it doesn't then that is easy and no prefix or suffix is needed
-      let findNondigits = /[^\d-+]+/g;
-
-      // Regex to find any leading characters before the number
-      let findPrefix = /^[^\d-+]+(?=[0-9]+)/g;
-
-      // Regex to find any trailing characters after the number
-      let findSuffix = /[^\d]*[\d]*(.*)/g;
       let newPrefix = prefix;
       let newSuffix = '';
       let newNum = input;
 
       // Only use this section if this is a number surrounded by letters
       if (
-        findNondigits.exec(input) !== null &&
+        NumericString.findNondigits.test(input) &&
         NumericString.matchings[NumericString.matchings.length - 1].regex === regex
       ) {
-        let prefixFound = findPrefix.exec(input);
-        let suffixFound = findSuffix.exec(input);
+        const prefixFound = NumericString.findPrefix.exec(input);
+        const suffixFound = NumericString.findSuffix.exec(input);
 
         // Find the prefix if it exists
         if (prefixFound !== null) {

--- a/test/mode/modeNormal.test.ts
+++ b/test/mode/modeNormal.test.ts
@@ -1725,6 +1725,48 @@ suite('Mode Normal', () => {
   });
 
   newTest({
+    title: 'can <C-a> in visual mode',
+    start: ['9 |9 9', '9 9 9', '9 9 9'],
+    keysPressed: 'vjj3<C-a>',
+    end: ['9 1|2 9', '12 9 9', '12 9 9'],
+  });
+
+  newTest({
+    title: 'can <C-a> in visual-line mode',
+    start: ['9 |9 9', '9 9 9', '9 9 9'],
+    keysPressed: 'Vjj3<C-a>',
+    end: ['1|2 9 9', '12 9 9', '12 9 9'],
+  });
+
+  newTest({
+    title: 'can <C-a> in visual-block mode',
+    start: ['9 |9 9', '9 9 9', '9 9 9'],
+    keysPressed: '<C-v>jj3<C-a>',
+    end: ['9 1|2 9', '9 12 9', '9 12 9'],
+  });
+
+  newTest({
+    title: 'can g<C-a> in visual mode',
+    start: ['9 |9 9', '9 9 9', '9 9 9'],
+    keysPressed: 'vjjg3<C-a>',
+    end: ['9 1|2 9', '15 9 9', '18 9 9'],
+  });
+
+  newTest({
+    title: 'can g<C-a> in visual-line mode',
+    start: ['9 |9 9', '9 9 9', '9 9 9'],
+    keysPressed: 'Vjjg3<C-a>',
+    end: ['1|2 9 9', '15 9 9', '18 9 9'],
+  });
+
+  newTest({
+    title: 'can g<C-a> in visual-block mode',
+    start: ['9 |9 9', '9 9 9', '9 9 9'],
+    keysPressed: '<C-v>jjg3<C-a>',
+    end: ['9 1|2 9', '9 15 9', '9 18 9'],
+  });
+
+  newTest({
     title: 'can do Y',
     start: ['|blah blah'],
     keysPressed: 'Yp',


### PR DESCRIPTION
This is WIP. Still to-do:

- When a 9 rolls over and it goes from i digits to i+1 digits, we need to put the cursor 1 space to the left
- Visual-block mode 1 column wide should only affect that column
- Sometimes text afterward is deleted

Fixes #4112, fixes #3226