### PR TITLE
Fix macros not handling registers correctly

### DIFF
--- a/src/mode/modeHandler.ts
+++ b/src/mode/modeHandler.ts
@@ -978,6 +978,10 @@ export class ModeHandler implements vscode.Disposable {
           let recordedMacro = (await Register.getByKey(transformation.register))
             .text as RecordedState;
 
+          if (!(recordedMacro instanceof RecordedState)) {
+            return vimState;
+          }
+
           vimState.isReplayingMacro = true;
 
           if (transformation.register === ':') {

--- a/test/macro.test.ts
+++ b/test/macro.test.ts
@@ -53,6 +53,34 @@ suite('Record and execute a macro', () => {
   });
 
   newTest({
+    title: 'Append command to a not yet created register creates a new register',
+    start: ['1. |one', '2. two', '3. three', '4. four'],
+    keysPressed: 'qB0f.r)w~jq3@b',
+    end: ['1) One', '2) Two', '3) Three', '4) F|our'],
+  });
+
+  newTest({
+    title: 'Can handle calling an uppercase register',
+    start: ['1. |one', '2. two', '3. three', '4. four'],
+    keysPressed: 'qa0f.r)w~jq3@A',
+    end: ['1) One', '2) Two', '3) Three', '4) F|our'],
+  });
+
+  newTest({
+    title: 'Can handle calling a non existing macro',
+    start: ['1. |one', '2. two', '3. three', '4. four'],
+    keysPressed: '@x',
+    end: ['1. |one', '2. two', '3. three', '4. four'],
+  });
+
+  newTest({
+    title: 'Can handle calling a non existing macro with uppercase letter',
+    start: ['1. |one', '2. two', '3. three', '4. four'],
+    keysPressed: '@Z',
+    end: ['1. |one', '2. two', '3. three', '4. four'],
+  });
+
+  newTest({
     title: 'Can record Ctrl Keys and repeat',
     start: ['1|.'],
     keysPressed: 'qayyp<C-a>q4@a',


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix macros not handling registers correctly:
- Recording a macro with an uppercase letter whose register doesn't
exist yet, now creates that corresponding register
- After finishing recording a macro by pressing 'q' no longer throws an
error with 'concat'
- Calling a macro that doesn't exist no longer throws error. It just
returns the same vimState.
- Add tests for these cases

**Which issue(s) this PR fixes**
fixes #4948
