### PR TITLE
Refactor <C-a> logic

### DIFF
--- a/src/common/number/numericString.ts
+++ b/src/common/number/numericString.ts
@@ -1,79 +1,158 @@
+/**
+ *      aaaa0x111bbbbbb
+ *      |-------------| => NumericString
+ *      |--|            => prefix
+ *          |---|       => core
+ *               |----| => suffix
+ *          ||          => numPrefix
+ *            |-|       => num
+ *
+ * Greedy matching, leftmost match wins.
+ * If multiple matches begin at the same position, the match with the biggest
+ *   span wins.
+ * If multiple matches have the same begin position and span (This usually
+ *   happens on octal and decimal), following priority sequence is used:
+ *   (decimal => octal => hexadecimal)
+ *
+ * Example:
+ *                    |  core  |     What we got      |     Rather than     |
+ *  ------------------|--------|----------------------|---------------------|
+ *  Leftmost rule:    | 010xff |    (010)xff [octal]  |    01(0xff) [hex]   |
+ *  Biggest span rule:| 0xff   |     (0xff) [hex]     |   (0)xff [decimal]  |
+ *  Priority rule:    | 00007  |    (00007) [octal]   |  (00007) [decimal]  |
+ *
+ * Side Effect:
+ *  -0xf  Will be parsed as (-0)xf rather than -(0xf), current workaround is
+ *          capturing '-' in hexadecimal regex but not consider '-' as a part
+ *          of the number. This is achieved by using `negative` boolean value
+ *          in `NumericString`.
+ */
 export class NumericString {
   radix: number;
   value: number;
+  numLength: number;
   prefix: string;
   suffix: string;
+  // If a negative sign should be manually added when converting to string.
+  negative: boolean;
 
-  private static matchings: { regex: RegExp; base: number; prefix: string }[] = [
-    { regex: /^([-+])?0([0-7]+)$/, base: 8, prefix: '0' },
-    { regex: /^([-+])?(\d+)$/, base: 10, prefix: '' },
-    { regex: /^([-+])?0x([\da-fA-F]+)$/, base: 16, prefix: '0x' },
-    { regex: /\d/, base: 10, prefix: '' },
+  // Map radix to number prefix
+  private static numPrefix = {
+    8: '0',
+    10: '',
+    16: '0x',
+  };
+
+  // Keep octal at the top of decimal to avoid regarding 0000007 as decimal.
+  // '000009' matches decimal.
+  // '000007' matches octal.
+  // '-0xf' matches hex rather than decimal '-0'
+  private static matchings: { regex: RegExp; radix: number }[] = [
+    { regex: /(-)?0[0-7]+/, radix: 8 },
+    { regex: /(-)?\d+/, radix: 10 },
+    { regex: /(-)?0x[\da-fA-F]+/, radix: 16 },
   ];
 
-  public static parse(input: string): NumericString | undefined {
-    for (const { regex, base, prefix } of NumericString.matchings) {
+  // Return parse result and offset of suffix
+  public static parse(input: string): { num, suffixOffset }  | undefined {
+    // Find core numeric part of input
+    let coreBegin = -1;
+    let coreLength = -1;
+    let coreRadix = -1;
+    let coreSign = false;
+    for (const { regex, radix } of NumericString.matchings) {
       const match = regex.exec(input);
-      if (match == null) {
-        continue;
-      }
-
-      // Regex to determine if this number has letters around it,
-      // if it doesn't then that is easy and no prefix or suffix is needed
-      let findNondigits = /[^\d-+]+/g;
-
-      // Regex to find any leading characters before the number
-      let findPrefix = /^[^\d-+]+(?=[0-9]+)/g;
-
-      // Regex to find any trailing characters after the number
-      let findSuffix = /[^\d]*[\d]*(.*)/g;
-      let newPrefix = prefix;
-      let newSuffix = '';
-      let newNum = input;
-
-      // Only use this section if this is a number surrounded by letters
-      if (
-        findNondigits.exec(input) !== null &&
-        NumericString.matchings[NumericString.matchings.length - 1].regex === regex
-      ) {
-        let prefixFound = findPrefix.exec(input);
-        let suffixFound = findSuffix.exec(input);
-
-        // Find the prefix if it exists
-        if (prefixFound !== null) {
-          newPrefix = prefixFound.toString();
+      if (match != null) {
+        // Get the leftmost and largest match
+        if (
+          coreRadix < 0 ||
+          match.index < coreBegin ||
+          (match.index === coreBegin && match[0].length > coreLength)
+        ) {
+          coreBegin = match.index;
+          coreLength = match[0].length;
+          coreRadix = radix;
+          coreSign = match[1] === '-';
         }
-
-        // Find the suffix if it exists
-        if (suffixFound !== null) {
-          newSuffix = suffixFound[1].toString();
-        }
-
-        // Obtain just the number with no extra letters
-        newNum = newNum.slice(newPrefix.length, newNum.length - newSuffix.length);
       }
-
-      return new NumericString(parseInt(newNum, base), base, newPrefix, newSuffix);
     }
 
-    return undefined;
+    if (coreRadix < 0) {
+      return undefined;
+    }
+
+    const coreEnd = coreBegin + coreLength;
+
+    const prefix = input.slice(0, coreBegin);
+    const core = input.slice(coreBegin, coreEnd);
+    const suffix = input.slice(coreEnd, input.length);
+
+    let value = parseInt(core, coreRadix);
+
+    // 0x00ff:  numLength = 4
+    // 077:     numLength = 2
+    // -0999:   numLength = 3
+    // The numLength is only useful for parsing non-decimal. Decimal with
+    // leading zero will be trimmed in `toString()`. If value is negative,
+    // remove the width of negative sign.
+    const numLength = coreLength - NumericString.numPrefix[coreRadix].length - (coreSign ? 1 : 0);
+
+    // According to original vim's behavior, for hex and octal, the leading
+    // '-' *should* be captured and preserved but *should not* be regarded as
+    // part of number, which means with <C-a>, `-0xf` turns into `-0x10`. So
+    // for hex and octal, we make the value absolute and set the negative
+    // sign flag.
+    let negative = false;
+    if (coreRadix !== 10 && coreSign) {
+      value = -value;
+      negative = true;
+    }
+
+    return {
+      num: new NumericString(value, coreRadix, numLength, prefix, suffix, negative),
+      suffixOffset: coreEnd,
+    };
   }
 
-  private constructor(value: number, radix: number, prefix: string, suffix: string) {
+  private constructor(
+    value: number,
+    radix: number,
+    numLength: number,
+    prefix: string,
+    suffix: string,
+    negative: boolean
+  ) {
     this.value = value;
     this.radix = radix;
+    this.numLength = numLength;
     this.prefix = prefix;
     this.suffix = suffix;
+    this.negative = negative;
   }
 
   public toString(): string {
-    // Allow signed hex represented as twos complement
-    if (this.radix === 16) {
-      if (this.value < 0) {
-        this.value = 0xffffffff + this.value + 1;
+    // For decreased octal and hexadecimal
+    if (this.radix !== 10) {
+      const max = 0xffffffff;
+      while (this.value < 0) {
+        this.value = max + this.value + 1;
       }
     }
 
-    return this.prefix + this.value.toString(this.radix) + this.suffix;
+    // Gen num part
+    const absValue = Math.abs(this.value);
+    let num = absValue.toString(this.radix);
+    // numLength of decimal *should not* be preserved.
+    if (this.radix !== 10) {
+      const diff = this.numLength - num.length;
+      if (diff > 0) {
+        // Preserve num length if it's narrower.
+        num = '0'.repeat(diff) + num;
+      }
+    }
+
+    const sign = this.negative || this.value < 0 ? '-' : '';
+    const core = sign + NumericString.numPrefix[this.radix] + num;
+    return this.prefix + core + this.suffix;
   }
 }

--- a/test/mode/modeNormal.test.ts
+++ b/test/mode/modeNormal.test.ts
@@ -1968,6 +1968,76 @@ suite('Mode Normal', () => {
   });
 
   newTest({
+    title: 'can ctrl-a on a hex number behind a word',
+    start: ['|test0xf'],
+    keysPressed: '<C-a>',
+    end: ['test0x1|0'],
+  });
+
+  newTest({
+    title: 'can ctrl-a distinguish fake hex number',
+    start: ['|00xf'],
+    keysPressed: '<C-a>',
+    end: ['0|1xf'],
+  });
+
+  newTest({
+    title: 'can ctrl-a preserve leading zeros of octal',
+    start: ['|000007'],
+    keysPressed: '<C-a>',
+    end: ['00001|0'],
+  });
+
+  newTest({
+    title: 'can ctrl-a trim leading zeros of decimal',
+    start: ['|000009'],
+    keysPressed: '<C-a>',
+    end: ['1|0'],
+  });
+
+  newTest({
+    title: 'can ctrl-a process `-0x0` correctly',
+    start: ['|-0x0'],
+    keysPressed: '<C-a>',
+    end: ['-0x|1'],
+  });
+
+  newTest({
+    title: 'can ctrl-a regard `0` as decimal',
+    start: ['|0'],
+    keysPressed: '10<C-a>',
+    end: ['1|0'],
+  });
+
+  newTest({
+    title: 'can ctrl-a on octal ignore negative sign',
+    start: ['|test-0116'],
+    keysPressed: '<C-a>',
+    end: ['test-011|7'],
+  });
+
+  newTest({
+    title: 'can ctrl-a on octal ignore positive sign',
+    start: ['|test+0116'],
+    keysPressed: '<C-a>',
+    end: ['test+011|7'],
+  });
+
+  newTest({
+    title: 'can ctrl-a on hex number ignore negative sign',
+    start: ['|test-0xf'],
+    keysPressed: '<C-a>',
+    end: ['test-0x1|0'],
+  });
+
+  newTest({
+    title: 'can ctrl-a on hex number ignore positive sign',
+    start: ['|test+0xf'],
+    keysPressed: '<C-a>',
+    end: ['test+0x1|0'],
+  });
+
+  newTest({
     title: 'can ctrl-x correctly behind a word',
     start: ['|one 10'],
     keysPressed: '<C-x>',
@@ -1991,8 +2061,8 @@ suite('Mode Normal', () => {
   newTest({
     title: 'can ctrl-x on a negative number with word before and after ',
     start: ['|test-2abc'],
-    keysPressed: '<C-a><C-a><C-a>',
-    end: ['test|1abc'],
+    keysPressed: '<C-x><C-x><C-x>',
+    end: ['test-|5abc'],
   });
 
   newTest({

--- a/test/number/numericString.test.ts
+++ b/test/number/numericString.test.ts
@@ -9,20 +9,20 @@ suite('numeric string', () => {
 
   test('handles hex round trip', () => {
     const input = '0xa1';
-    assert.strictEqual(input, NumericString.parse(input)?.toString());
+    assert.strictEqual(input, NumericString.parse(input)?.num.toString());
     // run each assertion twice to make sure that regex state doesn't cause failures
-    assert.strictEqual(input, NumericString.parse(input)?.toString());
+    assert.strictEqual(input, NumericString.parse(input)?.num.toString());
   });
 
   test('handles decimal round trip', () => {
     const input = '9';
-    assert.strictEqual(input, NumericString.parse(input)?.toString());
-    assert.strictEqual(input, NumericString.parse(input)?.toString());
+    assert.strictEqual(input, NumericString.parse(input)?.num.toString());
+    assert.strictEqual(input, NumericString.parse(input)?.num.toString());
   });
 
   test('handles octal trip', () => {
     const input = '07';
-    assert.strictEqual(input, NumericString.parse(input)?.toString());
-    assert.strictEqual(input, NumericString.parse(input)?.toString());
+    assert.strictEqual(input, NumericString.parse(input)?.num.toString());
+    assert.strictEqual(input, NumericString.parse(input)?.num.toString());
   });
 });


### PR DESCRIPTION
**The reason**
I've noticed the code about `<C-a>` and `<C-x>` is very fragile.
So I refactored it.

**What this PR achieves**
This PR totally fixes #4308, fixes #4457 and more.
Please check newly-added tests to get part of what this PR achieves.
These tests **all fails** without this PR, all of them are the correct behavior of original vim.
Now it's behavior on `<C-a>` and `<C-x>` is 99% similiar to the oiginal Vim.

**To the maintainer**:
PLZ don't ignore my pull request again... :-/
If something went wrong, at least give me a hint.