### PR TITLE
Add commas to statusBarColors JSON on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -399,12 +399,12 @@ Change the color of the status bar based on the current mode. Once enabled, conf
     "vim.statusBarColors.visual": "#B48EAD",
     "vim.statusBarColors.visualline": "#B48EAD",
     "vim.statusBarColors.visualblock": "#A3BE8C",
-    "vim.statusBarColors.replace": "#D08770"
-    "vim.statusBarColors.commandlineinprogress": "#007ACC"
-    "vim.statusBarColors.searchinprogressmode": "#007ACC"
-    "vim.statusBarColors.easymotionmode": "#007ACC"
-    "vim.statusBarColors.easymotioninputmode": "#007ACC"
-    "vim.statusBarColors.surroundinputmode": "#007ACC"
+    "vim.statusBarColors.replace": "#D08770",
+    "vim.statusBarColors.commandlineinprogress": "#007ACC",
+    "vim.statusBarColors.searchinprogressmode": "#007ACC",
+    "vim.statusBarColors.easymotionmode": "#007ACC",
+    "vim.statusBarColors.easymotioninputmode": "#007ACC",
+    "vim.statusBarColors.surroundinputmode": "#007ACC",
 ```
 
 ### vim-easymotion


### PR DESCRIPTION
I've tried copying this around to my config file and realized it had no commas on the ends of lines. I'm adding them here. :)

**What this PR does / why we need it**:
Fixes README by adding commas to the end of the chunk of JSON that enables statusBarColors.

**Which issue(s) this PR fixes**
Didn't file.

**Special notes for your reviewer**:
✨ 