### PR TITLE
Remove prepare-test step from CONTRIBUTING.md

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -45,8 +45,7 @@ When submitting a PR, please fill out the template that is presented by GitHub w
     # Or run tests by selecting the appropriate drop down option
 
     # Alternatively, build and run tests through gulp and npm scripts
-    npx gulp build                  # build extension
-    npx gulp prepare-test           # build sources and tests
+    npx gulp build                  # build
     npm test                        # test (must close all instances of VSCode)
 
     # Only available if Docker is installed and running


### PR DESCRIPTION
**What this PR does / why we need it**:
With the revert of the webpack build PR (#4217), we also need to revert the documentation change in CONTRIBUTING.md. 

(Just noticed this when making a PR earlier today, figured it would be good so that new contributors aren't confused!)

**Which issue(s) this PR fixes**
Reverts #4128 manually

**Special notes for your reviewer**:
