### PR TITLE
added escaped search string in global search state

### DIFF
--- a/src/actions/commands/commandLine.ts
+++ b/src/actions/commands/commandLine.ts
@@ -430,6 +430,7 @@ class CommandEscInSearchMode extends BaseCommand {
 
     await vimState.setCurrentMode(searchState.previousMode);
     vimState.statusBarCursorCharacterPos = 0;
+    globalState.addSearchStateToHistory(searchState);
 
     return vimState;
   }

--- a/test/cmd_line/command.test.ts
+++ b/test/cmd_line/command.test.ts
@@ -144,4 +144,10 @@ suite('cmd_line/search command', () => {
     await modeHandler.handleMultipleKeyEvents(['<Esc>', '/', '<C-r>', '<C-w>']);
     assertStatusBarEqual('/abc|', 'Failed to insert word under cursor');
   });
+
+  test('<C-p> insert word under cursor in search mode', async () => {
+    await modeHandler.handleMultipleKeyEvents('/abc'.split('').concat('<Esc>'));
+    await modeHandler.handleMultipleKeyEvents(['/', '<C-p>']);
+    assertStatusBarEqual('/abc|', 'Failed to insert word under cursor');
+  });
 });

--- a/test/cmd_line/command.test.ts
+++ b/test/cmd_line/command.test.ts
@@ -145,9 +145,9 @@ suite('cmd_line/search command', () => {
     assertStatusBarEqual('/abc|', 'Failed to insert word under cursor');
   });
 
-  test('<C-p> insert word under cursor in search mode', async () => {
+  test('<C-p> go to previous search string', async () => {
     await modeHandler.handleMultipleKeyEvents('/abc'.split('').concat('<Esc>'));
     await modeHandler.handleMultipleKeyEvents(['/', '<C-p>']);
-    assertStatusBarEqual('/abc|', 'Failed to insert word under cursor');
+    assertStatusBarEqual('/abc|', 'Failed to go to previous search string');
   });
 });


### PR DESCRIPTION
**What this PR does / why we need it**:
Cancelled Searched not being added to search history.
`/foobar<Esc>`, then `/<C-p>`. Notice "foobar" does not show up.

**Which issue(s) this PR fixes**
fixes #4650 

**Special notes for your reviewer**:
Let me know on the issues with the PR as this is my first open source PR.
