### PR TITLE
Remove old workaround that is no longer needed

### DIFF
--- a/src/actions/commands/actions.ts
+++ b/src/actions/commands/actions.ts
@@ -2635,15 +2635,7 @@ class CommandInsertNewLineAbove extends BaseCommand {
   public async execCount(position: Position, vimState: VimState): Promise<VimState> {
     await vimState.setCurrentMode(Mode.Insert);
     let count = vimState.recordedState.count || 1;
-    // Why do we do this? Who fucking knows??? If the cursor is at the
-    // beginning of the line, then editor.action.insertLineBefore does some
-    // weird things with following paste command. Refer to
-    // https://github.com/VSCodeVim/Vim/pull/1663#issuecomment-300573129 for
-    // more details.
-    const tPos = Position.FromVSCodePosition(
-      vscode.window.activeTextEditor!.selection.active
-    ).getRight();
-    vscode.window.activeTextEditor!.selection = new vscode.Selection(tPos, tPos);
+
     for (let i = 0; i < count; i++) {
       await vscode.commands.executeCommand('editor.action.insertLineBefore');
     }


### PR DESCRIPTION
**What this PR does / why we need it**:
The issue this workaround used to solve appears to have been fixed in the upstream and is no longer reproducible. Additionally, because it would update the `activeTextEditor.selection` it caused vscode to loose our selections in multicursor mode, thus `editor.action.insertLineBefore` would only insert a line above the first cursor and subsequently take us out of multicursor mode.

**Which issue(s) this PR fixes**
fixes #1962 

**Special notes for your reviewer**:
A bit unrelated but I'm unsure if I should open an issue for this, I normally do format on save but since prettier was added it re-formats the whole document and would have made this PR a mess. Should I push another commit with the prettier formatting?