### PR TITLE
Fix bug causing increment/decrement issues for some number formats

### DIFF
--- a/src/common/number/numericString.ts
+++ b/src/common/number/numericString.ts
@@ -5,9 +5,9 @@ export class NumericString {
   suffix: string;
 
   private static matchings: { regex: RegExp; base: number; prefix: string }[] = [
-    { regex: /^([-+])?0([0-7]+)$/g, base: 8, prefix: '0' },
-    { regex: /^([-+])?(\d+)$/g, base: 10, prefix: '' },
-    { regex: /^([-+])?0x([\da-fA-F]+)$/g, base: 16, prefix: '0x' },
+    { regex: /^([-+])?0([0-7]+)$/, base: 8, prefix: '0' },
+    { regex: /^([-+])?(\d+)$/, base: 10, prefix: '' },
+    { regex: /^([-+])?0x([\da-fA-F]+)$/, base: 16, prefix: '0x' },
     { regex: /\d/, base: 10, prefix: '' },
   ];
 

--- a/test/number/numericString.test.ts
+++ b/test/number/numericString.test.ts
@@ -10,15 +10,19 @@ suite('numeric string', () => {
   test('handles hex round trip', () => {
     const input = '0xa1';
     assert.strictEqual(input, NumericString.parse(input)!.toString());
+    // run each assertion twice to make sure that regex state doesn't cause failures
+    assert.strictEqual(input, NumericString.parse(input)!.toString());
   });
 
   test('handles decimal round trip', () => {
     const input = '9';
     assert.strictEqual(input, NumericString.parse(input)!.toString());
+    assert.strictEqual(input, NumericString.parse(input)!.toString());
   });
 
   test('handles octal trip', () => {
     const input = '07';
+    assert.strictEqual(input, NumericString.parse(input)!.toString());
     assert.strictEqual(input, NumericString.parse(input)!.toString());
   });
 });


### PR DESCRIPTION
**What this PR does / why we need it**:
When incrementing or decrementing a number, the `NumericString.parse` class is used to parse strings in to numbers of various formats. However, it used global (stateful) regexes to do this, which meant that funky things could happen after the first call to the method. This PR fixes the issue by simply removing the `g` flag from some regexes.

This fixes issues, for example, where pressing `<C-a>` on certain numbers more than once lead to numeric prefixes getting stripped or other odd behavior.

**Which issue(s) this PR fixes**
Fixes #3545

**Special notes for your reviewer**:
@Chillee added the `g` flag in https://github.com/VSCodeVim/Vim/pull/1721. I think the rest of the logic in that PR still works correctly _without_ the `g` flags, but feel free to take a look and verify that this change is safe.