### PR TITLE
Replace `assert.equal` with `assert.strictEqual`

### DIFF
--- a/test/actions/baseAction.test.ts
+++ b/test/actions/baseAction.test.ts
@@ -48,7 +48,7 @@ suite('base action', () => {
         const expected = testCases[test][2];
 
         const actual = BaseAction.CompareKeypressSequence(left, right);
-        assert.equal(actual, expected, `${left}. ${right}.`);
+        assert.strictEqual(actual, expected, `${left}. ${right}.`);
       }
     }
   });

--- a/test/cmd_line/command.test.ts
+++ b/test/cmd_line/command.test.ts
@@ -17,19 +17,19 @@ suite('cmd_line/search command', () => {
   test('command <C-w> can remove word in cmd line', async () => {
     await modeHandler.handleMultipleKeyEvents([':', 'a', 'b', 'c', '-', '1', '2', '3', '<C-w>']);
     let statusBar = StatusBar.Get().trim();
-    assert.equal(statusBar, ':abc-|', 'Failed to remove word');
+    assert.strictEqual(statusBar, ':abc-|', 'Failed to remove word');
 
     await modeHandler.handleKeyEvent('<C-w>');
     statusBar = StatusBar.Get().trim();
-    assert.equal(statusBar, ':abc|', 'Failed to remove word');
+    assert.strictEqual(statusBar, ':abc|', 'Failed to remove word');
 
     await modeHandler.handleKeyEvent('<C-w>');
     statusBar = StatusBar.Get().trim();
-    assert.equal(statusBar, ':|', 'Failed to remove word');
+    assert.strictEqual(statusBar, ':|', 'Failed to remove word');
 
     await modeHandler.handleKeyEvent('<C-w>');
     statusBar = StatusBar.Get().trim();
-    assert.equal(statusBar, ':|', 'Failed to remove word');
+    assert.strictEqual(statusBar, ':|', 'Failed to remove word');
 
     await modeHandler.handleKeyEvent('<Esc>');
   });
@@ -37,19 +37,19 @@ suite('cmd_line/search command', () => {
   test('command <C-w> can remove word in search mode', async () => {
     await modeHandler.handleMultipleKeyEvents(['/', 'a', 'b', 'c', '-', '1', '2', '3', '<C-w>']);
     let statusBar = StatusBar.Get().trim();
-    assert.equal(statusBar, '/abc-|', 'Failed to remove word');
+    assert.strictEqual(statusBar, '/abc-|', 'Failed to remove word');
 
     await modeHandler.handleKeyEvent('<C-w>');
     statusBar = StatusBar.Get().trim();
-    assert.equal(statusBar, '/abc|', 'Failed to remove word');
+    assert.strictEqual(statusBar, '/abc|', 'Failed to remove word');
 
     await modeHandler.handleKeyEvent('<C-w>');
     statusBar = StatusBar.Get().trim();
-    assert.equal(statusBar, '/|', 'Failed to remove word');
+    assert.strictEqual(statusBar, '/|', 'Failed to remove word');
 
     await modeHandler.handleKeyEvent('<C-w>');
     statusBar = StatusBar.Get().trim();
-    assert.equal(statusBar, '/|', 'Failed to remove word');
+    assert.strictEqual(statusBar, '/|', 'Failed to remove word');
 
     await modeHandler.handleKeyEvent('<Esc>');
   });
@@ -70,7 +70,7 @@ suite('cmd_line/search command', () => {
       '<C-w>',
     ]);
     const statusBar = StatusBar.Get().trim();
-    assert.equal(statusBar, ':|123', 'Failed to retain the text on the right of the cursor');
+    assert.strictEqual(statusBar, ':|123', 'Failed to retain the text on the right of the cursor');
     await modeHandler.handleKeyEvent('<Esc>');
   });
 
@@ -90,7 +90,7 @@ suite('cmd_line/search command', () => {
       '<C-w>',
     ]);
     const statusBar = StatusBar.Get().trim();
-    assert.equal(statusBar, '/|123', 'Failed to retain the text on the right of the cursor');
+    assert.strictEqual(statusBar, '/|123', 'Failed to retain the text on the right of the cursor');
     await modeHandler.handleKeyEvent('<Esc>');
   });
 
@@ -98,7 +98,7 @@ suite('cmd_line/search command', () => {
     await modeHandler.handleMultipleKeyEvents(':s/abc/xyz'.split(''));
     await modeHandler.handleMultipleKeyEvents(['<left>', '<left>', '<C-u>']);
     const statusBar = StatusBar.Get().trim();
-    assert.equal(statusBar, ':|yz');
+    assert.strictEqual(statusBar, ':|yz');
     await modeHandler.handleKeyEvent('<Esc>');
   });
 
@@ -106,7 +106,7 @@ suite('cmd_line/search command', () => {
     await modeHandler.handleMultipleKeyEvents(':s/abc/xyz'.split(''));
     await modeHandler.handleKeyEvent('<C-b>');
     const statusBar = StatusBar.Get().trim();
-    assert.equal(statusBar, ':|s/abc/xyz');
+    assert.strictEqual(statusBar, ':|s/abc/xyz');
     await modeHandler.handleKeyEvent('<Esc>');
   });
 
@@ -114,7 +114,7 @@ suite('cmd_line/search command', () => {
     await modeHandler.handleMultipleKeyEvents(':s/abc/xyz'.split(''));
     await modeHandler.handleKeyEvent('<Home>');
     const statusBar = StatusBar.Get().trim();
-    assert.equal(statusBar, ':|s/abc/xyz');
+    assert.strictEqual(statusBar, ':|s/abc/xyz');
     await modeHandler.handleKeyEvent('<Esc>');
   });
 
@@ -122,7 +122,7 @@ suite('cmd_line/search command', () => {
     await modeHandler.handleMultipleKeyEvents(':s/abc/xyz'.split(''));
     await modeHandler.handleMultipleKeyEvents(['<C-b>', '<C-e>']);
     const statusBar = StatusBar.Get().trim();
-    assert.equal(statusBar, ':s/abc/xyz|');
+    assert.strictEqual(statusBar, ':s/abc/xyz|');
     await modeHandler.handleKeyEvent('<Esc>');
   });
 
@@ -130,7 +130,7 @@ suite('cmd_line/search command', () => {
     await modeHandler.handleMultipleKeyEvents(':s/abc/xyz'.split(''));
     await modeHandler.handleMultipleKeyEvents(['<Home>', '<End>']);
     const statusBar = StatusBar.Get().trim();
-    assert.equal(statusBar, ':s/abc/xyz|');
+    assert.strictEqual(statusBar, ':s/abc/xyz|');
     await modeHandler.handleKeyEvent('<Esc>');
   });
 
@@ -142,17 +142,17 @@ suite('cmd_line/search command', () => {
     await modeHandler.handleMultipleKeyEvents([':', 'w', '<C-p>']);
 
     // Going backward - :s/x/y, then :s/a/b
-    assert.equal(StatusBar.Get().trim(), ':s/x/y|');
+    assert.strictEqual(StatusBar.Get().trim(), ':s/x/y|');
     await modeHandler.handleKeyEvent('<C-p>');
-    assert.equal(StatusBar.Get().trim(), ':s/a/b|');
+    assert.strictEqual(StatusBar.Get().trim(), ':s/a/b|');
 
     // Going forward again - :s/x/y, then :w (the one we started typing)
     await modeHandler.handleKeyEvent('<C-n>');
-    assert.equal(StatusBar.Get().trim(), ':s/x/y|');
+    assert.strictEqual(StatusBar.Get().trim(), ':s/x/y|');
     await modeHandler.handleKeyEvent('<C-n>');
 
     // TODO: Really, this should be `:w|`. See #4093.
-    assert.equal(StatusBar.Get().trim(), ':|');
+    assert.strictEqual(StatusBar.Get().trim(), ':|');
     await modeHandler.handleKeyEvent('<Esc>');
   });
 });

--- a/test/cmd_line/cursorLocation.test.ts
+++ b/test/cmd_line/cursorLocation.test.ts
@@ -34,7 +34,11 @@ suite('cursor location', () => {
     await modeHandler.handleKeyEvent('<Esc>');
 
     const statusBarAfterEsc = StatusBar.Get();
-    assert.equal(statusBarAfterCursorMovement.trim(), ':tes|t', 'Command Tab Completion Failed');
+    assert.strictEqual(
+      statusBarAfterCursorMovement.trim(),
+      ':tes|t',
+      'Command Tab Completion Failed'
+    );
   });
 
   test('cursor location in search', async () => {
@@ -54,6 +58,10 @@ suite('cursor location', () => {
 
     await modeHandler.handleKeyEvent('<Esc>');
     const statusBarAfterEsc = StatusBar.Get();
-    assert.equal(statusBarAfterCursorMovement.trim(), '/tes|t', 'Command Tab Completion Failed');
+    assert.strictEqual(
+      statusBarAfterCursorMovement.trim(),
+      '/tes|t',
+      'Command Tab Completion Failed'
+    );
   });
 });

