### PR TITLE
Feature/vimrc mappings

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,8 +46,6 @@ VSCodeVim is a Vim emulator for [Visual Studio Code](https://code.visualstudio.c
 
 VSCodeVim is automatically enabled following [installation](https://marketplace.visualstudio.com/items?itemName=vscodevim.vim) and reloading of VS Code.
 
-> :warning: Vimscript is _not_ supported; therefore, we are _not_ able to load your `.vimrc` or use `.vim` plugins. You have to replicate these using our [Settings](#settings) and [Emulated plugins](#-emulated-plugins).
-
 ### Mac
 
 To enable key-repeating execute the following in your Terminal and restart VS Code:
@@ -364,6 +362,12 @@ Configuration settings that have been copied from vim. Vim settings are loaded i
 | vim.timeout      | Timeout in milliseconds for remapped commands                                                                                                                                                                                                                         | Number  | 1000          |
 | vim.whichwrap    | Controls wrapping at beginning and end of line. Comma-separated set of keys that should wrap to next/previous line. Arrow keys are represented by `[` and `]` in insert mode, `<` and `>` in normal and visual mode. To wrap "everything", set this to `h,l,<,>,[,]`. | String  | ``            |
 | vim.report       | Threshold for reporting number of lines changed.                                                                                                                                                                                                                      | Number  | 2             |
+
+## .vimrc support
+
+> :warning: .vimrc support is currently experimental. Only remaps are supported, and you may experience bugs. Please [report them](https://github.com/VSCodeVim/Vim/issues/new?template=bug_report.md)!
+
+Set `vim.vimrc.enable` to `true` and set `vim.vimrc.path` appropriately.
 
 ## 🖱️ Multi-Cursor Mode
 

--- a/extension.ts
+++ b/extension.ts
@@ -6,6 +6,7 @@
 import './src/actions/include-all';
 
 import * as vscode from 'vscode';
+import * as path from 'path';
 
 import { CompositionState } from './src/state/compositionState';
 import { EditorIdentity } from './src/editorIdentity';
@@ -24,6 +25,7 @@ import { configuration } from './src/configuration/configuration';
 import { globalState } from './src/state/globalState';
 import { taskQueue } from './src/taskQueue';
 import { Register } from './src/register/register';
+import { vimrc } from './src/configuration/vimrc';
 
 let extensionContext: vscode.ExtensionContext;
 let previousActiveEditorId: EditorIdentity | null = null;
@@ -207,6 +209,16 @@ export async function activate(context: vscode.ExtensionContext) {
     },
     false
   );
+
+  registerEventListener(context, vscode.workspace.onDidSaveTextDocument, async document => {
+    if (
+      configuration.vimrc.enable &&
+      path.relative(document.fileName, configuration.vimrc.path) === ''
+    ) {
+      await configuration.load();
+      vscode.window.showInformationMessage('Sourced new .vimrc');
+    }
+  });
 
   // window events
   registerEventListener(

--- a/extension.ts
+++ b/extension.ts
@@ -87,6 +87,7 @@ async function loadConfiguration() {
     }
   }
 }
+
 export async function activate(context: vscode.ExtensionContext) {
   // before we do anything else,
   // we need to load the configuration first
@@ -392,7 +393,7 @@ export async function activate(context: vscode.ExtensionContext) {
   });
 
   registerCommand(context, 'vim.editVimrc', async () => {
-    const document = await vscode.workspace.openTextDocument(configuration.vimrcPath);
+    const document = await vscode.workspace.openTextDocument(configuration.vimrc.path);
     await vscode.window.showTextDocument(document);
   });
 

--- a/extension.ts
+++ b/extension.ts
@@ -391,6 +391,11 @@ export async function activate(context: vscode.ExtensionContext) {
     toggleExtension(configuration.disableExtension, compositionState);
   });
 
+  registerCommand(context, 'vim.editVimrc', async () => {
+    const document = await vscode.workspace.openTextDocument(configuration.vimrcPath);
+    await vscode.window.showTextDocument(document);
+  });
+
   for (const boundKey of configuration.boundKeyCombinations) {
     registerCommand(context, boundKey.command, () => handleKeyEvent(`${boundKey.key}`));
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1888,6 +1888,11 @@
         "map-cache": "^0.2.2"
       }
     },
+    "fs": {
+      "version": "0.0.1-security",
+      "resolved": "https://registry.npmjs.org/fs/-/fs-0.0.1-security.tgz",
+      "integrity": "sha1-invTcYa23d84E/I4WLV+yq9eQdQ="
+    },
     "fs-mkdirp-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs-mkdirp-stream/-/fs-mkdirp-stream-1.0.0.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -141,19 +141,10 @@
       "dev": true
     },
     "@types/lodash": {
-      "version": "4.14.138",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.138.tgz",
-      "integrity": "sha512-A4uJgHz4hakwNBdHNPdxOTkYmXNgmUAKLbXZ7PKGslgeV0Mb8P3BlbYfPovExek1qnod4pDfRbxuzcVs3dlFLg==",
+      "version": "4.14.144",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.144.tgz",
+      "integrity": "sha512-ogI4g9W5qIQQUhXAclq6zhqgqNUr7UlFaqDHbch7WLSLeeM/7d3CRaw7GLajxvyFvhJqw4Rpcz5bhoaYtIx6Tg==",
       "dev": true
-    },
-    "@types/lodash.escaperegexp": {
-      "version": "4.1.6",
-      "resolved": "https://registry.npmjs.org/@types/lodash.escaperegexp/-/lodash.escaperegexp-4.1.6.tgz",
-      "integrity": "sha512-uENiqxLlqh6RzeE1cC6Z2gHqakToN9vKlTVCFkSVjAfeMeh2fY0916tHwJHeeKs28qB/hGYvKuampGYH5QDVCw==",
-      "dev": true,
-      "requires": {
-        "@types/lodash": "*"
-      }
     },
     "@types/mocha": {
       "version": "5.2.7",
@@ -3528,11 +3519,6 @@
       "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
       "integrity": "sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0=",
       "dev": true
-    },
-    "lodash.escaperegexp": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/lodash.escaperegexp/-/lodash.escaperegexp-4.1.2.tgz",
-      "integrity": "sha1-ZHYsSGGAglGKw99Mz11YhtriA0c="
     },
     "lodash.template": {
       "version": "4.5.0",

--- a/package.json
+++ b/package.json
@@ -50,6 +50,10 @@
       {
         "command": "vim.showQuickpickCmdLine",
         "title": "Vim: Show Command Line"
+      },
+      {
+        "command": "vim.editVimrc",
+        "title": "Vim: Edit .vimrc"
       }
     ],
     "keybindings": [

--- a/package.json
+++ b/package.json
@@ -750,14 +750,14 @@
           "default": "",
           "scope": "machine"
         },
