### PR TITLE
Fix misplaced cursor after `VV`

### DIFF
--- a/src/actions/commands/actions.ts
+++ b/src/actions/commands/actions.ts
@@ -2364,6 +2364,12 @@ class CommandExitVisualLineMode extends BaseCommand {
   keys = ['V'];
 
   public async exec(position: Position, vimState: VimState): Promise<VimState> {
+    if (vimState.visualLineStartColumn !== undefined) {
+      vimState.cursorStopPosition = vimState.cursorStopPosition.withColumn(
+        vimState.visualLineStartColumn
+      );
+    }
+
     await vimState.setCurrentMode(Mode.Normal);
 
     return vimState;

--- a/test/mode/modeVisualLine.test.ts
+++ b/test/mode/modeVisualLine.test.ts
@@ -485,4 +485,11 @@ suite('Mode Visual Line', () => {
     keysPressed: 'Vj<Esc>',
     end: ['rocinante', 'nauvoo', 'anu|bis', 'canterbury'],
   });
+
+  newTest({
+    title: 'Exiting via `VV` returns cursor to original column',
+    start: ['rocinante', 'nau|voo', 'anubis', 'canterbury'],
+    keysPressed: 'VjV',
+    end: ['rocinante', 'nauvoo', 'anu|bis', 'canterbury'],
+  });
 });


### PR DESCRIPTION
So simple :-P
Fixes #4593
But currently these are just workaround. We need to simulate a cursor in visualLine mode in the future.