### PR TITLE
support vimrc map & noremap  

### DIFF
--- a/src/configuration/vimrc.ts
+++ b/src/configuration/vimrc.ts
@@ -42,33 +42,46 @@ class VimrcImpl {
    * Adds a remapping from .vimrc to the given configuration
    */
   private static addRemapToConfig(config: IConfiguration, remap: IVimrcKeyRemapping): void {
-    const remaps = (() => {
+    const mappings = (() => {
       switch (remap.keyRemappingType) {
+        case 'map':
+          return [
+            config.normalModeKeyBindings,
+            config.visualModeKeyBindings,
+          ];
         case 'nmap':
-          return config.normalModeKeyBindings;
+          return [config.normalModeKeyBindings];
         case 'vmap':
-          return config.visualModeKeyBindings;
+          return [config.visualModeKeyBindings];
         case 'imap':
-          return config.insertModeKeyBindings;
+          return [config.insertModeKeyBindings];
         case 'cmap':
-          return config.commandLineModeKeyBindings;
+          return [config.commandLineModeKeyBindings];
+        case 'noremap':
+          return [
+            config.normalModeKeyBindingsNonRecursive,
+            config.visualModeKeyBindingsNonRecursive,
+          ];
         case 'nnoremap':
-          return config.normalModeKeyBindingsNonRecursive;
+          return [config.normalModeKeyBindingsNonRecursive];
         case 'vnoremap':
-          return config.visualModeKeyBindingsNonRecursive;
+          return [config.visualModeKeyBindingsNonRecursive];
         case 'inoremap':
-          return config.insertModeKeyBindingsNonRecursive;
+          return [config.insertModeKeyBindingsNonRecursive];
         case 'cnoremap':
-          return config.commandLineModeKeyBindingsNonRecursive;
+          return [config.commandLineModeKeyBindingsNonRecursive];
         default:
+          console.warn('Encountered an unrecognized mapping type.');
           return undefined;
       }
     })();
 
-    // Don't override a mapping present in settings.json; those are more specific to VSCodeVim.
-    if (remaps && !remaps.some(r => _.isEqual(r.before, remap!.keyRemapping.before))) {
-      remaps.push(remap.keyRemapping);
-    }
+    mappings?.forEach(remaps => {
+      // Don't override a mapping present in settings.json; those are more specific to VSCodeVim.
+      if (!remaps.some(r => _.isEqual(r.before, remap!.keyRemapping.before))) {
+        remaps.push(remap.keyRemapping);
+      }
+    });
   }
 
   private static removeAllRemapsFromConfig(config: IConfiguration): void {


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds support for `map` and `renoremap` in .vimrc 

**Which issue(s) this PR fixes**
#4403 

**Special notes for your reviewer**:
Had a test failure however it's currently failing on master.

```
  1) Remapper
       leader, c -> closeActiveEditor in visual mode through modehandler:

      AssertionError [ERR_ASSERTION]: Expected values to be strictly equal:

1 !== 0
```