### PR TITLE
Add support for za Vim binding

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -567,7 +567,7 @@ Pretty much everything fold-related is blocked by [this issue](https://github.co
 | :white_check_mark: | zO                       | Open all folds under the cursor recursively.                                                                 |
 | :white_check_mark: | zc                       | Close one fold under the cursor. When a count is given, that many folds deep are closed.                     |
 | :white_check_mark: | zC                       | Close all folds under the cursor recursively.                                                                |
-| :arrow_down:       | za                       | When on a closed fold: open it. When on an open fold: close it and set 'foldenable'.                         |
+| :white_check_mark: | za                       | When on a closed fold: open it. When on an open fold: close it and set 'foldenable'.                         |
 | :arrow_down:       | zA                       | When on a closed fold: open it recursively. When on an open fold: close it recursively and set 'foldenable'. |
 | :arrow_down:       | zv                       | View cursor line: Open just enough folds to make the line in which the cursor is located not folded.         |
 | :arrow_down:       | zx                       | Update folds: Undo manually opened and closed folds: re-apply 'foldlevel', then do "zv": View cursor line.   |

--- a/src/actions/commands/actions.ts
+++ b/src/actions/commands/actions.ts
@@ -2374,6 +2374,12 @@ abstract class CommandFold extends BaseCommand {
 class CommandToggleFold extends CommandFold {
   keys = ['z', 'a'];
   commandName = 'editor.toggleFold';
+  public async exec(position: Position, vimState: VimState): Promise<VimState> {
+    await vscode.commands.executeCommand(this.commandName);
+    vimState.cursors = await getCursorsAfterSync();
+    await vimState.setCurrentMode(ModeName.Normal);
+    return vimState;
+  }
 }
 
 @RegisterAction

--- a/src/actions/commands/actions.ts
+++ b/src/actions/commands/actions.ts
@@ -2371,6 +2371,12 @@ abstract class CommandFold extends BaseCommand {
 }
 
 @RegisterAction
+class CommandToggleFold extends CommandFold {
+  keys = ['z', 'a'];
+  commandName = 'editor.toggleFold';
+}
+
+@RegisterAction
 class CommandCloseFold extends CommandFold {
   keys = ['z', 'c'];
   commandName = 'editor.fold';


### PR DESCRIPTION
<!--
Yay! Thanks for sending us a PR! 🎊

Please ensure your PR adheres to:

- [ ] Commit messages has a short & issue references when necessary
- [ ] Each commit does a logical chunk of work.
- [ ] It builds and tests pass (e.g `gulp`)
-->

**What this PR does / why we need it**:
Adds support for the Vim 'za' keybinding, which toggles a fold.

**Which issue(s) this PR fixes**
#1453 

<!--
Commits in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)
-->

**Special notes for your reviewer**:
This simply binds the new VSCode editor.toggleFold option to the 'za' combination. I was unable to find a way to implement specifying a number modifier, as you need to know whether or not to travel up or down.