### PR TITLE
Update statusbar with result of ex command from neovim

### DIFF
--- a/src/cmd_line/commandLine.ts
+++ b/src/cmd_line/commandLine.ts
@@ -88,7 +88,8 @@ class CommandLine {
     } catch (e) {
       if (e instanceof VimError) {
         if (e.code === ErrorCode.E492 && configuration.enableNeovim) {
-          await vimState.nvim.run(vimState, command);
+          const statusBarText = await vimState.nvim.run(vimState, command);
+          StatusBar.setText(vimState, statusBarText);
         } else {
           StatusBar.setText(vimState, `${e.toString()}. ${command}`, true);
         }

--- a/src/cmd_line/commandLine.ts
+++ b/src/cmd_line/commandLine.ts
@@ -89,7 +89,7 @@ class CommandLine {
       if (e instanceof VimError) {
         if (e.code === ErrorCode.E492 && configuration.enableNeovim) {
           const statusBarText = await vimState.nvim.run(vimState, command);
-          StatusBar.setText(vimState, statusBarText);
+          StatusBar.setText(vimState, statusBarText, true);
         } else {
           StatusBar.setText(vimState, `${e.toString()}. ${command}`, true);
         }


### PR DESCRIPTION
**What this PR does / why we need it**:

I noticed that when running certain ex commands with neovim integration enabled, I wasn't seeing any output in the statusbar, regardless of the success or failure of the command. As a result I wasn't sure if commands had been successful or not.

On investigation I realised that there are two cases in which the extension passes an ex command to neovim for execution, but currently only one of them displays the result in the status bar. This commit brings the second case in line with the first so that the result of running the command is displayed:

<img width="1050" alt="image" src="https://user-images.githubusercontent.com/1231200/71641538-96cd2f00-2c95-11ea-9aaa-96ca95441564.png">

**Which issue(s) this PR fixes**

As it was a simple fix I decided to just go ahead and make a PR rather than creating an issue.

**Special notes for your reviewer**:

As a side-note, watching the tests run was extremely cool. Nice work on those!