### PR TITLE
Fix numeric length on Ctrl A

### DIFF
--- a/src/common/number/numericString.ts
+++ b/src/common/number/numericString.ts
@@ -3,7 +3,7 @@ export class NumericString {
   value: number;
   prefix: string;
   suffix: string;
-  number_length: number;
+  number_length?: number;
 
   private static matchings: { regex: RegExp; base: number; prefix: string }[] = [
     { regex: /^([-+])?0([0-7]+)$/, base: 8, prefix: '0' },
@@ -71,16 +71,17 @@ export class NumericString {
     radix: number,
     prefix: string,
     suffix: string,
-    number_length: number
+    number_length?: number
   ) {
     this.value = value;
     this.radix = radix;
     this.prefix = prefix;
     this.suffix = suffix;
-    this.number_length = number_length || String(value).length;
+    this.number_length = number_length;
   }
 
   public toString(): string {
+    let result: string | number;
     // Allow signed hex represented as twos complement
     if (this.radix === 16) {
       if (this.value < 0) {
@@ -88,8 +89,12 @@ export class NumericString {
       }
     }
 
-    return (
-      this.prefix + this.value.toString(this.radix).padStart(this.number_length, '0') + this.suffix
-    );
+    result = this.value.toString(this.radix);
+
+    if (this.radix === 10 && this.number_length) {
+      result = result.padStart(this.number_length, '0');
+    }
+
+    return this.prefix + result + this.suffix;
   }
 }

--- a/src/common/number/numericString.ts
+++ b/src/common/number/numericString.ts
@@ -56,7 +56,7 @@ export class NumericString {
 
       let numLength = String(newNum).length;
       if (newNum[0] !== '0') {
-        numLength--;
+        numLength = 0;
       }
 
       return new NumericString(parseInt(newNum, base), base, newPrefix, newSuffix, numLength);

--- a/src/common/number/numericString.ts
+++ b/src/common/number/numericString.ts
@@ -3,6 +3,7 @@ export class NumericString {
   value: number;
   prefix: string;
   suffix: string;
+  number_length: number;
 
   private static matchings: { regex: RegExp; base: number; prefix: string }[] = [
     { regex: /^([-+])?0([0-7]+)$/, base: 8, prefix: '0' },
@@ -53,17 +54,30 @@ export class NumericString {
         newNum = newNum.slice(newPrefix.length, newNum.length - newSuffix.length);
       }
 
-      return new NumericString(parseInt(newNum, base), base, newPrefix, newSuffix);
+      return new NumericString(
+        parseInt(newNum, base),
+        base,
+        newPrefix,
+        newSuffix,
+        String(newNum).length
+      );
     }
 
     return undefined;
   }
 
-  private constructor(value: number, radix: number, prefix: string, suffix: string) {
+  private constructor(
+    value: number,
+    radix: number,
+    prefix: string,
+    suffix: string,
+    number_length: number
+  ) {
     this.value = value;
     this.radix = radix;
     this.prefix = prefix;
     this.suffix = suffix;
+    this.number_length = number_length || String(value).length;
   }
 
   public toString(): string {
@@ -74,6 +88,8 @@ export class NumericString {
       }
     }
 
-    return this.prefix + this.value.toString(this.radix) + this.suffix;
+    return (
+      this.prefix + this.value.toString(this.radix).padStart(this.number_length, '0') + this.suffix
+    );
   }
 }

--- a/src/common/number/numericString.ts
+++ b/src/common/number/numericString.ts
@@ -54,13 +54,12 @@ export class NumericString {
         newNum = newNum.slice(newPrefix.length, newNum.length - newSuffix.length);
       }
 
-      return new NumericString(
-        parseInt(newNum, base),
-        base,
-        newPrefix,
-        newSuffix,
-        String(newNum).length
-      );
+      let numLength = String(newNum).length;
+      if (newNum[0] !== '0') {
+        numLength--;
+      }
+
+      return new NumericString(parseInt(newNum, base), base, newPrefix, newSuffix, numLength);
     }
 
     return undefined;

--- a/test/mode/modeNormal.test.ts
+++ b/test/mode/modeNormal.test.ts
@@ -2024,6 +2024,13 @@ suite('Mode Normal', () => {
   });
 
   newTest({
+    title: 'can <C-a> on word with zero in front of it, without removed zero',
+    start: ['|A01'],
+    keysPressed: '<C-a>',
+    end: ['A0|2'],
+  });
+
+  newTest({
     title: 'can do Y',
     start: ['|blah blah'],
     keysPressed: 'Yp',


### PR DESCRIPTION
<!--
Yay! Thanks for sending us a PR! 🎊

Please ensure your PR adheres to:

- [ ] Commit messages has a short & issue references when necessary
- [ ] Each commit does a logical chunk of work.
- [ ] It builds and tests pass (e.g `gulp`)
-->

**What this PR does / why we need it**:
This will fix the numeric length

Example :
A01 will become A02,

in the previous version the number 0 is missing, it will be A2 instead of A02
