### PR TITLE
Require <CR> after a vim command in .vimrc if you want it to run

### DIFF
--- a/test/configuration/vimrcKeyRemappingBuilder.test.ts
+++ b/test/configuration/vimrcKeyRemappingBuilder.test.ts
@@ -37,7 +37,7 @@ suite('VimrcKeyRemappingBuilder', () => {
       },
       {
         // Mapping with a vim command
-        vimrcLine: 'nnoremap <C-s> :w',
+        vimrcLine: 'nnoremap <C-s> :w<CR>',
         keyRemapping: {
           before: ['<C-s>'],
           commands: [':w'],


### PR DESCRIPTION
Fixes #4311