### PR TITLE
Fix fs.readFileSync() receiving a possibly undefined path

### DIFF
--- a/src/cmd_line/commands/substitute.ts
+++ b/src/cmd_line/commands/substitute.ts
@@ -124,12 +124,12 @@ export class SubstituteCommand extends node.CommandBase {
     if (args.pattern === undefined) {
       // If no pattern is entered, use previous SUBSTITUTION state and don't update search state
       // i.e. :s
-      const prevSubstiteState = globalState.substituteState;
-      if (prevSubstiteState === undefined || prevSubstiteState.searchPattern === '') {
+      const prevSubstituteState = globalState.substituteState;
+      if (prevSubstituteState === undefined || prevSubstituteState.searchPattern === '') {
         throw VimError.fromCode(ErrorCode.E35);
       } else {
-        args.pattern = prevSubstiteState.searchPattern;
-        args.replace = prevSubstiteState.replaceString;
+        args.pattern = prevSubstituteState.searchPattern;
+        args.replace = prevSubstituteState.replaceString;
       }
     } else {
       if (args.pattern === '') {

--- a/src/configuration/iconfiguration.ts
+++ b/src/configuration/iconfiguration.ts
@@ -298,6 +298,9 @@ export interface IConfiguration {
    */
   vimrc: {
     enable: boolean;
+    /**
+     * Do not use this directly - VimrcImpl.path resolves this to a path that's guaranteed to exist.
+     */
     path: string;
   };
 

--- a/src/configuration/vimrc.ts
+++ b/src/configuration/vimrc.ts
@@ -24,7 +24,7 @@ class VimrcImpl {
     VimrcImpl.removeAllRemapsFromConfig(config);
 
     // Add the new remappings
-    const lines = fs.readFileSync(config.vimrc.path, { encoding: 'utf8' }).split(/\r?\n/);
+    const lines = fs.readFileSync(this.vimrcPath, { encoding: 'utf8' }).split(/\r?\n/);
     for (const line of lines) {
       const remap = await vimrcKeyRemappingBuilder.build(line);
       if (remap) {

--- a/src/configuration/vimrc.ts
+++ b/src/configuration/vimrc.ts
@@ -6,6 +6,10 @@ import { vimrcKeyRemappingBuilder } from './vimrcKeyRemappingBuilder';
 
 class VimrcImpl {
   private _vimrcPath: string;
+
+  /**
+   * Fully resolved path to the user's .vimrc
+   */
   public get vimrcPath(): string {
     return this._vimrcPath;
   }


### PR DESCRIPTION
<!--
Yay! Thanks for sending us a PR! 🎊

Please ensure your PR adheres to:

- [ ] Commit messages has a short & issue references when necessary
- [ ] Each commit does a logical chunk of work.
- [ ] It builds and tests pass (e.g `gulp`)
-->

**What this PR does / why we need it**:

When config.vimrc.path is undefined, fs.readFileSync() will throw an error which results in the extension failing to activate. This PR fixes that issue by changing the variable passed to fs.readFileSync() to one that is guaranteed to not be undefined.

**Which issue(s) this PR fixes**

Fixes #4336
<!--
Commits in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)
-->

**Special notes for your reviewer**:

The correct default path ($HOME/.vimrc or $HOME/_vimrc) is already being assigned to the local _path variable which is properly being checked before using it to set the vimrcPath property. Thus, it is safe to assume vimrcPath will never be an invalid path and is safe to be passed to fs.readFileSync().