### PR TITLE
Fix a bug of `J` command in visual block mode

### DIFF
--- a/src/actions/commands/actions.ts
+++ b/src/actions/commands/actions.ts
@@ -3246,13 +3246,15 @@ class ActionJoinVisualBlockMode extends BaseCommand {
   keys = ['J'];
 
   public async exec(position: Position, vimState: VimState): Promise<VimState> {
+    let start = vimState.cursorStartPosition;
+    let end = vimState.cursorStopPosition;
+
+    if (start.isAfter(end)) {
+      [start, end] = [end, start];
+    }
+
     vimState.currentRegisterMode = RegisterMode.CharacterWise;
-    vimState = await new ActionJoin().execJoinLines(
-      vimState.cursorStartPosition,
-      vimState.cursorStopPosition,
-      vimState,
-      1
-    );
+    vimState = await new ActionJoin().execJoinLines(start, end, vimState, 1);
     return vimState;
   }
 }

--- a/test/mode/modeVisualBlock.test.ts
+++ b/test/mode/modeVisualBlock.test.ts
@@ -204,4 +204,12 @@ suite('Mode Visual Block', () => {
     end: ['one| two three', 'four'],
     endMode: Mode.Normal,
   });
+
+  newTest({
+    title: "Can handle 'J' when start position of the visual block is below the stop",
+    start: ['one', 'two', 't|hree', 'four'],
+    keysPressed: '<C-v>kkJ',
+    end: ['one| two three', 'four'],
+    endMode: Mode.Normal,
+  });
 });


### PR DESCRIPTION
<!--
Yay! Thanks for sending us a PR! 🎊

Please ensure your PR adheres to:

- [ ] Commit messages has a short & issue references when necessary
- [ ] Each commit does a logical chunk of work.
- [ ] It builds and tests pass (e.g `gulp`)
-->

**What this PR does / why we need it**:

Sorry, my PR (#4663) contained a bug 🙁

`J` doesn't work properly when the start position of the visual block is below the end position.

e.g.

At first the cursor is on the `|`.
```
one
two
t|hree
four
```

If execute `<C-v>kkJ`, of course expected result is as follows:

```
one two three
four
```

but not.

**Which issue(s) this PR fixes**

<!--
Commits in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)
-->

**Special notes for your reviewer**:
