### PR TITLE
Fixed backward search from end of word (VSCodeVim #4266)

### DIFF
--- a/src/state/searchState.ts
+++ b/src/state/searchState.ts
@@ -325,7 +325,7 @@ export class SearchState {
         .slice(0)
         .reverse()
         .entries()) {
-        if (matchRange.start.compareTo(startPosition) < 0) {
+        if (matchRange.end.compareTo(startPosition) <= 0) {
           return {
             start: Position.FromVSCodePosition(matchRange.start),
             end: Position.FromVSCodePosition(matchRange.end),

--- a/test/mode/normalModeTests/motions.test.ts
+++ b/test/mode/normalModeTests/motions.test.ts
@@ -312,6 +312,13 @@ suite('Motions in Normal Mode', () => {
     end: ['one two |two two'],
   });
 
+  newTest({
+    title: 'Can run a forward and find previous search from end of word',
+    start: ['|one two one two'],
+    keysPressed: '/two/e\nN',
+    end: ['one two one tw|o'],
+  });
+
   // These "remembering history between editor" tests have started
   // breaking. Since I don't remember these tests ever breaking for real, and
   // because they're the cause of a lot of flaky tests, I'm disabling these for


### PR DESCRIPTION
Fixed backward search from end of word (VSCodeVim #4266)
- Searching with 'N' after /e at the end of search fixed
- Changed comparison for next search result
- Change made in getNextSearchMatchRange in searchState.ts

<!--
Yay! Thanks for sending us a PR! 🎊

Please ensure your PR adheres to:

- [ ] Commit messages has a short & issue references when necessary
- [ ] Each commit does a logical chunk of work.
- [ ] It builds and tests pass (e.g `gulp`)
-->

**What this PR does / why we need it**:
Fix the issue reported,
1. Search for a recurring word and use offset e. E.g.` /word/e`
2. The cursor should now be at the end of the next result
3. Repeat search backwards with `N`
4. The cursor is still on the current result

Also fixed the larger issue, where backward search was broken in general. For example, the previous steps could be repeated with `?word?e`, where backward search with `n` also did move the cursor. 

**Which issue(s) this PR fixes**
#4266 
<!--
Commits in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)
-->

**Special notes for your reviewer**:
We tested this manually to verify it works, please let us know if we should add actual tests to the suite. 
