### PR TITLE
Implement count for CommandDot

### DIFF
--- a/src/actions/commands/actions.ts
+++ b/src/actions/commands/actions.ts
@@ -1901,10 +1901,14 @@ class CommandDot extends BaseCommand {
   modes = [Mode.Normal];
   keys = ['.'];
 
-  public async exec(position: Position, vimState: VimState): Promise<VimState> {
-    vimState.recordedState.transformations.push({
-      type: 'dot',
-    });
+  public async execCount(position: Position, vimState: VimState): Promise<VimState> {
+    let count = vimState.recordedState.count || 1;
+
+    for (let i = 0; i < count; i++) {
+      vimState.recordedState.transformations.push({
+        type: 'dot',
+      });
+    }
 
     return vimState;
   }

--- a/src/actions/commands/actions.ts
+++ b/src/actions/commands/actions.ts
@@ -1908,6 +1908,18 @@ class CommandDot extends BaseCommand {
 
     return vimState;
   }
+
+  public async execCount(position: Position, vimState: VimState): Promise<VimState> {
+    let count = vimState.recordedState.count || 1;
+
+    for (let i = 0; i < count; i++) {
+      vimState.recordedState.transformations.push({
+        type: 'dot',
+      });
+    }
+
+    return vimState;
+  }
 }
 
 @RegisterAction

--- a/src/actions/commands/actions.ts
+++ b/src/actions/commands/actions.ts
@@ -1908,18 +1908,6 @@ class CommandDot extends BaseCommand {
 
     return vimState;
   }
-
-  public async execCount(position: Position, vimState: VimState): Promise<VimState> {
-    let count = vimState.recordedState.count || 1;
-
-    for (let i = 0; i < count; i++) {
-      vimState.recordedState.transformations.push({
-        type: 'dot',
-      });
-    }
-
-    return vimState;
-  }
 }
 
 @RegisterAction

--- a/test/mode/modeInsert.test.ts
+++ b/test/mode/modeInsert.test.ts
@@ -248,6 +248,14 @@ suite('Mode Insert', () => {
   });
 
   newTest({
+    title: 'Repeat insert by count times with dot',
+    start: ['give me an a|:'],
+    keysPressed: 'aa<Esc>4.',
+    end: ['give me an a:aaaa|a'],
+    endMode: Mode.Normal,
+  });
+
+  newTest({
     title: 'Can <Esc> after entering insert mode from <ctrl+o>',
     start: ['|'],
     keysPressed: 'i<C-o>i<Esc>',

--- a/test/mode/modeNormal.test.ts
+++ b/test/mode/modeNormal.test.ts
@@ -1903,6 +1903,20 @@ suite('Mode Normal', () => {
   });
 
   newTest({
+    title: 'Can repeat dw',
+    start: ['one |two three four'],
+    keysPressed: 'dw.',
+    end: ['one |four'],
+  });
+
+  newTest({
+    title: 'Can repeat dw with count',
+    start: ['one |two three four five'],
+    keysPressed: 'dw2.',
+    end: ['one |five'],
+  });
+
+  newTest({
     title: 'can delete linewise with d2G',
     start: ['|one', 'two', 'three'],
     keysPressed: 'd2G',


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR implements a count for repeat by "."

**Which issue(s) this PR fixes**
Fixes #2192

**Special notes for your reviewer**:
Here is one more simple change.
This replaces the "exec" method by an "execCount" method. I assume that is the correct thing to do.
But I do not know the codebase or  TS well enough to really know that.

It passes tests (although I found only one other test in normal mode with repeat) and it "behaves" correctly when I run the build.

First build failed on one new test, as expected:
https://travis-ci.org/github/VSCodeVim/Vim/jobs/708243710
