### PR TITLE
Improve multicursor support

### DIFF
--- a/src/actions/commands/insert.ts
+++ b/src/actions/commands/insert.ts
@@ -237,7 +237,7 @@ export class CommandBackspaceInInsertMode extends BaseCommand {
 
   public async exec(position: Position, vimState: VimState): Promise<VimState> {
     const line = TextEditor.getLineAt(position).text;
-    const selection = vimState.editor.selections.find(s => s.contains(position));
+    const selection = vimState.editor.selections.find((s) => s.contains(position));
 
     if (selection && !selection.isEmpty) {
       // If a selection is active, delete it

--- a/src/actions/commands/insert.ts
+++ b/src/actions/commands/insert.ts
@@ -293,18 +293,11 @@ export class CommandInsertInInsertMode extends BaseCommand {
   public async exec(position: Position, vimState: VimState): Promise<VimState> {
     const char = this.keysPressed[this.keysPressed.length - 1];
 
-    if (vimState.isMultiCursor) {
-      vimState.recordedState.transformations.push({
-        type: 'insertText',
-        text: char,
-        position: vimState.cursorStopPosition,
-      });
-    } else {
-      vimState.recordedState.transformations.push({
-        type: 'insertTextVSCode',
-        text: char,
-      });
-    }
+    vimState.recordedState.transformations.push({
+      type: 'insertTextVSCode',
+      text: char,
+      isMultiCursor: vimState.isMultiCursor,
+    });
 
     return vimState;
   }

--- a/src/actions/commands/insert.ts
+++ b/src/actions/commands/insert.ts
@@ -244,9 +244,9 @@ export class CommandBackspaceInInsertMode extends BaseCommand {
 
   public async exec(position: Position, vimState: VimState): Promise<VimState> {
     const line = TextEditor.getLineAt(position).text;
-    const selection = TextEditor.getSelection();
+    const selection = vimState.editor.selections.find(s => s.contains(position));
 
-    if (!selection.isEmpty) {
+    if (selection && !selection.isEmpty) {
       // If a selection is active, delete it
       vimState.recordedState.transformations.push({
         type: 'deleteRange',

--- a/src/mode/modeHandler.ts
+++ b/src/mode/modeHandler.ts
@@ -27,7 +27,7 @@ import { VsCodeContext } from '../util/vscode-context';
 import { commandLine } from '../cmd_line/commandLine';
 import { configuration } from '../configuration/configuration';
 import { decoration } from '../configuration/decoration';
-import { getCursorsAfterSync, scrollView, partition } from '../util/util';
+import { getCursorsAfterSync, scrollView } from '../util/util';
 import {
   BaseCommand,
   CommandQuitRecordMacro,
@@ -816,18 +816,16 @@ export class ModeHandler implements vscode.Disposable {
       return vimState;
     }
 
-
-    const textTransformations: TextTransformations[] = transformations.filter(x =>
+    const textTransformations: TextTransformations[] = transformations.filter((x) =>
       isTextTransformation(x)
     ) as any;
     const multicursorTextTransformations: InsertTextVSCodeTransformation[] = transformations.filter(
-      x => isMultiCursorTextTransformation(x)
+      (x) => isMultiCursorTextTransformation(x)
     ) as any;
 
     const otherTransformations = transformations.filter(
-      x => !isTextTransformation(x) && !isMultiCursorTextTransformation(x)
+      (x) => !isTextTransformation(x) && !isMultiCursorTextTransformation(x)
     );
-
 
     let accumulatedPositionDifferences: { [key: number]: PositionDiff[] } = {};
 
@@ -922,7 +920,6 @@ export class ModeHandler implements vscode.Disposable {
 
     for (const transformation of otherTransformations) {
       switch (transformation.type) {
-
         case 'insertTextVSCode':
           await TextEditor.insert(transformation.text);
           vimState.cursors[0] = Range.FromVSCodeSelection(this.vimState.editor.selection);

--- a/src/transformations/transformations.ts
+++ b/src/transformations/transformations.ts
@@ -343,11 +343,8 @@ export const areAllSameTransformation = (transformations: Transformation[]): Boo
   const firstTransformation = transformations[0];
 
   return transformations.every(t => {
-    for (const [key, value] of Object.entries(firstTransformation)) {
-      if (t[key] !== value) {
-        return false;
-      }
-    }
-    return true;
+    return Object.entries(t).every(([key, value]) => {
+      return firstTransformation[key] === value;
+    });
   });
 };

--- a/src/transformations/transformations.ts
+++ b/src/transformations/transformations.ts
@@ -100,6 +100,11 @@ export interface InsertTextVSCodeTransformation {
   text: string;
 
   /**
+   * Whether this transformation was created in multicursor mode.
+   */
+  isMultiCursor?: boolean;
+
+  /**
    * The index of the cursor that this transformation applies to.
    */
   cursorIndex?: number;
@@ -291,6 +296,9 @@ export const isTextTransformation = (x: Transformation): x is TextTransformation
     x.type === 'moveCursor'
   );
 };
+export const isMultiCursorTextTransformation = (x: Transformation): Boolean => {
+  return (x.type === 'insertTextVSCode' && x.isMultiCursor) ?? false;
+};
 
 const getRangeFromTextTransformation = (transformation: TextTransformations): Range | undefined => {
   switch (transformation.type) {
@@ -329,4 +337,17 @@ export const areAnyTransformationsOverlapping = (transformations: TextTransforma
   }
 
   return false;
+};
+
+export const areAllSameTransformation = (transformations: Transformation[]): Boolean => {
+  const firstTransformation = transformations[0];
+
+  return transformations.every(t => {
+    for (const [key, value] of Object.entries(firstTransformation)) {
+      if (t[key] !== value) {
+        return false;
+      }
+    }
+    return true;
+  });
 };

--- a/src/transformations/transformations.ts
+++ b/src/transformations/transformations.ts
@@ -342,7 +342,7 @@ export const areAnyTransformationsOverlapping = (transformations: TextTransforma
 export const areAllSameTransformation = (transformations: Transformation[]): Boolean => {
   const firstTransformation = transformations[0];
 
-  return transformations.every(t => {
+  return transformations.every((t) => {
     return Object.entries(t).every(([key, value]) => {
       return firstTransformation[key] === value;
     });

--- a/src/util/util.ts
+++ b/src/util/util.ts
@@ -53,18 +53,3 @@ export function scrollView(vimState: VimState, offset: number) {
     });
   }
 }
-
-/**
- * Partitions an array into two according to a given predicate
- * @param array Objects to partition
- * @param predicate Function according to which objects will be partitioned
- * @returns Array which contains all elements of `array` for which `predicate` is true, and one which contains the rest
- */
-export function partition<T>(array: T[], predicate: (x: T) => boolean): [T[], T[]] {
-  return array.reduce(
-    ([pass, fail], elem) => {
-      return predicate(elem) ? [[...pass, elem], fail] : [pass, [...fail, elem]];
-    },
-    [[], []]
-  );
-}


### PR DESCRIPTION
**What this PR does / why we need it**:
It fixes multicursor snippets, and adds support for stuff like auto-bracketing and auto-completion on multicursor mode.

5fd59f7: (Backspace Support)
Makes `range` represent the `selection` at `position`. This way we delete the correct `range` rather than the primary selection as it was before these changes.

59496be: (Multicursor Character Insert)
Makes multicursor text insertion behave like single cursor text insertion by ultimately using the `default: type` command rather than `vscode.TextEditor.insert()` which doesn't have support for snippet mode, auto completion, bracketing, etc.

To accomplish this, I've added an optional property (`isMultiCursor`) to `InsertTextVSCodeTransformation` which represents `vimState.isMultiCursor`at the time the transformation was created. This property is used to filter the multicursor transformations into  `multicursorTextTransformations`.

Because the `default: type` command handles inserting the text into the correct cursor positions there's no need to repeat the transformation multiple times and we can just execute the command once, as long as we know all transformations are trying to do the same thing. 

**Which issue(s) this PR fixes**
Fixes #4281
Fixes #4223
Fixes #3005 
Fixes #4522
Fixes #4515 
Fixes #1946
fix #3976

**Special notes for your reviewer**:
Is there a way to programmatically test this stuff?... I've pretty much just done a bunch of manual testing, and it all seems to work fine. Let me know what you think, I'd be happy to keep working on it. 
