### PR TITLE
Support multi-cursor in test harness

### DIFF
--- a/src/actions/commands/actions.ts
+++ b/src/actions/commands/actions.ts
@@ -511,7 +511,7 @@ class CommandEsc extends BaseCommand {
     }
 
     if (vimState.currentMode === Mode.Normal && vimState.isMultiCursor) {
-      vimState.isMultiCursor = false;
+      vimState.collapseCursors();
     }
 
     if (vimState.currentMode === Mode.EasyMotionMode) {
@@ -532,10 +532,6 @@ class CommandEsc extends BaseCommand {
     }
 
     await vimState.setCurrentMode(Mode.Normal);
-
-    if (!vimState.isMultiCursor) {
-      vimState.cursors = [vimState.cursors[0]];
-    }
 
     return vimState;
   }
@@ -2649,7 +2645,6 @@ class CommandInsertNewLineAbove extends BaseCommand {
     }
     vimState.cursors = vimState.cursors.reverse();
     vimState.isFakeMultiCursor = true;
-    vimState.isMultiCursor = true;
     return vimState;
   }
 }
@@ -2689,7 +2684,6 @@ class CommandInsertNewLineBefore extends BaseCommand {
     }
     vimState.cursors = vimState.cursors.reverse();
     vimState.isFakeMultiCursor = true;
-    vimState.isMultiCursor = true;
     return vimState;
   }
 }
