### PR TITLE
Fix recording macro not showing after 'setText'

### DIFF
--- a/src/mode/modeHandler.ts
+++ b/src/mode/modeHandler.ts
@@ -330,7 +330,8 @@ export class ModeHandler implements vscode.Disposable {
 
     // We don't want to immediately erase any message that resulted from the action just performed
     if (StatusBar.getText() === oldStatusBarText) {
-      // Clear the status bar of high priority messages if the mode has changed or the view has scrolled
+      // Clear the status bar of high priority messages if the mode has changed, the view has scrolled
+      // or it is recording a Macro
       const forceClearStatusBar =
         (this.vimState.currentMode !== oldMode && this.vimState.currentMode !== Mode.Normal) ||
         this.vimState.editor.visibleRanges[0] !== oldVisibleRange ||

--- a/src/mode/modeHandler.ts
+++ b/src/mode/modeHandler.ts
@@ -333,7 +333,8 @@ export class ModeHandler implements vscode.Disposable {
       // Clear the status bar of high priority messages if the mode has changed or the view has scrolled
       const forceClearStatusBar =
         (this.vimState.currentMode !== oldMode && this.vimState.currentMode !== Mode.Normal) ||
-        this.vimState.editor.visibleRanges[0] !== oldVisibleRange;
+        this.vimState.editor.visibleRanges[0] !== oldVisibleRange ||
+        this.vimState.isRecordingMacro;
       StatusBar.clear(this.vimState, forceClearStatusBar);
     }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix recording macro not showing after 'setText'
- If 'setText' was called somewhere else like when undoing or when ':w'
the Recording info would be lost
- This commit makes it so that after the next key press we will get the
info back, this is the same behavior as Vim

**Which issue(s) this PR fixes**
Fixes #4753

**Special notes for your reviewer**:
The `Recording @` message was being erased because every time the `StatusBar.setText` is called it replaces the existing text with the new message.

This happens, for example, when the `:write`  command calls `setText` or when you undo something, which might happen in the middle of the macro recording and erases the recording message.

The message would only update again with the `Recording @` after a mode change. This makes it update after the next key press, which means if you undo you get the undo message until you press some key which replaces that message with the clear text that includes the macro recording.

This is the Vim behavior but I think Neovim always shows it. We could make it always show up by appending it to `text` on the `StatusBar.setText(text)` function as well. Some users might prefer it that way.