### PR TITLE
Fix docker tests

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -213,7 +213,7 @@ gulp.task('run-test', function (done) {
   console.log('Building container...');
   var dockerBuildCmd = spawn(
     'docker',
-    ['build', '-f', './build/Dockerfile', '.', '-t', dockerTag],
+    ['build', '-f', './build/Dockerfile', './build/', '-t', dockerTag],
     {
       cwd: process.cwd(),
       stdio: 'inherit',
@@ -232,6 +232,7 @@ gulp.task('run-test', function (done) {
     const dockerRunArgs = [
       'run',
       '-it',
+      '--rm',
       '--env',
       `MOCHA_GREP=${options.grep}`,
       '-v',

--- a/test/index.ts
+++ b/test/index.ts
@@ -30,7 +30,7 @@ export function run(): Promise<void> {
     grep: mochaGrep,
   });
 
-  const testsRoot = path.resolve(__dirname, '..');
+  const testsRoot = path.resolve(__dirname, '.');
 
   return new Promise((c, e) => {
     glob('**/**.test.js', { cwd: testsRoot }, (err, files) => {

--- a/test/runTest.ts
+++ b/test/runTest.ts
@@ -6,7 +6,7 @@ async function main() {
   try {
     // The folder containing the Extension Manifest package.json
     // Passed to `--extensionDevelopmentPath`
-    const extensionDevelopmentPath = path.resolve(__dirname, '../../../');
+    const extensionDevelopmentPath = path.resolve(__dirname, '../../');
 
     // The path to the extension test runner script
     // Passed to --extensionTestsPath


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently when you run `npx gulp` to build and run the tests it creates a Docker image from Dockerfile but it uses the extension root path as the context to build the image even though it is not needed. This means that every time we run the tests we are sending over 400MB to the daemon just to build the image and we don't even use anything from that context.

I changed the context to the `./build/` folder that contains the Dockerfile.

Then we create a container from that image but we don't give it the `--rm` flag which means after a while we have docker full of stopped vscodevim containers. I have added that flag to remove the container when done with the tests.

Also the `runTests.ts` file had the wrong path to 'extensionDevelopmentPath' because the file is in `/app/src/test/` and is built to folder `/app/out/test/` but we were resolving the path with `../../../` which meant we were setting the extensionDevelopmentPath to `/` (root). I changed it to `../../` so that it resolves to `/app` as it should.

The file `index.ts` was setting the 'testsRoot' to `/out/` because the file is inside `/out/test/` and we were resolving the path with `..`. I changed it to just `.` so that the 'testsRoot' folder is set to `/out/test/`. This wasn't a problem because the only `**/**.test.js` files on `/out/` were the ones inside `/out/test/` but there is no need to be looking files in the wrong folder.