@@ -3594,7 +3588,6 @@ class ActionGoToInsertVisualBlockMode extends BaseCommand {
 
   public async exec(position: Position, vimState: VimState): Promise<VimState> {
     await vimState.setCurrentMode(Mode.Insert);
-    vimState.isMultiCursor = true;
     vimState.isFakeMultiCursor = true;
 
     for (const { line, start } of TextEditor.iterateLinesInBlock(vimState)) {
@@ -3626,7 +3619,6 @@ class ActionChangeInVisualBlockMode extends BaseCommand {
     }
 
     await vimState.setCurrentMode(Mode.Insert);
-    vimState.isMultiCursor = true;
     vimState.isFakeMultiCursor = true;
 
     for (const { start } of TextEditor.iterateLinesInBlock(vimState)) {
@@ -3656,7 +3648,6 @@ class ActionChangeToEOLInVisualBlockMode extends BaseCommand {
     }
 
     await vimState.setCurrentMode(Mode.Insert);
-    vimState.isMultiCursor = true;
     vimState.isFakeMultiCursor = true;
 
     for (const { end } of TextEditor.iterateLinesInBlock(vimState)) {
@@ -3681,7 +3672,6 @@ abstract class ActionGoToInsertVisualLineModeCommand extends BaseCommand {
 
   public async exec(position: Position, vimState: VimState): Promise<VimState> {
     await vimState.setCurrentMode(Mode.Insert);
-    vimState.isMultiCursor = true;
     vimState.isFakeMultiCursor = true;
 
     vimState.cursors = [];
@@ -3778,7 +3768,6 @@ class ActionGoToInsertVisualBlockModeAppend extends BaseCommand {
 
   public async exec(position: Position, vimState: VimState): Promise<VimState> {
     await vimState.setCurrentMode(Mode.Insert);
-    vimState.isMultiCursor = true;
     vimState.isFakeMultiCursor = true;
 
     for (const { line, end } of TextEditor.iterateLinesInBlock(vimState)) {

--- a/src/actions/commands/insert.ts
+++ b/src/actions/commands/insert.ts
@@ -102,8 +102,7 @@ class CommandEscInsertMode extends BaseCommand {
     }
 
     if (vimState.isFakeMultiCursor) {
-      vimState.cursors = [vimState.cursors[0]];
-      vimState.isMultiCursor = false;
+      vimState.collapseCursors();
       vimState.isFakeMultiCursor = false;
     }
     return vimState;

--- a/src/mode/modeHandler.ts
+++ b/src/mode/modeHandler.ts
@@ -162,10 +162,6 @@ export class ModeHandler implements vscode.Disposable {
       return;
     }
 
-    if (e.selections.length === 1) {
-      this.vimState.isMultiCursor = false;
-    }
-
     if (isStatusBarMode(this.vimState.currentMode)) {
       return;
     }

--- a/src/state/vimState.ts
+++ b/src/state/vimState.ts
@@ -51,12 +51,6 @@ export class VimState implements vscode.Disposable {
   public lastKeyPressedTimestamp = 0;
 
   /**
-   * Are multiple cursors currently present?
-   */
-  // TODO: why isn't this a function?
-  public isMultiCursor = false;
-
-  /**
    * Is the multicursor something like visual block "multicursor", where
    * natively in vim there would only be one cursor whose changes were applied
    * to all lines after edit.
@@ -174,7 +168,6 @@ export class VimState implements vscode.Disposable {
     }
 
     this._cursors = Array.from(map.values());
-    this.isMultiCursor = this._cursors.length > 1;
   }
 
   /**
@@ -186,6 +179,16 @@ export class VimState implements vscode.Disposable {
   }
   public set cursorsInitialState(value: Range[]) {
     this._cursorsInitialState = Object.assign([], value);
+  }
+
+  /**
+   * Are multiple cursors currently present?
+   */
+  public get isMultiCursor(): boolean {
+    return this.cursors.length > 1;
+  }
+  public collapseCursors(): void {
+    this.cursors = [this.cursors[0]];
   }
 
   public isRecordingMacro: boolean = false;

--- a/src/textEditor.ts
+++ b/src/textEditor.ts
@@ -139,6 +139,10 @@ export class TextEditor {
     return vscode.window.activeTextEditor!.selection;
   }
 
+  static getSelections(): vscode.Range[] {
+    return vscode.window.activeTextEditor!.selections;
+  }
+
   static getText(selection?: vscode.Range): string {
     return vscode.window.activeTextEditor!.document.getText(selection);
   }

--- a/test/mode/modeNormal.test.ts
+++ b/test/mode/modeNormal.test.ts
@@ -1940,8 +1940,8 @@ suite('Mode Normal', () => {
   });
 
   newTest({
-    title: 'can ctrl-a on an octal ',
-    start: ['07|'],
+    title: 'can ctrl-a on an octal',
+    start: ['0|7'],
     keysPressed: '<C-a>',
     end: ['01|0'],
   });
@@ -2309,10 +2309,10 @@ suite('Mode Normal', () => {
     title: "Can 'D'elete the characters under multiple cursors until the end of the line",
     start: [
       'test aaa test aaa test aaa test |aaa test',
-      'test aaa test aaa test aaa test aaa test',
+      'test aaa test aaa test aaa test |aaa test',
     ],
-    keysPressed: '<C-alt+down>D<Esc>',
-    end: ['test aaa test aaa test aaa test| ', 'test aaa test aaa test aaa test '],
+    keysPressed: 'D',
+    end: ['test aaa test aaa test aaa test| ', 'test aaa test aaa test aaa test| '],
   });
 
   newTest({

--- a/test/mode/modeVisual.test.ts
+++ b/test/mode/modeVisual.test.ts
@@ -1338,21 +1338,24 @@ suite('Mode Visual', () => {
       title: 'multiline insert from bottom up selection',
       start: ['111', '222', '333', '4|44', '555'],
       keysPressed: 'vkkI_',
-      end: ['111', '2_|22', '_333', '_444', '555'],
+      end: ['111', '2_|22', '_|333', '_|444', '555'],
+      endMode: Mode.Insert,
     });
 
     newTest({
       title: 'multiline insert from top down selection',
       start: ['111', '2|22', '333', '444', '555'],
       keysPressed: 'vjjI_',
-      end: ['111', '2_|22', '_333', '_444', '555'],
+      end: ['111', '2_|22', '_|333', '_|444', '555'],
+      endMode: Mode.Insert,
     });
 
     newTest({
       title: 'skips blank lines',
       start: ['111', '2|22', ' ', '444', '555'],
       keysPressed: 'vjjI_',
-      end: ['111', '2_|22', ' ', '_444', '555'],
+      end: ['111', '2_|22', ' ', '_|444', '555'],
+      endMode: Mode.Insert,
     });
   });
 
@@ -1361,21 +1364,24 @@ suite('Mode Visual', () => {
       title: 'multiline append from bottom up selection',
       start: ['111', '222', '333', '4|44', '555'],
       keysPressed: 'vkkA_',
-      end: ['111', '222_|', '333_', '44_4', '555'],
+      end: ['111', '222_|', '333_|', '44_|4', '555'],
+      endMode: Mode.Insert,
     });
 
     newTest({
       title: 'multiline append from top down selection',
       start: ['111', '2|22', '333', '444', '555'],
       keysPressed: 'vjjA_',
-      end: ['111', '222_|', '333_', '44_4', '555'],
+      end: ['111', '222_|', '333_|', '44_|4', '555'],
+      endMode: Mode.Insert,
     });
 
     newTest({
       title: 'skips blank lines',
       start: ['111', '2|22', ' ', '444', '555'],
       keysPressed: 'vjjA_',
-      end: ['111', '222_|', ' ', '44_4', '555'],
+      end: ['111', '222_|', ' ', '44_|4', '555'],
+      endMode: Mode.Insert,
     });
   });
 

--- a/test/mode/modeVisualBlock.test.ts
+++ b/test/mode/modeVisualBlock.test.ts
@@ -33,63 +33,64 @@ suite('Mode Visual Block', () => {
     title: 'Can handle A forward select',
     start: ['|test', 'test'],
     keysPressed: 'l<C-v>ljA123',
-    end: ['tes123|t', 'tes123t'],
+    end: ['tes123|t', 'tes123|t'],
   });
 
   newTest({
     title: 'Can handle A backwards select',
     start: ['tes|t', 'test'],
     keysPressed: 'h<C-v>hjA123',
-    end: ['tes123|t', 'tes123t'],
+    end: ['tes123|t', 'tes123|t'],
   });
 
   newTest({
     title: 'Can handle I forward select',
     start: ['|test', 'test'],
     keysPressed: 'l<C-v>ljI123',
-    end: ['t123|est', 't123est'],
+    end: ['t123|est', 't123|est'],
   });
 
   newTest({
     title: 'Can handle I backwards select',
     start: ['tes|t', 'test'],
     keysPressed: 'h<C-v>hjI123',
-    end: ['t123|est', 't123est'],
+    end: ['t123|est', 't123|est'],
   });
 
   newTest({
     title: 'Can handle I with empty lines on first character (inserts on empty line)',
     start: ['|test', '', 'test'],
     keysPressed: '<C-v>lljjI123',
-    end: ['123|test', '123', '123test'],
+    end: ['123|test', '123|', '123|test'],
   });
 
   newTest({
     title: 'Can handle I with empty lines on non-first character (does not insert on empty line)',
     start: ['t|est', '', 'test'],
     keysPressed: '<C-v>lljjI123',
-    end: ['t123|est', '', 't123est'],
+    end: ['t123|est', '', 't123|est'],
   });
 
   newTest({
     title: 'Can handle c forward select',
     start: ['|test', 'test'],
     keysPressed: 'l<C-v>ljc123',
-    end: ['t123|t', 't123t'],
+    end: ['t123|t', 't123|t'],
   });
 
   newTest({
     title: 'Can handle c backwards select',
     start: ['tes|t', 'test'],
     keysPressed: 'h<C-v>hjc123',
-    end: ['t123|t', 't123t'],
+    end: ['t123|t', 't123|t'],
   });
 
   newTest({
     title: 'Can handle C',
     start: ['tes|t', 'test'],
     keysPressed: 'h<C-v>hjC123',
-    end: ['t123|', 't123'],
+    end: ['t123|', 't123|'],
+    endMode: Mode.Insert,
   });
 
   newTest({
@@ -144,7 +145,7 @@ suite('Mode Visual Block', () => {
     title: 'Properly add to end of lines j then $',
     start: ['|Dog', 'Angry', 'Dog', 'Angry', 'Dog'],
     keysPressed: '<C-v>4j$Aaa',
-    end: ['Dogaa|', 'Angryaa', 'Dogaa', 'Angryaa', 'Dogaa'],
+    end: ['Dogaa|', 'Angryaa|', 'Dogaa|', 'Angryaa|', 'Dogaa|'],
   });
 
   newTest({

--- a/test/mode/modeVisualLine.test.ts
+++ b/test/mode/modeVisualLine.test.ts
@@ -441,21 +441,24 @@ suite('Mode Visual Line', () => {
       title: 'multiline insert from bottom up selection',
       start: ['111', '222', '333', '4|44', '555'],
       keysPressed: 'VkkI_',
-      end: ['111', '_|222', '_333', '_444', '555'],
+      end: ['111', '_|222', '_|333', '_|444', '555'],
+      endMode: Mode.Insert,
     });
 
     newTest({
       title: 'multiline insert from top down selection',
       start: ['111', '2|22', '333', '444', '555'],
       keysPressed: 'VjjI_',
-      end: ['111', '_|222', '_333', '_444', '555'],
+      end: ['111', '_|222', '_|333', '_|444', '555'],
+      endMode: Mode.Insert,
     });
 
     newTest({
       title: 'skips blank lines',
       start: ['111', '2|22', ' ', '444', '555'],
       keysPressed: 'VjjI_',
-      end: ['111', '_|222', ' ', '_444', '555'],
+      end: ['111', '_|222', ' ', '_|444', '555'],
+      endMode: Mode.Insert,
     });
   });
 
@@ -464,21 +467,24 @@ suite('Mode Visual Line', () => {
       title: 'multiline append from bottom up selection',
       start: ['111', '222', '333', '4|44', '555'],
       keysPressed: 'VkkA_',
-      end: ['111', '222_|', '333_', '444_', '555'],
+      end: ['111', '222_|', '333_|', '444_|', '555'],
+      endMode: Mode.Insert,
     });
 
     newTest({
       title: 'multiline append from top down selection',
       start: ['111', '2|22', '333', '444', '555'],
       keysPressed: 'VjjA_',
-      end: ['111', '222_|', '333_', '444_', '555'],
+      end: ['111', '222_|', '333_|', '444_|', '555'],
+      endMode: Mode.Insert,
     });
 
     newTest({
       title: 'skips blank lines',
       start: ['111', '2|22', ' ', '444', '555'],
       keysPressed: 'VjjA_',
-      end: ['111', '222_|', ' ', '444_', '555'],
+      end: ['111', '222_|', ' ', '444_|', '555'],
+      endMode: Mode.Insert,
     });
 
     newTest({

--- a/test/multicursor.test.ts
+++ b/test/multicursor.test.ts
@@ -2,9 +2,12 @@ import * as assert from 'assert';
 import { getAndUpdateModeHandler } from '../extension';
 import { ModeHandler } from '../src/mode/modeHandler';
 import { assertEqualLines, cleanUpWorkspace, setupWorkspace } from './testUtils';
+import { getTestingFunctions } from './testSimplifier';
+import { Mode } from '../src/mode/mode';
 
 suite('Multicursor', () => {
   let modeHandler: ModeHandler;
+  const { newTest, newTestOnly, newTestSkip } = getTestingFunctions();
 
   setup(async () => {
     await setupWorkspace();
@@ -24,7 +27,7 @@ suite('Multicursor', () => {
       await modeHandler.handleMultipleKeyEvents(['<C-alt+down>']);
     }
 
-    assert.strictEqual(modeHandler.vimState.cursors.length, 2, 'Cursor succesfully created.');
+    assert.strictEqual(modeHandler.vimState.cursors.length, 2, 'Cursor successfully created.');
     await modeHandler.handleMultipleKeyEvents(['c', 'w', '3', '3', '<Esc>']);
     assertEqualLines(['33', '33']);
   });
@@ -40,7 +43,7 @@ suite('Multicursor', () => {
       await modeHandler.handleMultipleKeyEvents(['<C-alt+up>', '<C-alt+up>']);
     }
 
-    assert.strictEqual(modeHandler.vimState.cursors.length, 3, 'Cursor succesfully created.');
+    assert.strictEqual(modeHandler.vimState.cursors.length, 3, 'Cursor successfully created.');
     await modeHandler.handleMultipleKeyEvents(['c', 'w', '4', '4', '<Esc>']);
     assertEqualLines(['44', '44', '44']);
   });
@@ -121,5 +124,62 @@ suite('Multicursor', () => {
     await modeHandler.handleMultipleKeyEvents(['v', 'i', 't', 'd']);
     assertEqualLines(['<div></div> asd', '<div></div>']);
     assert.strictEqual(modeHandler.vimState.cursors.length, 2);
+  });
+
+  newTest({
+    title: 'dd works with multi-cursor',
+    start: ['on|e', 'two', 't|hree', 'four'],
+    keysPressed: 'dd',
+    end: ['|two', '|four'],
+    endMode: Mode.Normal,
+  });
+
+  // TODO - this actually doesn't work, but it should
+  // newTest({
+  //   title: 'dab works with multi-cursor',
+  //   start: ['(on|e)', 'two', '(thre|e', 'four)'],
+  //   keysPressed: 'dd',
+  //   end: ['|', 'two', '|'],
+  //   endMode: Mode.Normal,
+  // });
+
+  newTest({
+    title: 'Vd works with multi-cursor',
+    start: ['on|e', 'two', 't|hree', 'four'],
+    keysPressed: 'dd',
+    end: ['|two', '|four'],
+    endMode: Mode.Normal,
+  });
+
+  newTest({
+    title: '<C-v>d works with multi-cursor',
+    start: ['|one', 'two', 't|hree', 'four'],
+    keysPressed: '<C-v>jld',
+    end: ['|e', 'o', 't|ee', 'fr'],
+    endMode: Mode.Normal,
+  });
+
+  newTest({
+    title: 'cw works with multi-cursor',
+    start: ['one |two three |four five'],
+    keysPressed: 'cw',
+    end: ['one | three | five'],
+    endMode: Mode.Insert,
+  });
+
+  newTest({
+    title: '<count>f<char> works with multi-cursor',
+    start: ['|apple. banana! cucumber!', '|date! eggplant! fig.'],
+    keysPressed: '2f!',
+    end: ['apple. banana! cucumber|!', 'date! eggplant|! fig.'],
+    endMode: Mode.Normal,
+  });
+
+  newTest({
+    title: 'o works with multi-cursor',
+    start: ['li|ne1', 'l|ine2'],
+    keysPressed: 'o',
+    end: ['line1', '|', 'line2', '|'],
+    endMode: Mode.Insert,
   });
 });

--- a/test/testUtils.ts
+++ b/test/testUtils.ts
@@ -76,6 +76,9 @@ export async function WaitForEditorsToClose(numExpectedEditors: number = 0): Pro
   }
 }
 
+/**
+ * Asserts that the contents of the active editor matches what's given
+ */
 export function assertEqualLines(expectedLines: string[]) {
   for (let i = 0; i < expectedLines.length; i++) {
     const expected = expectedLines[i];
@@ -83,7 +86,7 @@ export function assertEqualLines(expectedLines: string[]) {
     assert.strictEqual(
       actual,
       expected,
-      `Content does not match; Expected=${expected}. Actual=${actual}.`
+      `Content of line ${i + 1} does not match; Expected=${expected}. Actual=${actual}.`
     );
   }
 


### PR DESCRIPTION
Now you can just put multiple cursors into the 'start' or 'end' of a test, a few examples are in multicursor.test.ts.
Fixes #4582