### PR TITLE
Fix some commands not ignoring whitespace properly

### DIFF
--- a/src/cmd_line/subparsers/deleteRange.ts
+++ b/src/cmd_line/subparsers/deleteRange.ts
@@ -2,7 +2,7 @@ import * as node from '../commands/deleteRange';
 import { Scanner } from '../scanner';
 
 export function parseDeleteRangeLinesCommandArgs(args: string): node.DeleteRangeCommand {
-  if (!args) {
+  if (!args || !args.trim()) {
     return new node.DeleteRangeCommand({});
   }
 

--- a/src/cmd_line/subparsers/digraph.ts
+++ b/src/cmd_line/subparsers/digraph.ts
@@ -2,7 +2,7 @@ import * as node from '../commands/digraph';
 import { Scanner } from '../scanner';
 
 export function parseDigraphCommandArgs(args: string): node.DigraphsCommand {
-  if (!args) {
+  if (!args || !args.trim()) {
     return new node.DigraphsCommand({});
   }
 

--- a/src/cmd_line/subparsers/file.ts
+++ b/src/cmd_line/subparsers/file.ts
@@ -2,7 +2,7 @@ import * as node from '../commands/file';
 import { Scanner } from '../scanner';
 
 export function parseEditFileCommandArgs(args: string): node.FileCommand {
-  if (!args) {
+  if (!args || !args.trim()) {
     return new node.FileCommand({ name: '', createFileIfNotExists: true });
   }
 

--- a/src/cmd_line/subparsers/marks.ts
+++ b/src/cmd_line/subparsers/marks.ts
@@ -1,7 +1,7 @@
 import { MarksCommand } from '../commands/marks';
 
 export function parseMarksCommandArgs(args: string): MarksCommand {
-  if (!args) {
+  if (!args || !args.trim()) {
     return new MarksCommand();
   }
   return new MarksCommand(args.split(''));

--- a/src/cmd_line/subparsers/read.ts
+++ b/src/cmd_line/subparsers/read.ts
@@ -2,7 +2,7 @@ import { IReadCommandArguments, ReadCommand } from '../commands/read';
 import { Scanner } from '../scanner';
 
 export function parseReadCommandArgs(args: string): ReadCommand {
-  if (!args) {
+  if (!args || !args.trim()) {
     throw Error('Expected arguments.');
   }
 

--- a/src/cmd_line/subparsers/sort.ts
+++ b/src/cmd_line/subparsers/sort.ts
@@ -2,7 +2,7 @@ import * as node from '../commands/sort';
 import { Scanner } from '../scanner';
 
 export function parseSortCommandArgs(args: string): node.SortCommand {
-  if (!args) {
+  if (!args || !args.trim()) {
     return new node.SortCommand({ reverse: false, ignoreCase: false, unique: false });
   }
 

--- a/src/cmd_line/subparsers/substitute.ts
+++ b/src/cmd_line/subparsers/substitute.ts
@@ -134,7 +134,7 @@ export function parseSubstituteCommandArgs(args: string): node.SubstituteCommand
     let flags: number;
     let count: number;
 
-    if (!args) {
+    if (!args || !args.trim()) {
       // special case for :s
       return new node.SubstituteCommand({
         pattern: undefined,


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix some commands not ignoring whitespace properly
- Some commands have a different behavior when called without arguments
and weren't considering the cases when called with only whitespace as no
arguments

**Special notes for your reviewer**:
For example, the `:marks` command when called without arguments list all the marks. But if you called it with trailing whitespace like this `:marks         ` it would try to find the mark ' ' (\<space\>) and return "No marks set" when it should've listed all the marks.