### PR TITLE
Improved performance of addChange()

### DIFF
--- a/src/history/historyTracker.ts
+++ b/src/history/historyTracker.ts
@@ -437,7 +437,8 @@ export class HistoryTracker {
       return;
     }
 
-    // Determine if we should add a new Step. Additionally, If we are on Insert mode and this isn't the first change we made then we should get out of here.
+    // Determine if we should add a new Step.
+    // If we are on Insert mode and this isn't the first change we made then we should get out of here.
     if (
       this.currentHistoryStepIndex === this.historySteps.length - 1 &&
       this.currentHistoryStep.isFinished


### PR DESCRIPTION
Currently, HistoryTracker.addChange() has a major impact on performance, specially when working on large files. The issue stems largely due to processing the entire document on every call, and that the function gets called on every key press. My proposed changes are as follows:

**Check if offset at EOF is equals to oldText.length**

Currently the first thing addChange() does is grab the text of the entire document, which is a pretty expensive operation. We then check the newText against the oldText to see if there are any changes that need to be processed. There really is no need to get the entire document to know this.

The zero based offset at the document's end represents the location of the character that would follow the last character, thus it is equal to the length of the document's text. We can easily get this offset by using vscode.TextDocument.offsetAt() and passing it Position.getDocumentEnd(). If there are no changes this offset will be equals to historyTracker.oldText.length. 

This would increase the performance when navigating through large files.

**Improvements while on insert mode**

The major issue is that addChange() gets called on every key press, thus the entire document is getting processed every few milliseconds if we type too fast. Which is why we experience more lag the faster we make changes on large files. Currently the first change after going into insert mode triggers _addnewHistoryStep(), consequent changes are added to the historyStep and then when we get out of insert mode we finalise that historyStep.

We shouldn't really need to log each substep while we are on Insert Mode since we only go back one historyStep at a time. We can grab a snapshot of when we first start making changes and one at the end. I had initially thought we could just grab the last change, but we do need the first step to be logged so that we don't brake historyTracker.goBackHistoryStepsOnLine().

We can add a condition that checks if the currentMode === Mode.Insert to get out of addChange() and prevent processing the document while changes are still in progress. The condition shouldn't trigger if we just created a new history step, so that we may log the first step. When we get out of Insert Mode, the call from to addChange() within ModeHandler.runAction() will process the final step.

This change, while it has a major positive impact on performance, does change the workflow of the code a little bit, since calls to addChange() while we are on insert mode will not do anything. With the exception of the first change that creates the historyStep, the call made to addChange() from within ModeHandler.handleKeyEventHelper() will be go largely ignored. I don't believe this has any negative side effects, but is something we might want to be aware of.

**Which issue(s) this PR fixes**

Possibly fixes #3920, #2021, #2216
