### PR TITLE
Recognize VSCode commands in .vimrc

### DIFF
--- a/src/configuration/configuration.ts
+++ b/src/configuration/configuration.ts
@@ -88,7 +88,7 @@ class Configuration implements IConfiguration {
     }
 
     if (this.vimrc.enable) {
-      vimrc.load(this);
+      await vimrc.load(this);
     }
 
     this.leader = Notation.NormalizeKey(this.leader, this.leaderDefault);

--- a/src/configuration/vimrc.ts
+++ b/src/configuration/vimrc.ts
@@ -10,7 +10,7 @@ class VimrcImpl {
     return this._vimrcPath;
   }
 
-  public load(config: IConfiguration) {
+  public async load(config: IConfiguration) {
     const _path = config.vimrc.path
       ? VimrcImpl.expandHome(config.vimrc.path)
       : VimrcImpl.findDefaultVimrc();
@@ -26,7 +26,7 @@ class VimrcImpl {
     // Add the new remappings
     const lines = fs.readFileSync(config.vimrc.path, { encoding: 'utf8' }).split(/\r?\n/);
     for (const line of lines) {
-      const remap = vimrcKeyRemappingBuilder.build(line);
+      const remap = await vimrcKeyRemappingBuilder.build(line);
       if (remap) {
         VimrcImpl.addRemapToConfig(config, remap);
       }

--- a/src/configuration/vimrcKeyRemappingBuilder.ts
+++ b/src/configuration/vimrcKeyRemappingBuilder.ts
@@ -1,3 +1,4 @@
+import * as vscode from 'vscode';
 import { IKeyRemapping, IVimrcKeyRemapping } from './iconfiguration';
 
 class VimrcKeyRemappingBuilderImpl {
@@ -8,7 +9,7 @@ class VimrcKeyRemappingBuilderImpl {
   /**
    * @returns A remapping if the given `line` parses to one, and `undefined` otherwise.
    */
-  public build(line: string): IVimrcKeyRemapping | undefined {
+  public async build(line: string): Promise<IVimrcKeyRemapping | undefined> {
     const matches = VimrcKeyRemappingBuilderImpl.KEY_REMAPPING_REG_EX.exec(line);
     if (!matches || matches.length < 4) {
       return undefined;
@@ -19,7 +20,8 @@ class VimrcKeyRemappingBuilderImpl {
     const after = matches[3];
 
     let mapping: IKeyRemapping;
-    if (VimrcKeyRemappingBuilderImpl.isCommand(after)) {
+    const vscodeCommands = await vscode.commands.getCommands();
+    if (vscodeCommands.includes(after) || VimrcKeyRemappingBuilderImpl.isVimCommand(after)) {
       mapping = {
         before: VimrcKeyRemappingBuilderImpl.buildKeyList(before),
         commands: [after],
@@ -42,7 +44,7 @@ class VimrcKeyRemappingBuilderImpl {
   /**
    * @returns `true` if this remaps a key sequence to a `:` command
    */
-  private static isCommand(commandString: string): boolean {
+  private static isVimCommand(commandString: string): boolean {
     const matches = VimrcKeyRemappingBuilderImpl.COMMAND_REG_EX.exec(commandString);
     if (matches) {
       return true;

--- a/test/configuration/vimrcKeyRemappingBuilder.test.ts
+++ b/test/configuration/vimrcKeyRemappingBuilder.test.ts
@@ -3,7 +3,7 @@ import { IKeyRemapping, IVimrcKeyRemapping } from '../../src/configuration/iconf
 import { vimrcKeyRemappingBuilder } from '../../src/configuration/vimrcKeyRemappingBuilder';
 
 suite('VimrcKeyRemappingBuilder', () => {
-  test('Build IKeyRemapping objects from .vimrc lines', () => {
+  test('Build IKeyRemapping objects from .vimrc lines', async () => {
     const testCases = [
       {
         vimrcLine: 'nnoremap <C-h> <<',
@@ -36,11 +36,22 @@ suite('VimrcKeyRemappingBuilder', () => {
         expectNull: false,
       },
       {
-        // Mapping with a command
+        // Mapping with a vim command
         vimrcLine: 'nnoremap <C-s> :w',
         keyRemapping: {
           before: ['<C-s>'],
           commands: [':w'],
+          source: 'vimrc',
+        },
+        keyRemappingType: 'nnoremap',
+        expectNull: false,
+      },
+      {
+        // Mapping with a VSCode command
+        vimrcLine: 'nnoremap <C-t> workbench.action.files.newUntitledFile',
+        keyRemapping: {
+          before: ['<C-t>'],
+          commands: ['workbench.action.files.newUntitledFile'],
           source: 'vimrc',
         },
         keyRemappingType: 'nnoremap',
@@ -54,9 +65,7 @@ suite('VimrcKeyRemappingBuilder', () => {
     ];
 
     for (const testCase of testCases) {
-      const vimrcKeyRemapping: IVimrcKeyRemapping | undefined = vimrcKeyRemappingBuilder.build(
-        testCase.vimrcLine
-      );
+      const vimrcKeyRemapping = await vimrcKeyRemappingBuilder.build(testCase.vimrcLine);
 
       if (testCase.expectNull) {
         assert.strictEqual(vimrcKeyRemapping, undefined);


### PR DESCRIPTION
For instance, `nnoremap gs workbench.action.showAllSymbols` will now work.
Refs #463