### PR TITLE
Fix wrong return in ModeHandlerMap.get

### DIFF
--- a/src/editorIdentity.ts
+++ b/src/editorIdentity.ts
@@ -13,11 +13,15 @@ export class EditorIdentity {
   /**
    * For use in tests
    */
-  public static createRandomEditorIdentity(): EditorIdentity {
+  public static createRandomEditorIdentity(
+    injectName: string | undefined = undefined
+  ): EditorIdentity {
     return new EditorIdentity(
-      Math.random()
-        .toString(36)
-        .substring(7)
+      injectName
+        ? injectName
+        : Math.random()
+            .toString(36)
+            .substring(7)
     );
   }
 

--- a/src/editorIdentity.ts
+++ b/src/editorIdentity.ts
@@ -10,22 +10,7 @@ export class EditorIdentity {
     return new EditorIdentity(textEditor?.document?.fileName ?? '');
   }
 
-  /**
-   * For use in tests
-   */
-  public static createRandomEditorIdentity(
-    injectName: string | undefined = undefined
-  ): EditorIdentity {
-    return new EditorIdentity(
-      injectName
-        ? injectName
-        : Math.random()
-            .toString(36)
-            .substring(7)
-    );
-  }
-
-  private constructor(fileName: string) {
+  public constructor(fileName: string) {
     this._fileName = fileName;
   }
 

--- a/src/mode/modeHandlerMap.ts
+++ b/src/mode/modeHandlerMap.ts
@@ -9,12 +9,8 @@ class ModeHandlerMapImpl {
 
   public async getOrCreate(editorId: EditorIdentity): Promise<[ModeHandler, boolean]> {
     let isNew = false;
-    let modeHandler: ModeHandler | undefined;
-    for (const [key, value] of this.modeHandlerMap.entries()) {
-      if (key.isEqual(editorId)) {
-        modeHandler = value;
-      }
-    }
+    let modeHandler: ModeHandler | undefined = this.get(editorId);
+
     if (!modeHandler) {
       isNew = true;
       modeHandler = await ModeHandler.Create();
@@ -24,7 +20,12 @@ class ModeHandlerMapImpl {
   }
 
   public get(editorId: EditorIdentity): ModeHandler | undefined {
-    return this.modeHandlerMap.get(editorId);
+    for (const [key, value] of this.modeHandlerMap.entries()) {
+      if (key.isEqual(editorId)) {
+        return value;
+      }
+    }
+    return undefined;
   }
 
   public getKeys(): EditorIdentity[] {

--- a/test/mode/modeHandlerMap.test.ts
+++ b/test/mode/modeHandlerMap.test.ts
@@ -2,6 +2,8 @@ import * as assert from 'assert';
 
 import { ModeHandlerMap } from '../../src/mode/modeHandlerMap';
 import { EditorIdentity } from '../../src/editorIdentity';
+import { testIt } from '../testSimplifier';
+import { KeypressState } from '../../src/actions/base';
 
 suite('Mode Handler Map', () => {
   setup(() => {
@@ -33,5 +35,19 @@ suite('Mode Handler Map', () => {
     // delete
     ModeHandlerMap.delete(key);
     assert.strictEqual(ModeHandlerMap.getAll().length, 0);
+  });
+
+  test('get', async () => {
+    // same file name returns same modehandler
+    const key = EditorIdentity.createRandomEditorIdentity();
+
+    let [modeHandler, isNew] = await ModeHandlerMap.getOrCreate(key);
+    assert.strictEqual(isNew, true);
+    assert.notEqual(modeHandler, undefined);
+
+    [, isNew] = await ModeHandlerMap.getOrCreate(
+      EditorIdentity.createRandomEditorIdentity(key.fileName)
+    );
+    assert.strictEqual(isNew, false);
   });
 });

--- a/test/mode/modeHandlerMap.test.ts
+++ b/test/mode/modeHandlerMap.test.ts
@@ -5,6 +5,14 @@ import { EditorIdentity } from '../../src/editorIdentity';
 import { testIt } from '../testSimplifier';
 import { KeypressState } from '../../src/actions/base';
 
+function createRandomEditorIdentity(): EditorIdentity {
+  return new EditorIdentity(
+    Math.random()
+      .toString(36)
+      .substring(7)
+  );
+}
+
 suite('Mode Handler Map', () => {
   setup(() => {
     ModeHandlerMap.clear();
@@ -15,7 +23,7 @@ suite('Mode Handler Map', () => {
   });
 
   test('getOrCreate', async () => {
-    const key = EditorIdentity.createRandomEditorIdentity();
+    const key = createRandomEditorIdentity();
     let [modeHandler, isNew] = await ModeHandlerMap.getOrCreate(key);
     assert.strictEqual(isNew, true);
     assert.notEqual(modeHandler, undefined);
@@ -38,16 +46,16 @@ suite('Mode Handler Map', () => {
   });
 
   test('get', async () => {
-    // same file name returns same modehandler
-    const key = EditorIdentity.createRandomEditorIdentity();
+    // same file name should return the same modehandler
+    const identity = createRandomEditorIdentity();
 
-    let [modeHandler, isNew] = await ModeHandlerMap.getOrCreate(key);
+    let [modeHandler, isNew] = await ModeHandlerMap.getOrCreate(identity);
     assert.strictEqual(isNew, true);
     assert.notEqual(modeHandler, undefined);
 
-    [, isNew] = await ModeHandlerMap.getOrCreate(
-      EditorIdentity.createRandomEditorIdentity(key.fileName)
-    );
+    const prevModeHandler = modeHandler;
+    [modeHandler, isNew] = await ModeHandlerMap.getOrCreate(new EditorIdentity(identity.fileName));
     assert.strictEqual(isNew, false);
+    assert.strictEqual(prevModeHandler, modeHandler);
   });
 });


### PR DESCRIPTION
Hello, in my setup, this resolves #4479, #3277

From what i can observe, here's what i found to arrive to this conclusion:
- on `vscode.window.onDidChangeActiveTextEditor` i always get `lastClosedModeHandler = undefined` despite that the current file is exists on `ModeHandlerMap`
- due to `lastClosedModeHandler = undefined` jumping from current file doesn't push it to the jump stack
