### PR TITLE
Fix `gp` when pasting more than three lines

### DIFF
--- a/src/actions/commands/actions.ts
+++ b/src/actions/commands/actions.ts
@@ -1868,12 +1868,9 @@ export class GPutBeforeCommand extends BaseCommand {
     }
 
     if (vimState.effectiveRegisterMode === RegisterMode.LineWise) {
-      const line = TextEditor.getLineAt(position).text;
-      const addAnotherLine = line.length > 0 && addedLinesCount > 1;
-
       result.recordedState.transformations.push({
         type: 'moveCursor',
-        diff: PositionDiff.NewBOLDiff(1 + (addAnotherLine ? 1 : 0), 0),
+        diff: PositionDiff.NewBOLDiff(addedLinesCount, 0),
         cursorIndex: this.multicursorIndex,
       });
     }

--- a/src/actions/commands/actions.ts
+++ b/src/actions/commands/actions.ts
@@ -1725,12 +1725,9 @@ export class GPutCommand extends BaseCommand {
     const result = await super.execCount(position, vimState);
 
     if (vimState.effectiveRegisterMode === RegisterMode.LineWise) {
-      const line = TextEditor.getLineAt(position).text;
-      const addAnotherLine = line.length > 0 && addedLinesCount > 1;
-
       result.recordedState.transformations.push({
         type: 'moveCursor',
-        diff: PositionDiff.NewBOLDiff(addedLinesCount + (addAnotherLine ? 1 : 0), 0),
+        diff: PositionDiff.NewBOLDiff(addedLinesCount, 0),
         cursorIndex: this.multicursorIndex,
       });
     }

--- a/src/actions/commands/actions.ts
+++ b/src/actions/commands/actions.ts
@@ -1730,7 +1730,7 @@ export class GPutCommand extends BaseCommand {
 
       result.recordedState.transformations.push({
         type: 'moveCursor',
-        diff: PositionDiff.NewBOLDiff(1 + (addAnotherLine ? 1 : 0), 0),
+        diff: PositionDiff.NewBOLDiff(addedLinesCount + (addAnotherLine ? 1 : 0), 0),
         cursorIndex: this.multicursorIndex,
       });
     }

--- a/test/mode/modeNormal.test.ts
+++ b/test/mode/modeNormal.test.ts
@@ -1177,6 +1177,13 @@ suite('Mode Normal', () => {
   });
 
   newTest({
+    title: "Can handle 'gP' after 'Nyy' if pasting more than three lines",
+    start: ['on|e', 'two', 'three', 'four'],
+    keysPressed: '4yygP',
+    end: ['one', 'two', 'three', 'four', '|one', 'two', 'three', 'four'],
+  });
+
+  newTest({
     title: "Can handle ']p' after yy",
     start: ['  |one', '   two'],
     keysPressed: 'yyj]p',

--- a/test/mode/modeNormal.test.ts
+++ b/test/mode/modeNormal.test.ts
@@ -1149,6 +1149,13 @@ suite('Mode Normal', () => {
   });
 
   newTest({
+    title: "Can handle 'gp' after 'Nyy' if pasting more than three lines",
+    start: ['on|e', 'two', 'three', 'four'],
+    keysPressed: '4yyGgp',
+    end: ['one', 'two', 'three', 'four', 'one', 'two', 'three', '|four'],
+  });
+
+  newTest({
     title: "Can handle 'gp' after 'Nyy' if cursor is on the last line",
     start: ['on|e', 'two', 'three'],
     keysPressed: '2yyjjgp',


### PR DESCRIPTION
<!--
Yay! Thanks for sending us a PR! 🎊

Please ensure your PR adheres to:

- [v ] Commit messages has a short & issue references when necessary
- [v] Each commit does a logical chunk of work.
- [v] It builds and tests pass (e.g `gulp`)
-->

**What this PR does / why we need it**:
Make `gp` (and `gP`) correctly place cursor after pasting 4+ lines.

**Which issue(s) this PR fixes**:
#4246

<!--
Commits in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)
-->

**Special notes for your reviewer**:
This looks to me like a minor slip of the original author. Tests did not reveal the bug and it is not super obvious in day to day usage.