### PR TITLE
Throw E29 on empty `.` register

### DIFF
--- a/src/actions/commands/insert.ts
+++ b/src/actions/commands/insert.ts
@@ -1,5 +1,7 @@
 import * as vscode from 'vscode';
 
+import * as error from '../../error';
+
 import { lineCompletionProvider } from '../../completion/lineCompletionProvider';
 import { RecordedState } from '../../state/recordedState';
 import { VimState } from '../../state/vimState';
@@ -110,7 +112,12 @@ export class CommandInsertPreviousText extends BaseCommand {
   keys = ['<C-a>'];
 
   public async exec(position: Position, vimState: VimState): Promise<VimState> {
-    let actions = ((await Register.getByKey('.')).text as RecordedState).actionsRun.slice(0);
+    let lastInserted = (await Register.getByKey('.')).text as RecordedState;
+    if (!lastInserted.actionsRun) {
+      throw error.VimError.fromCode(error.ErrorCode.NoInsertedTextYet);
+    }
+
+    let actions = lastInserted.actionsRun.slice(0);
     // let actions = Register.lastContentChange.actionsRun.slice(0);
     // The first action is entering Insert Mode, which is not necessary in this case
     actions.shift();

--- a/src/error.ts
+++ b/src/error.ts
@@ -4,6 +4,7 @@ interface IErrorMessage {
 
 export enum ErrorCode {
   MarkNotSet = 20,
+  NoInsertedTextYet = 29,
   NoFileName = 32,
   NoPreviousRegularExpression = 35,
   NoWriteSinceLastChange = 37,
@@ -21,6 +22,7 @@ export enum ErrorCode {
 
 export const ErrorMessage: IErrorMessage = {
   20: 'Mark not set',
+  29: 'No inserted text yet',
   32: 'No file name',
   35: 'No previous regular expression',
   37: 'No write since last change (add ! to override)',

--- a/test/mode/modeInsert.test.ts
+++ b/test/mode/modeInsert.test.ts
@@ -1,4 +1,7 @@
 import * as assert from 'assert';
+
+import * as error from '../../src/error';
+
 import { getAndUpdateModeHandler } from '../../extension';
 import { Mode } from '../../src/mode/mode';
 import { ModeHandler } from '../../src/mode/modeHandler';
@@ -6,6 +9,7 @@ import { TextEditor } from '../../src/textEditor';
 import { getTestingFunctions } from '../testSimplifier';
 import {
   assertEqualLines,
+  assertStatusBarEqual,
   cleanUpWorkspace,
   setupWorkspace,
   reloadConfiguration,
@@ -358,5 +362,20 @@ suite('Mode Insert', () => {
     await reloadConfiguration();
     await modeHandler.handleMultipleKeyEvents(['i', '<C-k>', 'R', '!', '<C-k>', '!', 'R']);
     assertEqualLines(['🚀🚀']);
+  });
+
+  newTest({
+    title: 'Can insert last inserted text',
+    start: ['test|'],
+    keysPressed: 'ahello<Esc>a<C-a>',
+    end: ['testhellohello|'],
+  });
+
+  test('Can handle no inserted text yet when executing <ctrl-a>', async () => {
+    try {
+      await modeHandler.handleMultipleKeyEvents(['i', '<C-a>']);
+    } catch (e) {
+      assert(false);
+    }
   });
 });


### PR DESCRIPTION
Fixes #4846 

Throw E29 when there are no actions in '.' register