### PR TITLE
fix comment typos "postion" to "position"

### DIFF
--- a/src/actions/textobject.ts
+++ b/src/actions/textobject.ts
@@ -75,7 +75,7 @@ export class SelectWord extends TextObjectMovement {
       start = vimState.cursorStartPosition;
 
       if (vimState.cursorStopPosition.isBefore(vimState.cursorStartPosition)) {
-        // If current cursor postion is before cursor start position, we are selecting words in reverser order.
+        // If current cursor position is before cursor start position, we are selecting words in reverser order.
         if (/\s/.test(currentChar)) {
           stop = position.getWordLeft(true);
         } else {


### PR DESCRIPTION
I fixed comment typos "postion" to "position"

<!--
Yay! Thanks for sending us a PR! 🎊

Please ensure your PR adheres to:

- [ ] Commit messages has a short & issue references when necessary
- [ ] Each commit does a logical chunk of work.
- [ ] It builds and tests pass (e.g `gulp`)
-->

**What this PR does / why we need it**:
fixing comment typos "postion" to "position"/ because some people who do not well English miss understand comment

**Which issue(s) this PR fixes**
 "postion" to "position"
<!--
Commits in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)
-->

**Special notes for your reviewer**:

I'm a Korean college student who just started coding. I'm not good at it, but I'd also like to contribute comments in this project.
