### PR TITLE
Reduce side effects in actions

### DIFF
--- a/src/actions/commands/actions.ts
+++ b/src/actions/commands/actions.ts
@@ -599,7 +599,7 @@ abstract class CommandEditorScroll extends BaseCommand {
         by: this.by,
         value: timesToRepeat,
         revealCursor: true,
-        select: [Mode.Visual, Mode.VisualBlock, Mode.VisualLine].includes(vimState.currentMode),
+        select: isVisualMode(vimState.currentMode),
       },
     });
     return vimState;
@@ -649,7 +649,7 @@ abstract class CommandScrollAndMoveCursor extends BaseCommand {
       by: 'line',
       value: scrollLines,
       revealCursor: smoothScrolling,
-      select: [Mode.Visual, Mode.VisualBlock, Mode.VisualLine].includes(vimState.currentMode),
+      select: isVisualMode(vimState.currentMode),
     });
 
     const newPositionLine = clamp(

--- a/src/actions/commands/insert.ts
+++ b/src/actions/commands/insert.ts
@@ -184,7 +184,11 @@ class CommandInsertBelowChar extends BaseCommand {
     const char = TextEditor.getText(
       new vscode.Range(charBelowCursorPosition, charBelowCursorPosition.getRight())
     );
-    await TextEditor.insert(char, position);
+    vimState.recordedState.transformations.push({
+      type: 'insertText',
+      text: char,
+      position,
+    });
 
     vimState.cursorStartPosition = Position.FromVSCodePosition(vimState.editor.selection.start);
     vimState.cursorStopPosition = Position.FromVSCodePosition(vimState.editor.selection.start);
@@ -413,7 +417,11 @@ class CommandInsertRegisterContent extends BaseCommand {
       text += '\n';
     }
 
-    await TextEditor.insertAt(text, position);
+    vimState.recordedState.transformations.push({
+      type: 'insertText',
+      text,
+      position,
+    });
     await vimState.setCurrentMode(Mode.Insert);
     vimState.cursorStartPosition = Position.FromVSCodePosition(vimState.editor.selection.start);
     vimState.cursorStopPosition = Position.FromVSCodePosition(vimState.editor.selection.start);
@@ -462,7 +470,10 @@ class CommandCtrlW extends BaseCommand {
       wordBegin = position.getWordLeft();
     }
 
-    await TextEditor.delete(new vscode.Range(wordBegin, position));
+    vimState.recordedState.transformations.push({
+      type: 'deleteRange',
+      range: new Range(wordBegin, position),
+    });
 
     vimState.cursorStopPosition = wordBegin;
 
@@ -503,7 +514,10 @@ class CommandDeleteIndentInCurrentLine extends BaseCommand {
     );
     vimState.cursorStopPosition = cursorPosition;
     vimState.cursorStartPosition = cursorPosition;
+
+    // TODO: necessary?
     await vimState.setCurrentMode(Mode.Insert);
+
     return vimState;
   }
 }
@@ -528,7 +542,11 @@ class CommandInsertAboveChar extends BaseCommand {
     const char = TextEditor.getText(
       new vscode.Range(charAboveCursorPosition, charAboveCursorPosition.getRight())
     );
-    await TextEditor.insert(char, position);
+    vimState.recordedState.transformations.push({
+      type: 'insertText',
+      text: char,
+      position,
+    });
 
     vimState.cursorStartPosition = Position.FromVSCodePosition(vimState.editor.selection.start);
     vimState.cursorStopPosition = Position.FromVSCodePosition(vimState.editor.selection.start);
@@ -563,7 +581,10 @@ class CommandCtrlUInInsertMode extends BaseCommand {
     const start = position.isInLeadingWhitespace()
       ? position.getLineBegin()
       : position.getLineBeginRespectingIndent();
-    await TextEditor.delete(new vscode.Range(start, position));
+    vimState.recordedState.transformations.push({
+      type: 'deleteRange',
+      range: new Range(start, position),
+    });
     vimState.cursorStopPosition = start;
     vimState.cursorStartPosition = start;
     return vimState;

--- a/src/actions/operator.ts
+++ b/src/actions/operator.ts
@@ -404,7 +404,12 @@ export class UpperCaseOperator extends BaseOperator {
     const range = new vscode.Range(start, new Position(end.line, end.character + 1));
     let text = vimState.editor.document.getText(range);
 
-    await TextEditor.replace(range, text.toUpperCase());
+    vimState.recordedState.transformations.push({
+      type: 'replaceText',
+      start: Position.FromVSCodePosition(range.start),
+      end: Position.FromVSCodePosition(range.end),
+      text: text.toUpperCase(),
+    });
 
     await vimState.setCurrentMode(Mode.Normal);
     vimState.cursorStopPosition = start;
@@ -449,7 +454,12 @@ export class LowerCaseOperator extends BaseOperator {
     const range = new vscode.Range(start, new Position(end.line, end.character + 1));
     let text = vimState.editor.document.getText(range);
 
-    await TextEditor.replace(range, text.toLowerCase());
+    vimState.recordedState.transformations.push({
+      type: 'replaceText',
+      start: Position.FromVSCodePosition(range.start),
+      end: Position.FromVSCodePosition(range.end),
+      text: text.toLowerCase(),
+    });
 
     await vimState.setCurrentMode(Mode.Normal);
     vimState.cursorStopPosition = start;

--- a/src/history/historyTracker.ts
+++ b/src/history/historyTracker.ts
@@ -276,6 +276,7 @@ export class HistoryTracker {
     this.lastContentChanges = [];
   }
 
+  // Note: this is slow in large files; avoid calling if you can.
   private _getDocumentText(): string {
     return (
       (this.vimState.editor &&
@@ -486,7 +487,9 @@ export class HistoryTracker {
     // multiple changes in different places simultaneously. For those, we could require
     // them to call addChange manually, I guess...
 
+    const now = Number(new Date());
     const diffs = diffEngine.diff_main(this.oldText, newText);
+    this._logger.debug(`diff_main() took ${Number(new Date()) - now}ms`);
 
     /*
     this.historySteps.push(new HistoryStep({

--- a/src/mode/modeHandler.ts
+++ b/src/mode/modeHandler.ts
@@ -1280,6 +1280,8 @@ export class ModeHandler implements vscode.Disposable {
             }
             break;
           }
+          // TODO: Mode.VisualLine
+          // TODO: Mode.VisualBlock
           case Mode.Normal:
           case Mode.Insert: {
             for (const { stop: cursorStop } of vimState.cursors) {

--- a/src/textEditor.ts
+++ b/src/textEditor.ts
@@ -70,6 +70,9 @@ export class TextEditor {
     });
   }
 
+  /**
+   * @deprecated Use DeleteTextTransformation or DeleteTextRangeTransformation instead.
+   */
   static async delete(range: vscode.Range): Promise<boolean> {
     return vscode.window.activeTextEditor!.edit(editBuilder => {
       editBuilder.delete(range);

--- a/src/transformations/transformations.ts
+++ b/src/transformations/transformations.ts
@@ -256,7 +256,6 @@ export type Transformation =
   | Dot
   | Macro
   | ContentChangeTransformation
-  | DeleteTextTransformation
   | Tab
   | Reindent;
 


### PR DESCRIPTION
VSCodeVim's basic architecture is "actions modify the VimState, which is then rendered into VSCode". Some actions, however, modify VSCode's state themselves (for instance, with `TextEditor.insert()`).
I'm attempting to minimize the number of actions like this for several reasons, the main one being that I believe having "pure" actions will make #1490 more achievable.