### PR TITLE
Return cursor to start position when immediately exiting visual line mode

### DIFF
--- a/src/mode/modeHandler.ts
+++ b/src/mode/modeHandler.ts
@@ -613,7 +613,7 @@ export class ModeHandler implements vscode.Disposable {
         !vimState.visualLineStartPosIsDefault() && returnCursorFromVLMode(recentKeyHistory);
       /**
        * If the user entered visual line mode and immediately exited it then we
-       * want to return the cursor position to its original position instead at
+       * want to return the cursor position to its original position instead of
        * the end of the selection
        */
       if (returnCursorPos) {

--- a/src/mode/modeHandler.ts
+++ b/src/mode/modeHandler.ts
@@ -608,7 +608,12 @@ export class ModeHandler implements vscode.Disposable {
     vimState.currentRegisterMode = RegisterMode.AscertainFromCurrentMode;
 
     if (this.currentMode.name === ModeName.Normal) {
-      vimState.cursorStartPosition = vimState.cursorStopPosition;
+      if (vimState.visualLineStartPosIsDefault()) {
+        vimState.cursorStartPosition = vimState.cursorStopPosition;
+      } else {
+        vimState.cursorStopPosition = vimState.visualLineStartPos;
+        vimState.visualLineStartPos = new Position(0, 0);
+      }
     }
 
     // Ensure cursor is within bounds
@@ -1217,6 +1222,11 @@ export class ModeHandler implements vscode.Disposable {
 
           selections = [new vscode.Selection(start, stop)];
         } else if (selectionMode === ModeName.VisualLine) {
+          if (vimState.visualLineStartPosIsDefault()) {
+            // Track initial start position, we will return to it when we exit visual line mode
+            vimState.visualLineStartPos = start;
+          }
+
           selections = [
             new vscode.Selection(
               Position.EarlierOf(start, stop).getLineBegin(),

--- a/src/mode/modeHandler.ts
+++ b/src/mode/modeHandler.ts
@@ -21,7 +21,7 @@ import { VsCodeContext } from '../util/vscode-context';
 import { commandLine } from '../cmd_line/commandLine';
 import { configuration } from '../configuration/configuration';
 import { decoration } from '../configuration/decoration';
-import { getCursorsAfterSync } from '../util/util';
+import { getCursorsAfterSync, returnCursorFromVLMode } from '../util/util';
 import {
   BaseCommand,
   CommandQuitRecordMacro,
@@ -608,9 +608,14 @@ export class ModeHandler implements vscode.Disposable {
     vimState.currentRegisterMode = RegisterMode.AscertainFromCurrentMode;
 
     if (this.currentMode.name === ModeName.Normal) {
-      const immediatlyExitedVLMode =
-        JSON.stringify(vimState.keyHistory.slice(-2)) === JSON.stringify(['V', '<Esc>']);
-      const returnCursorPos = !vimState.visualLineStartPosIsDefault() && immediatlyExitedVLMode;
+      const recentKeyHistory = vimState.keyHistory.slice(-2);
+      const returnCursorPos =
+        !vimState.visualLineStartPosIsDefault() && returnCursorFromVLMode(recentKeyHistory);
+      /**
+       * If the user entered visual line mode and immediately exited it then we
+       * want to return the cursor position to its original position instead at
+       * the end of the selection
+       */
       if (returnCursorPos) {
         vimState.cursorStartPosition = vimState.visualLineStartPos;
         vimState.cursorStopPosition = vimState.visualLineStartPos;

--- a/src/mode/modeHandler.ts
+++ b/src/mode/modeHandler.ts
@@ -608,11 +608,15 @@ export class ModeHandler implements vscode.Disposable {
     vimState.currentRegisterMode = RegisterMode.AscertainFromCurrentMode;
 
     if (this.currentMode.name === ModeName.Normal) {
-      if (vimState.visualLineStartPosIsDefault()) {
-        vimState.cursorStartPosition = vimState.cursorStopPosition;
-      } else {
+      const immediatlyExitedVLMode =
+        JSON.stringify(vimState.keyHistory.slice(-2)) === JSON.stringify(['V', '<Esc>']);
+      const returnCursorPos = !vimState.visualLineStartPosIsDefault() && immediatlyExitedVLMode;
+      if (returnCursorPos) {
+        vimState.cursorStartPosition = vimState.visualLineStartPos;
         vimState.cursorStopPosition = vimState.visualLineStartPos;
         vimState.visualLineStartPos = new Position(0, 0);
+      } else {
+        vimState.cursorStartPosition = vimState.cursorStopPosition;
       }
     }
 

--- a/src/state/vimState.ts
+++ b/src/state/vimState.ts
@@ -127,7 +127,7 @@ export class VimState implements vscode.Disposable {
   /**
    * Has the visualLineStartPos been modified
    */
-  public visualLineStartPosIsDefault(): Boolean {
+  public visualLineStartPosIsDefault(): boolean {
     return this.visualLineStartPos.line === 0 && this.visualLineStartPos.character === 0;
   }
 

--- a/src/state/vimState.ts
+++ b/src/state/vimState.ts
@@ -119,6 +119,19 @@ export class VimState implements vscode.Disposable {
   public keyHistory: string[] = [];
 
   /**
+   * Track cursor position when initially starting a visual line selection so we
+   * can return to it when exiting that mode
+   */
+  public visualLineStartPos: Position = new Position(0, 0);
+
+  /**
+   * Has the visualLineStartPos been modified
+   */
+  public visualLineStartPosIsDefault(): Boolean {
+    return this.visualLineStartPos.line === 0 && this.visualLineStartPos.character === 0;
+  }
+
+  /**
    * The cursor position (start, stop) when this action finishes.
    */
   public get cursorStartPosition(): Position {

--- a/src/util/util.ts
+++ b/src/util/util.ts
@@ -65,3 +65,18 @@ export function executeShell(cmd: string): Promise<string> {
     }
   });
 }
+
+/**
+ * Examine the keyHistory to see if the last two keypresses were to enter visual
+ * line selection mode (V) and then immediately exit it with <Esc>
+ */
+export function returnCursorFromVLMode(keyHistory: string[]): boolean {
+  const expectedKeys = ['V', '<Esc>'];
+  for (let idx = 0; idx < 2; idx++) {
+    if (keyHistory[idx] !== expectedKeys[idx]) {
+      return false;
+    }
+  }
+
+  return true;
+}

--- a/test/mode/modeNormal.test.ts
+++ b/test/mode/modeNormal.test.ts
@@ -1337,8 +1337,8 @@ suite('Mode Normal', () => {
     ],
     keysPressed: 'Vgq',
     end: [
-      '//    We choose to write a vim extension, not because it is easy, but because it is',
-      '|//    hard.',
+      '//    We choose to write a vim extension, not because it is easy, but because it i|s',
+      '//    hard.',
     ],
   });
 
@@ -1349,8 +1349,8 @@ suite('Mode Normal', () => {
     ],
     keysPressed: 'Vgq',
     end: [
-      '    // We choose to write a vim extension, not because it is easy, but because',
-      '|    // it is hard.',
+      '    // We choose to write a vim extension, not because it is easy, but becaus|e',
+      '    // it is hard.',
     ],
   });
 
@@ -1361,8 +1361,8 @@ suite('Mode Normal', () => {
     ],
     keysPressed: 'Vgq',
     end: [
-      '\t\t// We choose to write a vim extension, not because it is easy, but',
-      '|\t\t// because it is hard.',
+      '\t\t// We choose to write a vim extension, not because it is easy, bu|t',
+      '\t\t// because it is hard.',
     ],
   });
 

--- a/test/mode/modeNormal.test.ts
+++ b/test/mode/modeNormal.test.ts
@@ -1337,8 +1337,8 @@ suite('Mode Normal', () => {
     ],
     keysPressed: 'Vgq',
     end: [
-      '//    We choose to write a vim extension, not because it is easy, but because it i|s',
-      '//    hard.',
+      '//    We choose to write a vim extension, not because it is easy, but because it is',
+      '|//    hard.',
     ],
   });
 
@@ -1349,8 +1349,8 @@ suite('Mode Normal', () => {
     ],
     keysPressed: 'Vgq',
     end: [
-      '    // We choose to write a vim extension, not because it is easy, but becaus|e',
-      '    // it is hard.',
+      '    // We choose to write a vim extension, not because it is easy, but because',
+      '|    // it is hard.',
     ],
   });
 
@@ -1361,8 +1361,8 @@ suite('Mode Normal', () => {
     ],
     keysPressed: 'Vgq',
     end: [
-      '\t\t// We choose to write a vim extension, not because it is easy, bu|t',
-      '\t\t// because it is hard.',
+      '\t\t// We choose to write a vim extension, not because it is easy, but',
+      '|\t\t// because it is hard.',
     ],
   });
 

--- a/test/mode/modeVisualLine.test.ts
+++ b/test/mode/modeVisualLine.test.ts
@@ -471,4 +471,26 @@ suite('Mode Visual Line', () => {
       end: ['111', '222_|', ' ', '444_', '555'],
     });
   });
+
+  suite('Cursor behavior when immediately exiting', () => {
+    newTest({
+      title: 'Returns cursor to original position when immediately exiting visual line',
+      start: ['rocinante', 'nauvoo', '|anubis', 'canterbury'],
+      keysPressed: 'V<Esc>',
+      end: ['rocinante', 'nauvoo', '|anubis', 'canterbury'],
+    });
+
+    newTest({
+      title: 'Does not return cursor if a movement is made before exiting visual line',
+      start: [
+        'Don\'t cry because it\'s over|,',
+        ':smile because it happened.',
+      ],
+      keysPressed: 'Vj<Esc>',
+      end: [
+        'Don\'t cry because it\'s over,',
+        ':smile because it happened|.',
+      ],
+    });
+  });
 });


### PR DESCRIPTION

**What this PR does / why we need it**:
This PR allows the cursor to return to its original position when the user enters visual line selection mode and then immediately exits it with `<Esc>`. This replicates VIM's behavior when pressing `V<Esc>`.

**Which issue(s) this PR fixes**
[This issue](https://github.com/VSCodeVim/Vim/issues/3975)

<!--
Commits in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)
-->

**Special notes for your reviewer**:
I noticed when working on this issue that in VIM when you enter visual line mode with `V` and then you select more lines with `j` for example, the cursor moves to that same column/position on the line below but it looks like VSCodeVIM always jumps to the end of the next line. 

Not sure if that's intended, perhaps it should be filed as another issue.