### PR TITLE
Add isJump to sneak actions

### DIFF
--- a/src/actions/plugins/sneak.ts
+++ b/src/actions/plugins/sneak.ts
@@ -11,6 +11,7 @@ export class SneakForward extends BaseMovement {
     ['s', '<character>', '<character>'],
     ['z', '<character>', '<character>'],
   ];
+  isJump = true;
 
   public couldActionApply(vimState: VimState, keysPressed: string[]): boolean {
     const startingLetter = vimState.recordedState.operator === undefined ? 's' : 'z';
@@ -76,6 +77,7 @@ export class SneakBackward extends BaseMovement {
     ['S', '<character>', '<character>'],
     ['Z', '<character>', '<character>'],
   ];
+  isJump = true;
 
   public couldActionApply(vimState: VimState, keysPressed: string[]): boolean {
     const startingLetter = vimState.recordedState.operator === undefined ? 'S' : 'Z';

--- a/test/plugins/sneak.test.ts
+++ b/test/plugins/sneak.test.ts
@@ -131,6 +131,34 @@ suite('sneak plugin', () => {
     keysPressed: '3sa\n',
     end: ['abc', 'aac', '|abc'],
   });
+
+  newTest({
+    title: 'Can go back using <C-o> once when going forward',
+    start: ['|abc abc'],
+    keysPressed: 'sab<C-o>',
+    end: ['|abc abc'],
+  });
+
+  newTest({
+    title: 'Can go back using <C-o> once when going backward',
+    start: ['abc |abc'],
+    keysPressed: 'Sab<C-o>',
+    end: ['abc |abc'],
+  });
+
+  newTest({
+    title: 'Can go back using <C-o> when repeting forward movement',
+    start: ['|abc abc abc'],
+    keysPressed: 'sab;<C-o>',
+    end: ['|abc abc abc'],
+  });
+
+  newTest({
+    title: 'Can go back using <C-o> when repeting backward movement',
+    start: ['abc abc |abc'],
+    keysPressed: 'sab;<C-o>',
+    end: ['abc abc |abc'],
+  });
 });
 
 suite('sneakReplacesF', () => {

--- a/test/plugins/sneak.test.ts
+++ b/test/plugins/sneak.test.ts
@@ -147,14 +147,14 @@ suite('sneak plugin', () => {
   });
 
   newTest({
-    title: 'Can go back using <C-o> when repeting forward movement',
+    title: 'Can go back using <C-o> when repeating forward movement',
     start: ['|abc abc abc'],
     keysPressed: 'sab;<C-o>',
     end: ['|abc abc abc'],
   });
 
   newTest({
-    title: 'Can go back using <C-o> when repeting backward movement',
+    title: 'Can go back using <C-o> when repeating backward movement',
     start: ['abc abc |abc'],
     keysPressed: 'sab;<C-o>',
     end: ['abc abc |abc'],


### PR DESCRIPTION




<!--
Yay! Thanks for sending us a PR! 🎊

Please ensure your PR adheres to:

- [ ] Commit messages has a short & issue references when necessary
- [ ] Each commit does a logical chunk of work.
- [ ] It builds and tests pass (e.g `gulp`)
-->

**What this PR does / why we need it**:

When you do a search with vim-sneak, VSCodeVim doesn't save your
position and you can't go back to where you were before using <C-o>.

This PR adds isJump to both sneak movements to fix that.

**Which issue(s) this PR fixes**

<!--
Commits in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)
-->

Fixes #4696.

