### PR TITLE
Update CONTRIBUTING.md after webpack bundling addition

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -46,7 +46,8 @@ When submitting a PR, please fill out the template that is presented by GitHub w
     # Or run tests by selecting the appropriate drop down option
 
     # Alternatively, build and run tests through gulp and npm scripts
-    gulp build                  # build
+    gulp build                  # build extension
+    gulp prepare-test           # build sources and tests
     npm test                    # test (must close all instances of VSCode)
 
     # Only available if Docker is installed and running


### PR DESCRIPTION
With the addition of Webpack bundling (issue #3127, commit 1f80b2d)
the instructions for how to run tests were no longer working.