### PR TITLE
readme: remove sneak from quick example

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,6 @@ Below is an example of a [settings.json](https://code.visualstudio.com/Docs/cust
 ```json
 {
   "vim.easymotion": true,
-  "vim.sneak": true,
   "vim.incsearch": true,
   "vim.useSystemClipboard": true,
   "vim.useCtrlKeys": true,


### PR DESCRIPTION
**What this PR does / why we need it**:
  * many people seem to copy the 'quick example' from the readme as
    their initial config. The problem with that quick example is that it
    enables 'sneak', which by defaults breaks the S and s commands (see
    issue #3274).

  * by removing that setting from the example, people should have a
    working config out of the box. If someone is interested in sneak,
    other sections of the readme still go into details.

**Which issue(s) this PR fixes**
  * #3274 

**Special notes for your reviewer**:
  * Please see comment by @jpoon : https://github.com/VSCodeVim/Vim/issues/3274#issuecomment-594106691
