### PR TITLE
Fixed modeHandler being recreated on every key stroke

### DIFF
--- a/src/mode/modeHandlerMap.ts
+++ b/src/mode/modeHandlerMap.ts
@@ -9,7 +9,12 @@ class ModeHandlerMapImpl {
 
   public async getOrCreate(editorId: EditorIdentity): Promise<[ModeHandler, boolean]> {
     let isNew = false;
-    let modeHandler = this.modeHandlerMap.get(editorId);
+    let modeHandler: ModeHandler | undefined;
+    for (const [key, value] of this.modeHandlerMap.entries()) {
+      if (key.isEqual(editorId)) {
+        modeHandler = value;
+      }
+    }
     if (!modeHandler) {
       isNew = true;
       modeHandler = await ModeHandler.Create();


### PR DESCRIPTION
<!--
Yay! Thanks for sending us a PR! 🎊

Please ensure your PR adheres to:

- [ ] Commit messages has a short & issue references when necessary
- [ ] Each commit does a logical chunk of work.
- [ ] It builds and tests pass (e.g `gulp`)
-->

**What this PR does / why we need it**:

this.modeHandlerMap.get(editorId) returns undefined all the time, which means that a new modeHandler gets created everytime getOrCreate() gets invoked on every key press. The result was modeHandler always being in its initial state and rendering the editor completely useless.

This fix properly checks if editorId exists in the map, if it does it properly retrieves its modeHandler.

**Which issue(s) this PR fixes**
Fixes #4332.
<!--
Commits in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)
-->

**Special notes for your reviewer**:
 I'm not sure if what was expected here was that Map.get() would call EditorIdentity.isEqual() to check editorId against the keys, but that's not what was happening.