### PR TITLE
Fix macros not updating cursorsInitialState before each action

### DIFF
--- a/src/mode/modeHandler.ts
+++ b/src/mode/modeHandler.ts
@@ -1147,6 +1147,8 @@ export class ModeHandler implements vscode.Disposable {
     for (let action of recordedMacro.actionsRun) {
       let originalLocation = Jump.fromStateNow(vimState);
 
+      vimState.cursorsInitialState = vimState.cursors;
+
       recordedState.actionsRun.push(action);
       vimState.keyHistory = vimState.keyHistory.concat(action.keysPressed);
 


### PR DESCRIPTION
Fix macros not updating cursorsInitialState before each action
fixes #4827

On issue #4827 when it makes the second 'yy' to yank line the YankOperator will set the cursors to cursorsInitialState which hasn't been changed since the beginning of the macro replay. The cursorsInitialState should have the cursors state before each action.