### PR TITLE
Update extensionKind

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,10 @@
     "Other",
     "Keymaps"
   ],
-  "extensionKind": "ui",
+  "extensionKind": [
+    "ui",
+    "workspace"
+  ],
   "activationEvents": [
     "*",
     "onCommand:type"


### PR DESCRIPTION
Fixes #4379 

> The old "ui" value (as a string) maps to this type for backwards compatibility, but is considered deprecated.