### PR TITLE
Stop using timeout in `getCursorsAfterSync()`

### DIFF
--- a/src/actions/commands/actions.ts
+++ b/src/actions/commands/actions.ts
@@ -2366,7 +2366,7 @@ class CommandToggleFold extends CommandFold {
   commandName = 'editor.toggleFold';
   public async exec(position: Position, vimState: VimState): Promise<VimState> {
     await vscode.commands.executeCommand(this.commandName);
-    vimState.cursors = await getCursorsAfterSync();
+    vimState.cursors = getCursorsAfterSync();
     await vimState.setCurrentMode(Mode.Normal);
     return vimState;
   }
@@ -2381,7 +2381,7 @@ class CommandCloseFold extends CommandFold {
   public async exec(position: Position, vimState: VimState): Promise<VimState> {
     let timesToRepeat = vimState.recordedState.count || 1;
     await vscode.commands.executeCommand('editor.fold', { levels: timesToRepeat, direction: 'up' });
-    vimState.cursors = await getCursorsAfterSync();
+    vimState.cursors = getCursorsAfterSync();
     return vimState;
   }
 }
@@ -3202,7 +3202,7 @@ class CommandInsertNewLineAbove extends BaseCommand {
       await vscode.commands.executeCommand('editor.action.insertLineBefore');
     }
 
-    vimState.cursors = await getCursorsAfterSync();
+    vimState.cursors = getCursorsAfterSync();
     for (let i = 0; i < count; i++) {
       const newPos = new Position(
         vimState.cursors[0].start.line + i,
@@ -3232,7 +3232,7 @@ class CommandInsertNewLineBefore extends BaseCommand {
     for (let i = 0; i < count; i++) {
       await vscode.commands.executeCommand('editor.action.insertLineAfter');
     }
-    vimState.cursors = await getCursorsAfterSync();
+    vimState.cursors = getCursorsAfterSync();
     for (let i = 1; i < count; i++) {
       const newPos = new Position(
         vimState.cursorStartPosition.line - i,
@@ -4604,7 +4604,7 @@ class ActionOverrideCmdD extends BaseCommand {
 
   public async exec(position: Position, vimState: VimState): Promise<VimState> {
     await vscode.commands.executeCommand('editor.action.addSelectionToNextFindMatch');
-    vimState.cursors = await getCursorsAfterSync();
+    vimState.cursors = getCursorsAfterSync();
 
     // If this is the first cursor, select 1 character less
     // so that only the word is selected, no extra character
@@ -4657,7 +4657,7 @@ class ActionOverrideCmdDInsert extends BaseCommand {
       }
     );
     await vscode.commands.executeCommand('editor.action.addSelectionToNextFindMatch');
-    vimState.cursors = await getCursorsAfterSync();
+    vimState.cursors = getCursorsAfterSync();
     return vimState;
   }
 }
@@ -4676,7 +4676,7 @@ class ActionOverrideCmdAltDown extends BaseCommand {
 
   public async exec(position: Position, vimState: VimState): Promise<VimState> {
     await vscode.commands.executeCommand('editor.action.insertCursorBelow');
-    vimState.cursors = await getCursorsAfterSync();
+    vimState.cursors = getCursorsAfterSync();
 
     return vimState;
   }
@@ -4696,7 +4696,7 @@ class ActionOverrideCmdAltUp extends BaseCommand {
 
   public async exec(position: Position, vimState: VimState): Promise<VimState> {
     await vscode.commands.executeCommand('editor.action.insertCursorAbove');
-    vimState.cursors = await getCursorsAfterSync();
+    vimState.cursors = getCursorsAfterSync();
 
     return vimState;
   }

--- a/src/jumps/jumpTracker.ts
+++ b/src/jumps/jumpTracker.ts
@@ -184,7 +184,7 @@ export class JumpTracker {
 
     if (jumpedFiles) {
       await this.performFileJump(jump, vimState);
-      vimState.cursors = await getCursorsAfterSync();
+      vimState.cursors = getCursorsAfterSync();
     } else {
       vimState.cursorStopPosition = jump.position;
     }

--- a/src/mode/modeHandler.ts
+++ b/src/mode/modeHandler.ts
@@ -1390,7 +1390,7 @@ export class ModeHandler implements vscode.Disposable {
 
     for (const viewChange of this.vimState.postponedCodeViewChanges) {
       await vscode.commands.executeCommand(viewChange.command, viewChange.args);
-      vimState.cursors = await getCursorsAfterSync();
+      vimState.cursors = getCursorsAfterSync();
     }
     this.vimState.postponedCodeViewChanges = [];
 

--- a/src/state/vimState.ts
+++ b/src/state/vimState.ts
@@ -13,7 +13,6 @@ import { Range } from './../common/motion/range';
 import { RecordedState } from './recordedState';
 import { RegisterMode } from './../register/register';
 import { ReplaceState } from './../state/replaceState';
-import { globalState } from './../state/globalState';
 
 /**
  * The VimState class holds permanent state that carries over from action

--- a/src/util/util.ts
+++ b/src/util/util.ts
@@ -5,33 +5,12 @@ import { Range } from '../common/motion/range';
 import { exec } from 'child_process';
 
 /**
- * This is certainly quite janky! The problem we're trying to solve
- * is that writing `editor.selection = new Position()` won't immediately
- * update the position of the cursor. So we have to wait!
+ * We used to have an issue where we would do something like execute a VSCode
+ * command, and would encounter race conditions because the cursor positions
+ * wouldn't yet be updated. So we waited for a selection change event, but
+ * this doesn't seem to be necessary any more.
  */
-export async function waitForCursorSync(
-  timeoutInMilliseconds: number = 0,
-  rejectOnTimeout = false
-): Promise<void> {
-  await new Promise((resolve, reject) => {
-    let timer = setTimeout(rejectOnTimeout ? reject : resolve, timeoutInMilliseconds);
-
-    const disposable = vscode.window.onDidChangeTextEditorSelection(x => {
-      disposable.dispose();
-      clearTimeout(timer);
-      resolve();
-    });
-  });
-}
-
-export async function getCursorsAfterSync(timeoutInMilliseconds: number = 0): Promise<Range[]> {
-  const logger = Logger.get('getCursorsAfterSync');
-  try {
-    await waitForCursorSync(timeoutInMilliseconds, true);
-  } catch (e) {
-    logger.warn(`getCursorsAfterSync: selection not updated within ${timeoutInMilliseconds}ms.`);
-  }
-
+export function getCursorsAfterSync(): Range[] {
   return vscode.window.activeTextEditor!.selections.map(
     x => new Range(Position.FromVSCodePosition(x.start), Position.FromVSCodePosition(x.end))
   );

--- a/test/completion/lineCompletion.test.ts
+++ b/test/completion/lineCompletion.test.ts
@@ -6,7 +6,6 @@ import { ModeHandler } from '../../src/mode/modeHandler';
 import { Position } from '../../src/common/motion/position';
 import { cleanUpWorkspace, setupWorkspace } from '../testUtils';
 import { VimState } from '../../src/state/vimState';
-import { waitForCursorSync } from '../../src/util/util';
 
 suite('Provide line completions', () => {
   let modeHandler: ModeHandler;
@@ -28,8 +27,6 @@ suite('Provide line completions', () => {
       builder.insert(new Position(0, 0), lines.join('\n'));
     });
     await modeHandler.handleMultipleKeyEvents(['<Esc>', 'g', 'g', 'j', 'j', 'A']);
-
-    await waitForCursorSync();
   };
 
   suite('Line Completion Provider unit tests', () => {

--- a/test/testSimplifier.ts
+++ b/test/testSimplifier.ts
@@ -7,7 +7,6 @@ import { Globals } from '../src/globals';
 import { Mode } from '../src/mode/mode';
 import { ModeHandler } from '../src/mode/modeHandler';
 import { TextEditor } from '../src/textEditor';
-import { waitForCursorSync } from '../src/util/util';
 import { assertEqualLines, setupWorkspace } from './testUtils';
 import { globalState } from '../src/state/globalState';
 
@@ -254,8 +253,6 @@ async function testIt(modeHandler: ModeHandler, testObj: ITestObject): Promise<v
 
   await modeHandler.handleMultipleKeyEvents(['<Esc>', 'g', 'g']);
 
-  await waitForCursorSync();
-
   // Since we bypassed VSCodeVim to add text,
   // we need to tell the history tracker that we added it.
   modeHandler.vimState.historyTracker.addChange();
@@ -263,8 +260,6 @@ async function testIt(modeHandler: ModeHandler, testObj: ITestObject): Promise<v
 
   // move cursor to start position using 'hjkl'
   await modeHandler.handleMultipleKeyEvents(helper.getKeyPressesToMoveToStartPosition());
-
-  await waitForCursorSync();
 
   Globals.mockModeHandler = modeHandler;
 


### PR DESCRIPTION
The issue this function was meant to solve seems to have disappeared.
Fixes #4432