### PR TITLE
Fix cursor position after executing `J` in visual mode

### DIFF
--- a/src/actions/commands/actions.ts
+++ b/src/actions/commands/actions.ts
@@ -3158,7 +3158,8 @@ class ActionJoin extends BaseCommand {
           manuallySetCursorPositions: true,
         });
 
-        vimState.cursorStartPosition = vimState.cursorStopPosition = startPosition.withColumn(
+        vimState.cursorStartPosition = vimState.cursorStopPosition = new Position(
+          startPosition.line,
           trimmedLinesContent.length - columnDeltaOffset
         );
         await vimState.setCurrentMode(Mode.Normal);

--- a/test/mode/modeVisual.test.ts
+++ b/test/mode/modeVisual.test.ts
@@ -1428,4 +1428,12 @@ suite('Mode Visual', () => {
       endMode: Mode.Normal,
     });
   });
+
+  newTest({
+    title: "Can handle 'J' when the selected area spans multiple lines",
+    start: ['o|ne', 'two', 'three', 'four'],
+    keysPressed: 'vjjJ',
+    end: ['one two| three', 'four'],
+    endMode: Mode.Normal,
+  });
 });

--- a/test/mode/modeVisualBlock.test.ts
+++ b/test/mode/modeVisualBlock.test.ts
@@ -201,7 +201,7 @@ suite('Mode Visual Block', () => {
     title: "Can handle 'J' when the visual block spans multiple lines",
     start: ['o|ne', 'two', 'three', 'four'],
     keysPressed: '<C-v>jjlJ',
-    end: ['one| two three', 'four'],
+    end: ['one two| three', 'four'],
     endMode: Mode.Normal,
   });
 
@@ -209,7 +209,7 @@ suite('Mode Visual Block', () => {
     title: "Can handle 'J' when start position of the visual block is below the stop",
     start: ['one', 'two', 't|hree', 'four'],
     keysPressed: '<C-v>kkJ',
-    end: ['one| two three', 'four'],
+    end: ['one two| three', 'four'],
     endMode: Mode.Normal,
   });
 });

--- a/test/mode/modeVisualLine.test.ts
+++ b/test/mode/modeVisualLine.test.ts
@@ -502,4 +502,12 @@ suite('Mode Visual Line', () => {
     keysPressed: 'VjV',
     end: ['rocinante', 'nauvoo', 'anu|bis', 'canterbury'],
   });
+
+  newTest({
+    title: "Can handle 'J' when the selected area spans multiple lines",
+    start: ['o|ne', 'two', 'three', 'four'],
+    keysPressed: 'VjjJ',
+    end: ['one two| three', 'four'],
+    endMode: Mode.Normal,
+  });
 });


### PR DESCRIPTION
<!--
Yay! Thanks for sending us a PR! 🎊

Please ensure your PR adheres to:

- [ ] Commit messages has a short & issue references when necessary
- [ ] Each commit does a logical chunk of work.
- [ ] It builds and tests pass (e.g `gulp`)
-->

**What this PR does / why we need it**:
The cursor position after executing `J` command in visual (line / block) mode is different from expected.

**e.g.**

In the following state, for example,

```
o|ne
two
three
four
five
```

now, if execute `vjjjJ`, we will get the following state in the original Vim.

```
one two three| four
five
```
(The cursor should be in the space in front of the last word.)

but now, it's like this:

```
one| two three four
five
```

the same is true for visual line mode and visual block mode.



**Which issue(s) this PR fixes**

<!--
Commits in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)
-->

**Special notes for your reviewer**:
Same fix is not made for `gJ` because `[count]gJ` doesn't work properly... (#2207)
