### PR TITLE
Fix surround alias using shortcut version with space instead of the ones without

### DIFF
--- a/src/actions/plugins/surround.ts
+++ b/src/actions/plugins/surround.ts
@@ -294,13 +294,16 @@ export class CommandSurroundAddToReplacement extends BaseCommand {
     // Convert a few shortcuts to the correct surround characters when NOT entering a tag
     if (vimState.surround.replacement.length === 0) {
       if (stringToAdd === 'b') {
-        stringToAdd = '(';
+        stringToAdd = ')';
       }
       if (stringToAdd === 'B') {
-        stringToAdd = '{';
+        stringToAdd = '}';
       }
       if (stringToAdd === 'r') {
-        stringToAdd = '[';
+        stringToAdd = ']';
+      }
+      if (stringToAdd === 'a') {
+        stringToAdd = '>';
       }
     }
 

--- a/test/plugins/surround.test.ts
+++ b/test/plugins/surround.test.ts
@@ -115,6 +115,34 @@ suite('surround plugin', () => {
   });
 
   newTest({
+    title: "'ysiwb' surrounds word with alias without space",
+    start: ['first li|ne test'],
+    keysPressed: 'ysiwb',
+    end: ['first |(line) test'],
+  });
+
+  newTest({
+    title: "'ysiwB' surrounds word with alias without space",
+    start: ['first li|ne test'],
+    keysPressed: 'ysiwB',
+    end: ['first |{line} test'],
+  });
+
+  newTest({
+    title: "'ysiwr' surrounds word with alias without space",
+    start: ['first li|ne test'],
+    keysPressed: 'ysiwr',
+    end: ['first |[line] test'],
+  });
+
+  newTest({
+    title: "'ysiwa' surrounds word with alias without space",
+    start: ['first li|ne test'],
+    keysPressed: 'ysiwa',
+    end: ['first |<line> test'],
+  });
+
+  newTest({
     title: 'change surround to tags',
     start: ['first [li|ne] test'],
     keysPressed: 'cs]tabc>',
@@ -241,6 +269,51 @@ suite('surround plugin', () => {
     end: ['foo b|ar'],
   });
 
-  // TODO: visual mode tests
-  // TODO: visual line mode tests
+  // Visual mode tests
+
+  newTest({
+    title: "'S)' surrounds visual selection without space",
+    start: ['first li|ne test'],
+    keysPressed: 'viwS)',
+    end: ['first (lin|e) test'],
+  });
+
+  newTest({
+    title: "'S(' surrounds visual selection with space",
+    start: ['first li|ne test'],
+    keysPressed: 'viwS(',
+    end: ['first ( lin|e ) test'],
+  });
+
+  newTest({
+    title: "'S<div>' surrounds selection with <div></div>",
+    start: ['first li|ne test'],
+    // I've added the '0' key press at the end because the test was behaving weirdly, if I ran
+    // the extension and did this test manually the cursor would end up on the first '<'. But
+    // when running the tests this test was failing saying the cursor was actually on the
+    // second '<' (character 15) instead of the first (character 6) as expected.
+    keysPressed: 'viwS<div>0',
+    end: ['|first <div>line</div> test'],
+  });
+
+  newTest({
+    title: "'S)' surrounds visual line selection without space",
+    start: ['first', 'sec|ond', 'third'],
+    keysPressed: 'VS)',
+    end: ['first', '(', 'second', '|)', 'third'],
+  });
+
+  newTest({
+    title: "'S(' surrounds visual line selection with space",
+    start: ['first', 'sec|ond', 'third'],
+    keysPressed: 'VS(',
+    end: ['first', '( ', 'second', '| )', 'third'],
+  });
+
+  newTest({
+    title: "'S<div>' surrounds visual line selection with <div></div>",
+    start: ['first', 'sec|ond', 'third'],
+    keysPressed: 'VS<div>',
+    end: ['first', '<div>', 'second', '|</div>', 'third'],
+  });
 });


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix surround alias using wrong shortcut version
- Shortcut alias were using the version with space but they are supposed
to use the version without space
fixes #4965
- Add 'a' shortcut alias to '>'
- Add tests for alias
- Add some tests for visual and visual line mode (they are not extensive
but should be enough for now) but they are currently being skipped
because of issue #4973

**Which issue(s) this PR fixes**
fixes #4965

**Special notes for your reviewer**:
I've added the alias 'a' to '\>'. I've also added some visual mode tests, they're not very extensive but should be enough for now just to have something. However, those visual tests are currently being skipped because of issue #4973