### PR TITLE
add setxkbmap escape caps remapping not working to FAQ

### DIFF
--- a/README.md
+++ b/README.md
@@ -692,6 +692,10 @@ VS Code has a lot of nifty tricks and we try to preserve some of them:
 
   **Caveats:** This solution restores the default VS Code behavior for the <kbd>j</kbd> and <kbd>k</kbd> keys, so motions like `10j` [will not work](https://github.com/VSCodeVim/Vim/pull/3623#issuecomment-481473981). If you need these motions to work, [other, less performant options exist](https://github.com/VSCodeVim/Vim/issues/2924#issuecomment-476121848).
 
+- I've swapped Escape and Caps Lock with setxkbmap and it isn't working
+
+  This is a (known issue in VS Code](https://github.com/microsoft/vscode/issues/23991), as a workaround you can set `"keyboard.dispatch": "keycode"` and restart VS Code.
+
 ## ❤️ Contributing
 
 This project is maintained by a group of awesome [people](https://github.com/VSCodeVim/Vim/graphs/contributors) and contributions are extremely welcome :heart:. For a quick tutorial on how you can help, see our [contributing guide](/.github/CONTRIBUTING.md).

--- a/README.md
+++ b/README.md
@@ -692,7 +692,7 @@ VS Code has a lot of nifty tricks and we try to preserve some of them:
 
   **Caveats:** This solution restores the default VS Code behavior for the <kbd>j</kbd> and <kbd>k</kbd> keys, so motions like `10j` [will not work](https://github.com/VSCodeVim/Vim/pull/3623#issuecomment-481473981). If you need these motions to work, [other, less performant options exist](https://github.com/VSCodeVim/Vim/issues/2924#issuecomment-476121848).
 
-- I've swapped Escape and Caps Lock with setxkbmap and it isn't working
+- I've swapped Escape and Caps Lock with setxkbmap and VSCodeVim isn't respecting the swap
 
   This is a [known issue in VS Code](https://github.com/microsoft/vscode/issues/23991), as a workaround you can set `"keyboard.dispatch": "keycode"` and restart VS Code.
 

--- a/README.md
+++ b/README.md
@@ -694,7 +694,7 @@ VS Code has a lot of nifty tricks and we try to preserve some of them:
 
 - I've swapped Escape and Caps Lock with setxkbmap and it isn't working
 
-  This is a (known issue in VS Code](https://github.com/microsoft/vscode/issues/23991), as a workaround you can set `"keyboard.dispatch": "keycode"` and restart VS Code.
+  This is a [known issue in VS Code](https://github.com/microsoft/vscode/issues/23991), as a workaround you can set `"keyboard.dispatch": "keycode"` and restart VS Code.
 
 ## ❤️ Contributing
 


### PR DESCRIPTION
- [x] Commit messages has a short & issue references when necessary
- [x] Each commit does a logical chunk of work.
- [x] It builds and tests pass (e.g `gulp`)

**What this PR does / why we need it**: Add a note to the FAQ about issues with setxkbmap. I think this is needed since it's common for people to remap escape and capslock with setxkbmap and given this isn't working but is possible to workaround we should add a note to the PAQ.

**Which issue(s) this PR fixes** closes https://github.com/VSCodeVim/Vim/issues/4612

**Special notes for your reviewer**:
