### PR TITLE
Recommend disabling html.mirrorCursorOnMatchingTag in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,8 @@ VSCodeVim is a Vim emulator for [Visual Studio Code](https://code.visualstudio.c
 
 VSCodeVim is automatically enabled following [installation](https://marketplace.visualstudio.com/items?itemName=vscodevim.vim) and reloading of VS Code.
 
+Vim keybindings are incompatible with [VSCode's HTML mirror cursor feature](https://code.visualstudio.com/updates/v1_41). You will need to set `"html.mirrorCursorOnMatchingTag": false` in `settings.json` to avoid errors and unexpected behavior (for both Mac and Windows).
+
 ### Mac
 
 To enable key-repeating execute the following in your Terminal and restart VS Code:


### PR DESCRIPTION
Adds note recommending disabling `html.mirrorCursorOnMatchingTag` in README to avoid errors and unexpected behaviors.

<!--
Yay! Thanks for sending us a PR! 🎊

Please ensure your PR adheres to:

- [ ] Commit messages has a short & issue references when necessary
- [ ] Each commit does a logical chunk of work.
- [ ] It builds and tests pass (e.g `gulp`)
-->

**What this PR does / why we need it**:
The new [VSCode `html.mirrorCursorOnMatchingTag` default setting](https://code.visualstudio.com/updates/v1_41) is incompatible with Vim UX. Since this is a default setting, it would be helpful in the setup instructions.

**Which issue(s) this PR fixes**
* https://github.com/VSCodeVim/Vim/issues/4439
* https://github.com/VSCodeVim/Vim/issues/4402
* https://github.com/VSCodeVim/Vim/issues/4378

<!--
Commits in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)
-->
