### PR TITLE
Implement "[count]D"

### DIFF
--- a/src/actions/commands/actions.ts
+++ b/src/actions/commands/actions.ts
@@ -2126,11 +2126,14 @@ class CommandDeleteToLineEnd extends BaseCommand {
       return vimState;
     }
 
-    return new operator.DeleteOperator(this.multicursorIndex).run(
-      vimState,
-      position,
-      position.getLineEnd().getLeft()
-    );
+    const linesDown = (vimState.recordedState.count || 1) - 1;
+    const start = position;
+    const end = position
+      .getDownByCount(linesDown)
+      .getLineEnd()
+      .getLeftThroughLineBreaks();
+
+    return new operator.DeleteOperator(this.multicursorIndex).run(vimState, start, end);
   }
 }
 

--- a/test/mode/normalModeTests/commands.test.ts
+++ b/test/mode/normalModeTests/commands.test.ts
@@ -112,6 +112,34 @@ suite('Mode Normal', () => {
   });
 
   newTest({
+    title: "Can handle 'D' with count 1",
+    start: ['o|ne', 'two', 'three'],
+    keysPressed: '1D',
+    end: ['|o', 'two', 'three'],
+  });
+
+  newTest({
+    title: "Can handle 'D' with count 3",
+    start: ['o|ne', 'two', 'three', 'four'],
+    keysPressed: '3D',
+    end: ['|o', 'four'],
+  });
+
+  newTest({
+    title: "Can handle 'D' with count exceeding max number of rows",
+    start: ['o|ne', 'two', 'three', 'four'],
+    keysPressed: '100D',
+    end: ['|o'],
+  });
+
+  newTest({
+    title: "Can handle 'D' with count when end position is on blank line",
+    start: ['o|ne', '', 'three'],
+    keysPressed: '2D',
+    end: ['|o', 'three'],
+  });
+
+  newTest({
     title: "Can handle 'DD'",
     start: ['tex|t'],
     keysPressed: '^llDD',


### PR DESCRIPTION

<!--
Yay! Thanks for sending us a PR! 🎊

Please ensure your PR adheres to:

- [ ] Commit messages has a short & issue references when necessary
- [ ] Each commit does a logical chunk of work.
- [ ] It builds and tests pass (e.g `gulp`)
-->

**What this PR does / why we need it**:

In original Vim, `[count]D` delete the characters under the cursor until the end of the line and (count - 1) more lines.
But this feature in not implemented.

e.g.
```
one
t|wo
three
four
```
execute `2D`, and then
```
one
|t
four
```

**Which issue(s) this PR fixes**

Fixes #3757

<!--
Commits in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)
-->

**Special notes for your reviewer**:
