### PR TITLE
Reset vimState.actionsCount when <C-o> pressed in insert mode

### DIFF
--- a/src/actions/commands/insert.ts
+++ b/src/actions/commands/insert.ts
@@ -64,7 +64,7 @@ class CommandEscInsertMode extends BaseCommand {
     // If we wanted to repeat this insert (only for i and a), now is the time to do it. Insert
     // count amount of these strings before returning back to normal mode
     const typeOfInsert =
-      vimState.recordedState.actionsRun[vimState.recordedState.actionsRun.length - 3];
+    vimState.recordedState.actionsRun[vimState.recordedState.actionsRun.length - 3];
     const isTypeToRepeatInsert =
       typeOfInsert instanceof CommandInsertAtCursor ||
       typeOfInsert instanceof CommandInsertAfterCursor ||
@@ -430,6 +430,7 @@ export class CommandOneNormalCommandInInsertMode extends BaseCommand {
 
   public async exec(position: Position, vimState: VimState): Promise<VimState> {
     vimState.returnToInsertAfterCommand = true;
+    vimState.actionCount = 0;
     return new CommandEscInsertMode().exec(position, vimState);
   }
 }

--- a/src/mode/modeHandler.ts
+++ b/src/mode/modeHandler.ts
@@ -584,7 +584,6 @@ export class ModeHandler implements vscode.Disposable {
       // Return to insert mode after 1 command in this case for <C-o>
       if (vimState.returnToInsertAfterCommand) {
         if (vimState.actionCount > 0) {
-          vimState.actionCount = 0;
           await this.setCurrentMode(Mode.Insert);
         } else {
           vimState.actionCount++;

--- a/test/mode/modeInsert.test.ts
+++ b/test/mode/modeInsert.test.ts
@@ -259,6 +259,14 @@ suite('Mode Insert', () => {
   });
 
   newTest({
+    title: 'Can <ctrl-o> after entering insert mode from <ctrl-o>',
+    start: ['|'],
+    keysPressed: 'i<C-o>i<C-o>',
+    end: ['|'],
+    endMode: Mode.Normal
+  });
+
+  newTest({
     title:
       'Can perform <ctrl+o> to exit and perform one command in normal at the beginning of a row',
     start: ['|testtest'],


### PR DESCRIPTION
Fixes #4841 

The existing implementation did not reset `vimState.actionsCount` when we perform action that put user in insert mode after pressing `<C-o>`