### PR TITLE
Fix laggy scrolling with <C-e> and <C-y> (WIP)

### DIFF
--- a/src/actions/commands/actions.ts
+++ b/src/actions/commands/actions.ts
@@ -690,15 +690,12 @@ abstract class CommandEditorScroll extends BaseCommand {
       vimState.cursors[0] = vimState.cursors[0].getDown(scrolloff - linesBelowCursor);
     }
 
-    vimState.postponedCodeViewChanges.push({
-      command: 'editorScroll',
-      args: {
-        to: this.to,
-        by: this.by,
-        value: timesToRepeat,
-        revealCursor: true,
-        select: [Mode.Visual, Mode.VisualBlock, Mode.VisualLine].includes(vimState.currentMode),
-      },
+    await vscode.commands.executeCommand('editorScroll', {
+      to: this.to,
+      by: this.by,
+      value: timesToRepeat,
+      revealCursor: true,
+      select: [Mode.Visual, Mode.VisualBlock, Mode.VisualLine].includes(vimState.currentMode),
     });
     return vimState;
   }


### PR DESCRIPTION
To fix #4309

This change fixes the performance issue, but causes an issue where &lt;C-y&gt; stops working when the cursor is at the bottom of the screen. This may not be the right fix.

Contributions to this PR are appreciated from people more familiar with the codebase.