--- a/test/cmd_line/historyFile.test.ts
+++ b/test/cmd_line/historyFile.test.ts
@@ -76,19 +76,19 @@ suite('HistoryFile', () => {
 
   test('file system', async () => {
     // history file is lazily created, should not exist
-    assert.equal(fs.existsSync(history.historyFilePath), false);
+    assert.strictEqual(fs.existsSync(history.historyFilePath), false);
 
     for (const cmd of run_cmds) {
       await history.add(cmd);
     }
 
     // history file should exist after an `add` operation
-    assert.equal(fs.existsSync(history.historyFilePath), true);
+    assert.strictEqual(fs.existsSync(history.historyFilePath), true);
 
     history.clear();
 
     // expect history file to be deleted from file system and empty
-    assert.equal(fs.existsSync(history.historyFilePath), false);
+    assert.strictEqual(fs.existsSync(history.historyFilePath), false);
   });
 
   test('change configuration.history', async () => {
@@ -96,7 +96,7 @@ suite('HistoryFile', () => {
       await history.add(cmd);
     }
 
-    assert.equal(history.get().length, configuration.history);
+    assert.strictEqual(history.get().length, configuration.history);
 
     configuration.history = 10;
     for (const cmd of run_cmds) {

--- a/test/cmd_line/lexer.test.ts
+++ b/test/cmd_line/lexer.test.ts
@@ -6,96 +6,99 @@ import { Token, TokenType } from '../../src/cmd_line/token';
 suite('command-line lexer', () => {
   test('can lex empty string', () => {
     const tokens = lexer.lex('');
-    assert.equal(tokens.length, 0);
+    assert.strictEqual(tokens.length, 0);
   });
 
   test('can lex comma', () => {
     const tokens = lexer.lex(',');
-    assert.equal(tokens[0].content, new Token(TokenType.Comma, ',').content);
+    assert.strictEqual(tokens[0].content, new Token(TokenType.Comma, ',').content);
   });
 
   test('can lex percent', () => {
     const tokens = lexer.lex('%');
-    assert.equal(tokens[0].content, new Token(TokenType.Percent, '%').content);
+    assert.strictEqual(tokens[0].content, new Token(TokenType.Percent, '%').content);
   });
 
   test('can lex dollar', () => {
     const tokens = lexer.lex('$');
-    assert.equal(tokens[0].content, new Token(TokenType.Dollar, '$').content);
+    assert.strictEqual(tokens[0].content, new Token(TokenType.Dollar, '$').content);
   });
 
   test('can lex dot', () => {
     const tokens = lexer.lex('.');
-    assert.equal(tokens[0].content, new Token(TokenType.Dot, '.').content);
+    assert.strictEqual(tokens[0].content, new Token(TokenType.Dot, '.').content);
   });
 
   test('can lex one number', () => {
     const tokens = lexer.lex('1');
-    assert.equal(tokens[0].content, new Token(TokenType.LineNumber, '1').content);
+    assert.strictEqual(tokens[0].content, new Token(TokenType.LineNumber, '1').content);
   });
 
   test('can lex longer number', () => {
     const tokens = lexer.lex('100');
-    assert.equal(tokens[0].content, new Token(TokenType.LineNumber, '100').content);
+    assert.strictEqual(tokens[0].content, new Token(TokenType.LineNumber, '100').content);
   });
 
   test('can lex plus', () => {
     const tokens = lexer.lex('+');
-    assert.equal(tokens[0].content, new Token(TokenType.Plus, '+').content);
+    assert.strictEqual(tokens[0].content, new Token(TokenType.Plus, '+').content);
   });
 
   test('can lex minus', () => {
     const tokens = lexer.lex('-');
-    assert.equal(tokens[0].content, new Token(TokenType.Minus, '-').content);
+    assert.strictEqual(tokens[0].content, new Token(TokenType.Minus, '-').content);
   });
 
   test('can lex forward search', () => {
     const tokens = lexer.lex('/horses/');
-    assert.equal(tokens[0].content, new Token(TokenType.ForwardSearch, 'horses').content);
+    assert.strictEqual(tokens[0].content, new Token(TokenType.ForwardSearch, 'horses').content);
   });
 
   test('can lex forward search escaping', () => {
     const tokens = lexer.lex('/hor\\/ses/');
-    assert.equal(tokens[0].content, new Token(TokenType.ForwardSearch, 'hor/ses').content);
+    assert.strictEqual(tokens[0].content, new Token(TokenType.ForwardSearch, 'hor/ses').content);
   });
 
   test('can lex reverse search', () => {
     const tokens = lexer.lex('?worms?');
-    assert.equal(tokens[0].content, new Token(TokenType.ReverseSearch, 'worms').content);
+    assert.strictEqual(tokens[0].content, new Token(TokenType.ReverseSearch, 'worms').content);
   });
 
   test('can lex reverse search escaping', () => {
     const tokens = lexer.lex('?wor\\?ms?');
-    assert.equal(tokens[0].content, new Token(TokenType.ReverseSearch, 'wor?ms').content);
+    assert.strictEqual(tokens[0].content, new Token(TokenType.ReverseSearch, 'wor?ms').content);
   });
 
   test('can lex command name', () => {
     const tokens = lexer.lex('w');
-    assert.equal(tokens[0].content, new Token(TokenType.CommandName, 'w').content);
+    assert.strictEqual(tokens[0].content, new Token(TokenType.CommandName, 'w').content);
   });
 
   test('can lex command args', () => {
     const tokens = lexer.lex('w something');
-    assert.equal(tokens[0].content, new Token(TokenType.CommandName, 'w').content);
-    assert.equal(tokens[1].content, new Token(TokenType.CommandArgs, ' something').content);
+    assert.strictEqual(tokens[0].content, new Token(TokenType.CommandName, 'w').content);
+    assert.strictEqual(tokens[1].content, new Token(TokenType.CommandArgs, ' something').content);
   });
 
   test('can lex command args with leading whitespace', () => {
     const tokens = lexer.lex('q something');
-    assert.equal(tokens[0].content, new Token(TokenType.CommandName, 'q').content);
-    assert.equal(tokens[1].content, new Token(TokenType.CommandArgs, ' something').content);
+    assert.strictEqual(tokens[0].content, new Token(TokenType.CommandName, 'q').content);
+    assert.strictEqual(tokens[1].content, new Token(TokenType.CommandArgs, ' something').content);
   });
 
   test('can lex long command name and args', () => {
     const tokens = lexer.lex('write12 something here');
-    assert.equal(tokens[0].content, new Token(TokenType.CommandName, 'write').content);
-    assert.equal(tokens[1].content, new Token(TokenType.CommandArgs, '12 something here').content);
+    assert.strictEqual(tokens[0].content, new Token(TokenType.CommandName, 'write').content);
+    assert.strictEqual(
+      tokens[1].content,
+      new Token(TokenType.CommandArgs, '12 something here').content
+    );
   });
 
   test('can lex left and right line refs', () => {
     const tokens = lexer.lex('20,30');
-    assert.equal(tokens[0].content, new Token(TokenType.LineNumber, '20').content);
-    assert.equal(tokens[1].content, new Token(TokenType.LineNumber, ',').content);
-    assert.equal(tokens[2].content, new Token(TokenType.LineNumber, '30').content);
+    assert.strictEqual(tokens[0].content, new Token(TokenType.LineNumber, '20').content);
+    assert.strictEqual(tokens[1].content, new Token(TokenType.LineNumber, ',').content);
+    assert.strictEqual(tokens[2].content, new Token(TokenType.LineNumber, '30').content);
   });
 });

--- a/test/cmd_line/parser.test.ts
+++ b/test/cmd_line/parser.test.ts
@@ -12,28 +12,28 @@ suite('command-line parser', () => {
 
   test('can parse left - dot', () => {
     const cmd: node.CommandLine = parser.parse('.');
-    assert.equal(cmd.range.left[0].type, token.TokenType.Dot);
+    assert.strictEqual(cmd.range.left[0].type, token.TokenType.Dot);
   });
 
   test('can parse left - dollar', () => {
     const cmd: node.CommandLine = parser.parse('$');
-    assert.equal(cmd.range.left[0].type, token.TokenType.Dollar);
+    assert.strictEqual(cmd.range.left[0].type, token.TokenType.Dollar);
   });
 
   test('can parse left - percent', () => {
     const cmd: node.CommandLine = parser.parse('%');
-    assert.equal(cmd.range.left[0].type, token.TokenType.Percent);
+    assert.strictEqual(cmd.range.left[0].type, token.TokenType.Percent);
   });
 
   test('can parse separator - comma', () => {
     const cmd: node.CommandLine = parser.parse(',');
-    assert.equal(cmd.range.separator.type, token.TokenType.Comma);
+    assert.strictEqual(cmd.range.separator.type, token.TokenType.Comma);
   });
 
   test('can parse right - dollar', () => {
     const cmd: node.CommandLine = parser.parse(',$');
-    assert.equal(cmd.range.left.length, 0);
-    assert.equal(cmd.range.right.length, 1);
-    assert.equal(cmd.range.right[0].type, token.TokenType.Dollar, 'unexpected token');
+    assert.strictEqual(cmd.range.left.length, 0);
+    assert.strictEqual(cmd.range.right.length, 1);
+    assert.strictEqual(cmd.range.right[0].type, token.TokenType.Dollar, 'unexpected token');
   });
 });

--- a/test/cmd_line/scanner.test.ts
+++ b/test/cmd_line/scanner.test.ts
@@ -5,7 +5,7 @@ import { Scanner } from '../../src/cmd_line/scanner';
 suite('command line scanner', () => {
   test('ctor', () => {
     const state = new Scanner('dog');
-    assert.equal(state.input, 'dog');
+    assert.strictEqual(state.input, 'dog');
   });
 
   test('can detect EOF with empty input', () => {
@@ -15,17 +15,17 @@ suite('command line scanner', () => {
 
   test('next() returns EOF at EOF', () => {
     const state = new Scanner('');
-    assert.equal(state.next(), Scanner.EOF);
-    assert.equal(state.next(), Scanner.EOF);
-    assert.equal(state.next(), Scanner.EOF);
+    assert.strictEqual(state.next(), Scanner.EOF);
+    assert.strictEqual(state.next(), Scanner.EOF);
+    assert.strictEqual(state.next(), Scanner.EOF);
   });
 
   test('can scan', () => {
     const state = new Scanner('dog');
-    assert.equal(state.next(), 'd');
-    assert.equal(state.next(), 'o');
-    assert.equal(state.next(), 'g');
-    assert.equal(state.next(), Scanner.EOF);
+    assert.strictEqual(state.next(), 'd');
+    assert.strictEqual(state.next(), 'o');
+    assert.strictEqual(state.next(), 'g');
+    assert.strictEqual(state.next(), Scanner.EOF);
   });
 
   test('can emit', () => {
@@ -33,12 +33,12 @@ suite('command line scanner', () => {
     state.next();
     state.next();
     state.next();
-    assert.equal(state.emit(), 'dog');
+    assert.strictEqual(state.emit(), 'dog');
     state.next();
     state.next();
     state.next();
     state.next();
-    assert.equal(state.emit(), ' cat');
+    assert.strictEqual(state.emit(), ' cat');
   });
 
   test('can ignore', () => {
@@ -51,7 +51,7 @@ suite('command line scanner', () => {
     state.next();
     state.next();
     state.next();
-    assert.equal(state.emit(), 'cat');
+    assert.strictEqual(state.emit(), 'cat');
   });
 
   test('can skip whitespace', () => {
@@ -61,7 +61,7 @@ suite('command line scanner', () => {
     state.next();
     state.ignore();
     state.skipWhiteSpace();
-    assert.equal(state.next(), 'c');
+    assert.strictEqual(state.next(), 'c');
   });
 
   test('can skip whitespace with one char before EOF', () => {
@@ -71,7 +71,7 @@ suite('command line scanner', () => {
     state.next();
     state.ignore();
     state.skipWhiteSpace();
-    assert.equal(state.next(), 'c');
+    assert.strictEqual(state.next(), 'c');
   });
 
   test('can skip whitespace at EOF', () => {
@@ -81,30 +81,30 @@ suite('command line scanner', () => {
     state.next();
     state.ignore();
     state.skipWhiteSpace();
-    assert.equal(state.next(), Scanner.EOF);
+    assert.strictEqual(state.next(), Scanner.EOF);
   });
 
   test('nextWord() return EOF at EOF', () => {
     const state = new Scanner('');
-    assert.equal(state.nextWord(), Scanner.EOF);
-    assert.equal(state.nextWord(), Scanner.EOF);
-    assert.equal(state.nextWord(), Scanner.EOF);
+    assert.strictEqual(state.nextWord(), Scanner.EOF);
+    assert.strictEqual(state.nextWord(), Scanner.EOF);
+    assert.strictEqual(state.nextWord(), Scanner.EOF);
   });
 
   test('nextWord() return word before trailing spaces', () => {
     const state = new Scanner('dog   cat');
-    assert.equal(state.nextWord(), 'dog');
+    assert.strictEqual(state.nextWord(), 'dog');
   });
 
   test('nextWord() can skip whitespaces and return word ', () => {
     const state = new Scanner('   dog   cat');
-    assert.equal(state.nextWord(), 'dog');
+    assert.strictEqual(state.nextWord(), 'dog');
   });
 
   test('nextWord() return word before EOF', () => {
     const state = new Scanner('dog   cat');
     state.nextWord();
-    assert.equal(state.nextWord(), 'cat');
+    assert.strictEqual(state.nextWord(), 'cat');
   });
 
   test('can expect one of a set', () => {

--- a/test/cmd_line/subparser.close.test.ts
+++ b/test/cmd_line/subparser.close.test.ts
@@ -5,20 +5,20 @@ import { commandParsers } from '../../src/cmd_line/subparser';
 suite(':close args parser', () => {
   test('can parse empty args', () => {
     const args = commandParsers.close.parser('');
-    assert.equal(args.arguments.bang, undefined);
-    assert.equal(args.arguments.range, undefined);
+    assert.strictEqual(args.arguments.bang, undefined);
+    assert.strictEqual(args.arguments.range, undefined);
   });
 
   test('ignores trailing white space', () => {
     const args = commandParsers.close.parser('  ');
-    assert.equal(args.arguments.bang, undefined);
-    assert.equal(args.arguments.range, undefined);
+    assert.strictEqual(args.arguments.bang, undefined);
+    assert.strictEqual(args.arguments.range, undefined);
   });
 
   test('can parse !', () => {
     const args = commandParsers.close.parser('!');
     assert.ok(args.arguments.bang);
-    assert.equal(args.arguments.range, undefined);
+    assert.strictEqual(args.arguments.range, undefined);
   });
 
   test('throws if space before !', () => {
@@ -27,8 +27,8 @@ suite(':close args parser', () => {
 
   test('ignores space after !', () => {
     const args = commandParsers.close.parser('! ');
-    assert.equal(args.arguments.bang, true);
-    assert.equal(args.arguments.range, undefined);
+    assert.strictEqual(args.arguments.bang, true);
+    assert.strictEqual(args.arguments.range, undefined);
   });
 
   test('throws if bad input', () => {

--- a/test/cmd_line/subparser.quit.test.ts
+++ b/test/cmd_line/subparser.quit.test.ts
@@ -5,20 +5,20 @@ import { commandParsers } from '../../src/cmd_line/subparser';
 suite(':quit args parser', () => {
   test('can parse empty args', () => {
     const args = commandParsers.quit.parser('');
-    assert.equal(args.arguments.bang, undefined);
-    assert.equal(args.arguments.range, undefined);
+    assert.strictEqual(args.arguments.bang, undefined);
+    assert.strictEqual(args.arguments.range, undefined);
   });
 
   test('ignores trailing white space', () => {
     const args = commandParsers.quit.parser('  ');
-    assert.equal(args.arguments.bang, undefined);
-    assert.equal(args.arguments.range, undefined);
+    assert.strictEqual(args.arguments.bang, undefined);
+    assert.strictEqual(args.arguments.range, undefined);
   });
 
   test('can parse !', () => {
     const args = commandParsers.quit.parser('!');
     assert.ok(args.arguments.bang);
-    assert.equal(args.arguments.range, undefined);
+    assert.strictEqual(args.arguments.range, undefined);
   });
 
   test('throws if space before !', () => {
@@ -27,8 +27,8 @@ suite(':quit args parser', () => {
 
   test('ignores space after !', () => {
     const args = commandParsers.quit.parser('! ');
-    assert.equal(args.arguments.bang, true);
-    assert.equal(args.arguments.range, undefined);
+    assert.strictEqual(args.arguments.bang, true);
+    assert.strictEqual(args.arguments.range, undefined);
   });
 
   test('throws if bad input', () => {

--- a/test/cmd_line/subparser.substitute.test.ts
+++ b/test/cmd_line/subparser.substitute.test.ts
@@ -5,31 +5,31 @@ import { commandParsers } from '../../src/cmd_line/subparser';
 suite(':substitute args parser', () => {
   test('can parse pattern, replace, and flags', () => {
     const args = commandParsers.substitute.parser('/a/b/g');
-    assert.equal(args.arguments.pattern, 'a');
-    assert.equal(args.arguments.replace, 'b');
-    assert.equal(args.arguments.flags, 8);
+    assert.strictEqual(args.arguments.pattern, 'a');
+    assert.strictEqual(args.arguments.replace, 'b');
+    assert.strictEqual(args.arguments.flags, 8);
   });
 
   test('can parse count', () => {
     const args = commandParsers.substitute.parser('/a/b/g 3');
-    assert.equal(args.arguments.count, 3);
+    assert.strictEqual(args.arguments.count, 3);
   });
 
   test('can parse custom delimiter', () => {
     const args = commandParsers.substitute.parser('#a#b#g');
-    assert.equal(args.arguments.pattern, 'a');
-    assert.equal(args.arguments.replace, 'b');
-    assert.equal(args.arguments.flags, 8);
+    assert.strictEqual(args.arguments.pattern, 'a');
+    assert.strictEqual(args.arguments.replace, 'b');
+    assert.strictEqual(args.arguments.flags, 8);
   });
 
   test('can escape delimiter', () => {
     const args = commandParsers.substitute.parser('/\\/\\/a/b/');
-    assert.equal(args.arguments.pattern, '//a');
-    assert.equal(args.arguments.replace, 'b');
+    assert.strictEqual(args.arguments.pattern, '//a');
+    assert.strictEqual(args.arguments.replace, 'b');
   });
 
   test('can parse flag KeepPreviousFlags', () => {
     const args = commandParsers.substitute.parser('/a/b/&');
-    assert.equal(args.arguments.flags, 1);
+    assert.strictEqual(args.arguments.flags, 1);
   });
 });

--- a/test/cmd_line/subparser.tabmove.test.ts
+++ b/test/cmd_line/subparser.tabmove.test.ts
@@ -5,8 +5,8 @@ import { commandParsers } from '../../src/cmd_line/subparser';
 function testTabMoveParse(args: string, count?: number, direction?: 'left' | 'right'): void {
   const test = (args1: string) => {
     const cmd = commandParsers.tabmove.parser(args1);
-    assert.equal(cmd.arguments.count, count);
-    assert.equal(cmd.arguments.direction, direction);
+    assert.strictEqual(cmd.arguments.count, count);
+    assert.strictEqual(cmd.arguments.direction, direction);
   };
 
   test(args);
@@ -24,7 +24,7 @@ function failsTabMoveParse(args: string): void {
 
 suite(':tabm[ove] args parser', () => {
   test('has :tabm alias', () => {
-    assert.equal(commandParsers.tabmove.abbrev, 'tabm');
+    assert.strictEqual(commandParsers.tabmove.abbrev, 'tabm');
   });
 
   test('can parse empty args', () => {

--- a/test/cmd_line/subparser.test.ts
+++ b/test/cmd_line/subparser.test.ts
@@ -4,53 +4,53 @@ import { commandParsers, getParser } from '../../src/cmd_line/subparser';
 
 suite('getParser', () => {
   test('empty', () => {
-    assert.equal(getParser(''), undefined);
+    assert.strictEqual(getParser(''), undefined);
   });
 
   test(':marks', () => {
     assert.notEqual(getParser('marks'), undefined);
-    assert.equal(getParser('marksx'), undefined);
+    assert.strictEqual(getParser('marksx'), undefined);
   });
 
   test(':write', () => {
     const w = getParser('w');
     assert.notEqual(w, undefined);
 
-    assert.equal(getParser('wr'), w);
-    assert.equal(getParser('wri'), w);
-    assert.equal(getParser('writ'), w);
-    assert.equal(getParser('write'), w);
+    assert.strictEqual(getParser('wr'), w);
+    assert.strictEqual(getParser('wri'), w);
+    assert.strictEqual(getParser('writ'), w);
+    assert.strictEqual(getParser('write'), w);
 
-    assert.equal(getParser('writex'), undefined);
+    assert.strictEqual(getParser('writex'), undefined);
   });
 
   test(':nohlsearch', () => {
-    assert.equal(getParser('no'), undefined);
+    assert.strictEqual(getParser('no'), undefined);
 
     const noh = getParser('noh');
     assert.notEqual(noh, undefined);
 
-    assert.equal(getParser('nohl'), noh);
-    assert.equal(getParser('nohls'), noh);
-    assert.equal(getParser('nohlse'), noh);
-    assert.equal(getParser('nohlsea'), noh);
-    assert.equal(getParser('nohlsear'), noh);
-    assert.equal(getParser('nohlsearc'), noh);
-    assert.equal(getParser('nohlsearch'), noh);
+    assert.strictEqual(getParser('nohl'), noh);
+    assert.strictEqual(getParser('nohls'), noh);
+    assert.strictEqual(getParser('nohlse'), noh);
+    assert.strictEqual(getParser('nohlsea'), noh);
+    assert.strictEqual(getParser('nohlsear'), noh);
+    assert.strictEqual(getParser('nohlsearc'), noh);
+    assert.strictEqual(getParser('nohlsearch'), noh);
 
-    assert.equal(getParser('nohlsearchx'), undefined);
+    assert.strictEqual(getParser('nohlsearchx'), undefined);
   });
 
   test(':quitall', () => {
     const qa = getParser('qa');
     assert.notEqual(qa, undefined);
 
-    assert.equal(getParser('qal'), qa);
-    assert.equal(getParser('qall'), qa);
+    assert.strictEqual(getParser('qal'), qa);
+    assert.strictEqual(getParser('qall'), qa);
 
-    assert.equal(getParser('quita'), qa);
-    assert.equal(getParser('quital'), qa);
-    assert.equal(getParser('quitall'), qa);
+    assert.strictEqual(getParser('quita'), qa);
+    assert.strictEqual(getParser('quital'), qa);
+    assert.strictEqual(getParser('quitall'), qa);
   });
 
   suite(':write args parser', () => {
@@ -59,24 +59,24 @@ suite('getParser', () => {
       // TODO: this func must return args only, not a command?
       // TODO: the range must be passed separately, not as arg.
       const args = commandParsers.write.parser('');
-      assert.equal(args.arguments.append, undefined);
-      assert.equal(args.arguments.bang, undefined);
-      assert.equal(args.arguments.cmd, undefined);
-      assert.equal(args.arguments.file, undefined);
-      assert.equal(args.arguments.opt, undefined);
-      assert.equal(args.arguments.optValue, undefined);
-      assert.equal(args.arguments.range, undefined);
+      assert.strictEqual(args.arguments.append, undefined);
+      assert.strictEqual(args.arguments.bang, undefined);
+      assert.strictEqual(args.arguments.cmd, undefined);
+      assert.strictEqual(args.arguments.file, undefined);
+      assert.strictEqual(args.arguments.opt, undefined);
+      assert.strictEqual(args.arguments.optValue, undefined);
+      assert.strictEqual(args.arguments.range, undefined);
     });
 
     test('can parse ++opt', () => {
       const args = commandParsers.write.parser('++enc=foo');
-      assert.equal(args.arguments.append, undefined);
-      assert.equal(args.arguments.bang, undefined);
-      assert.equal(args.arguments.cmd, undefined);
-      assert.equal(args.arguments.file, undefined);
-      assert.equal(args.arguments.opt, 'enc');
-      assert.equal(args.arguments.optValue, 'foo');
-      assert.equal(args.arguments.range, undefined);
+      assert.strictEqual(args.arguments.append, undefined);
+      assert.strictEqual(args.arguments.bang, undefined);
+      assert.strictEqual(args.arguments.cmd, undefined);
+      assert.strictEqual(args.arguments.file, undefined);
+      assert.strictEqual(args.arguments.opt, 'enc');
+      assert.strictEqual(args.arguments.optValue, 'foo');
+      assert.strictEqual(args.arguments.range, undefined);
     });
 
     test('throws if bad ++opt name', () => {
@@ -85,35 +85,35 @@ suite('getParser', () => {
 
     test('can parse bang', () => {
       const args = commandParsers.write.parser('!');
-      assert.equal(args.arguments.append, undefined);
-      assert.equal(args.arguments.bang, true);
-      assert.equal(args.arguments.cmd, undefined);
-      assert.equal(args.arguments.file, undefined);
-      assert.equal(args.arguments.opt, undefined);
-      assert.equal(args.arguments.optValue, undefined);
-      assert.equal(args.arguments.range, undefined);
+      assert.strictEqual(args.arguments.append, undefined);
+      assert.strictEqual(args.arguments.bang, true);
+      assert.strictEqual(args.arguments.cmd, undefined);
+      assert.strictEqual(args.arguments.file, undefined);
+      assert.strictEqual(args.arguments.opt, undefined);
+      assert.strictEqual(args.arguments.optValue, undefined);
+      assert.strictEqual(args.arguments.range, undefined);
     });
 
     test("can parse ' !cmd'", () => {
       const args = commandParsers.write.parser(' !foo');
-      assert.equal(args.arguments.append, undefined);
-      assert.equal(args.arguments.bang, undefined);
-      assert.equal(args.arguments.cmd, 'foo');
-      assert.equal(args.arguments.file, undefined);
-      assert.equal(args.arguments.opt, undefined);
-      assert.equal(args.arguments.optValue, undefined);
-      assert.equal(args.arguments.range, undefined);
+      assert.strictEqual(args.arguments.append, undefined);
+      assert.strictEqual(args.arguments.bang, undefined);
+      assert.strictEqual(args.arguments.cmd, 'foo');
+      assert.strictEqual(args.arguments.file, undefined);
+      assert.strictEqual(args.arguments.opt, undefined);
+      assert.strictEqual(args.arguments.optValue, undefined);
+      assert.strictEqual(args.arguments.range, undefined);
     });
 
     test("can parse ' !cmd' when cmd is empty", () => {
       const args = commandParsers.write.parser(' !');
-      assert.equal(args.arguments.append, undefined);
-      assert.equal(args.arguments.bang, undefined);
-      assert.equal(args.arguments.cmd, undefined);
-      assert.equal(args.arguments.file, undefined);
-      assert.equal(args.arguments.opt, undefined);
-      assert.equal(args.arguments.optValue, undefined);
-      assert.equal(args.arguments.range, undefined);
+      assert.strictEqual(args.arguments.append, undefined);
+      assert.strictEqual(args.arguments.bang, undefined);
+      assert.strictEqual(args.arguments.cmd, undefined);
+      assert.strictEqual(args.arguments.file, undefined);
+      assert.strictEqual(args.arguments.opt, undefined);
+      assert.strictEqual(args.arguments.optValue, undefined);
+      assert.strictEqual(args.arguments.range, undefined);
     });
   });
 });

--- a/test/cmd_line/tab.test.ts
+++ b/test/cmd_line/tab.test.ts
@@ -41,9 +41,9 @@ suite('cmd_line tab', () => {
       assert.fail('File did not open');
     } else {
       if (process.platform !== 'win32') {
-        assert.equal(editor.document.fileName, filePath, 'Opened wrong file');
+        assert.strictEqual(editor.document.fileName, filePath, 'Opened wrong file');
       } else {
-        assert.equal(
+        assert.strictEqual(
           editor.document.fileName.toLowerCase(),
           filePath.toLowerCase(),
           'Opened wrong file'
@@ -60,7 +60,7 @@ suite('cmd_line tab', () => {
     await commandLine.Run(`tabe ${filePath}`, modeHandler.vimState);
     const afterEditor = vscode.window.activeTextEditor;
 
-    assert.equal(
+    assert.strictEqual(
       beforeEditor,
       afterEditor,
       'Active editor changed even though :tabe opened the same file'

--- a/test/cmd_line/tabCompletion.test.ts
+++ b/test/cmd_line/tabCompletion.test.ts
@@ -24,7 +24,7 @@ suite('cmd_line tabComplete', () => {
     const statusBarAfterTab = StatusBar.Get();
 
     await modeHandler.handleKeyEvent('<Esc>');
-    assert.equal(statusBarAfterTab.trim(), ':edit|', 'Command Tab Completion Failed');
+    assert.strictEqual(statusBarAfterTab.trim(), ':edit|', 'Command Tab Completion Failed');
   });
 
   test('command line command shift+tab', async () => {
@@ -39,7 +39,7 @@ suite('cmd_line tabComplete', () => {
 
     await modeHandler.handleKeyEvent('<Esc>');
     assert.notEqual(firstTab, secondTab);
-    assert.equal(actual, firstTab, "Command can't go back with shift+tab");
+    assert.strictEqual(actual, firstTab, "Command can't go back with shift+tab");
   });
 
   test('command line file tab completion with no base path', async () => {
@@ -106,7 +106,11 @@ suite('cmd_line tabComplete', () => {
       await modeHandler.handleKeyEvent('<tab>');
       const statusBarAfterTab = StatusBar.Get().trim();
       await modeHandler.handleKeyEvent('<Esc>');
-      assert.equal(statusBarAfterTab, `:e ${dirPath}${sep}|`, 'Cannot complete with / at the end');
+      assert.strictEqual(
+        statusBarAfterTab,
+        `:e ${dirPath}${sep}|`,
+        'Cannot complete with / at the end'
+      );
     } finally {
       await t.removeDir(dirPath);
     }
@@ -128,13 +132,13 @@ suite('cmd_line tabComplete', () => {
       await modeHandler.handleKeyEvent('<tab>');
       let statusBarAfterTab = StatusBar.Get().trim();
       let expectedPath = `${tmpDir}${sep}inner0${sep}`;
-      assert.equal(statusBarAfterTab, `:e ${expectedPath}|`, '123');
+      assert.strictEqual(statusBarAfterTab, `:e ${expectedPath}|`, '123');
 
       // Tab to cycle the completion of tempDir
       await modeHandler.handleKeyEvent('<tab>');
       statusBarAfterTab = StatusBar.Get().trim();
       expectedPath = `${tmpDir}${sep}inner1${sep}`;
-      assert.equal(statusBarAfterTab, `:e ${expectedPath}|`, '123');
+      assert.strictEqual(statusBarAfterTab, `:e ${expectedPath}|`, '123');
 
       // <right> and <tab> to select and complete the content in
       // the inner1 directory
@@ -143,20 +147,20 @@ suite('cmd_line tabComplete', () => {
       await modeHandler.handleMultipleKeyEvents(['<right>', '<tab>']);
       statusBarAfterTab = StatusBar.Get().trim();
       expectedPath = `${tmpDir}${sep}inner1${sep}inner10${sep}`;
-      assert.equal(statusBarAfterTab, `:e ${expectedPath}|`, '123');
+      assert.strictEqual(statusBarAfterTab, `:e ${expectedPath}|`, '123');
 
       // A tab would try to complete the content in the inner10.
       // Since the pervious completion is complete, no <right> is needed to select
       await modeHandler.handleKeyEvent('<tab>');
       statusBarAfterTab = StatusBar.Get().trim();
       expectedPath = `${tmpDir}${sep}inner1${sep}inner10${sep}inner100${sep}`;
-      assert.equal(statusBarAfterTab, `:e ${expectedPath}|`, '123');
+      assert.strictEqual(statusBarAfterTab, `:e ${expectedPath}|`, '123');
 
       // Since there isn't any files or directories in inner100, no completion.
       await modeHandler.handleKeyEvent('<tab>');
       statusBarAfterTab = StatusBar.Get().trim();
       expectedPath = `${tmpDir}${sep}inner1${sep}inner10${sep}inner100${sep}`;
-      assert.equal(statusBarAfterTab, `:e ${expectedPath}|`, '123');
+      assert.strictEqual(statusBarAfterTab, `:e ${expectedPath}|`, '123');
 
       await modeHandler.handleKeyEvent('<Esc>');
     } finally {
@@ -172,15 +176,19 @@ suite('cmd_line tabComplete', () => {
     await modeHandler.handleMultipleKeyEvents([':', 'e', 'd', 'i']);
     await modeHandler.handleKeyEvent('<tab>');
     let statusBarAfterTab = StatusBar.Get().trim();
-    assert.equal(statusBarAfterTab, ':edit|', 'Command Tab Completion Failed');
+    assert.strictEqual(statusBarAfterTab, ':edit|', 'Command Tab Completion Failed');
 
     await modeHandler.handleMultipleKeyEvents(['<left>', '<left>']);
     statusBarAfterTab = StatusBar.Get().trim();
-    assert.equal(statusBarAfterTab, ':ed|it', 'Failed to move the cursor to the left');
+    assert.strictEqual(statusBarAfterTab, ':ed|it', 'Failed to move the cursor to the left');
 
     await modeHandler.handleKeyEvent('<tab>');
     statusBarAfterTab = StatusBar.Get().trim();
-    assert.equal(statusBarAfterTab, ':edit|it', 'Failed to complete content left of the cursor');
+    assert.strictEqual(
+      statusBarAfterTab,
+      ':edit|it',
+      'Failed to complete content left of the cursor'
+    );
 
     await modeHandler.handleKeyEvent('<Esc>');
   });
@@ -196,28 +204,36 @@ suite('cmd_line tabComplete', () => {
       // First tab - resolve to .testfile
       await modeHandler.handleKeyEvent('<tab>');
       let statusBarAfterTab = StatusBar.Get();
-      assert.equal(statusBarAfterTab.trim(), `:e ${testFilePath}|`, 'Cannot complete to .testfile');
+      assert.strictEqual(
+        statusBarAfterTab.trim(),
+        `:e ${testFilePath}|`,
+        'Cannot complete to .testfile'
+      );
       // Second tab - resolve to .testfile
       // ./ and ../ because . is not explicitly typed in.
       // This should be consistent with Vim
       await modeHandler.handleKeyEvent('<tab>');
       statusBarAfterTab = StatusBar.Get().trim();
-      assert.equal(statusBarAfterTab, `:e ${testFilePath}|`, 'Cannot complete to .testfile');
+      assert.strictEqual(statusBarAfterTab, `:e ${testFilePath}|`, 'Cannot complete to .testfile');
       await modeHandler.handleKeyEvent('<Esc>');
 
       await modeHandler.handleMultipleKeyEvents(baseCmd.concat('.'));
       // First tab - resolve to ../
       await modeHandler.handleKeyEvent('<tab>');
       statusBarAfterTab = StatusBar.Get().trim();
-      assert.equal(statusBarAfterTab, `:e ${dirPath}${sep}..${sep}|`, 'Cannot complete to ../');
+      assert.strictEqual(
+        statusBarAfterTab,
+        `:e ${dirPath}${sep}..${sep}|`,
+        'Cannot complete to ../'
+      );
       // Second tab - resolve to ./
       await modeHandler.handleKeyEvent('<tab>');
       statusBarAfterTab = StatusBar.Get().trim();
-      assert.equal(statusBarAfterTab, `:e ${dirPath}${sep}.${sep}|`, 'Cannot complete to ./');
+      assert.strictEqual(statusBarAfterTab, `:e ${dirPath}${sep}.${sep}|`, 'Cannot complete to ./');
       // Third tab - resolve to .testfile
       await modeHandler.handleKeyEvent('<tab>');
       statusBarAfterTab = StatusBar.Get().trim();
-      assert.equal(statusBarAfterTab, `:e ${testFilePath}|`, 'Cannot complete to .testfile');
+      assert.strictEqual(statusBarAfterTab, `:e ${testFilePath}|`, 'Cannot complete to .testfile');
       await modeHandler.handleKeyEvent('<Esc>');
     } finally {
       await t.removeFile(testFilePath);
@@ -242,7 +258,7 @@ suite('cmd_line tabComplete', () => {
       await modeHandler.handleKeyEvent('<tab>');
       let statusBarAfterTab = StatusBar.Get().trim();
       await modeHandler.handleKeyEvent('<Esc>');
-      assert.equal(statusBarAfterTab, `:e ${baseName}|`, `${failMsg} (no base path)`);
+      assert.strictEqual(statusBarAfterTab, `:e ${baseName}|`, `${failMsg} (no base path)`);
 
       // With multiple ./ ./ as base name
       cmd = `:e ././${baseNameExcludeSpace}`.split('');
@@ -250,7 +266,7 @@ suite('cmd_line tabComplete', () => {
       await modeHandler.handleKeyEvent('<tab>');
       statusBarAfterTab = StatusBar.Get().trim();
       await modeHandler.handleKeyEvent('<Esc>');
-      assert.equal(statusBarAfterTab, `:e ././${baseName}|`, `${failMsg} (w ././)`);
+      assert.strictEqual(statusBarAfterTab, `:e ././${baseName}|`, `${failMsg} (w ././)`);
 
       // With full path excluding the last space portion
       cmd = `:e ${fullPathExcludeSpace}`.split('');
@@ -258,7 +274,7 @@ suite('cmd_line tabComplete', () => {
       await modeHandler.handleKeyEvent('<tab>');
       statusBarAfterTab = StatusBar.Get().trim();
       await modeHandler.handleKeyEvent('<Esc>');
-      assert.equal(statusBarAfterTab, `:e ${spacedFilePath}|`, `(${failMsg} full path)`);
+      assert.strictEqual(statusBarAfterTab, `:e ${spacedFilePath}|`, `(${failMsg} full path)`);
     } finally {
       await t.removeFile(spacedFilePath);
     }

--- a/test/completion/lineCompletion.test.ts
+++ b/test/completion/lineCompletion.test.ts
@@ -66,7 +66,7 @@ suite('Provide line completions', () => {
         vimState.editor.document
       )!.slice(0, expectedCompletions.length);
 
-      assert.equal(completions.length, 0, 'Completions found, but none were expected');
+      assert.strictEqual(completions.length, 0, 'Completions found, but none were expected');
     });
   });
 });

--- a/test/configuration/configuration.test.ts
+++ b/test/configuration/configuration.test.ts
@@ -33,8 +33,8 @@ suite('Configuration', () => {
       srcConfiguration.configuration.normalModeKeyBindingsNonRecursiveMap;
     const testingKeybinds = configuration.normalModeKeyBindingsNonRecursive;
 
-    assert.equal(normalizedKeybinds.length, testingKeybinds.length);
-    assert.equal(normalizedKeybinds.length, normalizedKeybindsMap.size);
+    assert.strictEqual(normalizedKeybinds.length, testingKeybinds.length);
+    assert.strictEqual(normalizedKeybinds.length, normalizedKeybindsMap.size);
     assert.deepEqual(normalizedKeybinds[0].before, [' ', 'o']);
     assert.deepEqual(normalizedKeybinds[0].after, ['o', '<Esc>', 'k']);
   });
@@ -45,8 +45,8 @@ suite('Configuration', () => {
     const h = 'h';
     const j = 'j';
 
-    assert.equal(wrapKeys[h], true);
-    assert.equal(wrapKeys[j], undefined);
+    assert.strictEqual(wrapKeys[h], true);
+    assert.strictEqual(wrapKeys[j], undefined);
   });
 
   newTest({

--- a/test/configuration/notation.test.ts
+++ b/test/configuration/notation.test.ts
@@ -28,7 +28,7 @@ suite('Notation', () => {
         const expected = testCases[test];
 
         const actual = Notation.NormalizeKey(test, leaderKey);
-        assert.equal(actual, expected);
+        assert.strictEqual(actual, expected);
       }
     }
   });

--- a/test/configuration/remapper.test.ts
+++ b/test/configuration/remapper.test.ts
@@ -132,8 +132,8 @@ suite('Remapper', () => {
     const actual = testRemapper.getRemappedKeySequenceLengthRange(remappings);
 
     // assert
-    assert.equal(actual[0], 1);
-    assert.equal(actual[1], 3);
+    assert.strictEqual(actual[0], 1);
+    assert.strictEqual(actual[1], 3);
   });
 
   test('getMatchingRemap', async () => {
@@ -228,9 +228,9 @@ suite('Remapper', () => {
             ModeName[testCase.mode]
           }.`
         );
-        assert.deepEqual(actual!.after, testCase.expectedAfter.split(''));
+        assert.deepStrictEqual(actual!.after, testCase.expectedAfter.split(''));
       } else {
-        assert.equal(actual, undefined);
+        assert.strictEqual(actual, undefined);
       }
 
       if (testCase.expectedAfterMode) {
@@ -272,9 +272,9 @@ suite('Remapper', () => {
     }
 
     // assert
-    assert.equal(actual, true);
+    assert.strictEqual(actual, true);
     assertEqual(modeHandler.currentMode.name, ModeName.Normal);
-    assert.equal(vscode.window.activeTextEditor!.document.getText(), expectedDocumentContent);
+    assert.strictEqual(vscode.window.activeTextEditor!.document.getText(), expectedDocumentContent);
   });
 
   test('0 -> :wq through modehandler', async () => {
@@ -297,8 +297,8 @@ suite('Remapper', () => {
     }
 
     // assert
-    assert.equal(actual, true);
-    assert.equal(vscode.window.visibleTextEditors.length, 0);
+    assert.strictEqual(actual, true);
+    assert.strictEqual(vscode.window.visibleTextEditors.length, 0);
   });
 
   test('<c-e> -> <esc> in insert mode should go to normal mode', async () => {
@@ -333,9 +333,9 @@ suite('Remapper', () => {
     }
 
     // assert
-    assert.equal(actual, true);
+    assert.strictEqual(actual, true);
     assertEqual(modeHandler.currentMode.name, ModeName.Normal);
-    assert.equal(vscode.window.activeTextEditor!.document.getText(), expectedDocumentContent);
+    assert.strictEqual(vscode.window.activeTextEditor!.document.getText(), expectedDocumentContent);
   });
 
   test('leader, w -> closeActiveEditor in normal mode through modehandler', async () => {
@@ -358,8 +358,8 @@ suite('Remapper', () => {
     }
 
     // assert
-    assert.equal(actual, true);
-    assert.equal(vscode.window.visibleTextEditors.length, 0);
+    assert.strictEqual(actual, true);
+    assert.strictEqual(vscode.window.visibleTextEditors.length, 0);
   });
 
   test('leader, c -> closeActiveEditor in visual mode through modehandler', async () => {
@@ -385,8 +385,8 @@ suite('Remapper', () => {
     }
 
     // assert
-    assert.equal(actual, true);
-    assert.equal(vscode.window.visibleTextEditors.length, 0);
+    assert.strictEqual(actual, true);
+    assert.strictEqual(vscode.window.visibleTextEditors.length, 0);
   });
 
   test('d -> black hole register delete in normal mode through modehandler', async () => {
@@ -397,7 +397,7 @@ suite('Remapper', () => {
       visualModeKeyBindings: defaultVisualModeKeyBindings,
     });
 
-    assert.equal(modeHandler.currentMode.name, ModeName.Normal);
+    assert.strictEqual(modeHandler.currentMode.name, ModeName.Normal);
 
     await modeHandler.handleMultipleKeyEvents(['<Esc>', 'g', 'g']);
     await modeHandler.handleMultipleKeyEvents(['i', 'line1', '<Esc>', '0']);
@@ -406,14 +406,14 @@ suite('Remapper', () => {
     let actual: IRegisterContent;
     Register.put(expected, modeHandler.vimState);
     actual = await Register.get(vimState);
-    assert.equal(actual.text, expected);
+    assert.strictEqual(actual.text, expected);
 
     // act
     await modeHandler.handleMultipleKeyEvents(['d', 'd']);
 
     // assert
     actual = await Register.get(vimState);
-    assert.equal(actual.text, expected);
+    assert.strictEqual(actual.text, expected);
   });
 
   test('d -> black hole register delete in normal mode through modehandler', async () => {
@@ -424,7 +424,7 @@ suite('Remapper', () => {
       visualModeKeyBindings: defaultVisualModeKeyBindings,
     });
 
-    assert.equal(modeHandler.currentMode.name, ModeName.Normal);
+    assert.strictEqual(modeHandler.currentMode.name, ModeName.Normal);
 
     await modeHandler.handleMultipleKeyEvents(['<Esc>', 'g', 'g']);
     await modeHandler.handleMultipleKeyEvents(['i', 'word1 word2', '<Esc>', '0']);
@@ -433,14 +433,14 @@ suite('Remapper', () => {
     let actual: IRegisterContent;
     Register.put(expected, modeHandler.vimState);
     actual = await Register.get(vimState);
-    assert.equal(actual.text, expected);
+    assert.strictEqual(actual.text, expected);
 
     // act
     await modeHandler.handleMultipleKeyEvents(['d', 'w']);
 
     // assert
     actual = await Register.get(vimState);
-    assert.equal(actual.text, expected);
+    assert.strictEqual(actual.text, expected);
   });
 
   test('jj -> <Esc> after ciw operator through modehandler', async () => {
@@ -454,18 +454,18 @@ suite('Remapper', () => {
       ],
     });
 
-    assert.equal(modeHandler.currentMode.name, ModeName.Normal);
+    assert.strictEqual(modeHandler.currentMode.name, ModeName.Normal);
     await modeHandler.handleMultipleKeyEvents(['<Esc>', 'g', 'g']);
     await modeHandler.handleMultipleKeyEvents(['i', 'word1 word2', '<Esc>', '0']);
-    assert.equal(modeHandler.currentMode.name, ModeName.Normal);
+    assert.strictEqual(modeHandler.currentMode.name, ModeName.Normal);
 
     // act
     await modeHandler.handleMultipleKeyEvents(['c', 'i', 'w']);
-    assert.equal(modeHandler.currentMode.name, ModeName.Insert);
+    assert.strictEqual(modeHandler.currentMode.name, ModeName.Insert);
     await modeHandler.handleMultipleKeyEvents(['j', 'j']);
 
     // assert
-    assert.equal(modeHandler.currentMode.name, ModeName.Normal);
+    assert.strictEqual(modeHandler.currentMode.name, ModeName.Normal);
   });
 });
 

--- a/test/configuration/validators/neovimValidator.test.ts
+++ b/test/configuration/validators/neovimValidator.test.ts
@@ -15,9 +15,9 @@ suite('Neovim Validator', () => {
     validator.disable(configuration);
 
     // assert
-    assert.equal(actual.numErrors, 1);
-    assert.equal(actual.hasError, true);
-    assert.equal(configuration.enableNeovim, false);
+    assert.strictEqual(actual.numErrors, 1);
+    assert.strictEqual(actual.hasError, true);
+    assert.strictEqual(configuration.enableNeovim, false);
   });
 
   test('neovim disabled', async () => {
@@ -31,6 +31,6 @@ suite('Neovim Validator', () => {
     const actual = await validator.validate(configuration);
 
     // assert
-    assert.equal(actual.numErrors, 0);
+    assert.strictEqual(actual.numErrors, 0);
   });
 });

--- a/test/configuration/validators/remappingValidator.test.ts
+++ b/test/configuration/validators/remappingValidator.test.ts
@@ -18,17 +18,17 @@ suite('Remapping Validator', () => {
     const actual = await validator.validate(configuration);
 
     // assert
-    assert.equal(actual.numErrors, 0);
-    assert.equal(actual.hasError, false);
-    assert.equal(actual.numWarnings, 0);
-    assert.equal(actual.hasWarning, false);
+    assert.strictEqual(actual.numErrors, 0);
+    assert.strictEqual(actual.hasError, false);
+    assert.strictEqual(actual.numWarnings, 0);
+    assert.strictEqual(actual.hasWarning, false);
 
-    assert.equal(configuration.insertModeKeyBindingsMap.size, 0);
-    assert.equal(configuration.insertModeKeyBindingsNonRecursiveMap.size, 0);
-    assert.equal(configuration.normalModeKeyBindingsMap.size, 0);
-    assert.equal(configuration.normalModeKeyBindingsNonRecursiveMap.size, 0);
-    assert.equal(configuration.visualModeKeyBindingsMap.size, 0);
-    assert.equal(configuration.visualModeKeyBindingsNonRecursiveMap.size, 0);
+    assert.strictEqual(configuration.insertModeKeyBindingsMap.size, 0);
+    assert.strictEqual(configuration.insertModeKeyBindingsNonRecursiveMap.size, 0);
+    assert.strictEqual(configuration.normalModeKeyBindingsMap.size, 0);
+    assert.strictEqual(configuration.normalModeKeyBindingsNonRecursiveMap.size, 0);
+    assert.strictEqual(configuration.visualModeKeyBindingsMap.size, 0);
+    assert.strictEqual(configuration.visualModeKeyBindingsNonRecursiveMap.size, 0);
   });
 
   test('jj->esc', async () => {
@@ -51,19 +51,19 @@ suite('Remapping Validator', () => {
     const actual = await validator.validate(configuration);
 
     // assert
-    assert.equal(actual.numErrors, 0);
-    assert.equal(actual.hasError, false);
-    assert.equal(actual.numWarnings, 0);
-    assert.equal(actual.hasWarning, false);
+    assert.strictEqual(actual.numErrors, 0);
+    assert.strictEqual(actual.hasError, false);
+    assert.strictEqual(actual.numWarnings, 0);
+    assert.strictEqual(actual.hasWarning, false);
 
-    assert.equal(configuration.insertModeKeyBindingsMap.size, 1);
-    assert.equal(configuration.insertModeKeyBindingsNonRecursiveMap.size, 0);
-    assert.equal(configuration.normalModeKeyBindingsMap.size, 0);
-    assert.equal(configuration.normalModeKeyBindingsNonRecursiveMap.size, 0);
-    assert.equal(configuration.visualModeKeyBindingsMap.size, 0);
-    assert.equal(configuration.visualModeKeyBindingsNonRecursiveMap.size, 0);
+    assert.strictEqual(configuration.insertModeKeyBindingsMap.size, 1);
+    assert.strictEqual(configuration.insertModeKeyBindingsNonRecursiveMap.size, 0);
+    assert.strictEqual(configuration.normalModeKeyBindingsMap.size, 0);
+    assert.strictEqual(configuration.normalModeKeyBindingsNonRecursiveMap.size, 0);
+    assert.strictEqual(configuration.visualModeKeyBindingsMap.size, 0);
+    assert.strictEqual(configuration.visualModeKeyBindingsNonRecursiveMap.size, 0);
 
-    assert.equal(
+    assert.strictEqual(
       configuration.insertModeKeyBindingsMap.get('jj'),
       configuration.insertModeKeyBindings[0]
     );
@@ -88,17 +88,17 @@ suite('Remapping Validator', () => {
     const actual = await validator.validate(configuration);
 
     // assert
-    assert.equal(actual.numErrors, 1);
-    assert.equal(actual.hasError, true);
-    assert.equal(actual.numWarnings, 0);
-    assert.equal(actual.hasWarning, false);
+    assert.strictEqual(actual.numErrors, 1);
+    assert.strictEqual(actual.hasError, true);
+    assert.strictEqual(actual.numWarnings, 0);
+    assert.strictEqual(actual.hasWarning, false);
 
-    assert.equal(configuration.insertModeKeyBindingsMap.size, 0);
-    assert.equal(configuration.insertModeKeyBindingsNonRecursiveMap.size, 0);
-    assert.equal(configuration.normalModeKeyBindingsMap.size, 0);
-    assert.equal(configuration.normalModeKeyBindingsNonRecursiveMap.size, 0);
-    assert.equal(configuration.visualModeKeyBindingsMap.size, 0);
-    assert.equal(configuration.visualModeKeyBindingsNonRecursiveMap.size, 0);
+    assert.strictEqual(configuration.insertModeKeyBindingsMap.size, 0);
+    assert.strictEqual(configuration.insertModeKeyBindingsNonRecursiveMap.size, 0);
+    assert.strictEqual(configuration.normalModeKeyBindingsMap.size, 0);
+    assert.strictEqual(configuration.normalModeKeyBindingsNonRecursiveMap.size, 0);
+    assert.strictEqual(configuration.visualModeKeyBindingsMap.size, 0);
+    assert.strictEqual(configuration.visualModeKeyBindingsNonRecursiveMap.size, 0);
   });
 
   test('remappings are de-duped', async () => {
@@ -125,16 +125,16 @@ suite('Remapping Validator', () => {
     const actual = await validator.validate(configuration);
 
     // assert
-    assert.equal(actual.numErrors, 0);
-    assert.equal(actual.hasError, false);
-    assert.equal(actual.numWarnings, 1);
-    assert.equal(actual.hasWarning, true);
+    assert.strictEqual(actual.numErrors, 0);
+    assert.strictEqual(actual.hasError, false);
+    assert.strictEqual(actual.numWarnings, 1);
+    assert.strictEqual(actual.hasWarning, true);
 
-    assert.equal(configuration.insertModeKeyBindingsMap.size, 0);
-    assert.equal(configuration.insertModeKeyBindingsNonRecursiveMap.size, 0);
-    assert.equal(configuration.normalModeKeyBindingsMap.size, 1);
-    assert.equal(configuration.normalModeKeyBindingsNonRecursiveMap.size, 0);
-    assert.equal(configuration.visualModeKeyBindingsMap.size, 0);
-    assert.equal(configuration.visualModeKeyBindingsNonRecursiveMap.size, 0);
+    assert.strictEqual(configuration.insertModeKeyBindingsMap.size, 0);
+    assert.strictEqual(configuration.insertModeKeyBindingsNonRecursiveMap.size, 0);
+    assert.strictEqual(configuration.normalModeKeyBindingsMap.size, 1);
+    assert.strictEqual(configuration.normalModeKeyBindingsNonRecursiveMap.size, 0);
+    assert.strictEqual(configuration.visualModeKeyBindingsMap.size, 0);
+    assert.strictEqual(configuration.visualModeKeyBindingsNonRecursiveMap.size, 0);
   });
 });

--- a/test/extension.test.ts
+++ b/test/extension.test.ts
@@ -36,11 +36,11 @@ suite('package.json', () => {
     // configuration
     let handlers = Object.keys(srcConfiguration.configuration);
     let unhandled = keys.filter(k => handlers.includes(k));
-    assert.equal(unhandled, 0, 'Missing src handlers for ' + unhandled.join(','));
+    assert.strictEqual(unhandled.length, 0, 'Missing src handlers for ' + unhandled.join(','));
 
     // test configuration
     handlers = Object.keys(new testConfiguration.Configuration());
     unhandled = keys.filter(k => handlers.includes(k));
-    assert.equal(unhandled, 0, 'Missing test handlers for ' + unhandled.join(','));
+    assert.strictEqual(unhandled.length, 0, 'Missing test handlers for ' + unhandled.join(','));
   });
 });

--- a/test/jumpTracker.test.ts
+++ b/test/jumpTracker.test.ts
@@ -50,8 +50,12 @@ suite('Record and navigate jumps', () => {
         ['file1', 'file2', 'file3'],
         'Unexpected jumps found'
       );
-      assert.equal(jumpTracker.currentJump.fileName, 'file1', 'Unexpected current jump found');
-      assert.equal(jumpTracker.currentJumpNumber, 0, 'Unexpected current jump number found');
+      assert.strictEqual(
+        jumpTracker.currentJump.fileName,
+        'file1',
+        'Unexpected current jump found'
+      );
+      assert.strictEqual(jumpTracker.currentJumpNumber, 0, 'Unexpected current jump number found');
     });
 
     test('Can handle file jump events sent by vscode in response to recordJumpBack', async () => {
@@ -75,8 +79,12 @@ suite('Record and navigate jumps', () => {
         ['file1', 'file2', 'file3', 'file4'],
         'Unexpected jumps found'
       );
-      assert.equal(jumpTracker.currentJump.fileName, 'file2', 'Unexpected current jump found');
-      assert.equal(jumpTracker.currentJumpNumber, 1, 'Unexpected current jump number found');
+      assert.strictEqual(
+        jumpTracker.currentJump.fileName,
+        'file2',
+        'Unexpected current jump found'
+      );
+      assert.strictEqual(jumpTracker.currentJumpNumber, 1, 'Unexpected current jump number found');
     });
 
     test('Can record jumps between files after switching files', async () => {
@@ -93,7 +101,7 @@ suite('Record and navigate jumps', () => {
         ['file1', 'file2', 'file3', 'file2'],
         'Unexpected jumps found'
       );
-      assert.equal(jumpTracker.currentJump, null, 'Unexpected current jump found');
+      assert.strictEqual(jumpTracker.currentJump, null, 'Unexpected current jump found');
     });
 
     test('Can handle jumps to the same file multiple times', async () => {
@@ -109,7 +117,7 @@ suite('Record and navigate jumps', () => {
         ['file1', 'file2', 'file3'],
         'Unexpected jumps found'
       );
-      assert.equal(jumpTracker.currentJump, null, 'Unexpected current jump found');
+      assert.strictEqual(jumpTracker.currentJump, null, 'Unexpected current jump found');
     });
 
     test('Can record up to 100 jumps, the fixed length in vanilla Vim', async () => {
@@ -119,7 +127,7 @@ suite('Record and navigate jumps', () => {
         jumpTracker.recordJump(jump(iteration, 0), jump(iteration + 1, 0));
       });
 
-      assert.equal(jumpTracker.jumps.length, 100, 'Jump tracker should cut off jumps at 100');
+      assert.strictEqual(jumpTracker.jumps.length, 100, 'Jump tracker should cut off jumps at 100');
       assert.deepEqual(
         jumpTracker.jumps.map(j => j.position.line),
         range(102).slice(2, 102),

--- a/test/mode/modeHandler.test.ts
+++ b/test/mode/modeHandler.test.ts
@@ -16,14 +16,14 @@ suite('Mode Handler', () => {
   teardown(cleanUpWorkspace);
 
   test('ctor', () => {
-    assert.equal(modeHandler.currentMode.name, ModeName.Normal);
-    assert.equal(modeHandler.currentMode.isActive, true);
+    assert.strictEqual(modeHandler.currentMode.name, ModeName.Normal);
+    assert.strictEqual(modeHandler.currentMode.isActive, true);
   });
 
   test('can set current mode', async () => {
-    assert.equal(modeHandler.currentMode.name, ModeName.Normal);
+    assert.strictEqual(modeHandler.currentMode.name, ModeName.Normal);
 
     await modeHandler.handleKeyEvent('i');
-    assert.equal(modeHandler.currentMode.name, ModeName.Insert);
+    assert.strictEqual(modeHandler.currentMode.name, ModeName.Insert);
   });
 });

--- a/test/mode/modeHandlerMap.test.ts
+++ b/test/mode/modeHandlerMap.test.ts
@@ -17,23 +17,23 @@ suite('Mode Handler Map', () => {
       .toString(36)
       .substring(7);
     let [modeHandler, isNew] = await ModeHandlerMap.getOrCreate(key);
-    assert.equal(isNew, true);
+    assert.strictEqual(isNew, true);
     assert.notEqual(modeHandler, undefined);
 
     [, isNew] = await ModeHandlerMap.getOrCreate(key);
-    assert.equal(isNew, false);
+    assert.strictEqual(isNew, false);
 
     // getKeys
     const keys = ModeHandlerMap.getKeys();
-    assert.equal(keys.length, 1);
-    assert.equal(keys[0], key);
+    assert.strictEqual(keys.length, 1);
+    assert.strictEqual(keys[0], key);
 
     // getAll
     const modeHandlerList = ModeHandlerMap.getAll();
-    assert.equal(modeHandlerList.length, 1);
+    assert.strictEqual(modeHandlerList.length, 1);
 
     // delete
     ModeHandlerMap.delete(key);
-    assert.equal(ModeHandlerMap.getAll().length, 0);
+    assert.strictEqual(ModeHandlerMap.getAll().length, 0);
   });
 });

--- a/test/mode/modeVisual.test.ts
+++ b/test/mode/modeVisual.test.ts
@@ -40,13 +40,13 @@ suite('Mode Visual', () => {
 
     const sel = TextEditor.getSelection();
 
-    assert.equal(sel.start.character, 0);
-    assert.equal(sel.start.line, 0);
+    assert.strictEqual(sel.start.character, 0);
+    assert.strictEqual(sel.start.line, 0);
 
     // The input cursor comes BEFORE the block cursor. Try it out, this
     // is how Vim works.
-    assert.equal(sel.end.character, 6);
-    assert.equal(sel.end.line, 0);
+    assert.strictEqual(sel.end.character, 6);
+    assert.strictEqual(sel.end.line, 0);
   });
 
   test('Can handle wd', async () => {

--- a/test/mode/modeVisualLine.test.ts
+++ b/test/mode/modeVisualLine.test.ts
@@ -33,13 +33,13 @@ suite('Mode Visual Line', () => {
 
     const sel = TextEditor.getSelection();
 
-    assert.equal(sel.start.character, 0);
-    assert.equal(sel.start.line, 0);
+    assert.strictEqual(sel.start.character, 0);
+    assert.strictEqual(sel.start.line, 0);
 
     // The input cursor comes BEFORE the block cursor. Try it out, this
     // is how Vim works.
-    assert.equal(sel.end.character, 6);
-    assert.equal(sel.end.line, 0);
+    assert.strictEqual(sel.end.character, 6);
+    assert.strictEqual(sel.end.line, 0);
   });
 
   test('Can handle wd', async () => {

--- a/test/motion.test.ts
+++ b/test/motion.test.ts
@@ -15,121 +15,121 @@ suite('basic motion', () => {
 
   test('char right: should move one column right', () => {
     const position = new Position(0, 0);
-    assert.equal(position.line, 0);
-    assert.equal(position.character, 0);
+    assert.strictEqual(position.line, 0);
+    assert.strictEqual(position.character, 0);
 
     const next = position.getRight();
-    assert.equal(next.line, 0);
-    assert.equal(next.character, 1);
+    assert.strictEqual(next.line, 0);
+    assert.strictEqual(next.character, 1);
   });
 
   test('char right', () => {
     const motion = new Position(0, 9).getRight();
 
-    assert.equal(motion.line, 0);
-    assert.equal(motion.character, 9);
+    assert.strictEqual(motion.line, 0);
+    assert.strictEqual(motion.character, 9);
   });
 
   test('char left: should move cursor one column left', () => {
     let position = new Position(0, 5);
-    assert.equal(position.line, 0);
-    assert.equal(position.character, 5);
+    assert.strictEqual(position.line, 0);
+    assert.strictEqual(position.character, 5);
 
     position = position.getLeft();
-    assert.equal(position.line, 0);
-    assert.equal(position.character, 4);
+    assert.strictEqual(position.line, 0);
+    assert.strictEqual(position.character, 4);
   });
 
   test('char left: left-most column should stay at the same location', () => {
     let motion = new Position(0, 0);
-    assert.equal(motion.line, 0);
-    assert.equal(motion.character, 0);
+    assert.strictEqual(motion.line, 0);
+    assert.strictEqual(motion.character, 0);
 
     motion = motion.getLeft();
-    assert.equal(motion.line, 0);
-    assert.equal(motion.character, 0);
+    assert.strictEqual(motion.line, 0);
+    assert.strictEqual(motion.character, 0);
   });
 
   test('line down: should move cursor one line down', () => {
     let motion = new Position(1, 0);
-    assert.equal(motion.line, 1);
-    assert.equal(motion.character, 0);
+    assert.strictEqual(motion.line, 1);
+    assert.strictEqual(motion.character, 0);
 
     motion = motion.getDown(0);
-    assert.equal(motion.line, 2);
-    assert.equal(motion.character, 0);
+    assert.strictEqual(motion.line, 2);
+    assert.strictEqual(motion.character, 0);
   });
 
   test('line down: bottom-most line should stay at the same location', () => {
     let motion = new Position(3, 0);
-    assert.equal(motion.line, 3);
-    assert.equal(motion.character, 0);
+    assert.strictEqual(motion.line, 3);
+    assert.strictEqual(motion.character, 0);
 
     motion = motion.getDown(3);
-    assert.equal(motion.line, 3);
-    assert.equal(motion.character, 0);
+    assert.strictEqual(motion.line, 3);
+    assert.strictEqual(motion.character, 0);
   });
 
   suite('line up', () => {
     test('should move cursor one line up', () => {
       let position = new Position(1, 0);
-      assert.equal(position.line, 1);
-      assert.equal(position.character, 0);
+      assert.strictEqual(position.line, 1);
+      assert.strictEqual(position.character, 0);
 
       position = position.getUp(0);
-      assert.equal(position.line, 0);
-      assert.equal(position.character, 0);
+      assert.strictEqual(position.line, 0);
+      assert.strictEqual(position.character, 0);
     });
 
     test('top-most line should stay at the same location', () => {
       let motion = new Position(0, 1);
-      assert.equal(motion.line, 0);
-      assert.equal(motion.character, 1);
+      assert.strictEqual(motion.line, 0);
+      assert.strictEqual(motion.character, 1);
 
       motion = motion.getUp(0);
-      assert.equal(motion.line, 0);
-      assert.equal(motion.character, 1);
+      assert.strictEqual(motion.line, 0);
+      assert.strictEqual(motion.character, 1);
     });
   });
 
   test('line begin', () => {
     const motion = new Position(0, 3).getLineBegin();
-    assert.equal(motion.line, 0);
-    assert.equal(motion.character, 0);
+    assert.strictEqual(motion.line, 0);
+    assert.strictEqual(motion.character, 0);
   });
 
   test('line end', () => {
     let motion = new Position(0, 0).getLineEnd();
-    assert.equal(motion.line, 0);
-    assert.equal(motion.character, text[0].length);
+    assert.strictEqual(motion.line, 0);
+    assert.strictEqual(motion.character, text[0].length);
 
     motion = new Position(2, 0).getLineEnd();
-    assert.equal(motion.line, 2);
-    assert.equal(motion.character, text[2].length);
+    assert.strictEqual(motion.line, 2);
+    assert.strictEqual(motion.character, text[2].length);
   });
 
   test('document begin', () => {
     const motion = new Position(1, 0).getDocumentBegin();
-    assert.equal(motion.line, 0);
-    assert.equal(motion.character, 0);
+    assert.strictEqual(motion.line, 0);
+    assert.strictEqual(motion.character, 0);
   });
 
   test('document end', () => {
     const motion = new Position(0, 0).getDocumentEnd();
-    assert.equal(motion.line, text.length - 1);
-    assert.equal(motion.character, text[text.length - 1].length);
+    assert.strictEqual(motion.line, text.length - 1);
+    assert.strictEqual(motion.character, text[text.length - 1].length);
   });
 
   test('line begin cursor on first non-blank character', () => {
     const motion = new Position(0, 3).getFirstLineNonBlankChar();
-    assert.equal(motion.line, 0);
-    assert.equal(motion.character, 0);
+    assert.strictEqual(motion.line, 0);
+    assert.strictEqual(motion.character, 0);
   });
 
   test('last line begin cursor on first non-blank character', () => {
     const motion = new Position(3, 0).getFirstLineNonBlankChar();
-    assert.equal(motion.line, 3);
-    assert.equal(motion.character, 1);
+    assert.strictEqual(motion.line, 3);
+    assert.strictEqual(motion.character, 1);
   });
 });
 
@@ -155,199 +155,199 @@ suite('word motion', () => {
   suite('word right', () => {
     test('move to word right', () => {
       const motion = new Position(0, 3).getWordRight();
-      assert.equal(motion.line, 0);
-      assert.equal(motion.character, 4);
+      assert.strictEqual(motion.line, 0);
+      assert.strictEqual(motion.character, 4);
     });
 
     test('last word should move to next line', () => {
       const motion = new Position(0, 10).getWordRight();
-      assert.equal(motion.line, 1);
-      assert.equal(motion.character, 2);
+      assert.strictEqual(motion.line, 1);
+      assert.strictEqual(motion.character, 2);
     });
 
     test('last word should move to next line stops on empty line', () => {
       const motion = new Position(2, 7).getWordRight();
-      assert.equal(motion.line, 3);
-      assert.equal(motion.character, 0);
+      assert.strictEqual(motion.line, 3);
+      assert.strictEqual(motion.character, 0);
     });
 
     test('last word should move to next line skips whitespace only line', () => {
       const motion = new Position(4, 14).getWordRight();
-      assert.equal(motion.line, 6);
-      assert.equal(motion.character, 0);
+      assert.strictEqual(motion.line, 6);
+      assert.strictEqual(motion.character, 0);
     });
 
     test('last word on last line should go to end of document (special case!)', () => {
       const motion = new Position(6, 6).getWordRight();
-      assert.equal(motion.line, 6);
-      assert.equal(motion.character, 10);
+      assert.strictEqual(motion.line, 6);
+      assert.strictEqual(motion.character, 10);
     });
   });
 
   suite('word left', () => {
     test('move cursor word left across spaces', () => {
       const motion = new Position(0, 3).getWordLeft();
-      assert.equal(motion.line, 0);
-      assert.equal(motion.character, 0);
+      assert.strictEqual(motion.line, 0);
+      assert.strictEqual(motion.character, 0);
     });
 
     test('move cursor word left within word', () => {
       const motion = new Position(0, 5).getWordLeft();
-      assert.equal(motion.line, 0);
-      assert.equal(motion.character, 4);
+      assert.strictEqual(motion.line, 0);
+      assert.strictEqual(motion.character, 4);
     });
 
     test('first word should move to previous line, beginning of last word', () => {
       const motion = new Position(1, 2).getWordLeft();
-      assert.equal(motion.line, 0);
-      assert.equal(motion.character, 10);
+      assert.strictEqual(motion.line, 0);
+      assert.strictEqual(motion.character, 10);
     });
 
     test('first word should move to previous line, stops on empty line', () => {
       const motion = new Position(4, 2).getWordLeft();
-      assert.equal(motion.line, 3);
-      assert.equal(motion.character, 0);
+      assert.strictEqual(motion.line, 3);
+      assert.strictEqual(motion.character, 0);
     });
 
     test('first word should move to previous line, skips whitespace only line', () => {
       const motion = new Position(6, 0).getWordLeft();
-      assert.equal(motion.line, 4);
-      assert.equal(motion.character, 14);
+      assert.strictEqual(motion.line, 4);
+      assert.strictEqual(motion.character, 14);
     });
   });
 
   suite('WORD right', () => {
     test('move to WORD right', () => {
       const motion = new Position(0, 3).getBigWordRight();
-      assert.equal(motion.line, 0);
-      assert.equal(motion.character, 10);
+      assert.strictEqual(motion.line, 0);
+      assert.strictEqual(motion.character, 10);
     });
 
     test('last WORD should move to next line', () => {
       const motion = new Position(1, 10).getBigWordRight();
-      assert.equal(motion.line, 2);
-      assert.equal(motion.character, 0);
+      assert.strictEqual(motion.line, 2);
+      assert.strictEqual(motion.character, 0);
     });
 
     test('last WORD should move to next line stops on empty line', () => {
       const motion = new Position(2, 7).getBigWordRight();
-      assert.equal(motion.line, 3);
-      assert.equal(motion.character, 0);
+      assert.strictEqual(motion.line, 3);
+      assert.strictEqual(motion.character, 0);
     });
 
     test('last WORD should move to next line skips whitespace only line', () => {
       const motion = new Position(4, 12).getBigWordRight();
-      assert.equal(motion.line, 6);
-      assert.equal(motion.character, 0);
+      assert.strictEqual(motion.line, 6);
+      assert.strictEqual(motion.character, 0);
     });
   });
 
   suite('WORD left', () => {
     test('move cursor WORD left across spaces', () => {
       const motion = new Position(0, 3).getBigWordLeft();
-      assert.equal(motion.line, 0);
-      assert.equal(motion.character, 0);
+      assert.strictEqual(motion.line, 0);
+      assert.strictEqual(motion.character, 0);
     });
 
     test('move cursor WORD left within WORD', () => {
       const motion = new Position(0, 5).getBigWordLeft();
-      assert.equal(motion.line, 0);
-      assert.equal(motion.character, 3);
+      assert.strictEqual(motion.line, 0);
+      assert.strictEqual(motion.character, 3);
     });
 
     test('first WORD should move to previous line, beginning of last WORD', () => {
       const motion = new Position(2, 0).getBigWordLeft();
-      assert.equal(motion.line, 1);
-      assert.equal(motion.character, 9);
+      assert.strictEqual(motion.line, 1);
+      assert.strictEqual(motion.character, 9);
     });
 
     test('first WORD should move to previous line, stops on empty line', () => {
       const motion = new Position(4, 2).getBigWordLeft();
-      assert.equal(motion.line, 3);
-      assert.equal(motion.character, 0);
+      assert.strictEqual(motion.line, 3);
+      assert.strictEqual(motion.character, 0);
     });
 
     test('first WORD should move to previous line, skips whitespace only line', () => {
       const motion = new Position(6, 0).getBigWordLeft();
-      assert.equal(motion.line, 4);
-      assert.equal(motion.character, 9);
+      assert.strictEqual(motion.line, 4);
+      assert.strictEqual(motion.character, 9);
     });
   });
 
   suite('end of word right', () => {
     test('move to end of current word right', () => {
       const motion = new Position(0, 4).getCurrentWordEnd();
-      assert.equal(motion.line, 0);
-      assert.equal(motion.character, 7);
+      assert.strictEqual(motion.line, 0);
+      assert.strictEqual(motion.character, 7);
     });
 
     test('move to end of next word right', () => {
       const motion = new Position(0, 7).getCurrentWordEnd();
-      assert.equal(motion.line, 0);
-      assert.equal(motion.character, 8);
+      assert.strictEqual(motion.line, 0);
+      assert.strictEqual(motion.character, 8);
     });
 
     test('end of last word should move to next line', () => {
       const motion = new Position(0, 10).getCurrentWordEnd();
-      assert.equal(motion.line, 1);
-      assert.equal(motion.character, 7);
+      assert.strictEqual(motion.line, 1);
+      assert.strictEqual(motion.character, 7);
     });
 
     test('end of last word should move to next line skips empty line', () => {
       const motion = new Position(2, 7).getCurrentWordEnd();
-      assert.equal(motion.line, 4);
-      assert.equal(motion.character, 7);
+      assert.strictEqual(motion.line, 4);
+      assert.strictEqual(motion.character, 7);
     });
 
     test('end of last word should move to next line skips whitespace only line', () => {
       const motion = new Position(4, 14).getCurrentWordEnd();
-      assert.equal(motion.line, 6);
-      assert.equal(motion.character, 0);
+      assert.strictEqual(motion.line, 6);
+      assert.strictEqual(motion.character, 0);
     });
   });
 
   suite('end of WORD right', () => {
     test('move to end of current WORD right', () => {
       const motion = new Position(0, 4).getCurrentBigWordEnd();
-      assert.equal(motion.line, 0);
-      assert.equal(motion.character, 8);
+      assert.strictEqual(motion.line, 0);
+      assert.strictEqual(motion.character, 8);
     });
 
     test('move to end of next WORD right', () => {
       const motion = new Position(0, 8).getCurrentBigWordEnd();
-      assert.equal(motion.line, 0);
-      assert.equal(motion.character, 10);
+      assert.strictEqual(motion.line, 0);
+      assert.strictEqual(motion.character, 10);
     });
 
     test('end of last WORD should move to next line', () => {
       const motion = new Position(0, 10).getCurrentBigWordEnd();
-      assert.equal(motion.line, 1);
-      assert.equal(motion.character, 7);
+      assert.strictEqual(motion.line, 1);
+      assert.strictEqual(motion.character, 7);
     });
 
     test('end of last WORD should move to next line skips empty line', () => {
       const motion = new Position(2, 7).getCurrentBigWordEnd();
-      assert.equal(motion.line, 4);
-      assert.equal(motion.character, 7);
+      assert.strictEqual(motion.line, 4);
+      assert.strictEqual(motion.character, 7);
     });
 
     test('end of last WORD should move to next line skips whitespace only line', () => {
       const motion = new Position(4, 14).getCurrentBigWordEnd();
-      assert.equal(motion.line, 6);
-      assert.equal(motion.character, 0);
+      assert.strictEqual(motion.line, 6);
+      assert.strictEqual(motion.character, 0);
     });
   });
 
   test('line begin cursor on first non-blank character', () => {
     const motion = new Position(4, 3).getFirstLineNonBlankChar();
-    assert.equal(motion.line, 4);
-    assert.equal(motion.character, 2);
+    assert.strictEqual(motion.line, 4);
+    assert.strictEqual(motion.character, 2);
   });
 
   test('last line begin cursor on first non-blank character', () => {
     const motion = new Position(6, 0).getFirstLineNonBlankChar();
-    assert.equal(motion.line, 6);
-    assert.equal(motion.character, 0);
+    assert.strictEqual(motion.line, 6);
+    assert.strictEqual(motion.character, 0);
   });
 });
 
@@ -371,80 +371,80 @@ suite('unicode word motion', () => {
   suite('word right', () => {
     test('move cursor word right stops at different kind of character (ideograph -> hiragana)', () => {
       const motion = new Position(0, 0).getWordRight();
-      assert.equal(motion.line, 0);
-      assert.equal(motion.character, 2);
+      assert.strictEqual(motion.line, 0);
+      assert.strictEqual(motion.character, 2);
     });
 
     test('move cursor word right stops at different kind of character (katakana -> ascii)', () => {
       const motion = new Position(0, 7).getWordRight();
-      assert.equal(motion.line, 0);
-      assert.equal(motion.character, 10);
+      assert.strictEqual(motion.line, 0);
+      assert.strictEqual(motion.character, 10);
     });
 
     test('move cursor word right stops at different kind of chararacter (ascii -> punctuation)', () => {
       const motion = new Position(0, 10).getWordRight();
-      assert.equal(motion.line, 0);
-      assert.equal(motion.character, 19);
+      assert.strictEqual(motion.line, 0);
+      assert.strictEqual(motion.character, 19);
     });
 
     test('move cursor word right on non-ascii text', () => {
       const motion = new Position(1, 0).getWordRight();
-      assert.equal(motion.line, 1);
-      assert.equal(motion.character, 9);
+      assert.strictEqual(motion.line, 1);
+      assert.strictEqual(motion.character, 9);
     });
 
     test('move cursor word right recognizes a latin string which has diacritics as a single word', () => {
       const motion = new Position(2, 4).getWordRight();
-      assert.equal(motion.line, 2);
-      assert.equal(motion.character, 9);
+      assert.strictEqual(motion.line, 2);
+      assert.strictEqual(motion.character, 9);
     });
 
     test('move cursor word right recognizes a latin-1 symbol as punctuation', () => {
       let motion = new Position(4, 3).getWordRight();
-      assert.equal(motion.line, 4);
-      assert.equal(motion.character, 4);
+      assert.strictEqual(motion.line, 4);
+      assert.strictEqual(motion.character, 4);
 
       motion = motion.getWordRight(); // issue #3680
-      assert.equal(motion.line, 4);
-      assert.equal(motion.character, 10);
+      assert.strictEqual(motion.line, 4);
+      assert.strictEqual(motion.character, 10);
     });
 
     test('move cursor word right recognizes a sequence of latin-1 symbols and other symbols as a word', () => {
       const motion = new Position(4, 17).getWordRight();
-      assert.equal(motion.line, 4);
-      assert.equal(motion.character, 20);
+      assert.strictEqual(motion.line, 4);
+      assert.strictEqual(motion.character, 20);
     });
   });
 
   suite('word left', () => {
     test('move cursor word left across the different char kind', () => {
       const motion = new Position(0, 2).getWordLeft();
-      assert.equal(motion.line, 0);
-      assert.equal(motion.character, 0);
+      assert.strictEqual(motion.line, 0);
+      assert.strictEqual(motion.character, 0);
     });
 
     test('move cursor word left within the same char kind', () => {
       const motion = new Position(0, 5).getWordLeft();
-      assert.equal(motion.line, 0);
-      assert.equal(motion.character, 2);
+      assert.strictEqual(motion.line, 0);
+      assert.strictEqual(motion.character, 2);
     });
 
     test('move cursor word left across spaces on non-ascii text', () => {
       const motion = new Position(1, 9).getWordLeft();
-      assert.equal(motion.line, 1);
-      assert.equal(motion.character, 0);
+      assert.strictEqual(motion.line, 1);
+      assert.strictEqual(motion.character, 0);
     });
 
     test('move cursor word left within word on non-ascii text', () => {
       const motion = new Position(1, 11).getWordLeft();
-      assert.equal(motion.line, 1);
-      assert.equal(motion.character, 9);
+      assert.strictEqual(motion.line, 1);
+      assert.strictEqual(motion.character, 9);
     });
 
     test('move cursor word left recognizes a latin string which has diacritics as a single word', () => {
       const motion = new Position(3, 10).getWordLeft();
-      assert.equal(motion.line, 3);
-      assert.equal(motion.character, 5);
+      assert.strictEqual(motion.line, 3);
+      assert.strictEqual(motion.character, 5);
     });
   });
 });
@@ -474,58 +474,58 @@ suite('sentence motion', () => {
   suite('sentence forward', () => {
     test('next concrete sentence', () => {
       const motion = new Position(0, 0).getSentenceBegin({ forward: true });
-      assert.equal(motion.line, 0);
-      assert.equal(motion.character, 35);
+      assert.strictEqual(motion.line, 0);
+      assert.strictEqual(motion.character, 35);
     });
 
     test('next sentence that ends with paragraph ending', () => {
       const motion = new Position(2, 50).getNextLineBegin();
-      assert.equal(motion.line, 3);
-      assert.equal(motion.character, 0);
+      assert.strictEqual(motion.line, 3);
+      assert.strictEqual(motion.character, 0);
     });
 
     test('next sentence when cursor is at the end of previous paragraph', () => {
       const motion = new Position(3, 0).getSentenceBegin({ forward: true });
-      assert.equal(motion.line, 4);
-      assert.equal(motion.character, 0);
+      assert.strictEqual(motion.line, 4);
+      assert.strictEqual(motion.character, 0);
     });
 
     test('next sentence when paragraph contains a line of whilte spaces', () => {
       const motion = new Position(6, 2).getSentenceBegin({ forward: true });
-      assert.equal(motion.line, 9);
-      assert.equal(motion.character, 0);
+      assert.strictEqual(motion.line, 9);
+      assert.strictEqual(motion.character, 0);
     });
   });
 
   suite('sentence backward', () => {
     test('current sentence begin', () => {
       const motion = new Position(0, 37).getSentenceBegin({ forward: false });
-      assert.equal(motion.line, 0);
-      assert.equal(motion.character, 35);
+      assert.strictEqual(motion.line, 0);
+      assert.strictEqual(motion.character, 35);
     });
 
     test('sentence forward when cursor is at the beginning of the second sentence', () => {
       const motion = new Position(0, 35).getSentenceBegin({ forward: false });
-      assert.equal(motion.line, 0);
-      assert.equal(motion.character, 0);
+      assert.strictEqual(motion.line, 0);
+      assert.strictEqual(motion.character, 0);
     });
 
     test('current sentence begin with no concrete sentense inside', () => {
       const motion = new Position(3, 0).getSentenceBegin({ forward: false });
-      assert.equal(motion.line, 2);
-      assert.equal(motion.character, 0);
+      assert.strictEqual(motion.line, 2);
+      assert.strictEqual(motion.character, 0);
     });
 
     test("current sentence begin when it's not the same as current paragraph begin", () => {
       const motion = new Position(2, 0).getSentenceBegin({ forward: false });
-      assert.equal(motion.line, 1);
-      assert.equal(motion.character, 0);
+      assert.strictEqual(motion.line, 1);
+      assert.strictEqual(motion.character, 0);
     });
 
     test('current sentence begin when previous line ends with a concrete sentence', () => {
       const motion = new Position(9, 5).getSentenceBegin({ forward: false });
-      assert.equal(motion.line, 9);
-      assert.equal(motion.character, 0);
+      assert.strictEqual(motion.line, 9);
+      assert.strictEqual(motion.character, 0);
     });
   });
 });
@@ -554,46 +554,46 @@ suite('paragraph motion', () => {
   suite('paragraph down', () => {
     test('move down normally', () => {
       const motion = new Position(0, 0).getCurrentParagraphEnd();
-      assert.equal(motion.line, 1);
-      assert.equal(motion.character, 0);
+      assert.strictEqual(motion.line, 1);
+      assert.strictEqual(motion.character, 0);
     });
 
     test('move down longer paragraph', () => {
       const motion = new Position(2, 0).getCurrentParagraphEnd();
-      assert.equal(motion.line, 4);
-      assert.equal(motion.character, 0);
+      assert.strictEqual(motion.line, 4);
+      assert.strictEqual(motion.character, 0);
     });
 
     test('move down starting inside empty line', () => {
       const motion = new Position(4, 0).getCurrentParagraphEnd();
-      assert.equal(motion.line, 7);
-      assert.equal(motion.character, 0);
+      assert.strictEqual(motion.line, 7);
+      assert.strictEqual(motion.character, 0);
     });
 
     test('paragraph at end of document', () => {
       const motion = new Position(7, 0).getCurrentParagraphEnd();
-      assert.equal(motion.line, 8);
-      assert.equal(motion.character, 3);
+      assert.strictEqual(motion.line, 8);
+      assert.strictEqual(motion.character, 3);
     });
   });
 
   suite('paragraph up', () => {
     test('move up short paragraph', () => {
       const motion = new Position(1, 0).getCurrentParagraphBeginning();
-      assert.equal(motion.line, 0);
-      assert.equal(motion.character, 0);
+      assert.strictEqual(motion.line, 0);
+      assert.strictEqual(motion.character, 0);
     });
 
     test('move up longer paragraph', () => {
       const motion = new Position(3, 0).getCurrentParagraphBeginning();
-      assert.equal(motion.line, 1);
-      assert.equal(motion.character, 0);
+      assert.strictEqual(motion.line, 1);
+      assert.strictEqual(motion.character, 0);
     });
 
     test('move up starting inside empty line', () => {
       const motion = new Position(5, 0).getCurrentParagraphBeginning();
-      assert.equal(motion.line, 1);
-      assert.equal(motion.character, 0);
+      assert.strictEqual(motion.line, 1);
+      assert.strictEqual(motion.character, 0);
     });
   });
 });

--- a/test/number/numericString.test.ts
+++ b/test/number/numericString.test.ts
@@ -4,21 +4,21 @@ import { NumericString } from '../../src/common/number/numericString';
 
 suite('numeric string', () => {
   test('fails on non-string', () => {
-    assert.equal(null, NumericString.parse('hi'));
+    assert.strictEqual(null, NumericString.parse('hi'));
   });
 
   test('handles hex round trip', () => {
     const input = '0xa1';
-    assert.equal(input, NumericString.parse(input)!.toString());
+    assert.strictEqual(input, NumericString.parse(input)!.toString());
   });
 
   test('handles decimal round trip', () => {
     const input = '9';
-    assert.equal(input, NumericString.parse(input)!.toString());
+    assert.strictEqual(input, NumericString.parse(input)!.toString());
   });
 
   test('handles octal trip', () => {
     const input = '07';
-    assert.equal(input, NumericString.parse(input)!.toString());
+    assert.strictEqual(input, NumericString.parse(input)!.toString());
   });
 });

--- a/test/plugins/imswitcher.test.ts
+++ b/test/plugins/imswitcher.test.ts
@@ -44,25 +44,25 @@ suite('Input method plugin', () => {
     savedCmd = '';
     const inputMethodSwitcher = new InputMethodSwitcher(fakeExecuteDefault);
     await inputMethodSwitcher.switchInputMethod(ModeName.Normal, ModeName.Insert);
-    assert.equal('', savedCmd);
+    assert.strictEqual('', savedCmd);
     await inputMethodSwitcher.switchInputMethod(ModeName.Insert, ModeName.Normal);
-    assert.equal('', savedCmd);
+    assert.strictEqual('', savedCmd);
     await inputMethodSwitcher.switchInputMethod(ModeName.Normal, ModeName.Insert);
-    assert.equal('', savedCmd);
+    assert.strictEqual('', savedCmd);
     await inputMethodSwitcher.switchInputMethod(ModeName.Insert, ModeName.Normal);
-    assert.equal('', savedCmd);
+    assert.strictEqual('', savedCmd);
   });
 
   test('use other im in insert mode', async () => {
     savedCmd = '';
     const inputMethodSwitcher = new InputMethodSwitcher(fakeExecuteChinese);
     await inputMethodSwitcher.switchInputMethod(ModeName.Normal, ModeName.Insert);
-    assert.equal('', savedCmd);
+    assert.strictEqual('', savedCmd);
     await inputMethodSwitcher.switchInputMethod(ModeName.Insert, ModeName.Normal);
-    assert.equal('im-select default', savedCmd);
+    assert.strictEqual('im-select default', savedCmd);
     await inputMethodSwitcher.switchInputMethod(ModeName.Normal, ModeName.Insert);
-    assert.equal('im-select chinese', savedCmd);
+    assert.strictEqual('im-select chinese', savedCmd);
     await inputMethodSwitcher.switchInputMethod(ModeName.Insert, ModeName.Normal);
-    assert.equal('im-select default', savedCmd);
+    assert.strictEqual('im-select default', savedCmd);
   });
 });

--- a/test/register/register.test.ts
+++ b/test/register/register.test.ts
@@ -251,7 +251,7 @@ suite('register', () => {
     try {
       Register.put(expected, vimState);
       actual = await Register.get(vimState);
-      assert.equal(actual.text, expected);
+      assert.strictEqual(actual.text, expected);
     } catch (err) {
       assert.fail(err);
     }
@@ -312,15 +312,15 @@ suite('register', () => {
 
     // Register changed by forward search
     await modeHandler.handleMultipleKeyEvents('/katu\n'.split(''));
-    assert.equal((await Register.getByKey('/')).text, 'katu');
+    assert.strictEqual((await Register.getByKey('/')).text, 'katu');
 
     // Register changed even if search doesn't exist
     await modeHandler.handleMultipleKeyEvents('0/notthere\n'.split(''));
-    assert.equal((await Register.getByKey('/')).text, 'notthere');
+    assert.strictEqual((await Register.getByKey('/')).text, 'notthere');
 
     // Not changed if search is canceled
     await modeHandler.handleMultipleKeyEvents('0/Alaska'.split('').concat(['<Esc>']));
-    assert.equal((await Register.getByKey('/')).text, 'notthere');
+    assert.strictEqual((await Register.getByKey('/')).text, 'notthere');
   });
 
   test('Search register (/) is set by backward search', async () => {
@@ -330,15 +330,15 @@ suite('register', () => {
 
     // Register changed by forward search
     await modeHandler.handleMultipleKeyEvents('?katu\n'.split(''));
-    assert.equal((await Register.getByKey('/')).text, 'katu');
+    assert.strictEqual((await Register.getByKey('/')).text, 'katu');
 
     // Register changed even if search doesn't exist
     await modeHandler.handleMultipleKeyEvents('$?notthere\n'.split(''));
-    assert.equal((await Register.getByKey('/')).text, 'notthere');
+    assert.strictEqual((await Register.getByKey('/')).text, 'notthere');
 
     // Not changed if search is canceled
     await modeHandler.handleMultipleKeyEvents('$?Alaska'.split('').concat(['<Esc>']));
-    assert.equal((await Register.getByKey('/')).text, 'notthere');
+    assert.strictEqual((await Register.getByKey('/')).text, 'notthere');
   });
 
   test('Search register (/) is set by star search', async () => {
@@ -347,16 +347,16 @@ suite('register', () => {
     );
 
     await modeHandler.handleKeyEvent('*');
-    assert.equal((await Register.getByKey('/')).text, '\\bWake\\b');
+    assert.strictEqual((await Register.getByKey('/')).text, '\\bWake\\b');
 
     await modeHandler.handleMultipleKeyEvents(['g', '*']);
-    assert.equal((await Register.getByKey('/')).text, 'Wake');
+    assert.strictEqual((await Register.getByKey('/')).text, 'Wake');
 
     await modeHandler.handleKeyEvent('#');
-    assert.equal((await Register.getByKey('/')).text, '\\bWake\\b');
+    assert.strictEqual((await Register.getByKey('/')).text, '\\bWake\\b');
 
     await modeHandler.handleMultipleKeyEvents(['g', '#']);
-    assert.equal((await Register.getByKey('/')).text, 'Wake');
+    assert.strictEqual((await Register.getByKey('/')).text, 'Wake');
   });
 
   test('Command register (:) is set by command line', async () => {
@@ -367,7 +367,7 @@ suite('register', () => {
     await modeHandler.handleMultipleKeyEvents(':reg\n'.split(''));
 
     const regStr = ((await Register.getByKey(':')).text as RecordedState).commandString;
-    assert.equal(regStr, command);
+    assert.strictEqual(regStr, command);
   });
 
   test('Read-only registers cannot be written to', async () => {
@@ -383,9 +383,9 @@ suite('register', () => {
     await modeHandler.handleMultipleKeyEvents('"%yy'.split(''));
     await modeHandler.handleMultipleKeyEvents('":yy'.split(''));
 
-    assert.equal((await Register.getByKey('/')).text, 'Expected for /');
-    assert.equal((await Register.getByKey('.')).text, 'Expected for .');
-    assert.equal((await Register.getByKey('%')).text, 'Expected for %');
-    assert.equal((await Register.getByKey(':')).text, 'Expected for :');
+    assert.strictEqual((await Register.getByKey('/')).text, 'Expected for /');
+    assert.strictEqual((await Register.getByKey('.')).text, 'Expected for .');
+    assert.strictEqual((await Register.getByKey('%')).text, 'Expected for %');
+    assert.strictEqual((await Register.getByKey(':')).text, 'Expected for :');
   });
 });

--- a/test/state/vimState.test.ts
+++ b/test/state/vimState.test.ts
@@ -23,7 +23,7 @@ suite('VimState', () => {
     vimState.cursors = initialCursors;
 
     // assert
-    assert.equal(vimState.cursors.length, 1);
+    assert.strictEqual(vimState.cursors.length, 1);
   });
 
   test('cursorStart/cursorStop should be first cursor in cursors', () => {
@@ -40,8 +40,8 @@ suite('VimState', () => {
     vimState.cursors = initialCursors;
 
     // assert
-    assert.equal(vimState.cursors.length, 2);
-    assert.equal(vimState.isMultiCursor, true);
+    assert.strictEqual(vimState.cursors.length, 2);
+    assert.strictEqual(vimState.isMultiCursor, true);
     vimState.cursorStartPosition = cursorStart;
     vimState.cursorStopPosition = cursorStop;
   });

--- a/test/testSimplifier.ts
+++ b/test/testSimplifier.ts
@@ -280,8 +280,8 @@ async function testIt(modeHandler: ModeHandler, testObj: ITestObject): Promise<v
   //
   const actualPosition = Position.FromVSCodePosition(TextEditor.getSelection().start);
   const expectedPosition = helper.endPosition;
-  assert.equal(actualPosition.line, expectedPosition.line, 'Cursor LINE position is wrong.');
-  assert.equal(
+  assert.strictEqual(actualPosition.line, expectedPosition.line, 'Cursor LINE position is wrong.');
+  assert.strictEqual(
     actualPosition.character,
     expectedPosition.character,
     'Cursor CHARACTER position is wrong.'
@@ -291,7 +291,7 @@ async function testIt(modeHandler: ModeHandler, testObj: ITestObject): Promise<v
   if (typeof testObj.endMode !== 'undefined') {
     const actualMode = ModeName[modeHandler.currentMode.name].toUpperCase();
     const expectedMode = ModeName[testObj.endMode].toUpperCase();
-    assert.equal(actualMode, expectedMode, "Didn't enter correct mode.");
+    assert.strictEqual(actualMode, expectedMode, "Didn't enter correct mode.");
   }
 
   // jumps: check jumps are correct if given

--- a/test/testUtils.ts
+++ b/test/testUtils.ts
@@ -79,24 +79,24 @@ export function assertEqualLines(expectedLines: string[]) {
   for (let i = 0; i < expectedLines.length; i++) {
     const expected = expectedLines[i];
     const actual = TextEditor.readLineAt(i);
-    assert.equal(
+    assert.strictEqual(
       actual,
       expected,
       `Content does not match; Expected=${expected}. Actual=${actual}.`
     );
   }
 
-  assert.equal(TextEditor.getLineCount(), expectedLines.length, 'Line count does not match.');
+  assert.strictEqual(TextEditor.getLineCount(), expectedLines.length, 'Line count does not match.');
 }
 
 /**
  * Assert that the first two arguments are equal, and fail a test otherwise.
  *
- * The only difference between this and assert.equal is that here we
+ * The only difference between this and assert.strictEqual is that here we
  * check to ensure the types of the variables are correct.
  */
 export function assertEqual<T>(one: T, two: T, message: string = ''): void {
-  assert.equal(one, two, message);
+  assert.strictEqual(one, two, message);
 }
 
 export async function setupWorkspace(
@@ -154,7 +154,7 @@ export async function cleanUpWorkspace(): Promise<void> {
       }
     );
   }).then(() => {
-    assert.equal(vscode.window.visibleTextEditors.length, 0, 'Expected all editors closed.');
+    assert.strictEqual(vscode.window.visibleTextEditors.length, 0, 'Expected all editors closed.');
     assert(!vscode.window.activeTextEditor, 'Expected no active text editor.');
   });
 }

--- a/test/textEditor.test.ts
+++ b/test/textEditor.test.ts
@@ -16,9 +16,9 @@ suite('text editor', () => {
 
     await TextEditor.insert(expectedText);
 
-    assert.equal(vscode.window.activeTextEditor!.document.lineCount, 1);
+    assert.strictEqual(vscode.window.activeTextEditor!.document.lineCount, 1);
     const actualText = TextEditor.readLineAt(0);
-    assert.equal(actualText, expectedText);
+    assert.strictEqual(actualText, expectedText);
   });
 
   test("replace 'World' with 'Foo Bar'", async () => {
@@ -28,35 +28,35 @@ suite('text editor', () => {
     const range: vscode.Range = new vscode.Range(start, end);
 
     await TextEditor.replace(range, newText);
-    assert.equal(vscode.window.activeTextEditor!.document.lineCount, 1);
+    assert.strictEqual(vscode.window.activeTextEditor!.document.lineCount, 1);
 
     const actualText = TextEditor.readLineAt(0);
-    assert.equal(actualText, 'Hello Foo Bar');
+    assert.strictEqual(actualText, 'Hello Foo Bar');
   });
 
   test('delete `Hello`', async () => {
-    assert.equal(vscode.window.activeTextEditor!.document.lineCount, 1);
+    assert.strictEqual(vscode.window.activeTextEditor!.document.lineCount, 1);
 
     const end = new vscode.Position(0, 5);
     const range = new vscode.Range(new vscode.Position(0, 0), end);
 
     await TextEditor.delete(range);
     const actualText = TextEditor.readLineAt(0);
-    assert.equal(actualText, ' Foo Bar');
+    assert.strictEqual(actualText, ' Foo Bar');
   });
 
   test('delete the whole line', async () => {
-    assert.equal(vscode.window.activeTextEditor!.document.lineCount, 1);
+    assert.strictEqual(vscode.window.activeTextEditor!.document.lineCount, 1);
 
     const range = vscode.window.activeTextEditor!.document.lineAt(0).range;
 
     await TextEditor.delete(range);
     const actualText = TextEditor.readLineAt(0);
-    assert.equal(actualText, '');
+    assert.strictEqual(actualText, '');
   });
 
   test("try to read lines that don't exist", () => {
-    assert.equal(vscode.window.activeTextEditor!.document.lineCount, 1);
+    assert.strictEqual(vscode.window.activeTextEditor!.document.lineCount, 1);
     assert.throws(() => TextEditor.readLineAt(1), RangeError);
     assert.throws(() => TextEditor.readLineAt(2), RangeError);
   });

--- a/test/util/path.test.ts
+++ b/test/util/path.test.ts
@@ -96,15 +96,15 @@ suite('util path', () => {
     test('posix', () => {
       let testUri = vscode.Uri.file('/test/path');
       let resultUri = resolveUri('C:\\', path.posix.sep, testUri, false);
-      assert.equal(resultUri, null, 'Failed to return null when it is not posix path');
+      assert.strictEqual(resultUri, null, 'Failed to return null when it is not posix path');
 
       testUri = vscode.Uri.file('/test/path');
       resultUri = resolveUri('/abc/123', path.posix.sep, testUri, false);
       if (resultUri === null) {
         assert.fail("null shouldn't be returned.");
       } else {
-        assert.equal(resultUri.scheme, 'file');
-        assert.equal(resultUri.path, '/abc/123');
+        assert.strictEqual(resultUri.scheme, 'file');
+        assert.strictEqual(resultUri.path, '/abc/123');
       }
 
       // Convert Uri to local fs Uri if Uri is local untitled
@@ -113,8 +113,8 @@ suite('util path', () => {
       if (resultUri === null) {
         assert.fail("null shouldn't be returned.");
       } else {
-        assert.equal(resultUri.scheme, 'file');
-        assert.equal(resultUri.path, '/abc/123');
+        assert.strictEqual(resultUri.scheme, 'file');
+        assert.strictEqual(resultUri.path, '/abc/123');
       }
 
       testUri = testUri.with({ scheme: 'vscode-remote' });
@@ -123,22 +123,22 @@ suite('util path', () => {
       if (resultUri === null) {
         assert.fail("null shouldn't be returned.");
       } else {
-        assert.equal(resultUri.scheme, 'vscode-remote');
-        assert.equal(resultUri.path, '/abc/123');
+        assert.strictEqual(resultUri.scheme, 'vscode-remote');
+        assert.strictEqual(resultUri.path, '/abc/123');
       }
     });
     test('win32', () => {
       let testUri = vscode.Uri.file('C:\\123');
       let resultUri = resolveUri('/', path.win32.sep, testUri, false);
-      assert.equal(resultUri, null, 'Failed to return null when it is not win32 path');
+      assert.strictEqual(resultUri, null, 'Failed to return null when it is not win32 path');
 
       testUri = vscode.Uri.file('C:\\test');
       resultUri = resolveUri('C:\\123\\abc', path.win32.sep, testUri, false);
       if (resultUri === null) {
         assert.fail("null shouldn't be returned.");
       } else {
-        assert.equal(resultUri.scheme, 'file');
-        assert.equal(resultUri.fsPath, `c:\\123\\abc`);
+        assert.strictEqual(resultUri.scheme, 'file');
+        assert.strictEqual(resultUri.fsPath, `c:\\123\\abc`);
       }
 
       // Even if remote is true, we can only return local file scheme
@@ -146,8 +146,8 @@ suite('util path', () => {
       if (resultUri === null) {
         assert.fail("null shouldn't be returned.");
       } else {
-        assert.equal(resultUri.scheme, 'file');
-        assert.equal(resultUri.fsPath, `c:\\123\\abc`);
+        assert.strictEqual(resultUri.scheme, 'file');
+        assert.strictEqual(resultUri.fsPath, `c:\\123\\abc`);
       }
 
       // Convert Uri to local fs Uri if Uri is local untitled
@@ -156,8 +156,8 @@ suite('util path', () => {
       if (resultUri === null) {
         assert.fail("null shouldn't be returned.");
       } else {
-        assert.equal(resultUri.scheme, 'file');
-        assert.equal(resultUri.path, '/abc/123');
+        assert.strictEqual(resultUri.scheme, 'file');
+        assert.strictEqual(resultUri.path, '/abc/123');
       }
 
       testUri = testUri.with({ scheme: 'vscode-remote' });
@@ -166,8 +166,8 @@ suite('util path', () => {
       if (resultUri === null) {
         assert.fail("null shouldn't be returned.");
       } else {
-        assert.equal(resultUri.scheme, 'vscode-remote');
-        assert.equal(resultUri.path, '/abc/123');
+        assert.strictEqual(resultUri.scheme, 'vscode-remote');
+        assert.strictEqual(resultUri.path, '/abc/123');
       }
     });
   });


### PR DESCRIPTION
The former is deprecated and does not check the types of its arguments.