### PR TITLE
Fix bug on issue #5029

### DIFF
--- a/package.json
+++ b/package.json
@@ -113,12 +113,12 @@
       {
         "key": "up",
         "command": "extension.vim_up",
-        "when": "editorTextFocus && vim.active && !inDebugRepl && !suggestWidgetVisible && !suggestWidgetMultipleSuggestions && !parameterHintsMultipleSignatures"
+        "when": "editorTextFocus && vim.active && !inDebugRepl && !suggestWidgetVisible && !parameterHintsVisible"
       },
       {
         "key": "down",
         "command": "extension.vim_down",
-        "when": "editorTextFocus && vim.active && !inDebugRepl && !suggestWidgetVisible && !suggestWidgetMultipleSuggestions && !parameterHintsMultipleSignatures"
+        "when": "editorTextFocus && vim.active && !inDebugRepl && !suggestWidgetVisible && !parameterHintsVisible"
       },
       {
         "key": "g g",


### PR DESCRIPTION
**What this PR does / why we need it**:
Change the up/down arrow keys to check only if the 'parameterHints' or 'suggestWidget' are visible because the `parameterHintsMultipleSignatures` and the `suggestWidgetMultipleSuggestions` stay true even when the widgets aren't visible.

**Which issue(s) this PR fixes**
fixes #5029 
