### PR TITLE
Implement <Del> handler for insert mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
       {
         "key": "Delete",
         "command": "extension.vim_delete",
-        "when": "editorTextFocus && vim.active && vim.mode != 'Insert' && !inDebugRepl"
+        "when": "editorTextFocus && vim.active && !inDebugRepl"
       },
       {
         "key": "tab",

--- a/src/actions/commands/insert.ts
+++ b/src/actions/commands/insert.ts
@@ -270,7 +270,7 @@ export class CommandBackspaceInInsertMode extends BaseCommand {
         type: 'deleteRange',
         range: new Range(position.withColumn(desiredLineLength), position.withColumn(line.length)),
       });
-    } else if (position.line !== 0 || position.character !== 0) {
+    } else if (!position.isAtDocumentBegin()) {
       // Otherwise, just delete a character (unless we're at the start of the document)
       vimState.recordedState.transformations.push({
         type: 'deleteText',

--- a/src/actions/commands/insert.ts
+++ b/src/actions/commands/insert.ts
@@ -285,6 +285,32 @@ export class CommandBackspaceInInsertMode extends BaseCommand {
 }
 
 @RegisterAction
+export class CommandDeleteInInsertMode extends BaseCommand {
+  modes = [Mode.Insert];
+  keys = ['<Del>'];
+  mightChangeDocument = true;
+
+  public async exec(position: Position, vimState: VimState): Promise<VimState> {
+    const selection = TextEditor.getSelection();
+
+    if (!selection.isEmpty) {
+      // If a selection is active, delete it
+      vimState.recordedState.transformations.push({
+        type: 'deleteRange',
+        range: new Range(selection.start as Position, selection.end as Position),
+      });
+    } else if (!position.isAtDocumentEnd()) {
+      // Otherwise, just delete a character (unless we're at the end of the document)
+      vimState.recordedState.transformations.push({
+        type: 'deleteText',
+        position: position.getRightThroughLineBreaks(true),
+      });
+    }
+    return vimState;
+  }
+}
+
+@RegisterAction
 export class CommandInsertInInsertMode extends BaseCommand {
   modes = [Mode.Insert];
   keys = ['<character>'];

--- a/src/editorIdentity.ts
+++ b/src/editorIdentity.ts
@@ -1,7 +1,7 @@
 import * as vscode from 'vscode';
 
 /**
- * We consider two editors to be the same iff their EditorIdentities are the same
+ * We consider two editors to be the same if their EditorIdentities are the same
  */
 export class EditorIdentity {
   private _fileName: string;

--- a/src/editorIdentity.ts
+++ b/src/editorIdentity.ts
@@ -1,7 +1,7 @@
 import * as vscode from 'vscode';
 
 /**
- * We consider two editors to be the same if their EditorIdentities are the same
+ * We consider two editors to be the same iff their EditorIdentities are the same
  */
 export class EditorIdentity {
   private _fileName: string;

--- a/test/mode/modeInsert.test.ts
+++ b/test/mode/modeInsert.test.ts
@@ -216,6 +216,34 @@ suite('Mode Insert', () => {
   });
 
   newTest({
+    title: 'Delete works in insert mode',
+    start: ['leather ma|an'],
+    keysPressed: 'i<Del><Esc>',
+    end: ['leather m|an'],
+  });
+
+  newTest({
+    title: 'Delete works at line end',
+    start: ['boy next| ', 'door'],
+    keysPressed: 'a<Del><Esc>',
+    end: ['boy next| door'],
+  });
+
+  newTest({
+    title: 'Delete works at end of file',
+    start: ['yes si|r'],
+    keysPressed: 'a<Del><Esc>',
+    end: ['yes si|r'],
+  });
+
+  newTest({
+    title: 'Delete works with repeat',
+    start: ['This is| not good'],
+    keysPressed: 'a<Del><Del><Del><Del><Esc>.aawesome!<Esc>',
+    end: ['This is awesome|!'],
+  });
+
+  newTest({
     title: 'Can <Esc> after entering insert mode from <ctrl+o>',
     start: ['|'],
     keysPressed: 'i<C-o>i<Esc>',


### PR DESCRIPTION
In the insert mode, `<Del>` key are not handled by VSCodeVim. So `<Del>` commands used in insert mode are transparent to the `dot` command and cannot be repeated with it, which is very inconvenient. And another problem is that user cannot remap any key to `<Del>`.

With this pull request, these problems are solved.  
Fixes #2423, fixes #4219, fixes #4082. 

BTW: I think we need some documentation and code annotations. I spent a whole night tracking the missing delete commands and find out that this bug can be easily located even with a little documentation describing the key handling precedure......
