### PR TITLE
Optimize HistoryTracker using a cached TextDocument.version

### DIFF
--- a/package.json
+++ b/package.json
@@ -918,11 +918,6 @@
           "type": "boolean",
           "markdownDescription": "When `true` the commands listed below move the cursor to the first non-blank of the line.  When `false` the cursor is kept in the same column (if possible).  This applies to the commands: `<C-d>`, `<C-u>`, `<C-b>`, `<C-f>`, `G`, `H`, `M`, `L`, `gg`, and to the commands `d`, `<<` and `>>` with a linewise operator.",
           "default": true
-        },
-        "vim.experimentalOptimizations": {
-          "type": "boolean",
-          "description": "Increase performance of the extension, especially when navigating or editing large files. This is an experimental option and may cause unpredicted behaviour.",
-          "default": false
         }
       }
     },

--- a/src/actions/base.ts
+++ b/src/actions/base.ts
@@ -47,21 +47,6 @@ export class BaseAction {
   private static readonly isSingleAlpha: RegExp = /^[a-zA-Z]$/;
 
   /**
-   * True if this action has the potential to change the document's text, and therefore trigger an
-   * undo step. This is for optimization purposes - we skip the expensive process of figuring out
-   * what changed to create that undo step if this returns false.
-   *
-   * Most commands do not modify the document, so this is false by default. This means if you add a
-   * command that can modify the document or switch modes, you MUST set mightChangeDocument = true. Otherwise undo
-   * will not work properly.
-   *
-   *
-   * TODO: if all actions were pure, I think this would be unnecessary, as we could deduce it from
-   * vimState.transformations being empty or not.
-   */
-  public mightChangeDocument: boolean = false;
-
-  /**
    * Is this action valid in the current Vim state?
    */
   public doesActionApply(vimState: VimState, keysPressed: string[]): boolean {

--- a/src/actions/commands/actions.ts
+++ b/src/actions/commands/actions.ts
@@ -37,7 +37,6 @@ export class DocumentContentChangeAction extends BaseAction {
     positionDiff: PositionDiff;
     textDiff: vscode.TextDocumentContentChangeEvent;
   }[] = [];
-  mightChangeDocument = true;
 
   public async exec(position: Position, vimState: VimState): Promise<VimState> {
     if (this.contentChanges.length === 0) {
@@ -416,7 +415,6 @@ class CommandExecuteMacro extends BaseCommand {
   keys = ['@', '<character>'];
   runsOnceForEachCountPrefix = true;
   canBeRepeatedWithDot = true;
-  mightChangeDocument = true;
 
   public async exec(position: Position, vimState: VimState): Promise<VimState> {
     const register = this.keysPressed[1];
@@ -453,7 +451,6 @@ class CommandExecuteLastMacro extends BaseCommand {
   runsOnceForEachCountPrefix = true;
   canBeRepeatedWithDot = true;
   isJump = true;
-  mightChangeDocument = true;
 
   public async exec(position: Position, vimState: VimState): Promise<VimState> {
     const { lastInvokedMacro } = vimState.historyTracker;
@@ -474,7 +471,6 @@ class CommandExecuteLastMacro extends BaseCommand {
 class CtrlM extends BaseCommand {
   modes = [Mode.Insert];
   keys = [['<C-m>']];
-  mightChangeDocument = true;
 
   public async exec(position: Position, vimState: VimState): Promise<VimState> {
     vimState.recordedState.transformations.push({
@@ -554,7 +550,6 @@ class CommandEsc extends BaseCommand {
 class CommandEscReplaceMode extends BaseCommand {
   modes = [Mode.Replace];
   keys = [['<Esc>'], ['<C-c>'], ['<C-[>']];
-  mightChangeDocument = true;
 
   public async exec(position: Position, vimState: VimState): Promise<VimState> {
     const timesToRepeat = vimState.replaceState!.timesToRepeat;
@@ -790,7 +785,6 @@ class CommandReplaceInReplaceMode extends BaseCommand {
   modes = [Mode.Replace];
   keys = ['<character>'];
   canBeRepeatedWithDot = true;
-  mightChangeDocument = true;
 
   public async exec(position: Position, vimState: VimState): Promise<VimState> {
     const char = this.keysPressed[0];
@@ -857,10 +851,6 @@ class CommandReplaceInReplaceMode extends BaseCommand {
 class CommandOverrideCopy extends BaseCommand {
   modes = [Mode.Visual, Mode.VisualLine, Mode.VisualBlock, Mode.Insert, Mode.Normal];
   keys = ['<copy>']; // A special key - see ModeHandler
-
-  // We need this because <C-c>(CommandEscInsertMode)
-  // may be overwritten to <copy>
-  mightChangeDocument = true;
 
   runsOnceForEveryCursor() {
     return false;
@@ -1176,7 +1166,6 @@ export class PutCommand extends BaseCommand {
   modes = [Mode.Normal];
   runsOnceForEachCountPrefix = true;
   canBeRepeatedWithDot = true;
-  mightChangeDocument = true;
 
   constructor(multicursorIndex?: number) {
     super();
@@ -1462,7 +1451,6 @@ export class GPutCommand extends BaseCommand {
   modes = [Mode.Normal, Mode.Visual, Mode.VisualLine];
   runsOnceForEachCountPrefix = true;
   canBeRepeatedWithDot = true;
-  mightChangeDocument = true;
 
   public async exec(position: Position, vimState: VimState): Promise<VimState> {
     return new PutCommand().exec(position, vimState);
@@ -1508,7 +1496,6 @@ export class PutWithIndentCommand extends BaseCommand {
   modes = [Mode.Normal, Mode.Visual, Mode.VisualLine];
   runsOnceForEachCountPrefix = true;
   canBeRepeatedWithDot = true;
-  mightChangeDocument = true;
 
   public async exec(position: Position, vimState: VimState): Promise<VimState> {
     const result = await new PutCommand().exec(position, vimState, false, true);
@@ -1525,7 +1512,6 @@ export class PutCommandVisual extends BaseCommand {
   keys = [['p'], ['P']];
   modes = [Mode.Visual, Mode.VisualLine];
   runsOnceForEachCountPrefix = true;
-  mightChangeDocument = true;
 
   public async exec(
     position: Position,
@@ -1599,7 +1585,6 @@ export class PutBeforeCommand extends BaseCommand {
   public modes = [Mode.Normal];
   canBeRepeatedWithDot = true;
   runsOnceForEachCountPrefix = true;
-  mightChangeDocument = true;
 
   public async exec(position: Position, vimState: VimState): Promise<VimState> {
     const command = new PutCommand();
@@ -1615,7 +1600,6 @@ export class PutBeforeCommand extends BaseCommand {
 export class GPutBeforeCommand extends BaseCommand {
   keys = ['g', 'P'];
   modes = [Mode.Normal];
-  mightChangeDocument = true;
 
   public async exec(position: Position, vimState: VimState): Promise<VimState> {
     const result = await new PutCommand().exec(position, vimState, true);
@@ -1653,7 +1637,6 @@ export class GPutBeforeCommand extends BaseCommand {
 export class PutBeforeWithIndentCommand extends BaseCommand {
   keys = ['[', 'p'];
   modes = [Mode.Normal];
-  mightChangeDocument = true;
 
   public async exec(position: Position, vimState: VimState): Promise<VimState> {
     const result = await new PutCommand().exec(position, vimState, true, true);
@@ -1766,7 +1749,6 @@ export class CommandShowSearchHistory extends BaseCommand {
 class CommandDot extends BaseCommand {
   modes = [Mode.Normal];
   keys = ['.'];
-  mightChangeDocument = true;
 
   public async exec(position: Position, vimState: VimState): Promise<VimState> {
     vimState.recordedState.transformations.push({
@@ -1781,7 +1763,6 @@ class CommandDot extends BaseCommand {
 class CommandRepeatSubstitution extends BaseCommand {
   modes = [Mode.Normal];
   keys = ['&'];
-  mightChangeDocument = true;
 
   public async exec(position: Position, vimState: VimState): Promise<VimState> {
     // Parsing the command from a string, while not ideal, is currently
@@ -2073,7 +2054,6 @@ class CommandUndo extends BaseCommand {
     return false;
   }
   mustBeFirstKey = true;
-  mightChangeDocument = true;
 
   public async exec(position: Position, vimState: VimState): Promise<VimState> {
     const newPositions = await vimState.historyTracker.goBackHistoryStep();
@@ -2098,7 +2078,6 @@ class CommandUndoOnLine extends BaseCommand {
     return false;
   }
   mustBeFirstKey = true;
-  mightChangeDocument = true;
 
   public async exec(position: Position, vimState: VimState): Promise<VimState> {
     const newPositions = await vimState.historyTracker.goBackHistoryStepsOnLine();
@@ -2116,7 +2095,6 @@ class CommandUndoOnLine extends BaseCommand {
 class CommandRedo extends BaseCommand {
   modes = [Mode.Normal];
   keys = ['<C-r>'];
-  mightChangeDocument = true;
   runsOnceForEveryCursor() {
     return false;
   }
@@ -2140,7 +2118,6 @@ class CommandDeleteToLineEnd extends BaseCommand {
   modes = [Mode.Normal];
   keys = ['D'];
   canBeRepeatedWithDot = true;
-  mightChangeDocument = true;
   runsOnceForEveryCursor() {
     return true;
   }
@@ -2182,7 +2159,6 @@ class CommandChangeToLineEnd extends BaseCommand {
   modes = [Mode.Normal];
   keys = ['C'];
   runsOnceForEachCountPrefix = false;
-  mightChangeDocument = true;
 
   public async exec(position: Position, vimState: VimState): Promise<VimState> {
     const count = vimState.recordedState.count || 1;
@@ -2203,7 +2179,6 @@ class CommandClearLine extends BaseCommand {
   modes = [Mode.Normal];
   keys = ['S'];
   runsOnceForEachCountPrefix = false;
-  mightChangeDocument = true;
 
   public async exec(position: Position, vimState: VimState): Promise<VimState> {
     return new operator.ChangeOperator(this.multicursorIndex).runRepeat(
@@ -2656,7 +2631,6 @@ export class CommandInsertAtLineEnd extends BaseCommand {
 class CommandInsertNewLineAbove extends BaseCommand {
   modes = [Mode.Normal];
   keys = ['O'];
-  mightChangeDocument = true;
   runsOnceForEveryCursor() {
     return false;
   }
@@ -2696,7 +2670,6 @@ class CommandInsertNewLineAbove extends BaseCommand {
 class CommandInsertNewLineBefore extends BaseCommand {
   modes = [Mode.Normal];
   keys = ['o'];
-  mightChangeDocument = true;
   runsOnceForEveryCursor() {
     return false;
   }
@@ -3015,7 +2988,6 @@ export class ActionDeleteChar extends BaseCommand {
   modes = [Mode.Normal];
   keys = ['x'];
   canBeRepeatedWithDot = true;
-  mightChangeDocument = true;
 
   public async exec(position: Position, vimState: VimState): Promise<VimState> {
     // If line is empty, do nothing
@@ -3043,7 +3015,6 @@ export class ActionDeleteCharWithDeleteKey extends BaseCommand {
   keys = ['<Del>'];
   runsOnceForEachCountPrefix = true;
   canBeRepeatedWithDot = true;
-  mightChangeDocument = true;
 
   public async execCount(position: Position, vimState: VimState): Promise<VimState> {
     // If <del> has a count in front of it, then <del> deletes a character
@@ -3065,7 +3036,6 @@ export class ActionDeleteLastChar extends BaseCommand {
   modes = [Mode.Normal];
   keys = ['X'];
   canBeRepeatedWithDot = true;
-  mightChangeDocument = true;
 
   public async exec(position: Position, vimState: VimState): Promise<VimState> {
     if (position.character === 0) {
@@ -3090,7 +3060,6 @@ class ActionJoin extends BaseCommand {
   keys = ['J'];
   canBeRepeatedWithDot = true;
   runsOnceForEachCountPrefix = false;
-  mightChangeDocument = true;
 
   private firstNonWhitespaceIndex(str: string): number {
     for (let i = 0, len = str.length; i < len; i++) {
@@ -3254,7 +3223,6 @@ class ActionJoin extends BaseCommand {
 class ActionJoinVisualMode extends BaseCommand {
   modes = [Mode.Visual, Mode.VisualLine];
   keys = ['J'];
-  mightChangeDocument = true;
 
   public async exec(position: Position, vimState: VimState): Promise<VimState> {
     let actionJoin = new ActionJoin();
@@ -3279,7 +3247,6 @@ class ActionJoinVisualMode extends BaseCommand {
 class ActionJoinVisualBlockMode extends BaseCommand {
   modes = [Mode.VisualBlock];
   keys = ['J'];
-  mightChangeDocument = true;
 
   public async exec(position: Position, vimState: VimState): Promise<VimState> {
     vimState.currentRegisterMode = RegisterMode.CharacterWise;
@@ -3299,7 +3266,6 @@ class ActionJoinNoWhitespace extends BaseCommand {
   keys = ['g', 'J'];
   canBeRepeatedWithDot = true;
   runsOnceForEachCountPrefix = true;
-  mightChangeDocument = true;
 
   // gJ is essentially J without the edge cases. ;-)
 
@@ -3343,7 +3309,6 @@ class ActionJoinNoWhitespace extends BaseCommand {
 class ActionJoinNoWhitespaceVisualMode extends BaseCommand {
   modes = [Mode.Visual];
   keys = ['g', 'J'];
-  mightChangeDocument = true;
 
   public async exec(position: Position, vimState: VimState): Promise<VimState> {
     let actionJoin = new ActionJoinNoWhitespace();
@@ -3372,7 +3337,6 @@ class ActionReplaceCharacter extends BaseCommand {
   keys = ['r', '<character>'];
   canBeRepeatedWithDot = true;
   runsOnceForEachCountPrefix = false;
-  mightChangeDocument = true;
 
   public async exec(position: Position, vimState: VimState): Promise<VimState> {
     let timesToRepeat = vimState.recordedState.count || 1;
@@ -3450,7 +3414,6 @@ class ActionReplaceCharacterVisual extends BaseCommand {
     return false;
   }
   canBeRepeatedWithDot = true;
-  mightChangeDocument = true;
 
   public async exec(position: Position, vimState: VimState): Promise<VimState> {
     let toInsert = this.keysPressed[1];
@@ -3534,7 +3497,6 @@ class ActionReplaceCharacterVisualBlock extends BaseCommand {
     return false;
   }
   canBeRepeatedWithDot = true;
-  mightChangeDocument = true;
 
   public async exec(position: Position, vimState: VimState): Promise<VimState> {
     let toInsert = this.keysPressed[1];
@@ -3576,7 +3538,6 @@ class ActionDeleteVisualBlock extends BaseCommand {
   runsOnceForEveryCursor() {
     return false;
   }
-  mightChangeDocument = true;
 
   public async exec(position: Position, vimState: VimState): Promise<VimState> {
     const lines: string[] = [];
@@ -3614,7 +3575,6 @@ class ActionShiftDVisualBlock extends BaseCommand {
   runsOnceForEveryCursor() {
     return false;
   }
-  mightChangeDocument = true;
 
   public async exec(position: Position, vimState: VimState): Promise<VimState> {
     for (const { start } of Position.IterateLinesInBlock(vimState)) {
@@ -3665,7 +3625,6 @@ class ActionGoToInsertVisualBlockMode extends BaseCommand {
 class ActionChangeInVisualBlockMode extends BaseCommand {
   modes = [Mode.VisualBlock];
   keys = [['c'], ['s']];
-  mightChangeDocument = true;
   runsOnceForEveryCursor() {
     return false;
   }
@@ -3696,7 +3655,6 @@ class ActionChangeInVisualBlockMode extends BaseCommand {
 class ActionChangeToEOLInVisualBlockMode extends BaseCommand {
   modes = [Mode.VisualBlock];
   keys = [['C'], ['S']];
-  mightChangeDocument = true;
   runsOnceForEveryCursor() {
     return false;
   }
@@ -3827,7 +3785,6 @@ export class ActionGoToInsertVisualModeAppend extends ActionGoToInsertVisualLine
 class ActionGoToInsertVisualBlockModeAppend extends BaseCommand {
   modes = [Mode.VisualBlock];
   keys = ['A'];
-  mightChangeDocument = true;
   runsOnceForEveryCursor() {
     return false;
   }
@@ -3857,7 +3814,6 @@ class ActionGoToInsertVisualBlockModeAppend extends BaseCommand {
 class ActionDeleteLineVisualMode extends BaseCommand {
   modes = [Mode.Visual, Mode.VisualLine];
   keys = ['X'];
-  mightChangeDocument = true;
 
   public async exec(position: Position, vimState: VimState): Promise<VimState> {
     if (vimState.currentMode === Mode.Visual) {
@@ -3880,7 +3836,6 @@ class ActionDeleteLineVisualMode extends BaseCommand {
 class ActionChangeLineVisualMode extends BaseCommand {
   modes = [Mode.Visual];
   keys = ['C'];
-  mightChangeDocument = true;
 
   public async exec(position: Position, vimState: VimState): Promise<VimState> {
     return new operator.DeleteOperator(this.multicursorIndex).run(
@@ -3895,7 +3850,6 @@ class ActionChangeLineVisualMode extends BaseCommand {
 class ActionRemoveLineVisualMode extends BaseCommand {
   modes = [Mode.Visual];
   keys = ['R'];
-  mightChangeDocument = true;
 
   public async exec(position: Position, vimState: VimState): Promise<VimState> {
     return new operator.DeleteOperator(this.multicursorIndex).run(
@@ -3911,7 +3865,6 @@ class ActionChangeChar extends BaseCommand {
   modes = [Mode.Normal];
   keys = ['s'];
   runsOnceForEachCountPrefix = true;
-  mightChangeDocument = true;
 
   public async exec(position: Position, vimState: VimState): Promise<VimState> {
     const state = await new operator.ChangeOperator().run(vimState, position, position);
@@ -3945,7 +3898,6 @@ class ToggleCaseAndMoveForward extends BaseCommand {
   keys = ['~'];
   canBeRepeatedWithDot = true;
   runsOnceForEachCountPrefix = true;
-  mightChangeDocument = true;
 
   public async exec(position: Position, vimState: VimState): Promise<VimState> {
     await new operator.ToggleCaseOperator().run(
@@ -3963,7 +3915,6 @@ abstract class IncrementDecrementNumberAction extends BaseCommand {
   modes = [Mode.Normal];
   canBeRepeatedWithDot = true;
   offset: number;
-  mightChangeDocument = true;
 
   public async exec(position: Position, vimState: VimState): Promise<VimState> {
     const text = TextEditor.getLineAt(position).text;

--- a/src/actions/commands/commandLine.ts
+++ b/src/actions/commands/commandLine.ts
@@ -136,7 +136,6 @@ class CommandTabInCommandline extends BaseCommand {
 class CommandEnterInCommandline extends BaseCommand {
   modes = [Mode.CommandlineInProgress];
   keys = [['\n'], ['<C-m>']];
-  mightChangeDocument = true;
   runsOnceForEveryCursor() {
     return this.keysPressed[0] === '\n';
   }

--- a/src/actions/commands/insert.ts
+++ b/src/actions/commands/insert.ts
@@ -26,7 +26,6 @@ import { Clipboard } from '../../util/clipboard';
 class CommandEscInsertMode extends BaseCommand {
   modes = [Mode.Insert];
   keys = [['<Esc>'], ['<C-c>'], ['<C-[>']];
-  mightChangeDocument = true;
 
   runsOnceForEveryCursor() {
     return false;
@@ -119,7 +118,6 @@ class CommandEscInsertMode extends BaseCommand {
 export class CommandInsertPreviousText extends BaseCommand {
   modes = [Mode.Insert];
   keys = ['<C-a>'];
-  mightChangeDocument = true;
 
   public async exec(position: Position, vimState: VimState): Promise<VimState> {
     let actions = ((await Register.getByKey('.')).text as RecordedState).actionsRun.slice(0);
@@ -155,7 +153,6 @@ export class CommandInsertPreviousText extends BaseCommand {
 class CommandInsertPreviousTextAndQuit extends BaseCommand {
   modes = [Mode.Insert];
   keys = ['<C-shift+2>']; // <C-@>
-  mightChangeDocument = true;
 
   public async exec(position: Position, vimState: VimState): Promise<VimState> {
     vimState = await new CommandInsertPreviousText().exec(position, vimState);
@@ -168,7 +165,6 @@ class CommandInsertPreviousTextAndQuit extends BaseCommand {
 class CommandInsertBelowChar extends BaseCommand {
   modes = [Mode.Insert];
   keys = ['<C-e>'];
-  mightChangeDocument = true;
 
   public async exec(position: Position, vimState: VimState): Promise<VimState> {
     if (TextEditor.isLastLine(position)) {
@@ -197,7 +193,6 @@ class CommandInsertBelowChar extends BaseCommand {
 class CommandInsertIndentInCurrentLine extends BaseCommand {
   modes = [Mode.Insert];
   keys = ['<C-t>'];
-  mightChangeDocument = true;
 
   public async exec(position: Position, vimState: VimState): Promise<VimState> {
     const originalText = TextEditor.getLineAt(position).text;
@@ -225,7 +220,6 @@ class CommandInsertIndentInCurrentLine extends BaseCommand {
 // export class CommandInsertTabInInsertMode extends BaseCommand {
 //   modes = [ModeName.Insert];
 //   keys = ["<tab>"];
-//   mightChangeDocument = true;
 //   runsOnceForEveryCursor() { return false; }
 
 //   public async exec(position: Position, vimState: VimState): Promise<VimState> {
@@ -240,7 +234,6 @@ class CommandInsertIndentInCurrentLine extends BaseCommand {
 export class CommandBackspaceInInsertMode extends BaseCommand {
   modes = [Mode.Insert];
   keys = ['<BS>'];
-  mightChangeDocument = true;
 
   public async exec(position: Position, vimState: VimState): Promise<VimState> {
     const line = TextEditor.getLineAt(position).text;
@@ -288,7 +281,6 @@ export class CommandBackspaceInInsertMode extends BaseCommand {
 export class CommandDeleteInInsertMode extends BaseCommand {
   modes = [Mode.Insert];
   keys = ['<Del>'];
-  mightChangeDocument = true;
 
   public async exec(position: Position, vimState: VimState): Promise<VimState> {
     const selection = TextEditor.getSelection();
@@ -314,7 +306,6 @@ export class CommandDeleteInInsertMode extends BaseCommand {
 export class CommandInsertInInsertMode extends BaseCommand {
   modes = [Mode.Insert];
   keys = ['<character>'];
-  mightChangeDocument = true;
 
   public async exec(position: Position, vimState: VimState): Promise<VimState> {
     const char = this.keysPressed[this.keysPressed.length - 1];
@@ -345,7 +336,6 @@ class CommandInsertDigraph extends BaseCommand {
   modes = [Mode.Insert];
   keys = ['<C-k>', '<any>', '<any>'];
   isCompleteAction = false;
-  mightChangeDocument = true;
 
   public async exec(position: Position, vimState: VimState): Promise<VimState> {
     const digraph = this.keysPressed.slice(1, 3).join('');
@@ -414,7 +404,6 @@ class CommandInsertRegisterContent extends BaseCommand {
   modes = [Mode.Insert];
   keys = ['<C-r>', '<character>'];
   isCompleteAction = false;
-  mightChangeDocument = true;
 
   public async exec(position: Position, vimState: VimState): Promise<VimState> {
     vimState.recordedState.registerName = this.keysPressed[1];
@@ -464,7 +453,6 @@ class CommandInsertRegisterContent extends BaseCommand {
 export class CommandOneNormalCommandInInsertMode extends BaseCommand {
   modes = [Mode.Insert];
   keys = ['<C-o>'];
-  mightChangeDocument = true;
 
   public async exec(position: Position, vimState: VimState): Promise<VimState> {
     vimState.returnToInsertAfterCommand = true;
@@ -476,7 +464,6 @@ export class CommandOneNormalCommandInInsertMode extends BaseCommand {
 class CommandCtrlW extends BaseCommand {
   modes = [Mode.Insert];
   keys = ['<C-w>'];
-  mightChangeDocument = true;
 
   public async exec(position: Position, vimState: VimState): Promise<VimState> {
     let wordBegin;
@@ -500,7 +487,6 @@ class CommandCtrlW extends BaseCommand {
 class CommandDeleteIndentInCurrentLine extends BaseCommand {
   modes = [Mode.Insert];
   keys = ['<C-d>'];
-  mightChangeDocument = true;
 
   public async exec(position: Position, vimState: VimState): Promise<VimState> {
     const originalText = TextEditor.getLineAt(position).text;
@@ -538,7 +524,6 @@ class CommandDeleteIndentInCurrentLine extends BaseCommand {
 class CommandInsertAboveChar extends BaseCommand {
   modes = [Mode.Insert];
   keys = ['<C-y>'];
-  mightChangeDocument = true;
 
   public async exec(position: Position, vimState: VimState): Promise<VimState> {
     if (TextEditor.isFirstLine(position)) {
@@ -567,7 +552,6 @@ class CommandInsertAboveChar extends BaseCommand {
 class CommandCtrlHInInsertMode extends BaseCommand {
   modes = [Mode.Insert];
   keys = ['<C-h>'];
-  mightChangeDocument = true;
 
   public async exec(position: Position, vimState: VimState): Promise<VimState> {
     vimState.recordedState.transformations.push({
@@ -583,7 +567,6 @@ class CommandCtrlHInInsertMode extends BaseCommand {
 class CommandCtrlUInInsertMode extends BaseCommand {
   modes = [Mode.Insert];
   keys = ['<C-u>'];
-  mightChangeDocument = true;
 
   public async exec(position: Position, vimState: VimState): Promise<VimState> {
     const start = position.isInLeadingWhitespace()
@@ -656,7 +639,6 @@ class CommandNavigateAutocompleteUp extends BaseCommand {
 class CommandCtrlVInInsertMode extends BaseCommand {
   modes = [Mode.Insert];
   keys = ['<C-v>'];
-  mightChangeDocument = true;
 
   public async exec(position: Position, vimState: VimState): Promise<VimState> {
     const textFromClipboard = await Clipboard.Paste();

--- a/src/actions/operator.ts
+++ b/src/actions/operator.ts
@@ -20,9 +20,6 @@ export class BaseOperator extends BaseAction {
   canBeRepeatedWithDot = true;
   isOperator = true;
 
-  // All operators other than yank can change the document
-  mightChangeDocument = true;
-
   /**
    * If this is being run in multi cursor mode, the index of the cursor
    * this operator is being applied to.
@@ -262,7 +259,6 @@ export class YankOperator extends BaseOperator {
   public keys = ['y'];
   public modes = [Mode.Normal, Mode.Visual, Mode.VisualLine];
   canBeRepeatedWithDot = false;
-  mightChangeDocument = false;
 
   public async run(vimState: VimState, start: Position, end: Position): Promise<VimState> {
     // Hack to make Surround with y (which takes a motion) work.
@@ -336,7 +332,6 @@ export class YankOperator extends BaseOperator {
 export class ShiftYankOperatorVisual extends BaseOperator {
   public keys = ['Y'];
   public modes = [Mode.Visual, Mode.VisualLine, Mode.VisualBlock];
-  mightChangeDocument = false;
 
   public async run(vimState: VimState, start: Position, end: Position): Promise<VimState> {
     vimState.currentRegisterMode = RegisterMode.LineWise;
@@ -674,7 +669,6 @@ export class YankVisualBlockMode extends BaseOperator {
   public keys = ['y'];
   public modes = [Mode.VisualBlock];
   canBeRepeatedWithDot = false;
-  mightChangeDocument = false;
   runsOnceForEveryCursor() {
     return false;
   }

--- a/src/actions/plugins/replaceWithRegister.ts
+++ b/src/actions/plugins/replaceWithRegister.ts
@@ -12,7 +12,6 @@ import { RegisterAction } from './../base';
 export class ReplaceOperator extends BaseOperator {
   public keys = ['g', 'r'];
   public modes = [Mode.Normal, Mode.Visual, Mode.VisualLine];
-  mightChangeDocument = true;
 
   public doesActionApply(vimState: VimState, keysPressed: string[]): boolean {
     return configuration.replaceWithRegister && super.doesActionApply(vimState, keysPressed);

--- a/src/actions/plugins/surround.ts
+++ b/src/actions/plugins/surround.ts
@@ -56,7 +56,6 @@ class CommandSurroundAddTarget extends BaseCommand {
     ['a'],
   ];
   isCompleteAction = false;
-  mightChangeDocument = true;
   runsOnceForEveryCursor() {
     return false;
   }
@@ -276,7 +275,6 @@ class CommandSurroundModeStartVisual extends BaseCommand {
 export class CommandSurroundAddToReplacement extends BaseCommand {
   modes = [Mode.SurroundInputMode];
   keys = ['<any>'];
-  mightChangeDocument = true;
 
   public async exec(position: Position, vimState: VimState): Promise<VimState> {
     if (!vimState.surround) {

--- a/src/configuration/configuration.ts
+++ b/src/configuration/configuration.ts
@@ -163,8 +163,6 @@ class Configuration implements IConfiguration {
     return this.cursorTypeMap[cursorStyle];
   }
 
-  experimentalOptimizations = false;
-
   handleKeys: IHandleKeys[] = [];
 
   useSystemClipboard = false;

--- a/src/configuration/iconfiguration.ts
+++ b/src/configuration/iconfiguration.ts
@@ -79,14 +79,6 @@ export interface ICamelCaseMotionConfiguration {
 
 export interface IConfiguration {
   /**
-   * When `true` it changes the way a HistoryTracker adds changes.
-   * Instead of adding each individual change to a historyStep,
-   * we will only store the first change and the last one.
-   * Increases performance when editing and navigating through large files.
-   */
-  experimentalOptimizations: boolean;
-
-  /**
    * Use the system's clipboard when copying.
    */
   useSystemClipboard: boolean;

--- a/src/mode/modeHandler.ts
+++ b/src/mode/modeHandler.ts
@@ -606,21 +606,11 @@ export class ModeHandler implements vscode.Disposable {
       // we'll grab the text of the incorrect active window and assume the
       // whole document changed!
 
-      const mightChangeDocument =
-        recordedState.hasRunOperator && recordedState.operator
-          ? recordedState.operator.mightChangeDocument
-          : action.mightChangeDocument;
-
       if (this.vimState.alteredHistory) {
         this.vimState.alteredHistory = false;
         vimState.historyTracker.ignoreChange();
-      } else if (!configuration.experimentalOptimizations || mightChangeDocument) {
-        const addedChange = vimState.historyTracker.addChange(
-          this.vimState.cursorsInitialState.map(c => c.stop)
-        );
-        if (addedChange && !mightChangeDocument) {
-          throw new Error(`Action '${action.toString()}' changed the document unexpectedly!`);
-        }
+      } else {
+        vimState.historyTracker.addChange(this.vimState.cursorsInitialState.map(c => c.stop));
       }
     }
 

--- a/test/testConfiguration.ts
+++ b/test/testConfiguration.ts
@@ -7,7 +7,6 @@ import {
 } from '../src/configuration/iconfiguration';
 
 export class Configuration implements IConfiguration {
-  experimentalOptimizations = false;
   useSystemClipboard = false;
   useCtrlKeys = false;
   overrideCopy = true;


### PR DESCRIPTION
This replaces `mightChangeDocument`, which sought to do the same sort of optimization in a less effective and far more clumsy way.

Fixes #4665