### PR TITLE
Improve performance on large files by not checking for changes after commands which never change the document

### DIFF
--- a/src/actions/base.ts
+++ b/src/actions/base.ts
@@ -47,6 +47,20 @@ export class BaseAction {
   private static readonly isSingleAlpha: RegExp = /^[a-zA-Z]$/;
 
   /**
+   * True if this action has the potential to change the document's text, and therefore trigger an
+   * undo step. This is for optimization purposes - we skip the expensive process of figuring out
+   * what changed to create that undo step if this returns false.
+   *
+   * Most commands do not modify the document, so this is false by default. This means if you add a
+   * command that can modify the document, you MUST set mightChangeDocument = true. Otherwise undo
+   * will not work properly.
+   *
+   * TODO: if all actions were pure, I think this would be unnecessary, as we could deduce it from
+   * vimState.transformations being empty or not.
+   */
+  public mightChangeDocument: boolean = false;
+
+  /**
    * Is this action valid in the current Vim state?
    */
   public doesActionApply(vimState: VimState, keysPressed: string[]): boolean {

--- a/src/actions/commands/actions.ts
+++ b/src/actions/commands/actions.ts
@@ -34,6 +34,7 @@ export class DocumentContentChangeAction extends BaseAction {
     positionDiff: PositionDiff;
     textDiff: vscode.TextDocumentContentChangeEvent;
   }[] = [];
+  mightChangeDocument = true;
 
   public async exec(position: Position, vimState: VimState): Promise<VimState> {
     if (this.contentChanges.length === 0) {
@@ -510,6 +511,7 @@ class CommandExecuteMacro extends BaseCommand {
   keys = ['@', '<character>'];
   runsOnceForEachCountPrefix = true;
   canBeRepeatedWithDot = true;
+  mightChangeDocument = true;
 
   public async exec(position: Position, vimState: VimState): Promise<VimState> {
     const register = this.keysPressed[1];
@@ -546,6 +548,7 @@ class CommandExecuteLastMacro extends BaseCommand {
   runsOnceForEachCountPrefix = true;
   canBeRepeatedWithDot = true;
   isJump = true;
+  mightChangeDocument = true;
 
   public async exec(position: Position, vimState: VimState): Promise<VimState> {
     let lastInvokedMacro = vimState.historyTracker.lastInvokedMacro;
@@ -624,6 +627,7 @@ class CommandEsc extends BaseCommand {
 class CommandEscReplaceMode extends BaseCommand {
   modes = [Mode.Replace];
   keys = [['<Esc>'], ['<C-c>'], ['<C-[>']];
+  mightChangeDocument = true;
 
   public async exec(position: Position, vimState: VimState): Promise<VimState> {
     const timesToRepeat = vimState.replaceState!.timesToRepeat;
@@ -859,6 +863,7 @@ class CommandReplaceInReplaceMode extends BaseCommand {
   modes = [Mode.Replace];
   keys = ['<character>'];
   canBeRepeatedWithDot = true;
+  mightChangeDocument = true;
 
   public async exec(position: Position, vimState: VimState): Promise<VimState> {
     const char = this.keysPressed[0];
@@ -1433,6 +1438,7 @@ export class PutCommand extends BaseCommand {
   modes = [Mode.Normal];
   runsOnceForEachCountPrefix = true;
   canBeRepeatedWithDot = true;
+  mightChangeDocument = true;
 
   constructor(multicursorIndex?: number) {
     super();
@@ -1718,6 +1724,7 @@ export class GPutCommand extends BaseCommand {
   modes = [Mode.Normal, Mode.Visual, Mode.VisualLine];
   runsOnceForEachCountPrefix = true;
   canBeRepeatedWithDot = true;
+  mightChangeDocument = true;
 
   public async exec(position: Position, vimState: VimState): Promise<VimState> {
     return new PutCommand().exec(position, vimState);
@@ -1763,6 +1770,7 @@ export class PutWithIndentCommand extends BaseCommand {
   modes = [Mode.Normal, Mode.Visual, Mode.VisualLine];
   runsOnceForEachCountPrefix = true;
   canBeRepeatedWithDot = true;
+  mightChangeDocument = true;
 
   public async exec(position: Position, vimState: VimState): Promise<VimState> {
     const result = await new PutCommand().exec(position, vimState, false, true);
@@ -1779,6 +1787,7 @@ export class PutCommandVisual extends BaseCommand {
   keys = [['p'], ['P']];
   modes = [Mode.Visual, Mode.VisualLine];
   runsOnceForEachCountPrefix = true;
+  mightChangeDocument = true;
 
   public async exec(
     position: Position,
@@ -1852,6 +1861,7 @@ export class PutBeforeCommand extends BaseCommand {
   public modes = [Mode.Normal];
   canBeRepeatedWithDot = true;
   runsOnceForEachCountPrefix = true;
+  mightChangeDocument = true;
 
   public async exec(position: Position, vimState: VimState): Promise<VimState> {
     const command = new PutCommand();
@@ -1867,6 +1877,7 @@ export class PutBeforeCommand extends BaseCommand {
 export class GPutBeforeCommand extends BaseCommand {
   keys = ['g', 'P'];
   modes = [Mode.Normal];
+  mightChangeDocument = true;
 
   public async exec(position: Position, vimState: VimState): Promise<VimState> {
     const result = await new PutCommand().exec(position, vimState, true);
@@ -1904,6 +1915,7 @@ export class GPutBeforeCommand extends BaseCommand {
 export class PutBeforeWithIndentCommand extends BaseCommand {
   keys = ['[', 'p'];
   modes = [Mode.Normal];
+  mightChangeDocument = true;
 
   public async exec(position: Position, vimState: VimState): Promise<VimState> {
     const result = await new PutCommand().exec(position, vimState, true, true);
@@ -2093,7 +2105,7 @@ class CommandTabInCommandline extends BaseCommand {
   }
 }
 
-// TODO: Split this into multiple commands and maybe move them to another file
+// TODO: Split this into multiple commands and maybe move them to another file (mightChangeDocument can be false for some!)
 @RegisterAction
 class CommandInsertInCommandline extends BaseCommand {
   modes = [Mode.CommandlineInProgress];
@@ -2115,6 +2127,7 @@ class CommandInsertInCommandline extends BaseCommand {
   runsOnceForEveryCursor() {
     return this.keysPressed[0] === '\n';
   }
+  mightChangeDocument = true;
 
   public async exec(position: Position, vimState: VimState): Promise<VimState> {
     const key = this.keysPressed[0];
@@ -2326,6 +2339,7 @@ export class CommandShowSearchHistory extends BaseCommand {
 class CommandDot extends BaseCommand {
   modes = [Mode.Normal];
   keys = ['.'];
+  mightChangeDocument = true;
 
   public async exec(position: Position, vimState: VimState): Promise<VimState> {
     vimState.recordedState.transformations.push({
@@ -2340,6 +2354,7 @@ class CommandDot extends BaseCommand {
 class CommandRepeatSubstitution extends BaseCommand {
   modes = [Mode.Normal];
   keys = ['&'];
+  mightChangeDocument = true;
 
   public async exec(position: Position, vimState: VimState): Promise<VimState> {
     // Parsing the command from a string, while not ideal, is currently
@@ -2631,6 +2646,7 @@ class CommandUndo extends BaseCommand {
     return false;
   }
   mustBeFirstKey = true;
+  mightChangeDocument = true;
 
   public async exec(position: Position, vimState: VimState): Promise<VimState> {
     const newPositions = await vimState.historyTracker.goBackHistoryStep();
@@ -2655,6 +2671,7 @@ class CommandUndoOnLine extends BaseCommand {
     return false;
   }
   mustBeFirstKey = true;
+  mightChangeDocument = true;
 
   public async exec(position: Position, vimState: VimState): Promise<VimState> {
     const newPositions = await vimState.historyTracker.goBackHistoryStepsOnLine();
@@ -2672,6 +2689,7 @@ class CommandUndoOnLine extends BaseCommand {
 class CommandRedo extends BaseCommand {
   modes = [Mode.Normal];
   keys = ['<C-r>'];
+  mightChangeDocument = true;
   runsOnceForEveryCursor() {
     return false;
   }
@@ -2695,6 +2713,7 @@ class CommandDeleteToLineEnd extends BaseCommand {
   modes = [Mode.Normal];
   keys = ['D'];
   canBeRepeatedWithDot = true;
+  mightChangeDocument = true;
   runsOnceForEveryCursor() {
     return true;
   }
@@ -2733,6 +2752,7 @@ class CommandChangeToLineEnd extends BaseCommand {
   modes = [Mode.Normal];
   keys = ['C'];
   runsOnceForEachCountPrefix = false;
+  mightChangeDocument = true;
 
   public async exec(position: Position, vimState: VimState): Promise<VimState> {
     const count = vimState.recordedState.count || 1;
@@ -2753,6 +2773,7 @@ class CommandClearLine extends BaseCommand {
   modes = [Mode.Normal];
   keys = ['S'];
   runsOnceForEachCountPrefix = false;
+  mightChangeDocument = true;
 
   public async exec(position: Position, vimState: VimState): Promise<VimState> {
     return new operator.ChangeOperator(this.multicursorIndex).runRepeat(
@@ -3187,6 +3208,7 @@ export class CommandInsertAtLineEnd extends BaseCommand {
 class CommandInsertNewLineAbove extends BaseCommand {
   modes = [Mode.Normal];
   keys = ['O'];
+  mightChangeDocument = true;
   runsOnceForEveryCursor() {
     return false;
   }
@@ -3226,6 +3248,7 @@ class CommandInsertNewLineAbove extends BaseCommand {
 class CommandInsertNewLineBefore extends BaseCommand {
   modes = [Mode.Normal];
   keys = ['o'];
+  mightChangeDocument = true;
   runsOnceForEveryCursor() {
     return false;
   }
@@ -3544,6 +3567,7 @@ export class ActionDeleteChar extends BaseCommand {
   modes = [Mode.Normal];
   keys = ['x'];
   canBeRepeatedWithDot = true;
+  mightChangeDocument = true;
 
   public async exec(position: Position, vimState: VimState): Promise<VimState> {
     // If line is empty, do nothing
@@ -3571,6 +3595,7 @@ export class ActionDeleteCharWithDeleteKey extends BaseCommand {
   keys = ['<Del>'];
   runsOnceForEachCountPrefix = true;
   canBeRepeatedWithDot = true;
+  mightChangeDocument = true;
 
   public async execCount(position: Position, vimState: VimState): Promise<VimState> {
     // If <del> has a count in front of it, then <del> deletes a character
@@ -3592,6 +3617,7 @@ export class ActionDeleteLastChar extends BaseCommand {
   modes = [Mode.Normal];
   keys = ['X'];
   canBeRepeatedWithDot = true;
+  mightChangeDocument = true;
 
   public async exec(position: Position, vimState: VimState): Promise<VimState> {
     if (position.character === 0) {
@@ -3616,6 +3642,7 @@ class ActionJoin extends BaseCommand {
   keys = ['J'];
   canBeRepeatedWithDot = true;
   runsOnceForEachCountPrefix = false;
+  mightChangeDocument = true;
 
   private firstNonWhitespaceIndex(str: string): number {
     for (let i = 0, len = str.length; i < len; i++) {
@@ -3779,6 +3806,7 @@ class ActionJoin extends BaseCommand {
 class ActionJoinVisualMode extends BaseCommand {
   modes = [Mode.Visual, Mode.VisualLine];
   keys = ['J'];
+  mightChangeDocument = true;
 
   public async exec(position: Position, vimState: VimState): Promise<VimState> {
     let actionJoin = new ActionJoin();
@@ -3805,6 +3833,7 @@ class ActionJoinNoWhitespace extends BaseCommand {
   keys = ['g', 'J'];
   canBeRepeatedWithDot = true;
   runsOnceForEachCountPrefix = true;
+  mightChangeDocument = true;
 
   // gJ is essentially J without the edge cases. ;-)
 
@@ -3848,6 +3877,7 @@ class ActionJoinNoWhitespace extends BaseCommand {
 class ActionJoinNoWhitespaceVisualMode extends BaseCommand {
   modes = [Mode.Visual];
   keys = ['g', 'J'];
+  mightChangeDocument = true;
 
   public async exec(position: Position, vimState: VimState): Promise<VimState> {
     let actionJoin = new ActionJoinNoWhitespace();
@@ -3876,6 +3906,7 @@ class ActionReplaceCharacter extends BaseCommand {
   keys = ['r', '<character>'];
   canBeRepeatedWithDot = true;
   runsOnceForEachCountPrefix = false;
+  mightChangeDocument = true;
 
   public async exec(position: Position, vimState: VimState): Promise<VimState> {
     let timesToRepeat = vimState.recordedState.count || 1;
@@ -3951,6 +3982,7 @@ class ActionReplaceCharacterVisual extends BaseCommand {
     return false;
   }
   canBeRepeatedWithDot = true;
+  mightChangeDocument = true;
 
   public async exec(position: Position, vimState: VimState): Promise<VimState> {
     let toInsert = this.keysPressed[1];
@@ -4034,6 +4066,7 @@ class ActionReplaceCharacterVisualBlock extends BaseCommand {
     return false;
   }
   canBeRepeatedWithDot = true;
+  mightChangeDocument = true;
 
   public async exec(position: Position, vimState: VimState): Promise<VimState> {
     let toInsert = this.keysPressed[1];
@@ -4075,6 +4108,7 @@ class ActionXVisualBlock extends BaseCommand {
   runsOnceForEveryCursor() {
     return false;
   }
+  mightChangeDocument = true;
 
   public async exec(position: Position, vimState: VimState): Promise<VimState> {
     const lines: string[] = [];
@@ -4106,9 +4140,11 @@ class ActionXVisualBlock extends BaseCommand {
 
 @RegisterAction
 class ActionDVisualBlock extends ActionXVisualBlock {
+  // TODO: can't this be lumped in with the previous command without subclassing?
   modes = [Mode.VisualBlock];
   keys = ['d'];
   canBeRepeatedWithDot = true;
+  mightChangeDocument = true;
   runsOnceForEveryCursor() {
     return false;
   }
@@ -4122,6 +4158,7 @@ class ActionShiftDVisualBlock extends BaseCommand {
   runsOnceForEveryCursor() {
     return false;
   }
+  mightChangeDocument = true;
 
   public async exec(position: Position, vimState: VimState): Promise<VimState> {
     for (const { start } of Position.IterateLine(vimState)) {
@@ -4172,6 +4209,7 @@ class ActionGoToInsertVisualBlockMode extends BaseCommand {
 class ActionChangeInVisualBlockMode extends BaseCommand {
   modes = [Mode.VisualBlock];
   keys = [['c'], ['s']];
+  mightChangeDocument = true;
   runsOnceForEveryCursor() {
     return false;
   }
@@ -4202,6 +4240,7 @@ class ActionChangeInVisualBlockMode extends BaseCommand {
 class ActionChangeToEOLInVisualBlockMode extends BaseCommand {
   modes = [Mode.VisualBlock];
   keys = [['C'], ['S']];
+  mightChangeDocument = true;
   runsOnceForEveryCursor() {
     return false;
   }
@@ -4328,6 +4367,7 @@ export class ActionGoToInsertVisualModeAppend extends ActionGoToInsertVisualLine
 class ActionGoToInsertVisualBlockModeAppend extends BaseCommand {
   modes = [Mode.VisualBlock];
   keys = ['A'];
+  mightChangeDocument = true;
   runsOnceForEveryCursor() {
     return false;
   }
@@ -4357,6 +4397,7 @@ class ActionGoToInsertVisualBlockModeAppend extends BaseCommand {
 class ActionDeleteLineVisualMode extends BaseCommand {
   modes = [Mode.Visual, Mode.VisualLine];
   keys = ['X'];
+  mightChangeDocument = true;
 
   public async exec(position: Position, vimState: VimState): Promise<VimState> {
     if (vimState.currentMode === Mode.Visual) {
@@ -4379,6 +4420,7 @@ class ActionDeleteLineVisualMode extends BaseCommand {
 class ActionChangeLineVisualMode extends BaseCommand {
   modes = [Mode.Visual];
   keys = ['C'];
+  mightChangeDocument = true;
 
   public async exec(position: Position, vimState: VimState): Promise<VimState> {
     return new operator.DeleteOperator(this.multicursorIndex).run(
@@ -4393,6 +4435,7 @@ class ActionChangeLineVisualMode extends BaseCommand {
 class ActionRemoveLineVisualMode extends BaseCommand {
   modes = [Mode.Visual];
   keys = ['R'];
+  mightChangeDocument = true;
 
   public async exec(position: Position, vimState: VimState): Promise<VimState> {
     return new operator.DeleteOperator(this.multicursorIndex).run(
@@ -4408,6 +4451,7 @@ class ActionChangeChar extends BaseCommand {
   modes = [Mode.Normal];
   keys = ['s'];
   runsOnceForEachCountPrefix = true;
+  mightChangeDocument = true;
 
   public async exec(position: Position, vimState: VimState): Promise<VimState> {
     const state = await new operator.ChangeOperator().run(vimState, position, position);
@@ -4441,6 +4485,7 @@ class ToggleCaseAndMoveForward extends BaseCommand {
   keys = ['~'];
   canBeRepeatedWithDot = true;
   runsOnceForEachCountPrefix = true;
+  mightChangeDocument = true;
 
   public async exec(position: Position, vimState: VimState): Promise<VimState> {
     await new operator.ToggleCaseOperator().run(
@@ -4458,6 +4503,7 @@ abstract class IncrementDecrementNumberAction extends BaseCommand {
   modes = [Mode.Normal];
   canBeRepeatedWithDot = true;
   offset: number;
+  mightChangeDocument = true;
 
   public async exec(position: Position, vimState: VimState): Promise<VimState> {
     const text = TextEditor.getLineAt(position).text;

--- a/src/actions/commands/insert.ts
+++ b/src/actions/commands/insert.ts
@@ -26,6 +26,7 @@ import { Clipboard } from '../../util/clipboard';
 class CommandEscInsertMode extends BaseCommand {
   modes = [Mode.Insert];
   keys = [['<Esc>'], ['<C-c>'], ['<C-[>']];
+  mightChangeDocument = true;
 
   runsOnceForEveryCursor() {
     return false;
@@ -118,6 +119,7 @@ class CommandEscInsertMode extends BaseCommand {
 export class CommandInsertPreviousText extends BaseCommand {
   modes = [Mode.Insert];
   keys = ['<C-a>'];
+  mightChangeDocument = true;
 
   public async exec(position: Position, vimState: VimState): Promise<VimState> {
     let actions = ((await Register.getByKey('.')).text as RecordedState).actionsRun.slice(0);
@@ -153,6 +155,7 @@ export class CommandInsertPreviousText extends BaseCommand {
 class CommandInsertPreviousTextAndQuit extends BaseCommand {
   modes = [Mode.Insert];
   keys = ['<C-shift+2>']; // <C-@>
+  mightChangeDocument = true;
 
   public async exec(position: Position, vimState: VimState): Promise<VimState> {
     vimState = await new CommandInsertPreviousText().exec(position, vimState);
@@ -165,6 +168,7 @@ class CommandInsertPreviousTextAndQuit extends BaseCommand {
 class CommandInsertBelowChar extends BaseCommand {
   modes = [Mode.Insert];
   keys = ['<C-e>'];
+  mightChangeDocument = true;
 
   public async exec(position: Position, vimState: VimState): Promise<VimState> {
     if (TextEditor.isLastLine(position)) {
@@ -193,6 +197,7 @@ class CommandInsertBelowChar extends BaseCommand {
 class CommandInsertIndentInCurrentLine extends BaseCommand {
   modes = [Mode.Insert];
   keys = ['<C-t>'];
+  mightChangeDocument = true;
 
   public async exec(position: Position, vimState: VimState): Promise<VimState> {
     const originalText = TextEditor.getLineAt(position).text;
@@ -220,6 +225,7 @@ class CommandInsertIndentInCurrentLine extends BaseCommand {
 // export class CommandInsertTabInInsertMode extends BaseCommand {
 //   modes = [ModeName.Insert];
 //   keys = ["<tab>"];
+//   mightChangeDocument = true;
 //   runsOnceForEveryCursor() { return false; }
 
 //   public async exec(position: Position, vimState: VimState): Promise<VimState> {
@@ -234,6 +240,7 @@ class CommandInsertIndentInCurrentLine extends BaseCommand {
 export class CommandBackspaceInInsertMode extends BaseCommand {
   modes = [Mode.Insert];
   keys = ['<BS>'];
+  mightChangeDocument = true;
 
   public async exec(position: Position, vimState: VimState): Promise<VimState> {
     const line = TextEditor.getLineAt(position).text;
@@ -281,6 +288,7 @@ export class CommandBackspaceInInsertMode extends BaseCommand {
 export class CommandInsertInInsertMode extends BaseCommand {
   modes = [Mode.Insert];
   keys = ['<character>'];
+  mightChangeDocument = true;
 
   public async exec(position: Position, vimState: VimState): Promise<VimState> {
     const char = this.keysPressed[this.keysPressed.length - 1];
@@ -311,6 +319,7 @@ class CommandInsertDigraph extends BaseCommand {
   modes = [Mode.Insert];
   keys = ['<C-k>', '<any>', '<any>'];
   isCompleteAction = false;
+  mightChangeDocument = true;
 
   public async exec(position: Position, vimState: VimState): Promise<VimState> {
     const digraph = this.keysPressed.slice(1, 3).join('');
@@ -379,6 +388,7 @@ class CommandInsertRegisterContent extends BaseCommand {
   modes = [Mode.Insert];
   keys = ['<C-r>', '<character>'];
   isCompleteAction = false;
+  mightChangeDocument = true;
 
   public async exec(position: Position, vimState: VimState): Promise<VimState> {
     vimState.recordedState.registerName = this.keysPressed[1];
@@ -439,6 +449,7 @@ export class CommandOneNormalCommandInInsertMode extends BaseCommand {
 class CommandCtrlW extends BaseCommand {
   modes = [Mode.Insert];
   keys = ['<C-w>'];
+  mightChangeDocument = true;
 
   public async exec(position: Position, vimState: VimState): Promise<VimState> {
     let wordBegin;
@@ -462,6 +473,7 @@ class CommandCtrlW extends BaseCommand {
 class CommandDeleteIndentInCurrentLine extends BaseCommand {
   modes = [Mode.Insert];
   keys = ['<C-d>'];
+  mightChangeDocument = true;
 
   public async exec(position: Position, vimState: VimState): Promise<VimState> {
     const originalText = TextEditor.getLineAt(position).text;
@@ -499,6 +511,7 @@ class CommandDeleteIndentInCurrentLine extends BaseCommand {
 class CommandInsertAboveChar extends BaseCommand {
   modes = [Mode.Insert];
   keys = ['<C-y>'];
+  mightChangeDocument = true;
 
   public async exec(position: Position, vimState: VimState): Promise<VimState> {
     if (TextEditor.isFirstLine(position)) {
@@ -527,6 +540,7 @@ class CommandInsertAboveChar extends BaseCommand {
 class CommandCtrlHInInsertMode extends BaseCommand {
   modes = [Mode.Insert];
   keys = ['<C-h>'];
+  mightChangeDocument = true;
 
   public async exec(position: Position, vimState: VimState): Promise<VimState> {
     vimState.recordedState.transformations.push({
@@ -542,6 +556,7 @@ class CommandCtrlHInInsertMode extends BaseCommand {
 class CommandCtrlUInInsertMode extends BaseCommand {
   modes = [Mode.Insert];
   keys = ['<C-u>'];
+  mightChangeDocument = true;
 
   public async exec(position: Position, vimState: VimState): Promise<VimState> {
     const start = position.isInLeadingWhitespace()
@@ -614,6 +629,7 @@ class CommandNavigateAutocompleteUp extends BaseCommand {
 class CommandCtrlVInInsertMode extends BaseCommand {
   modes = [Mode.Insert];
   keys = ['<C-v>'];
+  mightChangeDocument = true;
 
   public async exec(position: Position, vimState: VimState): Promise<VimState> {
     const textFromClipboard = await Clipboard.Paste();

--- a/src/actions/operator.ts
+++ b/src/actions/operator.ts
@@ -20,6 +20,9 @@ export class BaseOperator extends BaseAction {
   canBeRepeatedWithDot = true;
   isOperator = true;
 
+  // All operators other than yank can change the document
+  mightChangeDocument = true;
+
   /**
    * If this is being run in multi cursor mode, the index of the cursor
    * this operator is being applied to.
@@ -259,6 +262,7 @@ export class YankOperator extends BaseOperator {
   public keys = ['y'];
   public modes = [Mode.Normal, Mode.Visual, Mode.VisualLine];
   canBeRepeatedWithDot = false;
+  mightChangeDocument = false;
 
   public async run(vimState: VimState, start: Position, end: Position): Promise<VimState> {
     // Hack to make Surround with y (which takes a motion) work.
@@ -332,6 +336,7 @@ export class YankOperator extends BaseOperator {
 export class ShiftYankOperatorVisual extends BaseOperator {
   public keys = ['Y'];
   public modes = [Mode.Visual, Mode.VisualLine, Mode.VisualBlock];
+  mightChangeDocument = false;
 
   public async run(vimState: VimState, start: Position, end: Position): Promise<VimState> {
     vimState.currentRegisterMode = RegisterMode.LineWise;
@@ -671,6 +676,7 @@ export class YankVisualBlockMode extends BaseOperator {
   public keys = ['y'];
   public modes = [Mode.VisualBlock];
   canBeRepeatedWithDot = false;
+  mightChangeDocument = false;
   runsOnceForEveryCursor() {
     return false;
   }

--- a/src/actions/plugins/replaceWithRegister.ts
+++ b/src/actions/plugins/replaceWithRegister.ts
@@ -12,6 +12,7 @@ import { RegisterAction } from './../base';
 export class ReplaceOperator extends BaseOperator {
   public keys = ['g', 'r'];
   public modes = [Mode.Normal, Mode.Visual, Mode.VisualLine];
+  mightChangeDocument = true;
 
   public doesActionApply(vimState: VimState, keysPressed: string[]): boolean {
     return configuration.replaceWithRegister && super.doesActionApply(vimState, keysPressed);

--- a/src/actions/plugins/surround.ts
+++ b/src/actions/plugins/surround.ts
@@ -56,6 +56,7 @@ class CommandSurroundAddTarget extends BaseCommand {
     ['a'],
   ];
   isCompleteAction = false;
+  mightChangeDocument = true;
   runsOnceForEveryCursor() {
     return false;
   }
@@ -275,6 +276,7 @@ class CommandSurroundModeStartVisual extends BaseCommand {
 export class CommandSurroundAddToReplacement extends BaseCommand {
   modes = [Mode.SurroundInputMode];
   keys = ['<any>'];
+  mightChangeDocument = true;
 
   public async exec(position: Position, vimState: VimState): Promise<VimState> {
     if (!vimState.surround) {

--- a/src/history/historyTracker.ts
+++ b/src/history/historyTracker.ts
@@ -425,12 +425,14 @@ export class HistoryTracker {
    *
    * Determines what changed by diffing the document against what it
    * used to look like.
+   *
+   * @returns true if a change was added
    */
-  public addChange(cursorPosition = [new Position(0, 0)]): void {
+  public addChange(cursorPosition = [new Position(0, 0)]): boolean {
     const newText = this._getDocumentText();
 
     if (newText === this.oldText) {
-      return;
+      return false;
     }
 
     // Determine if we should add a new Step.
@@ -495,6 +497,8 @@ export class HistoryTracker {
 
     // A change has been made, reset the changelist navigation index to the end
     this.changelistIndex = this.historySteps.length - 1;
+
+    return true;
   }
 
   /**

--- a/src/mode/modeHandler.ts
+++ b/src/mode/modeHandler.ts
@@ -603,7 +603,15 @@ export class ModeHandler implements vscode.Disposable {
         this.vimState.alteredHistory = false;
         vimState.historyTracker.ignoreChange();
       } else {
-        vimState.historyTracker.addChange(this.vimState.cursorsInitialState.map(c => c.stop));
+        const addedChange = vimState.historyTracker.addChange(
+          this.vimState.cursorsInitialState.map(c => c.stop)
+        );
+        const mightChangeDocument = recordedState.hasRunOperator
+          ? recordedState.operator.mightChangeDocument
+          : action.mightChangeDocument;
+        if (addedChange && !mightChangeDocument) {
+          throw new Error(`Action '${action.toString()}' changed the document unexpectedly!`);
+        }
       }
     }
 


### PR DESCRIPTION
Many commands, like movement and typing a search, will never change the document. We waste considerable time diffing the entire document on each of these keystrokes to figure out if we should add an undo step.
I've added a property to BaseAction, `mightChangeDocument`, which determines whether we should check for changes.
This defaults to false for the sake of brevity (most commands actually don't change the document), but this is a bit dangerous - what if I forgot to override it in a command that changes the document?
The planned solution is to release this as a check - we will always run the diff, as we currently do, then make sure a command didn't add a change when we asserted it wouldn't. After this is in the wild for a little while with no reported issues, we'll actually flip the switch to optimize.
In my testing on a ~80,000 line file, this saves maybe 10-15ms per keystroke on average, which does translate into a noticeable improvement in responsiveness.

<!--
Yay! Thanks for sending us a PR! 🎊

Please ensure your PR adheres to:

- [ ] Commit messages has a short & issue references when necessary
- [ ] Each commit does a logical chunk of work.
- [ ] It builds and tests pass (e.g `gulp`)
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**

<!--
Commits in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)
-->

**Special notes for your reviewer**:
