### PR TITLE
Fix getCursorStyleForMode() always returned undefined

### DIFF
--- a/src/configuration/configuration.ts
+++ b/src/configuration/configuration.ts
@@ -15,7 +15,6 @@ import {
   IHighlightedYankConfiguration,
   ICamelCaseMotionConfiguration,
 } from './iconfiguration';
-import { Mode } from '../mode/mode';
 
 const packagejson: {
   contributes: {
@@ -349,8 +348,8 @@ class Configuration implements IConfiguration {
     replace: undefined,
   };
 
-  getCursorStyleForMode(modeName: Mode): vscode.TextEditorCursorStyle | undefined {
-    let cursorStyle = this.cursorStylePerMode[modeName.toString().toLowerCase()];
+  getCursorStyleForMode(modeName: string): vscode.TextEditorCursorStyle | undefined {
+    let cursorStyle = this.cursorStylePerMode[modeName.toLowerCase()];
     if (cursorStyle) {
       return this.cursorStyleFromString(cursorStyle);
     }

--- a/src/mode/modeHandler.ts
+++ b/src/mode/modeHandler.ts
@@ -1329,7 +1329,8 @@ export class ModeHandler implements vscode.Disposable {
     }
 
     // cursor style
-    let cursorStyle = configuration.getCursorStyleForMode(this.currentMode);
+    const modeName = Mode[this.currentMode];
+    let cursorStyle = configuration.getCursorStyleForMode(modeName);
     if (!cursorStyle) {
       const cursorType = getCursorType(this.currentMode);
       cursorStyle = getCursorStyle(cursorType);


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR fixes the issue of not changing the cursor style as per the user settings when we switch modes. I've done this by changing `modeName` from being a type `Mode` back to a type `string`, and having the modeHandler resolve `ModeHandler.currentMode` into a `string`. 


**Which issue(s) this PR fixes**
Fixes #4355 
<!--
Commits in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)
-->

**Special notes for your reviewer**:

The first reason why we cannot have `modeName` be a `Mode` is because it is a [numeric enum](https://www.typescriptlang.org/docs/handbook/enums.html#numeric-enums) and not an [string enum](https://www.typescriptlang.org/docs/handbook/enums.html#string-enums), which means that `modeName.toString()` will simply be the number corresponding to that particular member (e.g. `Mode.Normal.toString() === 0`). The second reason is because it seems we cannot refer to `Mode` inside configuration.ts, i.e. doing `Mode[modeName]` or even checking if `Mode` is `undefined` inside of `getCursorStyleForMode()` breaks the entire extension as it fails to validate with an error:

```
Activating extension 'vscodevim.vim' failed: Cannot read property 'iskeyword' of undefined.
```
I'm unsure why this happens, it seems as if the Mode module doesn't get loaded until the extension has been activated? If you know what may cause this, please let me know.