### PR TITLE
`gq` range when cursor is in the middle of a line.

### DIFF
--- a/src/actions/operator.ts
+++ b/src/actions/operator.ts
@@ -906,7 +906,9 @@ class ActionVisualReflowParagraph extends BaseOperator {
     return '';
   }
 
-  public reflowParagraph(s: string, indent: string): string {
+  public reflowParagraph(s: string): string {
+    const indent = this.getIndentation(s);
+
     let indentLevel = 0;
     for (const char of indent) {
       indentLevel += char === '\t' ? configuration.tabstop : 1;
@@ -1086,10 +1088,11 @@ class ActionVisualReflowParagraph extends BaseOperator {
   public async run(vimState: VimState, start: Position, end: Position): Promise<VimState> {
     [start, end] = Position.sorted(start, end);
 
-    let textToReflow = TextEditor.getText(new vscode.Range(start, end));
-    let indent = this.getIndentation(textToReflow);
+    start = start.getLineBegin();
+    end = end.getLineEnd();
 
-    textToReflow = this.reflowParagraph(textToReflow, indent);
+    let textToReflow = TextEditor.getText(new vscode.Range(start, end));
+    textToReflow = this.reflowParagraph(textToReflow);
 
     vimState.recordedState.transformations.push({
       type: 'replaceText',

--- a/test/mode/modeNormal.test.ts
+++ b/test/mode/modeNormal.test.ts
@@ -1617,6 +1617,20 @@ suite('Mode Normal', () => {
   });
 
   newTest({
+    title: 'gq work correctly with cursor in the middle of a line',
+    start: [
+      '// We choose to write a vim extension, not |because it is easy, but because it is hard.',
+      '// We choose to write a vim extension, not because it is easy, but because it is hard.',
+    ],
+    keysPressed: 'gqj',
+    end: [
+      '|// We choose to write a vim extension, not because it is easy, but because it is',
+      '// hard. We choose to write a vim extension, not because it is easy, but because',
+      '// it is hard.',
+    ],
+  });
+
+  newTest({
     title: 'Can handle space',
     start: ['|abc', 'def'],
     keysPressed: '  ',


### PR DESCRIPTION
**Bugs:**
Incorrect behaviour when cursor is in the middle of a line.(fixed by expanding start and end.)

**Small Refactor:**
Indentation should be got in paragraph reflow rather than being passed in as a parameter.

Fixes #4590 