### PR TITLE
Support `J` in visual block mode

### DIFF
--- a/src/actions/commands/actions.ts
+++ b/src/actions/commands/actions.ts
@@ -3282,13 +3282,11 @@ class ActionJoinVisualBlockMode extends BaseCommand {
   mightChangeDocument = true;
 
   public async exec(position: Position, vimState: VimState): Promise<VimState> {
-    let actionJoin = new ActionJoin();
-    const range = vimState.cursors[0];
-    const topLeft = visualBlockGetTopLeftPosition(range.start, range.stop);
-    const bottomRight = visualBlockGetBottomRightPosition(range.start, range.stop);
+    const start = vimState.cursorStartPosition;
+    const end = vimState.cursorStopPosition;
 
     vimState.currentRegisterMode = RegisterMode.CharacterWise;
-    vimState = await actionJoin.execJoinLines(topLeft, bottomRight, vimState, 1);
+    vimState = await new ActionJoin().execJoinLines(start, end, vimState, 1);
     return vimState;
   }
 }

--- a/src/actions/commands/actions.ts
+++ b/src/actions/commands/actions.ts
@@ -3282,11 +3282,13 @@ class ActionJoinVisualBlockMode extends BaseCommand {
   mightChangeDocument = true;
 
   public async exec(position: Position, vimState: VimState): Promise<VimState> {
-    const start = vimState.cursorStartPosition;
-    const end = vimState.cursorStopPosition;
-
     vimState.currentRegisterMode = RegisterMode.CharacterWise;
-    vimState = await new ActionJoin().execJoinLines(start, end, vimState, 1);
+    vimState = await new ActionJoin().execJoinLines(
+      vimState.cursorStartPosition,
+      vimState.cursorStopPosition,
+      vimState,
+      1
+    );
     return vimState;
   }
 }

--- a/src/actions/commands/actions.ts
+++ b/src/actions/commands/actions.ts
@@ -13,7 +13,12 @@ import { Position, PositionDiff, PositionDiffType } from './../../common/motion/
 import { Range } from './../../common/motion/range';
 import { NumericString } from './../../common/number/numericString';
 import { configuration } from './../../configuration/configuration';
-import { Mode, visualBlockGetTopLeftPosition, isVisualMode } from './../../mode/mode';
+import {
+  Mode,
+  visualBlockGetTopLeftPosition,
+  visualBlockGetBottomRightPosition,
+  isVisualMode,
+} from './../../mode/mode';
 import { Register, RegisterMode } from './../../register/register';
 import { SearchDirection, SearchState } from './../../state/searchState';
 import { EditorScrollByUnit, EditorScrollDirection, TextEditor } from './../../textEditor';
@@ -3264,6 +3269,24 @@ class ActionJoinVisualMode extends BaseCommand {
     vimState.currentRegisterMode = RegisterMode.CharacterWise;
     vimState = await actionJoin.execJoinLines(start, end, vimState, 1);
 
+    return vimState;
+  }
+}
+
+@RegisterAction
+class ActionJoinVisualBlockMode extends BaseCommand {
+  modes = [Mode.VisualBlock];
+  keys = ['J'];
+  mightChangeDocument = true;
+
+  public async exec(position: Position, vimState: VimState): Promise<VimState> {
+    let actionJoin = new ActionJoin();
+    const range = vimState.cursors[0];
+    const topLeft = visualBlockGetTopLeftPosition(range.start, range.stop);
+    const bottomRight = visualBlockGetBottomRightPosition(range.start, range.stop);
+
+    vimState.currentRegisterMode = RegisterMode.CharacterWise;
+    vimState = await actionJoin.execJoinLines(topLeft, bottomRight, vimState, 1);
     return vimState;
   }
 }

--- a/src/mode/modeHandler.ts
+++ b/src/mode/modeHandler.ts
@@ -1329,10 +1329,15 @@ export class ModeHandler implements vscode.Disposable {
       vimState.postponedCodeViewChanges.filter(change => change.command === 'editorScroll')
         .length === 0
     ) {
-      const visibleRange = vimState.editor.visibleRanges[0];
-      const centerViewportAroundCursor =
-        visibleRange.start.line - vimState.cursorStopPosition.line >= 15 ||
+      const isCursorAboveRange = (visibleRange: vscode.Range): boolean =>
+        visibleRange.start.line - vimState.cursorStopPosition.line >= 15;
+      const isCursorBelowRange = (visibleRange: vscode.Range): boolean =>
         vimState.cursorStopPosition.line - visibleRange.end.line >= 15;
+
+      const { visibleRanges } = vimState.editor;
+      const centerViewportAroundCursor =
+        visibleRanges.every(isCursorAboveRange) || visibleRanges.every(isCursorBelowRange);
+
       const revealType = centerViewportAroundCursor
         ? vscode.TextEditorRevealType.InCenter
         : vscode.TextEditorRevealType.Default;

--- a/test/mode/modeVisualBlock.test.ts
+++ b/test/mode/modeVisualBlock.test.ts
@@ -188,4 +188,12 @@ suite('Mode Visual Block', () => {
     keysPressed: '<C-v>llj"ayGo<C-r>a<Esc>',
     end: ['abcde', '01234', 'abcde', '01234', '123', 'bcd', '|'],
   });
+
+  newTest({
+    title: "Can handle 'J'",
+    start: ['o|ne', 'two', 'three', 'four'],
+    keysPressed: '<C-v>jjlJ',
+    end: ['one| two three', 'four'],
+    endMode: Mode.Normal,
+  });
 });

--- a/test/mode/modeVisualBlock.test.ts
+++ b/test/mode/modeVisualBlock.test.ts
@@ -190,7 +190,15 @@ suite('Mode Visual Block', () => {
   });
 
   newTest({
-    title: "Can handle 'J'",
+    title: "Can handle 'J' when the entire visual block is on the same line",
+    start: ['one', '|two', 'three', 'four'],
+    keysPressed: '<C-v>lJ',
+    end: ['one', 'two| three', 'four'],
+    endMode: Mode.Normal,
+  });
+
+  newTest({
+    title: "Can handle 'J' when the visual block spans multiple lines",
     start: ['o|ne', 'two', 'three', 'four'],
     keysPressed: '<C-v>jjlJ',
     end: ['one| two three', 'four'],


### PR DESCRIPTION
<!--
Yay! Thanks for sending us a PR! 🎊

Please ensure your PR adheres to:

- [ ] Commit messages has a short & issue references when necessary
- [ ] Each commit does a logical chunk of work.
- [ ] It builds and tests pass (e.g `gulp`)
-->

**What this PR does / why we need it**:

`J` (join lines) works in visual block mode in original Vim, but this is not supported this extension.

expected:

![image](https://user-images.githubusercontent.com/31386431/77243807-8fdd0980-6c51-11ea-92ce-7d8a189213aa.png)

If `J` is executed in the state of this image, expected to be:

```
one two three
four
```

**Which issue(s) this PR fixes**

<!--
Commits in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)
-->

**Special notes for your reviewer**:

- Cursor position after execution is different from original Vim, but this is the same behavior as visual mode and visual line mode. So I think this should be fixed as another Pull Request.
  - In the above example, cursor should be before `three` after execution, but actually it is before `two`.
- `gJ` doesn't work either, but doesn't fix it. Because `gJ` has a bug like #2207 and it doesn't work properly.

And if necessary, I'd like to fix and create another PR for these as well 👻