### PR TITLE
Add `<C-u>` insert mode stop point at column where cursor started

### DIFF
--- a/src/actions/commands/insert.ts
+++ b/src/actions/commands/insert.ts
@@ -563,7 +563,10 @@ class CommandCtrlUInInsertMode extends BaseCommand {
         ? position.getLineBegin()
         : position.getLineBeginRespectingIndent();
     }
-    await TextEditor.delete(new vscode.Range(start, position));
+    vimState.recordedState.transformations.push({
+      type: 'deleteRange',
+      range: new Range(start, position),
+    });
     vimState.cursorStopPosition = start;
     vimState.cursorStartPosition = start;
     return vimState;

--- a/src/actions/commands/insert.ts
+++ b/src/actions/commands/insert.ts
@@ -551,9 +551,18 @@ class CommandCtrlUInInsertMode extends BaseCommand {
   keys = ['<C-u>'];
 
   public async exec(position: Position, vimState: VimState): Promise<VimState> {
-    const start = position.isInLeadingWhitespace()
-      ? position.getLineBegin()
-      : position.getLineBeginRespectingIndent();
+    let start: Position;
+
+    if (
+      vimState.insertModeCursorCtrlUStopPosition?.line === position.line &&
+      vimState.insertModeCursorCtrlUStopPosition?.isBefore(position)
+    ) {
+      start = vimState.insertModeCursorCtrlUStopPosition;
+    } else {
+      start = position.isInLeadingWhitespace()
+        ? position.getLineBegin()
+        : position.getLineBeginRespectingIndent();
+    }
     await TextEditor.delete(new vscode.Range(start, position));
     vimState.cursorStopPosition = start;
     vimState.cursorStartPosition = start;

--- a/src/actions/motion.ts
+++ b/src/actions/motion.ts
@@ -2038,9 +2038,11 @@ export abstract class ArrowsInInsertMode extends BaseMovement {
     switch (this.keys[0]) {
       case '<up>':
         newPosition = <Position>await new MoveUpArrow().execAction(position, vimState);
+        vimState.insertModeCursorCtrlUStopPosition = newPosition;
         break;
       case '<down>':
         newPosition = <Position>await new MoveDownArrow().execAction(position, vimState);
+        vimState.insertModeCursorCtrlUStopPosition = newPosition;
         break;
       case '<left>':
         newPosition = await new MoveLeftArrow(this.keysPressed).execAction(position, vimState);

--- a/src/state/vimState.ts
+++ b/src/state/vimState.ts
@@ -80,6 +80,11 @@ export class VimState implements vscode.Disposable {
   public isRunningDotCommand = false;
 
   /**
+   * Cursor position to stop at when deleting backwards with Ctrl+U.
+   */
+  public insertModeCursorCtrlUStopPosition: Position | undefined = undefined;
+
+  /**
    * The last visual selection before running the dot command
    */
   public dotCommandPreviousVisualSelection: vscode.Selection | undefined = undefined;
@@ -226,6 +231,9 @@ export class VimState implements vscode.Disposable {
     } else {
       this.firstVisibleLineBeforeSearch = undefined;
     }
+
+    this.insertModeCursorCtrlUStopPosition =
+      mode === Mode.Insert ? this.cursorStartPosition : undefined;
   }
 
   public currentRegisterMode = RegisterMode.AscertainFromCurrentMode;

--- a/test/mode/modeInsert.test.ts
+++ b/test/mode/modeInsert.test.ts
@@ -157,6 +157,27 @@ suite('Mode Insert', () => {
     end: ['{', '|true', '}'],
   });
 
+  newTest({
+    title: '<C-u> deletes to cursor start position after inserting text',
+    start: ['{', 'foo: |true', '}'],
+    keysPressed: 'ifalse<C-u>',
+    end: ['{', 'foo: |true', '}'],
+  });
+
+  newTest({
+    title: '<C-u> deletes to cursor start position after moving to the right',
+    start: ['{', 'foo: |bar', '}'],
+    keysPressed: 'i<right><right><right><C-u>',
+    end: ['{', 'foo: |', '}'],
+  });
+
+  newTest({
+    title: '<C-u> follows default behavior after moving to the left',
+    start: ['{', 'foo: |bar', '}'],
+    keysPressed: 'i<left><C-u>',
+    end: ['{', '| bar', '}'],
+  });
+
   test('Correctly places the cursor after deleting the previous line break', async () => {
     await modeHandler.handleMultipleKeyEvents([
       'i',


### PR DESCRIPTION
NOTE: I also discovered #4913 while debugging this issue. The bug was pre-existing but seems pretty important to fix (undo bugs seem really potentially catastrophic).
<!--
Yay! Thanks for sending us a PR! 🎊

Please ensure your PR adheres to:

- [ ] Commit messages has a short & issue references when necessary
- [ ] Each commit does a logical chunk of work.
- [ ] It builds and tests pass (e.g `gulp`)
-->

**What this PR does / why we need it**:
Gets us closer to functionality parity with Vim's Ctrl+U, which has a separate stop point if you are to the right of the original column in insert mode.

**Which issue(s) this PR fixes**
Fixes #4875 
<!--
Commits in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)
-->
