### PR TITLE
WIP - Fix surround for multicursor mode

### DIFF
--- a/src/actions/commands/actions.ts
+++ b/src/actions/commands/actions.ts
@@ -1741,6 +1741,9 @@ export class CommandShowSearchHistory extends BaseCommand {
 class CommandDot extends BaseCommand {
   modes = [Mode.Normal];
   keys = ['.'];
+  runsOnceForEveryCursor() {
+    return false;
+  }
 
   public async exec(position: Position, vimState: VimState): Promise<VimState> {
     vimState.recordedState.transformations.push({

--- a/src/actions/operator.ts
+++ b/src/actions/operator.ts
@@ -264,7 +264,11 @@ export class YankOperator extends BaseOperator {
     // Hack to make Surround with y (which takes a motion) work.
 
     if (vimState.surround) {
-      vimState.surround.range = new Range(start, end);
+      if (vimState.surround.ranges) {
+        vimState.surround.ranges.push(new Range(start, end));
+      } else {
+        vimState.surround.ranges = [new Range(start, end)];
+      }
       await vimState.setCurrentMode(Mode.SurroundInputMode);
       vimState.cursorStopPosition = start;
       vimState.cursorStartPosition = start;

--- a/src/actions/plugins/surround.ts
+++ b/src/actions/plugins/surround.ts
@@ -515,6 +515,8 @@ export class CommandSurroundAddToReplacement extends BaseCommand {
 
     let allFinished: boolean = true;
     let replaceAndDeleteRanges: ReplaceAndDeleteRange[] = [];
+    let wordMatchingPerformed: boolean = false;
+
     for (const cursor of vimState.cursors) {
       const replaceAndDeleteRange = await this.getReplaceAndDeleteRanges(
         cursor,
@@ -559,11 +561,13 @@ export class CommandSurroundAddToReplacement extends BaseCommand {
             continue;
           }
 
-          if (addNewline === 'end-only' || addNewline === 'both') {
-            endReplace = '\n' + endReplace;
-          }
-          if (addNewline === 'both') {
-            startReplace += '\n';
+          if (!wordMatchingPerformed) {
+            if (addNewline === 'end-only' || addNewline === 'both') {
+              endReplace = '\n' + endReplace;
+            }
+            if (addNewline === 'both') {
+              startReplace += '\n';
+            }
           }
 
           vimState.recordedState.transformations.push({
@@ -577,14 +581,14 @@ export class CommandSurroundAddToReplacement extends BaseCommand {
             position: stop,
           });
 
-          continue;
+          wordMatchingPerformed = true;
         }
       }
 
       allFinished = false;
     }
 
-    if (allFinished) {
+    if (allFinished || wordMatchingPerformed) {
       return CommandSurroundAddToReplacement.Finish(vimState);
     }
 

--- a/src/actions/plugins/surround.ts
+++ b/src/actions/plugins/surround.ts
@@ -275,6 +275,9 @@ class CommandSurroundModeStartVisual extends BaseCommand {
 export class CommandSurroundAddToReplacement extends BaseCommand {
   modes = [Mode.SurroundInputMode];
   keys = ['<any>'];
+  runsOnceForEveryCursor() {
+    return false;
+  }
 
   public async exec(position: Position, vimState: VimState): Promise<VimState> {
     if (!vimState.surround) {

--- a/src/state/vimState.ts
+++ b/src/state/vimState.ts
@@ -103,7 +103,7 @@ export class VimState implements vscode.Disposable {
         operator: 'change' | 'delete' | 'yank';
         target: string | undefined;
         replacement: string | undefined;
-        range: Range | undefined;
+        ranges: Range[] | undefined;
         isVisualLine: boolean;
       } = undefined;
 


### PR DESCRIPTION
<!--
Yay! Thanks for sending us a PR! 🎊

Please ensure your PR adheres to:

- [ ] Commit messages has a short & issue references when necessary
- [ ] Each commit does a logical chunk of work.
- [ ] It builds and tests pass (e.g `gulp`)
-->

**What this PR does / why we need it**:
This PR fixes the vim-surround plugin for multicursor mode. The plugin tries to do the best it can, meaning that if the operation is applicable for the first but not for the second cursor. the operation is then still executed for the first cursor, instead of doing nothing. 

**Which issue(s) this PR fixes**
Fixes #1818 
Fixes #3691 

<!--
Commits in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)
-->

**Special notes for your reviewer**:
I've tested it manually and as far as I can tell, every functionality works for multicursor mode now. I'm marking it as WIP however, because I haven't written the tests for it yet, because it would be infinitely easier to do that once #4583 is done. 
Perhaps I could write the tests now in the format #4583 allows and after that PR is merged, we can run the tests, hopefully get the all clear and merge this?
