### PR TITLE
Fix surround cursor placement bug (#3461)

### DIFF
--- a/src/actions/plugins/surround.ts
+++ b/src/actions/plugins/surround.ts
@@ -1,6 +1,6 @@
 import { VimState } from '../../state/vimState';
 import { PairMatcher } from './../../common/matching/matcher';
-import { Position } from './../../common/motion/position';
+import { Position, PositionDiff } from './../../common/motion/position';
 import { Range } from './../../common/motion/range';
 import { configuration } from './../../configuration/configuration';
 import { Mode } from './../../mode/mode';
@@ -485,6 +485,9 @@ export class CommandSurroundAddToReplacement extends BaseCommand {
         type: 'insertText',
         text: startReplace,
         position: start,
+        // This PositionDiff places the cursor at the start of startReplace text the we insert rather than after
+        // which matches vim-surround better
+        diff: new PositionDiff({ character: -startReplace.length }),
       });
       vimState.recordedState.transformations.push({
         type: 'insertText',

--- a/test/plugins/surround.test.ts
+++ b/test/plugins/surround.test.ts
@@ -14,62 +14,62 @@ suite('surround plugin', () => {
     title: "'ysiw)' surrounds word without space",
     start: ['first li|ne test'],
     keysPressed: 'ysiw)',
-    end: ['first (|line) test'],
+    end: ['first |(line) test'],
   });
 
   newTest({
     title: "'ysiw(' surrounds word with space",
     start: ['first li|ne test'],
     keysPressed: 'ysiw(',
-    end: ['first ( |line ) test'],
+    end: ['first |( line ) test'],
   });
 
   newTest({
     title: "'ysw)' surrounds word without space",
     start: ['first |line test'],
     keysPressed: 'ysw)',
-    end: ['first (|line) test'],
+    end: ['first |(line) test'],
   });
 
   newTest({
     title: "'ysw(' surrounds word with space",
     start: ['first |line test'],
     keysPressed: 'ysw(',
-    end: ['first ( |line ) test'],
+    end: ['first |( line ) test'],
   });
   newTest({
     title: "'ysaw)' surrounds word without space",
     start: ['first li|ne test'],
     keysPressed: 'ysaw)',
-    end: ['first (|line) test'],
+    end: ['first |(line) test'],
   });
 
   newTest({
     title: "'ysaw(' surrounds word with space",
     start: ['first li|ne test'],
     keysPressed: 'ysaw(',
-    end: ['first ( |line ) test'],
+    end: ['first |( line ) test'],
   });
 
   newTest({
     title: "'ysiw(' surrounds word with space and ignores punctuation",
     start: ['first li|ne.test'],
     keysPressed: 'ysiw(',
-    end: ['first ( |line ).test'],
+    end: ['first |( line ).test'],
   });
 
   newTest({
     title: "'ysiw<' surrounds word with tags",
     start: ['first li|ne test'],
     keysPressed: 'ysiw<123>',
-    end: ['first <123>|line</123> test'],
+    end: ['first |<123>line</123> test'],
   });
 
   newTest({
     title: "'ysiw<' surrounds word with tags and attributes",
     start: ['first li|ne test'],
     keysPressed: 'ysiw<abc attr1 attr2="test">',
-    end: ['first <abc attr1 attr2="test">|line</abc> test'],
+    end: ['first |<abc attr1 attr2="test">line</abc> test'],
   });
 
   newTest({
@@ -83,7 +83,7 @@ suite('surround plugin', () => {
     title: "'yss)' surrounds entire line respecting whitespace",
     start: ['foo', '    foob|ar  '],
     keysPressed: 'yss)',
-    end: ['foo', '    (|foobar)  '],
+    end: ['foo', '    |(foobar)  '],
   });
 
   newTest({


### PR DESCRIPTION
**What this PR does / why we need it**:
This makes VSCodeVim behave more like vim-surround, which I think users would find more intuitive.

**Which issue(s) this PR fixes**
https://github.com/VSCodeVim/Vim/issues/3461

**Special notes for your reviewer**:
I've run the npm test. I had to change a few because the surround ones were checking for the old behavior. I checked that the new tests are consistent with vim-surround's behavior though.
I'm not too familiar with either typescript nor this repo, so I'm grateful for the patience and possibly extra support.