### PR TITLE
Change count handling on remapping, vscode commands and operators

### DIFF
--- a/src/configuration/remapper.ts
+++ b/src/configuration/remapper.ts
@@ -150,36 +150,39 @@ export class Remapper implements IRemapper {
     vimState.keyHistory = vimState.keyHistory.slice(0, -numCharsToRemove);
 
     if (remapping.after) {
-      const count = vimState.recordedState.count || 1;
-      vimState.recordedState.count = 0;
-      for (let i = 0; i < count; i++) {
-        await modeHandler.handleMultipleKeyEvents(remapping.after);
-      }
+      await modeHandler.handleMultipleKeyEvents(remapping.after);
     }
 
     if (remapping.commands) {
-      for (const command of remapping.commands) {
-        let commandString: string;
-        let commandArgs: string[];
-        if (typeof command === 'string') {
-          commandString = command;
-          commandArgs = [];
-        } else {
-          commandString = command.command;
-          commandArgs = command.args;
-        }
+      const count = vimState.recordedState.count || 1;
+      vimState.recordedState.count = 0;
+      for (let i = 0; i < count; i++) {
+        for (const command of remapping.commands) {
+          let commandString: string;
+          let commandArgs: string[];
+          if (typeof command === 'string') {
+            commandString = command;
+            commandArgs = [];
+          } else {
+            commandString = command.command;
+            commandArgs = command.args;
+          }
 
-        if (commandString.slice(0, 1) === ':') {
-          // Check if this is a vim command by looking for :
-          await commandLine.Run(commandString.slice(1, commandString.length), modeHandler.vimState);
-          await modeHandler.updateView(modeHandler.vimState);
-        } else if (commandArgs) {
-          await vscode.commands.executeCommand(commandString, commandArgs);
-        } else {
-          await vscode.commands.executeCommand(commandString);
-        }
+          if (commandString.slice(0, 1) === ':') {
+            // Check if this is a vim command by looking for :
+            await commandLine.Run(
+              commandString.slice(1, commandString.length),
+              modeHandler.vimState
+            );
+            await modeHandler.updateView(modeHandler.vimState);
+          } else if (commandArgs) {
+            await vscode.commands.executeCommand(commandString, commandArgs);
+          } else {
+            await vscode.commands.executeCommand(commandString);
+          }
 
-        StatusBar.setText(vimState, `${commandString} ${commandArgs}`);
+          StatusBar.setText(vimState, `${commandString} ${commandArgs}`);
+        }
       }
     }
   }

--- a/src/mode/modeHandler.ts
+++ b/src/mode/modeHandler.ts
@@ -39,6 +39,7 @@ import { reportSearch } from '../util/statusBarTextUtils';
 import { Notation } from '../configuration/notation';
 import { ModeHandlerMap } from './modeHandlerMap';
 import { EditorIdentity } from '../editorIdentity';
+import { BaseOperator } from '../actions/operator';
 
 /**
  * ModeHandler is the extension's backbone. It listens to events and updates the VimState.
@@ -490,6 +491,10 @@ export class ModeHandler implements vscode.Disposable {
 
     if (action instanceof DocumentContentChangeAction) {
       vimState = await action.exec(vimState.cursorStopPosition, vimState);
+    }
+
+    if (action instanceof BaseOperator) {
+      recordedState.operatorCount = recordedState.count;
     }
 
     // Update mode (note the ordering allows you to go into search mode,

--- a/src/state/recordedState.ts
+++ b/src/state/recordedState.ts
@@ -141,6 +141,14 @@ export class RecordedState {
   public count: number = 0;
 
   /**
+   * The number of times the user wants to repeat the operator. If after the operator the user
+   * uses a motion with count that count will be multiplied by this count.
+   *
+   * Example: if user presses 2d3w it deletes 6 words.
+   */
+  public operatorCount: number = 0;
+
+  /**
    * The register name for this action.
    */
   public registerName: string;

--- a/test/configuration/remapper.test.ts
+++ b/test/configuration/remapper.test.ts
@@ -468,6 +468,32 @@ suite('Remapper', () => {
     assert.strictEqual(modeHandler.currentMode, Mode.Normal);
   });
 
+  test('jj -> <Esc> after using <Count>i=jj should insert ===', async () => {
+    // setup
+    await setupWithBindings({
+      insertModeKeyBindings: [
+        {
+          before: ['j', 'j'],
+          after: ['<Esc>'],
+        },
+      ],
+    });
+
+    assert.strictEqual(modeHandler.currentMode, Mode.Normal);
+    await modeHandler.handleMultipleKeyEvents(['<Esc>', 'g', 'g']);
+    await modeHandler.handleMultipleKeyEvents(['i', 'word1 word2', '<Esc>', 'b']);
+    assert.strictEqual(modeHandler.currentMode, Mode.Normal);
+
+    // act
+    await modeHandler.handleMultipleKeyEvents(['3', 'i', '=']);
+    assert.strictEqual(modeHandler.currentMode, Mode.Insert);
+    await modeHandler.handleMultipleKeyEvents(['j', 'j']);
+
+    // assert
+    assert.strictEqual(modeHandler.currentMode, Mode.Normal);
+    assertEqualLines(['word1 ===word2']);
+  });
+
   test('jj -> <Esc> does not leave behind character a j', async () => {
     // setup
     await setupWithBindings({

--- a/test/mode/modeNormal.test.ts
+++ b/test/mode/modeNormal.test.ts
@@ -1884,6 +1884,17 @@ suite('Mode Normal', () => {
   });
 
   newTest({
+    title: 'can delete with count before and after operator, 2d12w deletes 24 words',
+    start: [
+      '|one two three four five six seven eight nine ten',
+      'one two three four five six seven eight nine ten',
+      'one two three four five six seven eight nine ten',
+    ],
+    keysPressed: '2d12w',
+    end: ['|five six seven eight nine ten'],
+  });
+
+  newTest({
     title: 'can dE correctly',
     start: ['|one two three'],
     keysPressed: 'dE',


### PR DESCRIPTION
**What this PR does / why we need it**:
Change Count handling when remapping:
- The count value is already stored on RecordedState so we only need to
send the remap keys and the corresponding actions will act accordingly
- The commands weren't respecting the count, if we mapped '<' in visual
mode to the command 'editor.action.outdentLines' we couldn't use it with
count, now we can.
- If you pressed '2d3w' it would delete 23 words, when it should multiply both counts and only delete 6 words. This PR implements an `'operatorCount'` to keep track of the count before the operator to be able to multiply it to the count numbers after it.

**Which issue(s) this PR fixes**
fixes #2244
fixes #4903

**Special notes for your reviewer**:
I've only added a simple test. But I'm trying to create a new simplified way of handling tests with remaps on the PR #4735, after that gets implemented it should be easier to create test with remaps like this one.