-        "vim.enableVimrc": {
+        "vim.vimrc.enable": {
           "type": "boolean",
-          "description": "Use key mappings from a .vimrc file",
+          "description": "Use key mappings from a .vimrc file.",
           "default": "true"
         },
-        "vim.vimrcPath": {
+        "vim.vimrc.path": {
           "type": "string",
-          "description": "Path to a Vim configuration file. If unset, it will check for $HOME/.vimrc or $HOME/_vimrc"
+          "description": "Path to a Vim configuration file. If unset, it will check for $HOME/.vimrc or $HOME/_vimrc."
         },
         "vim.substituteGlobalFlag": {
           "type": "boolean",
@@ -907,7 +907,7 @@
   "dependencies": {
     "diff-match-patch": "1.0.4",
     "fs": "0.0.1-security",
-    "lodash.escaperegexp": "4.1.2",
+    "lodash": "^4.17.15",
     "neovim": "4.5.0",
     "untildify": "4.0.0",
     "winston": "3.2.1",
@@ -917,7 +917,7 @@
   "devDependencies": {
     "@types/diff": "4.0.2",
     "@types/diff-match-patch": "1.0.32",
-    "@types/lodash.escaperegexp": "4.1.6",
+    "@types/lodash": "^4.14.144",
     "@types/mocha": "5.2.7",
     "@types/node": "12.12.5",
     "@types/sinon": "7.5.0",

--- a/package.json
+++ b/package.json
@@ -750,6 +750,15 @@
           "default": "",
           "scope": "machine"
         },
+        "vim.enableVimrc": {
+          "type": "boolean",
+          "description": "Use key mappings from a .vimrc file",
+          "default": "true"
+        },
+        "vim.vimrcPath": {
+          "type": "string",
+          "description": "Path to a Vim configuration file. If unset, it will check for $HOME/.vimrc or $HOME/_vimrc"
+        },
         "vim.substituteGlobalFlag": {
           "type": "boolean",
           "markdownDescription": "Automatically apply the global flag, `/g`, to substitute commands. When set to true, use `/g` to mean only first match should be replaced.",
@@ -897,6 +906,7 @@
   },
   "dependencies": {
     "diff-match-patch": "1.0.4",
+    "fs": "0.0.1-security",
     "lodash.escaperegexp": "4.1.2",
     "neovim": "4.5.0",
     "untildify": "4.0.0",

--- a/src/common/motion/position.ts
+++ b/src/common/motion/position.ts
@@ -4,7 +4,7 @@ import { VimState } from '../../state/vimState';
 import { configuration } from './../../configuration/configuration';
 import { VisualBlockMode } from './../../mode/modes';
 import { TextEditor } from './../../textEditor';
-import escapeRegExp = require('lodash.escaperegexp');
+import * as _ from 'lodash';
 
 enum PositionDiffType {
   Offset,
@@ -874,7 +874,7 @@ export class Position extends vscode.Position {
   }
 
   private static makeWordRegex(characterSet: string): RegExp {
-    let escaped = characterSet && escapeRegExp(characterSet).replace(/-/g, '\\-');
+    let escaped = characterSet && _.escapeRegExp(characterSet).replace(/-/g, '\\-');
     let segments: string[] = [];
 
     segments.push(`([^\\s${escaped}]+)`);
@@ -886,7 +886,7 @@ export class Position extends vscode.Position {
   }
 
   private static makeCamelCaseWordRegex(characterSet: string): RegExp {
-    const escaped = characterSet && escapeRegExp(characterSet).replace(/-/g, '\\-');
+    const escaped = characterSet && _.escapeRegExp(characterSet).replace(/-/g, '\\-');
     const segments: string[] = [];
 
     // old versions of VSCode before 1.31 will crash when trying to parse a regex with a lookbehind
@@ -1028,7 +1028,7 @@ export class Position extends vscode.Position {
 
     // Symbols in vim.iskeyword or editor.wordSeparators
     // are treated as CharKind.Punctuation
-    const escapedKeywordChars = escapeRegExp(keywordChars).replace(/-/g, '\\-');
+    const escapedKeywordChars = _.escapeRegExp(keywordChars).replace(/-/g, '\\-');
     codePointRangePatterns[Number(CharKind.Punctuation)].push(escapedKeywordChars);
 
     const codePointRanges = codePointRangePatterns.map(patterns => patterns.join(''));

--- a/src/configuration/configuration.ts
+++ b/src/configuration/configuration.ts
@@ -5,6 +5,7 @@ import { ValidatorResults } from './iconfigurationValidator';
 import { VsCodeContext } from '../util/vscode-context';
 import { configurationValidator } from './configurationValidator';
 import { decoration } from './decoration';
+import { vimrc } from './vimrc';
 import {
   IConfiguration,
   IKeyRemapping,
@@ -84,6 +85,10 @@ class Configuration implements IConfiguration {
         }
         this[option] = val;
       }
+    }
+
+    if (this.enableVimrc) {
+      vimrc.load(this);
     }
 
     this.leader = Notation.NormalizeKey(this.leader, this.leaderDefault);
@@ -302,6 +307,9 @@ class Configuration implements IConfiguration {
 
   enableNeovim = false;
   neovimPath = '';
+
+  enableVimrc = true;
+  vimrcPath = '';
 
   digraphs = {};
 

--- a/src/configuration/configuration.ts
+++ b/src/configuration/configuration.ts
@@ -87,7 +87,7 @@ class Configuration implements IConfiguration {
       }
     }
 
-    if (this.enableVimrc) {
+    if (this.vimrc.enable) {
       vimrc.load(this);
     }
 
@@ -308,8 +308,10 @@ class Configuration implements IConfiguration {
   enableNeovim = false;
   neovimPath = '';
 
-  enableVimrc = true;
-  vimrcPath = '';
+  vimrc = {
+    enable: true,
+    path: '',
+  };
 
   digraphs = {};
 

--- a/src/configuration/configuration.ts
+++ b/src/configuration/configuration.ts
@@ -309,7 +309,7 @@ class Configuration implements IConfiguration {
   neovimPath = '';
 
   vimrc = {
-    enable: true,
+    enable: false,
     path: '',
   };
 

--- a/src/configuration/configurationValidator.ts
+++ b/src/configuration/configurationValidator.ts
@@ -3,6 +3,7 @@ import { IConfigurationValidator, ValidatorResults } from './iconfigurationValid
 import { InputMethodSwitcherConfigurationValidator } from './validators/inputMethodSwitcherValidator';
 import { NeovimValidator } from './validators/neovimValidator';
 import { RemappingValidator } from './validators/remappingValidator';
+import { VimrcValidator } from './validators/vimrcValidator';
 
 class ConfigurationValidator {
   private _validators: IConfigurationValidator[];
@@ -12,6 +13,7 @@ class ConfigurationValidator {
       new InputMethodSwitcherConfigurationValidator(),
       new NeovimValidator(),
       new RemappingValidator(),
+      new VimrcValidator(),
     ];
   }
 

--- a/src/configuration/iconfiguration.ts
+++ b/src/configuration/iconfiguration.ts
@@ -295,8 +295,10 @@ export interface IConfiguration {
   /**
    * .vimrc
    */
-  enableVimrc: boolean;
-  vimrcPath: string;
+  vimrc: {
+    enable: boolean;
+    path: string;
+  };
 
   /**
    * Automatically apply the `/g` flag to substitute commands.

--- a/src/configuration/iconfiguration.ts
+++ b/src/configuration/iconfiguration.ts
@@ -15,6 +15,7 @@ export interface IKeyRemapping {
   before: string[];
   after?: string[];
   commands?: ({ command: string; args: any[] } | string)[];
+  source?: 'vscode' | 'vimrc';
 }
 
 export interface IVimrcKeyRemapping {

--- a/src/configuration/iconfiguration.ts
+++ b/src/configuration/iconfiguration.ts
@@ -17,6 +17,11 @@ export interface IKeyRemapping {
   commands?: ({ command: string; args: any[] } | string)[];
 }
 
+export interface IVimrcKeyRemapping {
+  keyRemapping: IKeyRemapping;
+  keyRemappingType: string;
+}
+
 export interface IAutoSwitchInputMethod {
   enable: boolean;
   defaultIM: string;
@@ -286,6 +291,12 @@ export interface IConfiguration {
    */
   enableNeovim: boolean;
   neovimPath: string;
+
+  /**
+   * .vimrc
+   */
+  enableVimrc: boolean;
+  vimrcPath: string;
 
   /**
    * Automatically apply the `/g` flag to substitute commands.

--- a/src/configuration/iconfigurationValidator.ts
+++ b/src/configuration/iconfigurationValidator.ts
@@ -39,5 +39,5 @@ export class ValidatorResults {
 
 export interface IConfigurationValidator {
   validate(config: IConfiguration): Promise<ValidatorResults>;
-  disable(config: IConfiguration);
+  disable(config: IConfiguration): void;
 }

--- a/src/configuration/validators/vimrcValidator.ts
+++ b/src/configuration/validators/vimrcValidator.ts
@@ -1,15 +1,16 @@
 import * as fs from 'fs';
-import { IConfiguration } from "../iconfiguration";
-import { IConfigurationValidator, ValidatorResults } from "../iconfigurationValidator";
+import { IConfiguration } from '../iconfiguration';
+import { IConfigurationValidator, ValidatorResults } from '../iconfigurationValidator';
+import { vimrc } from '../vimrc';
 
 export class VimrcValidator implements IConfigurationValidator {
   async validate(config: IConfiguration): Promise<ValidatorResults> {
     const result = new ValidatorResults();
 
-    if (config.vimrc.enable && !fs.existsSync(config.vimrc.path) ) {
+    if (config.vimrc.enable && !fs.existsSync(vimrc.vimrcPath)) {
       result.append({
         level: 'error',
-        message: `.vimrc not found at ${config.vimrc.path}`
+        message: `.vimrc not found at ${config.vimrc.path}`,
       });
     }
 

--- a/src/configuration/validators/vimrcValidator.ts
+++ b/src/configuration/validators/vimrcValidator.ts
@@ -1,0 +1,22 @@
+import * as fs from 'fs';
+import { IConfiguration } from "../iconfiguration";
+import { IConfigurationValidator, ValidatorResults } from "../iconfigurationValidator";
+
+export class VimrcValidator implements IConfigurationValidator {
+  async validate(config: IConfiguration): Promise<ValidatorResults> {
+    const result = new ValidatorResults();
+
+    if (config.vimrc.enable && !fs.existsSync(config.vimrc.path) ) {
+      result.append({
+        level: 'error',
+        message: `.vimrc not found at ${config.vimrc.path}`
+      });
+    }
+
+    return result;
+  }
+
+  disable(config: IConfiguration): void {
+    // no-op
+  }
+}

--- a/src/configuration/vimrc.ts
+++ b/src/configuration/vimrc.ts
@@ -1,0 +1,96 @@
+import * as _ from 'lodash';
+import * as fs from 'fs';
+import * as path from 'path';
+import { IConfiguration, IKeyRemapping, IVimrcKeyRemapping } from './iconfiguration';
+import { vimrcKeyRemappingBuilder } from './vimrcKeyRemappingBuilder';
+
+class VimrcImpl {
+  public load(configuration: IConfiguration) {
+    if (configuration.vimrcPath) {
+      configuration.vimrcPath = VimrcImpl.expandHome(configuration.vimrcPath);
+      if (!fs.existsSync(configuration.vimrcPath)) {
+        return;
+      }
+    } else {
+      configuration.vimrcPath = VimrcImpl.findDefaultVimrc();
+      if (!configuration.vimrcPath) {
+        return;
+      }
+    }
+
+    let vimrcContent = fs.readFileSync(configuration.vimrcPath, { encoding: 'utf8' });
+    let lines = vimrcContent.split(/\r?\n/);
+
+    for (const line of lines) {
+      VimrcImpl.tryKeyRemapping(configuration, line);
+    }
+  }
+
+  private static tryKeyRemapping(configuration: IConfiguration, line: string): boolean {
+    let mapping: IVimrcKeyRemapping | null = vimrcKeyRemappingBuilder.build(line);
+    if (!mapping) {
+      return false;
+    }
+
+    let collection: IKeyRemapping[];
+    switch (mapping.keyRemappingType) {
+      case 'nmap':
+        collection = configuration.normalModeKeyBindings;
+        break;
+      case 'vmap':
+        collection = configuration.visualModeKeyBindings;
+        break;
+      case 'imap':
+        collection = configuration.insertModeKeyBindings;
+        break;
+      case 'nnoremap':
+        collection = configuration.normalModeKeyBindingsNonRecursive;
+        break;
+      case 'vnoremap':
+        collection = configuration.visualModeKeyBindingsNonRecursive;
+        break;
+      case 'inoremap':
+        collection = configuration.insertModeKeyBindingsNonRecursive;
+        break;
+      default:
+        return false;
+    }
+
+    // Don't override a mapping present in settings.json; those are more specific to VSCodeVim.
+    if (!collection.some(r => _.isEqual(r.before, mapping!.keyRemapping.before))) {
+      collection.push(mapping.keyRemapping);
+    }
+
+    return true;
+  }
+
+  private static findDefaultVimrc(): string {
+    if (!process.env.HOME) {
+      return '';
+    }
+
+    let vimrcPath = path.join(process.env.HOME, '.vimrc');
+    if (!fs.existsSync(vimrcPath)) {
+      vimrcPath = path.join(process.env.HOME, '_vimrc');
+      if (!fs.existsSync(vimrcPath)) {
+        return '';
+      }
+    }
+
+    return vimrcPath;
+  }
+
+  private static expandHome(filePath: string): string {
+    if (!process.env.HOME) {
+      return filePath;
+    }
+
+    if (!filePath.startsWith('~')) {
+      return filePath;
+    }
+
+    return path.join(process.env.HOME, filePath.slice(1));
+  }
+}
+
+export const vimrc = new VimrcImpl();

--- a/src/configuration/vimrc.ts
+++ b/src/configuration/vimrc.ts
@@ -22,18 +22,19 @@ class VimrcImpl {
     let lines = vimrcContent.split(/\r?\n/);
 
     for (const line of lines) {
-      VimrcImpl.addKeyRemapping(configuration, line);
+      const remap: IVimrcKeyRemapping | undefined = vimrcKeyRemappingBuilder.build(line);
+      if (remap) {
+        VimrcImpl.addRemapToConfig(configuration, remap);
+      }
     }
   }
 
-  private static addKeyRemapping(configuration: IConfiguration, line: string): void {
-    let mapping: IVimrcKeyRemapping | null = vimrcKeyRemappingBuilder.build(line);
-    if (!mapping) {
-      return;
-    }
-
+  /**
+   * Adds a remapping from .vimrc to the given configuration
+   */
+  private static addRemapToConfig(configuration: IConfiguration, remap: IVimrcKeyRemapping): void {
     let collection: IKeyRemapping[];
-    switch (mapping.keyRemappingType) {
+    switch (remap.keyRemappingType) {
       case 'nmap':
         collection = configuration.normalModeKeyBindings;
         break;
@@ -57,8 +58,8 @@ class VimrcImpl {
     }
 
     // Don't override a mapping present in settings.json; those are more specific to VSCodeVim.
-    if (!collection.some(r => _.isEqual(r.before, mapping!.keyRemapping.before))) {
-      collection.push(mapping.keyRemapping);
+    if (!collection.some(r => _.isEqual(r.before, remap!.keyRemapping.before))) {
+      collection.push(remap.keyRemapping);
     }
   }
 

--- a/src/configuration/vimrc.ts
+++ b/src/configuration/vimrc.ts
@@ -22,14 +22,14 @@ class VimrcImpl {
     let lines = vimrcContent.split(/\r?\n/);
 
     for (const line of lines) {
-      VimrcImpl.tryKeyRemapping(configuration, line);
+      VimrcImpl.addKeyRemapping(configuration, line);
     }
   }
 
-  private static tryKeyRemapping(configuration: IConfiguration, line: string): boolean {
+  private static addKeyRemapping(configuration: IConfiguration, line: string): void {
     let mapping: IVimrcKeyRemapping | null = vimrcKeyRemappingBuilder.build(line);
     if (!mapping) {
-      return false;
+      return;
     }
 
     let collection: IKeyRemapping[];
@@ -53,15 +53,13 @@ class VimrcImpl {
         collection = configuration.insertModeKeyBindingsNonRecursive;
         break;
       default:
-        return false;
+        return;
     }
 
     // Don't override a mapping present in settings.json; those are more specific to VSCodeVim.
     if (!collection.some(r => _.isEqual(r.before, mapping!.keyRemapping.before))) {
       collection.push(mapping.keyRemapping);
     }
-
-    return true;
   }
 
   private static findDefaultVimrc(): string {

--- a/src/configuration/vimrc.ts
+++ b/src/configuration/vimrc.ts
@@ -6,19 +6,19 @@ import { vimrcKeyRemappingBuilder } from './vimrcKeyRemappingBuilder';
 
 class VimrcImpl {
   public load(configuration: IConfiguration) {
-    if (configuration.vimrcPath) {
-      configuration.vimrcPath = VimrcImpl.expandHome(configuration.vimrcPath);
-      if (!fs.existsSync(configuration.vimrcPath)) {
+    if (configuration.vimrc.path) {
+      configuration.vimrc.path = VimrcImpl.expandHome(configuration.vimrc.path);
+      if (!fs.existsSync(configuration.vimrc.path)) {
         return;
       }
     } else {
-      configuration.vimrcPath = VimrcImpl.findDefaultVimrc();
-      if (!configuration.vimrcPath) {
+      configuration.vimrc.path = VimrcImpl.findDefaultVimrc();
+      if (!configuration.vimrc.path) {
         return;
       }
     }
 
-    let vimrcContent = fs.readFileSync(configuration.vimrcPath, { encoding: 'utf8' });
+    let vimrcContent = fs.readFileSync(configuration.vimrc.path, { encoding: 'utf8' });
     let lines = vimrcContent.split(/\r?\n/);
 
     for (const line of lines) {

--- a/src/configuration/vimrcKeyRemappingBuilder.ts
+++ b/src/configuration/vimrcKeyRemappingBuilder.ts
@@ -1,0 +1,60 @@
+import { IKeyRemapping, IVimrcKeyRemapping } from './iconfiguration';
+
+class VimrcKeyRemappingBuilderImpl {
+  private static readonly KEY_REMAPPING_REG_EX = /(^.*map)\s([\S]+)\s+([\S]+)$/;
+  private static readonly KEY_LIST_REG_EX = /(<[^>]+>|.)/g;
+  private static readonly COMMAND_REG_EX = /(:\w+)/;
+
+  public build(line: string): IVimrcKeyRemapping | null {
+    let matches = VimrcKeyRemappingBuilderImpl.KEY_REMAPPING_REG_EX.exec(line);
+    if (!matches || matches.length < 4) {
+      return null;
+    }
+
+    let type = matches[1];
+    let before = matches[2];
+    let after = matches[3];
+    let mapping: IKeyRemapping;
+
+    if (VimrcKeyRemappingBuilderImpl.isCommand(after)) {
+      mapping = {
+        before: VimrcKeyRemappingBuilderImpl.buildKeyList(before),
+        commands: [after],
+      };
+    } else {
+      mapping = {
+        before: VimrcKeyRemappingBuilderImpl.buildKeyList(before),
+        after: VimrcKeyRemappingBuilderImpl.buildKeyList(after),
+      };
+    }
+
+    return {
+      keyRemapping: mapping,
+      keyRemappingType: type,
+    };
+  }
+
+  private static isCommand(commandString: string): boolean {
+    let matches = VimrcKeyRemappingBuilderImpl.COMMAND_REG_EX.exec(commandString);
+    if (matches) {
+      return true;
+    }
+    return false;
+  }
+
+  private static buildKeyList(keyString: string): string[] {
+    let keyList: string[] = [];
+    let matches;
+
+    do {
+      matches = VimrcKeyRemappingBuilderImpl.KEY_LIST_REG_EX.exec(keyString);
+      if (matches) {
+        keyList.push(matches[0]);
+      }
+    } while (matches);
+
+    return keyList;
+  }
+}
+
+export const vimrcKeyRemappingBuilder = new VimrcKeyRemappingBuilderImpl();

--- a/src/configuration/vimrcKeyRemappingBuilder.ts
+++ b/src/configuration/vimrcKeyRemappingBuilder.ts
@@ -6,16 +6,16 @@ class VimrcKeyRemappingBuilderImpl {
   private static readonly COMMAND_REG_EX = /(:\w+)/;
 
   public build(line: string): IVimrcKeyRemapping | null {
-    let matches = VimrcKeyRemappingBuilderImpl.KEY_REMAPPING_REG_EX.exec(line);
+    const matches = VimrcKeyRemappingBuilderImpl.KEY_REMAPPING_REG_EX.exec(line);
     if (!matches || matches.length < 4) {
       return null;
     }
 
-    let type = matches[1];
-    let before = matches[2];
-    let after = matches[3];
-    let mapping: IKeyRemapping;
+    const type = matches[1];
+    const before = matches[2];
+    const after = matches[3];
 
+    let mapping: IKeyRemapping;
     if (VimrcKeyRemappingBuilderImpl.isCommand(after)) {
       mapping = {
         before: VimrcKeyRemappingBuilderImpl.buildKeyList(before),
@@ -35,7 +35,7 @@ class VimrcKeyRemappingBuilderImpl {
   }
 
   private static isCommand(commandString: string): boolean {
-    let matches = VimrcKeyRemappingBuilderImpl.COMMAND_REG_EX.exec(commandString);
+    const matches = VimrcKeyRemappingBuilderImpl.COMMAND_REG_EX.exec(commandString);
     if (matches) {
       return true;
     }
@@ -44,8 +44,7 @@ class VimrcKeyRemappingBuilderImpl {
 
   private static buildKeyList(keyString: string): string[] {
     let keyList: string[] = [];
-    let matches;
-
+    let matches: RegExpMatchArray | null = null;
     do {
       matches = VimrcKeyRemappingBuilderImpl.KEY_LIST_REG_EX.exec(keyString);
       if (matches) {

--- a/src/configuration/vimrcKeyRemappingBuilder.ts
+++ b/src/configuration/vimrcKeyRemappingBuilder.ts
@@ -23,11 +23,13 @@ class VimrcKeyRemappingBuilderImpl {
       mapping = {
         before: VimrcKeyRemappingBuilderImpl.buildKeyList(before),
         commands: [after],
+        source: 'vimrc',
       };
     } else {
       mapping = {
         before: VimrcKeyRemappingBuilderImpl.buildKeyList(before),
         after: VimrcKeyRemappingBuilderImpl.buildKeyList(after),
+        source: 'vimrc',
       };
     }
 

--- a/src/configuration/vimrcKeyRemappingBuilder.ts
+++ b/src/configuration/vimrcKeyRemappingBuilder.ts
@@ -5,10 +5,10 @@ class VimrcKeyRemappingBuilderImpl {
   private static readonly KEY_LIST_REG_EX = /(<[^>]+>|.)/g;
   private static readonly COMMAND_REG_EX = /(:\w+)/;
 
-  public build(line: string): IVimrcKeyRemapping | null {
+  public build(line: string): IVimrcKeyRemapping | undefined {
     const matches = VimrcKeyRemappingBuilderImpl.KEY_REMAPPING_REG_EX.exec(line);
     if (!matches || matches.length < 4) {
-      return null;
+      return undefined;
     }
 
     const type = matches[1];

--- a/src/configuration/vimrcKeyRemappingBuilder.ts
+++ b/src/configuration/vimrcKeyRemappingBuilder.ts
@@ -5,6 +5,9 @@ class VimrcKeyRemappingBuilderImpl {
   private static readonly KEY_LIST_REG_EX = /(<[^>]+>|.)/g;
   private static readonly COMMAND_REG_EX = /(:\w+)/;
 
+  /**
+   * @returns A remapping if the given `line` parses to one, and `undefined` otherwise.
+   */
   public build(line: string): IVimrcKeyRemapping | undefined {
     const matches = VimrcKeyRemappingBuilderImpl.KEY_REMAPPING_REG_EX.exec(line);
     if (!matches || matches.length < 4) {
@@ -34,6 +37,9 @@ class VimrcKeyRemappingBuilderImpl {
     };
   }
 
+  /**
+   * @returns `true` if this remaps a key sequence to a `:` command
+   */
   private static isCommand(commandString: string): boolean {
     const matches = VimrcKeyRemappingBuilderImpl.COMMAND_REG_EX.exec(commandString);
     if (matches) {

--- a/test/configuration/vimrcKeyRemappingBuilder.test.ts
+++ b/test/configuration/vimrcKeyRemappingBuilder.test.ts
@@ -1,0 +1,64 @@
+import * as assert from 'assert';
+import { IKeyRemapping, IVimrcKeyRemapping } from '../../src/configuration/iconfiguration';
+import { vimrcKeyRemappingBuilder } from '../../src/configuration/vimrcKeyRemappingBuilder';
+
+suite('VimrcKeyRemappingBuilder', () => {
+  test('Build IKeyRemapping objects from .vimrc lines', () => {
+    const testCases = [
+      {
+        vimrcLine: 'nnoremap <C-h> <<',
+        keyRemapping: {
+          before: ['<C-h>'],
+          after: ['<', '<'],
+        },
+        keyRemappingType: 'nnoremap',
+        expectNull: false
+      },
+      {
+        vimrcLine: 'imap jj <Esc>',
+        keyRemapping: {
+          before: ['j', 'j'],
+          after: ['<Esc>'],
+        },
+        keyRemappingType: 'imap',
+        expectNull: false
+      },
+      {
+        vimrcLine: 'vnoremap <leader>" c""<Esc>P',
+        keyRemapping: {
+          before: ['<leader>', '"'],
+          after: ['c', '"', '"', '<Esc>', 'P'],
+        },
+        keyRemappingType: 'vnoremap',
+        expectNull: false
+      },
+      {
+        // Mapping with a command
+        vimrcLine: 'nnoremap <C-s> :w',
+        keyRemapping: {
+          before: ['<C-s>'],
+          commands: [':w'],
+        },
+        keyRemappingType: 'nnoremap',
+        expectNull: false
+      },
+      {
+        // Ignore non-mapping lines
+        vimrcLine: 'set scrolloff=8',
+        expectNull: true
+      },
+    ];
+
+    for (const testCase of testCases) {
+      let vimrcKeyRemapping: IVimrcKeyRemapping | null =
+        vimrcKeyRemappingBuilder.build(testCase.vimrcLine);
+
+      if (testCase.expectNull) {
+        assert.equal(vimrcKeyRemapping, null);
+      } else {
+        assert.deepEqual(vimrcKeyRemapping!.keyRemapping, testCase.keyRemapping);
+        assert.equal(vimrcKeyRemapping!.keyRemappingType, testCase.keyRemappingType);
+      }
+    }
+  });
+});

--- a/test/configuration/vimrcKeyRemappingBuilder.test.ts
+++ b/test/configuration/vimrcKeyRemappingBuilder.test.ts
@@ -12,7 +12,7 @@ suite('VimrcKeyRemappingBuilder', () => {
           after: ['<', '<'],
         },
         keyRemappingType: 'nnoremap',
-        expectNull: false
+        expectNull: false,
       },
       {
         vimrcLine: 'imap jj <Esc>',
@@ -21,7 +21,7 @@ suite('VimrcKeyRemappingBuilder', () => {
           after: ['<Esc>'],
         },
         keyRemappingType: 'imap',
-        expectNull: false
+        expectNull: false,
       },
       {
         vimrcLine: 'vnoremap <leader>" c""<Esc>P',
@@ -30,7 +30,7 @@ suite('VimrcKeyRemappingBuilder', () => {
           after: ['c', '"', '"', '<Esc>', 'P'],
         },
         keyRemappingType: 'vnoremap',
-        expectNull: false
+        expectNull: false,
       },
       {
         // Mapping with a command
@@ -40,24 +40,25 @@ suite('VimrcKeyRemappingBuilder', () => {
           commands: [':w'],
         },
         keyRemappingType: 'nnoremap',
-        expectNull: false
+        expectNull: false,
       },
       {
         // Ignore non-mapping lines
         vimrcLine: 'set scrolloff=8',
-        expectNull: true
+        expectNull: true,
       },
     ];
 
     for (const testCase of testCases) {
-      let vimrcKeyRemapping: IVimrcKeyRemapping | null =
-        vimrcKeyRemappingBuilder.build(testCase.vimrcLine);
+      const vimrcKeyRemapping: IVimrcKeyRemapping | undefined = vimrcKeyRemappingBuilder.build(
+        testCase.vimrcLine
+      );
 
       if (testCase.expectNull) {
-        assert.equal(vimrcKeyRemapping, null);
+        assert.strictEqual(vimrcKeyRemapping, undefined);
       } else {
-        assert.deepEqual(vimrcKeyRemapping!.keyRemapping, testCase.keyRemapping);
-        assert.equal(vimrcKeyRemapping!.keyRemappingType, testCase.keyRemappingType);
+        assert.deepStrictEqual(vimrcKeyRemapping!.keyRemapping, testCase.keyRemapping);
+        assert.strictEqual(vimrcKeyRemapping!.keyRemappingType, testCase.keyRemappingType);
       }
     }
   });

--- a/test/testConfiguration.ts
+++ b/test/testConfiguration.ts
@@ -84,8 +84,10 @@ export class Configuration implements IConfiguration {
   gdefault = false;
   substituteGlobalFlag = false; // Deprecated in favor of gdefault
   neovimPath = 'nvim';
-  enableVimrc = false;
-  vimrcPath = '';
+  vimrc = {
+    enable: false,
+    path: '',
+  };
   cursorStylePerMode: IModeSpecificStrings<string> = {
     normal: 'line',
     insert: 'block',

--- a/test/testConfiguration.ts
+++ b/test/testConfiguration.ts
@@ -81,9 +81,11 @@ export class Configuration implements IConfiguration {
   foldfix = false;
   disableExtension = false;
   enableNeovim = false;
-  neovimPath = '';
   gdefault = false;
   substituteGlobalFlag = false; // Deprecated in favor of gdefault
+  neovimPath = 'nvim';
+  enableVimrc = false;
+  vimrcPath = '';
   cursorStylePerMode: IModeSpecificStrings<string> = {
     normal: 'line',
     insert: 'block',


### PR DESCRIPTION

[package.txt](https://github.com/VSCodeVim/Vim/files/4601047/package.txt)


By default vim extension, doesn't recognise <shift+space> keystroke. We need to add

{"key": "shift+space","command": "extension.vim_shift+space", "when": "editorTextFocus && vim.active && vim.use<shift+space> && !inDebugRepl"},

to .vscode\extensions\vscodevim.vim-1.8.0\package.json, to do so.

When the extension gets updated, this gets deleted, and when i press <shift+space> in vscode it says "command 'extension.vim_shift+space' not found". We need to add again the code above.
So I think this command must included in default package.json
