### PR TITLE
Add support for <C-m> in insert, search in progress and commandline in progress modes

### DIFF
--- a/package.json
+++ b/package.json
@@ -221,6 +221,11 @@
         "when": "editorTextFocus && vim.active && vim.use<C-l> && !inDebugRepl"
       },
       {
+        "key": "ctrl+m",
+        "command": "extension.vim_ctrl+m",
+        "when": "editorTextFocus && vim.active && vim.use<C-m> && !inDebugRepl || vim.mode == 'CommandlineInProgress' && vim.active && vim.use<C-m> && !inDebugRepl || vim.mode == 'SearchInProgressMode' && vim.active && vim.use<C-m> && !inDebugRepl"
+      },
+      {
         "key": "ctrl+n",
         "command": "extension.vim_ctrl+n",
         "when": "editorTextFocus && vim.active && vim.use<C-n> && !inDebugRepl || vim.mode == 'CommandlineInProgress' && vim.active && vim.use<C-n> && !inDebugRepl || vim.mode == 'SearchInProgressMode' && vim.active && vim.use<C-n> && !inDebugRepl"

--- a/src/actions/commands/actions.ts
+++ b/src/actions/commands/actions.ts
@@ -466,6 +466,23 @@ class CommandExecuteLastMacro extends BaseCommand {
 }
 
 @RegisterAction
+class CtrlM extends BaseCommand {
+  modes = [Mode.Insert];
+  keys = [['<C-m>']];
+  mightChangeDocument = true;
+
+  public async exec(position: Position, vimState: VimState): Promise<VimState> {
+    vimState.recordedState.transformations.push({
+      type: 'insertText',
+      text: '\n',
+      position: position,
+      diff: new PositionDiff({ character: -1 }),
+    });
+    return vimState;
+  }
+}
+
+@RegisterAction
 class CommandEsc extends BaseCommand {
   modes = [
     Mode.Visual,

--- a/src/actions/commands/commandLine.ts
+++ b/src/actions/commands/commandLine.ts
@@ -259,8 +259,7 @@ class CommandInsertInSearchMode extends BaseCommand {
     ['<C-n>'], // Next
     ['<C-f>'], // Find
     ['<C-u>'], // Delete to beginning
-    // Another way to run search
-    ['<C-m>'],
+    ['<C-m>'], // Another way to run search
     ['<Home>'],
     ['<End>'],
     ['<Del>'],

--- a/src/actions/commands/commandLine.ts
+++ b/src/actions/commands/commandLine.ts
@@ -134,7 +134,7 @@ class CommandTabInCommandline extends BaseCommand {
 @RegisterAction
 class CommandEnterInCommandline extends BaseCommand {
   modes = [Mode.CommandlineInProgress];
-  keys = ['\n'];
+  keys = [['\n'], ['<C-m>']];
   mightChangeDocument = true;
   runsOnceForEveryCursor() {
     return this.keysPressed[0] === '\n';
@@ -259,6 +259,8 @@ class CommandInsertInSearchMode extends BaseCommand {
     ['<C-n>'], // Next
     ['<C-f>'], // Find
     ['<C-u>'], // Delete to beginning
+    // Another way to run search
+    ['<C-m>'],
     ['<Home>'],
     ['<End>'],
     ['<Del>'],
@@ -305,7 +307,7 @@ class CommandInsertInSearchMode extends BaseCommand {
       vimState.statusBarCursorCharacterPos = 0;
     } else if (key === '<End>' || key === '<C-e>') {
       vimState.statusBarCursorCharacterPos = globalState.searchState!.searchString.length;
-    } else if (key === '\n') {
+    } else if (key === '\n' || key === '<C-m>') {
       await vimState.setCurrentMode(globalState.searchState!.previousMode);
 
       // Repeat the previous search if no new string is entered


### PR DESCRIPTION
This pull request addresses issue #1505 
Summary: In vim `<C-m>` key binding works in the same way as pressing enter in all modes. This is not very common across editors but is very handy since requires much less movements.

I've made necessary changes only to discover that I cannot really
capture exactly `<C-m>` shortcut, because it's used by vscode "Tab moves focus"
shortcut. I removed it from the settings, but it looks like Vim plugin
still is not able to get it.

As a proof of concept I added another shortcut - `<C-q>` that does what
`<C-m>` should do. This shortcut should be removed before this pull
request is merged.

I have a couple ideas on how to approach the problem:

1. Disable this setting totally in case of vim plugin enabled
2. Temporary disable "tab moves focus" shortcut in all modes concerned.
3. Do changes on vscode to allow this keybinding to work if default shortcut is erased.

1 sounds to drastic, so I think 2 or 3 are the real options, but at the moment I don't have a good enough understanding of vscode code base to understand how to achieve it.

Can anyone give me some pointers to do progress with either option 2 or option 3? Any other ideas are welcome!
