### PR TITLE
Fix visual mode not preserving desiredColumn

### DIFF
--- a/src/mode/modeHandler.ts
+++ b/src/mode/modeHandler.ts
@@ -477,6 +477,10 @@ export class ModeHandler implements vscode.Disposable {
     }
     */
 
+    // We handle the end of selections different to VSCode. In order for VSCode to select
+    // including the last character we will at the end of 'runAction' shift our stop position
+    // to the right. So here we shift it back by one so that our actions have our correct
+    // position instead of the position sent to VSCode.
     if (vimState.currentMode === Mode.Visual) {
       vimState.cursors = vimState.cursors.map((c) =>
         c.start.isBefore(c.stop) ? c.withNewStop(c.stop.getLeftThroughLineBreaks(true)) : c
@@ -543,16 +547,6 @@ export class ModeHandler implements vscode.Disposable {
       }
     }
 
-    if (vimState.currentMode === Mode.Visual) {
-      vimState.cursors = vimState.cursors.map((c) =>
-        c.start.isBefore(c.stop)
-          ? c.withNewStop(
-              c.stop.isLineEnd() ? c.stop.getRightThroughLineBreaks() : c.stop.getRight()
-            )
-          : c
-      );
-    }
-
     // And then we have to do it again because an operator could
     // have changed it as well. (TODO: do you even decomposition bro)
     if (vimState.currentMode !== this.currentMode) {
@@ -596,6 +590,20 @@ export class ModeHandler implements vscode.Disposable {
         // TODO: explain why not VisualBlock
         vimState.desiredColumn = vimState.cursorStopPosition.character;
       }
+    }
+
+    // Like previously stated we handle the end of selections different to VSCode. In order
+    // for VSCode to select including the last character we shift our stop position to the
+    // right now that all steps that need that position have already run. On the next action
+    // we will shift it back again on the start of 'runAction'.
+    if (vimState.currentMode === Mode.Visual) {
+      vimState.cursors = vimState.cursors.map((c) =>
+        c.start.isBefore(c.stop)
+          ? c.withNewStop(
+              c.stop.isLineEnd() ? c.stop.getRightThroughLineBreaks() : c.stop.getRight()
+            )
+          : c
+      );
     }
 
     if (ranAction) {

--- a/test/mode/modeVisual.test.ts
+++ b/test/mode/modeVisual.test.ts
@@ -1490,8 +1490,8 @@ suite('Mode Visual', () => {
   newTest({
     title: 'Preserves desired column correctly when moving in visual mode',
     start: ['|one', '', 'two', 'three'],
-    keysPressed: 'vljj<Esc>',
-    end: ['one', '', 't|wo', 'three'],
+    keysPressed: 'vjj<Esc>',
+    end: ['one', '', '|two', 'three'],
     endMode: Mode.Normal,
   });
 

--- a/test/mode/modeVisual.test.ts
+++ b/test/mode/modeVisual.test.ts
@@ -1487,6 +1487,22 @@ suite('Mode Visual', () => {
     endMode: Mode.Normal,
   });
 
+  newTest({
+    title: 'Preserves desired column correctly when moving in visual mode',
+    start: ['|one', '', 'two', 'three'],
+    keysPressed: 'vljj<Esc>',
+    end: ['one', '', 't|wo', 'three'],
+    endMode: Mode.Normal,
+  });
+
+  newTest({
+    title: 'Updates desired column correctly when moving in visual mode',
+    start: ['|one', 'two', 'three'],
+    keysPressed: 'vlj<Esc>',
+    end: ['one', 't|wo', 'three'],
+    endMode: Mode.Normal,
+  });
+
   suite('C, R, and S', () => {
     for (const command of ['C', 'R', 'S']) {
       newTest({


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix visual mode not preserving desiredColumn
- When moving horizontally on visual mode the desiredColumn wasn't being kept correctly, because we were updating the desiredColumn after correcting our cursors by shifting the stop to the right so that vscode included our stop on its selection.
- Add test for this.

**Which issue(s) this PR fixes**
fixes #5048 

**Special notes for your reviewer**:
Why are we changing our cursors just to make vscode selection include the last character? Couldn't we just set the editor selections with the adjusted positions on 'updateView' without changing our cursors?
Also we are doing this adjust on 'runAction' when the start is before stop but then on 'updateView' we also make another adjust when start is after stop (changing our cursors once more).