### PR TITLE
Fix bugs with a remapped <Esc> in insert mode

### DIFF
--- a/src/history/historyTracker.ts
+++ b/src/history/historyTracker.ts
@@ -609,16 +609,21 @@ export class HistoryTracker {
       this.currentContentChanges.length - n,
       this.currentContentChanges.length
     );
-    const firstRemovedChange = removedChanges[0];
 
     // Remove the characters from the editor.
-    await vscode.window.activeTextEditor?.edit((edit) =>
-      edit.delete(
-        new vscode.Range(
-          firstRemovedChange!.range.start,
-          firstRemovedChange!.range.end.translate(0, n)
+    for (const removedChange of removedChanges) {
+      await vscode.window.activeTextEditor?.edit((edit) =>
+        edit.delete(
+          new vscode.Range(removedChange!.range.start, removedChange!.range.end.translate(0, n))
         )
-      )
+      );
+    }
+
+    // Remove the previous deletions from currentContentChanges otherwise the DotCommand
+    // or a recorded macro will be deleting a character that wasn't typed.
+    this.currentContentChanges.splice(
+      this.currentContentChanges.length - removedChanges.length,
+      removedChanges.length
     );
 
     // We can't ignore the change, because that would mean that addChange() doesn't run.

--- a/src/history/historyTracker.ts
+++ b/src/history/historyTracker.ts
@@ -612,13 +612,16 @@ export class HistoryTracker {
 
     // Remove the characters from the editor in reverse order otherwise the characters
     // position would change.
-    for (const removedChange of removedChanges.reverse()) {
-      await vscode.window.activeTextEditor?.edit((edit) =>
+    await vscode.window.activeTextEditor?.edit((edit) => {
+      for (const removedChange of removedChanges.reverse()) {
         edit.delete(
-          new vscode.Range(removedChange!.range.start, removedChange!.range.end.translate(0, 1))
-        )
-      );
-    }
+          new vscode.Range(
+            removedChange.range.start,
+            removedChange.range.end.translate({ characterDelta: 1 })
+          )
+        );
+      }
+    });
 
     // Remove the previous deletions from currentContentChanges otherwise the DotCommand
     // or a recorded macro will be deleting a character that wasn't typed.

--- a/src/history/historyTracker.ts
+++ b/src/history/historyTracker.ts
@@ -610,11 +610,12 @@ export class HistoryTracker {
       this.currentContentChanges.length
     );
 
-    // Remove the characters from the editor.
-    for (const removedChange of removedChanges) {
+    // Remove the characters from the editor in reverse order otherwise the characters
+    // position would change.
+    for (const removedChange of removedChanges.reverse()) {
       await vscode.window.activeTextEditor?.edit((edit) =>
         edit.delete(
-          new vscode.Range(removedChange!.range.start, removedChange!.range.end.translate(0, n))
+          new vscode.Range(removedChange!.range.start, removedChange!.range.end.translate(0, 1))
         )
       );
     }

--- a/test/mode/normalModeTests/dot.test.ts
+++ b/test/mode/normalModeTests/dot.test.ts
@@ -113,3 +113,42 @@ suite('Repeat content change', () => {
     end: ['\tonecb', 'tw|co'],
   });
 });
+
+suite('Dot Operator repeat with remap', () => {
+  const { newTest, newTestOnly } = getTestingFunctions();
+
+  setup(async () => {
+    const configuration = new Configuration();
+    configuration.insertModeKeyBindings = [
+      {
+        before: ['j', 'j', 'k'],
+        after: ['<esc>'],
+      },
+    ];
+    configuration.normalModeKeyBindings = [
+      {
+        before: ['<leader>', 'w'],
+        after: ['d', 'w'],
+      },
+    ];
+    configuration.leader = ' ';
+
+    await setupWorkspace(configuration);
+  });
+
+  teardown(cleanUpWorkspace);
+
+  newTest({
+    title: "Can repeat content change using 'jjk' mapped to '<Esc>' without trailing characters",
+    start: ['on|e', 'two'],
+    keysPressed: 'ciwfoojjkj.',
+    end: ['foo', 'fo|o'],
+  });
+
+  newTest({
+    title: "Can repeat '<leader>w' when mapped to 'dw'",
+    start: ['|one two three'],
+    keysPressed: ' w.',
+    end: ['|three'],
+  });
+});

--- a/test/multicursor.test.ts
+++ b/test/multicursor.test.ts
@@ -2,6 +2,8 @@ import * as assert from 'assert';
 import { getAndUpdateModeHandler } from '../extension';
 import { ModeHandler } from '../src/mode/modeHandler';
 import { assertEqualLines, cleanUpWorkspace, setupWorkspace } from './testUtils';
+import { getTestingFunctions } from './testSimplifier';
+import { Configuration } from './testConfiguration';
 
 suite('Multicursor', () => {
   let modeHandler: ModeHandler;
@@ -101,5 +103,30 @@ suite('Multicursor', () => {
     await modeHandler.handleMultipleKeyEvents(['v', 'i', 't', 'd']);
     assertEqualLines(['<div></div> asd', '<div></div>']);
     assert.strictEqual(modeHandler.vimState.cursors.length, 2);
+  });
+});
+
+suite('Multicursor with remaps', () => {
+  const { newTest, newTestOnly } = getTestingFunctions();
+
+  setup(async () => {
+    const configuration = new Configuration();
+    configuration.insertModeKeyBindings = [
+      {
+        before: ['j', 'j', 'k'],
+        after: ['<esc>'],
+      },
+    ];
+
+    await setupWorkspace(configuration);
+  });
+
+  teardown(cleanUpWorkspace);
+
+  newTest({
+    title: "Using 'jjk' mapped to '<Esc>' doesn't leave trailing characters",
+    start: ['o|ne', 'two'],
+    keysPressed: '<C-v>jAfoojjk<Esc>',
+    end: ['onfo|oe', 'twfooo'],
   });
 });


### PR DESCRIPTION
**What this PR does / why we need it**:
- Fix DotCommand deleting extra character when used after a remapped \<Esc\> in insert mode
Fixes #4817 and fixes #4814

- Fix remapped \<Esc\> leaving trailing character when used with multiple cursors
Fixes #4811