### PR TITLE
Fixed the workaround on line 713 so that it actually works

### DIFF
--- a/README.md
+++ b/README.md
@@ -710,7 +710,7 @@ VS Code has a lot of nifty tricks and we try to preserve some of them:
 
 - I've swapped Escape and Caps Lock with setxkbmap and VSCodeVim isn't respecting the swap
 
-  This is a [known issue in VS Code](https://github.com/microsoft/vscode/issues/23991), as a workaround you can set `"keyboard.dispatch": "keycode"` and restart VS Code.
+  This is a [known issue in VS Code](https://github.com/microsoft/vscode/issues/23991), as a workaround you can set `"keyboard.dispatch": "keyCode"` and restart VS Code.
 
 ## ❤️ Contributing
 


### PR DESCRIPTION
The workaround for linux key changes & vsCode, which is displayed on line 713 ( "keyboard.dispatch": "keyCode"  ) had 'keycode' but it should be 'keyCode'. Using 'keycode' does not resolve the issue. The link 'known issue in VS Code' has the solution in it, and they also use keyCode. I've tested that keyCode resolves the issue still.

<!--
Yay! Thanks for sending us a PR! 🎊

Please ensure your PR adheres to:

- [ ] Commit messages has a short & issue references when necessary
- [ ] Each commit does a logical chunk of work.
- [ ] It builds and tests pass (e.g `gulp`)
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**

<!--
Commits in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)
-->

**Special notes for your reviewer**:
