### PR TITLE
Add `init.vim` support for vimrc

### DIFF
--- a/package.json
+++ b/package.json
@@ -787,7 +787,7 @@
         },
         "vim.vimrc.path": {
           "type": "string",
-          "description": "Path to a Vim configuration file. If unset, it will check for $HOME/.vimrc, $HOME/_vimrc, or $HOME/config/nvim/init.vim, in that order."
+          "description": "Path to a Vim configuration file. If unset, it will check for $HOME/.vimrc, $HOME/_vimrc, or $HOME/.config/nvim/init.vim, in that order."
         },
         "vim.substituteGlobalFlag": {
           "type": "boolean",

--- a/package.json
+++ b/package.json
@@ -787,7 +787,7 @@
         },
         "vim.vimrc.path": {
           "type": "string",
-          "description": "Path to a Vim configuration file. If unset, it will check for $HOME/.vimrc or $HOME/_vimrc."
+          "description": "Path to a Vim configuration file. If unset, it will check for $HOME/.vimrc, $HOME/_vimrc, or $HOME/config/nvim/init.vim, in that order."
         },
         "vim.substituteGlobalFlag": {
           "type": "boolean",

--- a/package.json
+++ b/package.json
@@ -787,7 +787,7 @@
         },
         "vim.vimrc.path": {
           "type": "string",
-          "description": "Path to a Vim configuration file. If unset, it will check for $HOME/.vimrc, $HOME/_vimrc, or $HOME/.config/nvim/init.vim, in that order."
+          "description": "Path to a Vim configuration file. If unset, it will check for $HOME/.vimrc, $HOME/_vimrc, and $HOME/.config/nvim/init.vim, in that order."
         },
         "vim.substituteGlobalFlag": {
           "type": "boolean",

--- a/src/configuration/vimrc.ts
+++ b/src/configuration/vimrc.ts
@@ -130,6 +130,11 @@ class VimrcImpl {
       return vimrcPath;
     }
 
+    vimrcPath = path.join(os.homedir(), '.config/', 'nvim/', 'init.vim');
+    if (fs.existsSync(vimrcPath)) {
+      return vimrcPath;
+    }
+
     return undefined;
   }
 


### PR DESCRIPTION
<!--
Yay! Thanks for sending us a PR! 🎊

Please ensure your PR adheres to:

- [ x] Commit messages has a short & issue references when necessary
- [x ] Each commit does a logical chunk of work.
- [x ] It builds and tests pass (e.g `gulp`)
-->

**What this PR does / why we need it**:
This PR adds support for `init.vim` for automatic detection in `vim.vimrc.enable`.  We need this because as neovim becomes more and more popular, more people will be using `init.vim` files instead of `.vimrc` files.  Now, many people use both, and tell their `init.vim` to source `.vimrc`.  I put the `init.vim` as the lowest priority; favoring `.vimrc` before `init.vim`.



**Which issue(s) this PR fixes**
I was thinking of making an issue for this this morning, when I figured I could probably do it myself.  Should I make an issue too?

<!--
Commits in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)
-->

**Special notes for your reviewer**:
I put the `init.vim` as the lowest priority; favoring `.vimrc` before `init.vim`.  I looked through [vimrc.test](https://github.com/VSCodeVim/Vim/blob/master/test/configuration/vimrc.test.ts) and didn't see any tests that needed to be modified.