### PR TITLE
fix replace commands from visual and visual block mode not inserting tab

### DIFF
--- a/src/actions/commands/actions.ts
+++ b/src/actions/commands/actions.ts
@@ -3869,7 +3869,7 @@ class ActionReplaceCharacterVisual extends BaseCommand {
     let toInsert = this.keysPressed[1];
 
     if (toInsert === '<tab>') {
-      toInsert = TextEditor.getTabCharacter(vimState);
+      toInsert = TextEditor.getTabCharacter(vimState.editor);
     }
 
     let visualSelectionOffset = 1;
@@ -3952,7 +3952,7 @@ class ActionReplaceCharacterVisualBlock extends BaseCommand {
     let toInsert = this.keysPressed[1];
 
     if (toInsert === '<tab>') {
-      toInsert = TextEditor.getTabCharacter(vimState);
+      toInsert = TextEditor.getTabCharacter(vimState.editor);
     }
 
     for (const { start, end } of Position.IterateLine(vimState)) {

--- a/src/actions/commands/actions.ts
+++ b/src/actions/commands/actions.ts
@@ -3869,7 +3869,7 @@ class ActionReplaceCharacterVisual extends BaseCommand {
     let toInsert = this.keysPressed[1];
 
     if (toInsert === '<tab>') {
-      toInsert = TextEditor.getTabCharacter();
+      toInsert = TextEditor.getTabCharacter(vimState);
     }
 
     let visualSelectionOffset = 1;
@@ -3952,7 +3952,7 @@ class ActionReplaceCharacterVisualBlock extends BaseCommand {
     let toInsert = this.keysPressed[1];
 
     if (toInsert === '<tab>') {
-      toInsert = TextEditor.getTabCharacter();
+      toInsert = TextEditor.getTabCharacter(vimState);
     }
 
     for (const { start, end } of Position.IterateLine(vimState)) {

--- a/src/actions/commands/actions.ts
+++ b/src/actions/commands/actions.ts
@@ -3866,7 +3866,11 @@ class ActionReplaceCharacterVisual extends BaseCommand {
   canBeRepeatedWithDot = true;
 
   public async exec(position: Position, vimState: VimState): Promise<VimState> {
-    const toInsert = this.keysPressed[1];
+    let toInsert = this.keysPressed[1];
+
+    if (toInsert === '<tab>') {
+      toInsert = TextEditor.getTabCharacter();
+    }
 
     let visualSelectionOffset = 1;
     let start = vimState.cursorStartPosition;
@@ -3945,7 +3949,12 @@ class ActionReplaceCharacterVisualBlock extends BaseCommand {
   canBeRepeatedWithDot = true;
 
   public async exec(position: Position, vimState: VimState): Promise<VimState> {
-    const toInsert = this.keysPressed[1];
+    let toInsert = this.keysPressed[1];
+
+    if (toInsert === '<tab>') {
+      toInsert = TextEditor.getTabCharacter();
+    }
+
     for (const { start, end } of Position.IterateLine(vimState)) {
       if (end.isBeforeOrEqual(start)) {
         continue;

--- a/src/textEditor.ts
+++ b/src/textEditor.ts
@@ -160,6 +160,14 @@ export class TextEditor {
     return word;
   }
 
+  static getTabCharacter(): string {
+    const { tabstop, expandtab } = configuration;
+    if (expandtab) {
+      return ' '.repeat(tabstop);
+    }
+    return '\t';
+  }
+
   static isFirstLine(position: vscode.Position): boolean {
     return position.line === 0;
   }

--- a/src/textEditor.ts
+++ b/src/textEditor.ts
@@ -2,6 +2,7 @@ import * as vscode from 'vscode';
 
 import { Position } from './common/motion/position';
 import { configuration } from './configuration/configuration';
+import { VimState } from './state/vimState';
 
 /**
  * Collection of helper functions around vscode.window.activeTextEditor
@@ -160,10 +161,11 @@ export class TextEditor {
     return word;
   }
 
-  static getTabCharacter(): string {
-    const { tabstop, expandtab } = configuration;
-    if (expandtab) {
-      return ' '.repeat(tabstop);
+  static getTabCharacter(vimState: VimState): string {
+    if (vimState.editor.options.insertSpaces) {
+      // This will always be a number when we're getting it from the options
+      const tabSize = vimState.editor.options.tabSize as number;
+      return ' '.repeat(tabSize);
     }
     return '\t';
   }

--- a/src/textEditor.ts
+++ b/src/textEditor.ts
@@ -161,10 +161,10 @@ export class TextEditor {
     return word;
   }
 
-  static getTabCharacter(vimState: VimState): string {
-    if (vimState.editor.options.insertSpaces) {
+  static getTabCharacter(editor: vscode.TextEditor): string {
+    if (editor.options.insertSpaces) {
       // This will always be a number when we're getting it from the options
-      const tabSize = vimState.editor.options.tabSize as number;
+      const tabSize = editor.options.tabSize as number;
       return ' '.repeat(tabSize);
     }
     return '\t';


### PR DESCRIPTION
<!--
Yay! Thanks for sending us a PR! 🎊

Please ensure your PR adheres to:

- [ ] Commit messages has a short & issue references when necessary
- [ ] Each commit does a logical chunk of work.
- [ ] It builds and tests pass (e.g `gulp`)
-->

**What this PR does / why we need it**:
Currently, when replacing characters using replace command from Visual and Visual block mode. Pressing tab replaces characters with `<tab>` instead of the tab character. This PR fixes the issue so that every character in the selection is replaced by the tab character (affected by `tabstop` and `expandtab` configuration).

**Which issue(s) this PR fixes**
#2499 
<!--
Commits in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)
-->

**Special notes for your reviewer**:
This is my first time contributing to an open source project. Please be kind 😄 .
