### PR TITLE
Added test to check can handle 'u' after :s/abc/def

### DIFF
--- a/test/mode/modeNormal.test.ts
+++ b/test/mode/modeNormal.test.ts
@@ -1486,6 +1486,13 @@ suite('Mode Normal', () => {
   });
 
   newTest({
+    title: "Can handle 'u' after :s/abc/def",
+    start: ['|'],
+    keysPressed: 'iabc<Esc>:s/abc/def/\nu',
+    end: ['ab|c'],
+  });
+
+  newTest({
     title: 'Redo',
     start: ['|'],
     keysPressed: 'iabc<Esc>adef<Esc>uu<C-r>',


### PR DESCRIPTION
**What this PR does / why we need it**:
We should make sure `:s/abc/def` is handled correctly. 

**Special notes for your reviewer**:
Never added a test to this repo before, please let me know if I'm doing things incorrectly.