### PR TITLE
Fix cursor off after leaving multi-cursor mode

### DIFF
--- a/src/actions/commands/actions.ts
+++ b/src/actions/commands/actions.ts
@@ -590,18 +590,6 @@ class CommandEsc extends BaseCommand {
       return vimState;
     }
 
-    if (
-      vimState.currentMode !== Mode.Visual &&
-      vimState.currentMode !== Mode.VisualLine &&
-      vimState.currentMode !== Mode.EasyMotionMode
-    ) {
-      // Normally, you don't have to iterate over all cursors,
-      // as that is handled for you by the state machine. ESC is
-      // a special case since runsOnceForEveryCursor is false.
-
-      vimState.cursors = vimState.cursors.map(x => x.withNewStop(x.stop.getLeft()));
-    }
-
     if (vimState.currentMode === Mode.SearchInProgressMode) {
       vimState.statusBarCursorCharacterPos = 0;
       if (globalState.searchState) {

--- a/test/mode/modeNormal.test.ts
+++ b/test/mode/modeNormal.test.ts
@@ -2063,7 +2063,7 @@ suite('Mode Normal', () => {
       'test aaa test aaa test aaa test aaa test',
     ],
     keysPressed: '<C-alt+down>D<Esc>',
-    end: ['test aaa test aaa test aaa tes|t ', 'test aaa test aaa test aaa test '],
+    end: ['test aaa test aaa test aaa test| ', 'test aaa test aaa test aaa test '],
   });
 
   newTest({


### PR DESCRIPTION
<!--
Yay! Thanks for sending us a PR! 🎊

Please ensure your PR adheres to:

- [v] Commit messages has a short & issue references when necessary
- [v] Each commit does a logical chunk of work.
- [v] It builds and tests pass (e.g `gulp`)
-->

**What this PR does / why we need it**:
Previously when leaving multi-cursor mode with `<Esc>` the cursor would move one column to the left. For instance, when triggering multi-cursor mode on a single word, the cursor would end at the second to last character. While this is expected behavior when leaving insert mode, it is not for visual mode (which multi-cursor mode is based on). To fix, remove special case handling altogether.

**Which issue(s) this PR fixes**:
#3775 

<!--
Commits in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)
-->

**Special notes for your reviewer**:
After giving it some thoughts, I decided to remove the special case completely. I could not reproduce any other case where conditions would match other than move-left after multi-cursor mode. To verify, I added a `console.log()` in the branch in question, and ran the complete test suite. Only one test wrote a message to the console (the one I changed to expected behavior).
