### PR TITLE
Go the dest line directly when execute move up/down with count

### DIFF
--- a/src/actions/motion.ts
+++ b/src/actions/motion.ts
@@ -233,8 +233,11 @@ class MoveDown extends BaseMovement {
     vimState: VimState,
     count: number
   ): Promise<Position | IMovement> {
+    if (count <= 1) {
+      return super.execActionWithCount(position, vimState, count);
+    }
     vimState.currentRegisterMode = RegisterMode.LineWise;
-    const line = position.getDownByCount(Math.max(count, 1)).line;
+    const line = position.getDownByCount(count).line;
     return new Position(line, Math.min(Position.getLineLength(line), vimState.desiredColumn));
   }
 }
@@ -266,8 +269,11 @@ class MoveUp extends BaseMovement {
     vimState: VimState,
     count: number
   ): Promise<Position | IMovement> {
+    if (count <= 1) {
+      return super.execActionWithCount(position, vimState, count);
+    }
     vimState.currentRegisterMode = RegisterMode.LineWise;
-    const line = position.getUpByCount(Math.max(count, 1)).line;
+    const line = position.getUpByCount(count).line;
     return new Position(line, Math.min(Position.getLineLength(line), vimState.desiredColumn));
   }
 }

--- a/src/actions/motion.ts
+++ b/src/actions/motion.ts
@@ -227,6 +227,16 @@ class MoveDown extends BaseMovement {
     vimState.currentRegisterMode = RegisterMode.LineWise;
     return position.getDown(position.getLineEnd().character);
   }
+
+  public async execActionWithCount(
+    position: Position,
+    vimState: VimState,
+    count: number
+  ): Promise<Position | IMovement> {
+    vimState.currentRegisterMode = RegisterMode.LineWise;
+    const line = position.getDownByCount(Math.max(count, 1)).line;
+    return new Position(line, Math.min(Position.getLineLength(line), vimState.desiredColumn));
+  }
 }
 
 @RegisterAction
@@ -249,6 +259,16 @@ class MoveUp extends BaseMovement {
   public async execActionForOperator(position: Position, vimState: VimState): Promise<Position> {
     vimState.currentRegisterMode = RegisterMode.LineWise;
     return position.getUp(position.getLineEnd().character);
+  }
+
+  public async execActionWithCount(
+    position: Position,
+    vimState: VimState,
+    count: number
+  ): Promise<Position | IMovement> {
+    vimState.currentRegisterMode = RegisterMode.LineWise;
+    const line = position.getUpByCount(Math.max(count, 1)).line;
+    return new Position(line, Math.min(Position.getLineLength(line), vimState.desiredColumn));
   }
 }
 

--- a/test/mode/normalModeTests/motions.test.ts
+++ b/test/mode/normalModeTests/motions.test.ts
@@ -574,6 +574,20 @@ suite('Motions in Normal Mode', () => {
   });
 
   newTest({
+    title: 'Can handle j with count',
+    start: ['|blah blah', 'blah', 'blah blah'],
+    keysPressed: '5l2j',
+    end: ['blah blah', 'blah', 'blah |blah']
+  });
+
+  newTest({
+    title: 'Can handle k with count',
+    start: ['blah blah', 'blah', 'blah b|lah'],
+    keysPressed: '2k',
+    end: ['blah b|lah', 'blah', 'blah blah']
+  });
+
+  newTest({
     title: 'Can handle g*',
     start: ['|blah duh blahblah duh blah'],
     keysPressed: 'g*',


### PR DESCRIPTION
<!--
Yay! Thanks for sending us a PR! 🎊

Please ensure your PR adheres to:

- [ ] Commit messages has a short & issue references when necessary
- [ ] Each commit does a logical chunk of work.
- [ ] It builds and tests pass (e.g `gulp`)
-->

**What this PR does / why we need it**:
Executing move up/down with count is not efficient. `100j` runs `moveDown` 100 times instead of going to the dest line directly.

**Special notes for your reviewer**:
First time contributing to this repo, please let me know if there are any problems.