### PR TITLE
Fix cursor movement with large folded regions.

### DIFF
--- a/src/mode/modeHandler.ts
+++ b/src/mode/modeHandler.ts
@@ -1336,11 +1336,7 @@ export class ModeHandler implements vscode.Disposable {
 
       const { visibleRanges } = vimState.editor;
       const centerViewportAroundCursor =
-        visibleRanges.reduce(
-          (acc, visibleRange) => acc && isCursorAboveRange(visibleRange),
-          true
-        ) ||
-        visibleRanges.reduce((acc, visibleRange) => acc && isCursorBelowRange(visibleRange), true);
+        visibleRanges.every(isCursorAboveRange) || visibleRanges.every(isCursorBelowRange);
 
       const revealType = centerViewportAroundCursor
         ? vscode.TextEditorRevealType.InCenter

--- a/src/mode/modeHandler.ts
+++ b/src/mode/modeHandler.ts
@@ -1329,10 +1329,19 @@ export class ModeHandler implements vscode.Disposable {
       vimState.postponedCodeViewChanges.filter(change => change.command === 'editorScroll')
         .length === 0
     ) {
-      const visibleRange = vimState.editor.visibleRanges[0];
-      const centerViewportAroundCursor =
-        visibleRange.start.line - vimState.cursorStopPosition.line >= 15 ||
+      const isCursorAboveRange = (visibleRange: vscode.Range): boolean =>
+        visibleRange.start.line - vimState.cursorStopPosition.line >= 15;
+      const isCursorBelowRange = (visibleRange: vscode.Range): boolean =>
         vimState.cursorStopPosition.line - visibleRange.end.line >= 15;
+
+      const { visibleRanges } = vimState.editor;
+      const centerViewportAroundCursor =
+        visibleRanges.reduce(
+          (acc, visibleRange) => acc && isCursorAboveRange(visibleRange),
+          true
+        ) ||
+        visibleRanges.reduce((acc, visibleRange) => acc && isCursorBelowRange(visibleRange), true);
+
       const revealType = centerViewportAroundCursor
         ? vscode.TextEditorRevealType.InCenter
         : vscode.TextEditorRevealType.Default;


### PR DESCRIPTION
With a folded region larger than 15 lines, when the cursor is below the
folded region, it is always 15 lines below the end of the first region,
so the existing logic will incorrectly tell vim to always re-center the
cursor. Instead, we should check if the cursor is either below all
visible regions, or above all visible regions.

Fixes:

https://github.com/VSCodeVim/Vim/issues/4643
https://github.com/VSCodeVim/Vim/issues/4632
