### PR TITLE
Improve digraph support.

### DIFF
--- a/src/actions/commands/actions.ts
+++ b/src/actions/commands/actions.ts
@@ -34,6 +34,8 @@ import { globalState } from '../../state/globalState';
 import { VimError, ErrorCode } from '../../error';
 import { SpecialKeys } from '../../util/specialKeys';
 import _ = require('lodash');
+import { digraphsForChar } from './digraphs';
+import { EasyMotionCharMoveCommandBase } from '../plugins/easymotion/easymotion.cmd';
 
 export class DocumentContentChangeAction extends BaseAction {
   private contentChanges: vscode.TextDocumentContentChangeEvent[] = [];
@@ -3353,12 +3355,17 @@ class CommandUnicodeName extends BaseCommand {
 
   public async exec(position: Position, vimState: VimState): Promise<void> {
     const char = vimState.editor.document.getText(new vscode.Range(position, position.getRight()));
-    const charCode = char.charCodeAt(0);
+
     // TODO: Handle charCode > 127 by also including <M-x>
-    StatusBar.setText(
-      vimState,
-      `<${char}>  ${charCode},  Hex ${charCode.toString(16)},  Octal ${charCode.toString(8)}`
-    );
+    const charCode = char.charCodeAt(0);
+    const hex = charCode.toString(16);
+    const octal = charCode.toString(8);
+    const charCodesDisplay = `<${char}>  ${charCode},  Hex ${hex},  Octal ${octal}`;
+
+    const digraphs = digraphsForChar(char);
+    const digraphDisplay = digraphs.length > 0 ? `, Digraphs ['${digraphs.join(`', '`)}']` : '';
+
+    StatusBar.setText(vimState, `${charCodesDisplay}${digraphDisplay}`);
   }
 }
 

--- a/src/actions/commands/commandLine.ts
+++ b/src/actions/commands/commandLine.ts
@@ -18,6 +18,7 @@ import { Position } from '../../common/motion/position';
 import { VimError, ErrorCode } from '../../error';
 import { SearchDirection } from '../../state/searchState';
 import { scrollView } from '../../util/util';
+import { parseDigraph, isPartialDigraph } from './digraphs';
 
 /**
  * Commands that are only relevant when entering a command or search
@@ -482,6 +483,61 @@ class CommandEscInSearchMode extends BaseCommand {
     if (searchState.searchString.length > 0) {
       globalState.addSearchStateToHistory(searchState);
     }
+  }
+}
+
+@RegisterAction
+class CommandInsertDigraphInCommandline extends BaseCommand {
+  modes = [Mode.CommandlineInProgress];
+  keys = ['<C-k>', '<any>', '<any>'];
+  isCompleteAction = false;
+
+  public async exec(position: Position, vimState: VimState): Promise<void> {
+    const char = parseDigraph(this.keysPressed.slice(1, 3)) || '';
+    vimState.currentCommandlineText += char;
+    vimState.statusBarCursorCharacterPos += char.length;
+  }
+
+  public doesActionApply(vimState: VimState, keysPressed: string[]): boolean {
+    if (!super.doesActionApply(vimState, keysPressed)) {
+      return false;
+    }
+    return !!parseDigraph(keysPressed.slice(1, 3));
+  }
+
+  public couldActionApply(vimState: VimState, keysPressed: string[]): boolean {
+    if (!super.couldActionApply(vimState, keysPressed)) {
+      return false;
+    }
+    return isPartialDigraph(keysPressed.slice(1, 3));
+  }
+}
+
+@RegisterAction
+class CommandInsertDigraphInSearchMode extends BaseCommand {
+  modes = [Mode.SearchInProgressMode];
+  keys = ['<C-k>', '<any>', '<any>'];
+  isCompleteAction = false;
+
+  public async exec(position: Position, vimState: VimState): Promise<void> {
+    const char = parseDigraph(this.keysPressed.slice(1, 3)) || '';
+    const searchState = globalState.searchState!;
+    searchState.searchString += char;
+    vimState.statusBarCursorCharacterPos += char.length;
+  }
+
+  public doesActionApply(vimState: VimState, keysPressed: string[]): boolean {
+    if (!super.doesActionApply(vimState, keysPressed)) {
+      return false;
+    }
+    return !!parseDigraph(keysPressed.slice(1, 3));
+  }
+
+  public couldActionApply(vimState: VimState, keysPressed: string[]): boolean {
+    if (!super.couldActionApply(vimState, keysPressed)) {
+      return false;
+    }
+    return isPartialDigraph(keysPressed.slice(1, 3));
   }
 }
 

--- a/test/mode/modeInsert.test.ts
+++ b/test/mode/modeInsert.test.ts
@@ -380,6 +380,30 @@ suite('Mode Insert', () => {
     assertEqualLines(['🚀🚀']);
   });
 
+  test('Can handle custom digraph insert with priority', async () => {
+    Globals.mockConfiguration.digraphs = {
+      'a*': ['a', 97],
+      '*b': ['b', 98],
+    };
+    await reloadConfiguration();
+    await modeHandler.handleMultipleKeyEvents([
+      'i',
+      '<C-k>',
+      'a',
+      '*',
+      '<C-k>',
+      '*',
+      'a',
+      '<C-k>',
+      'b',
+      '*',
+      '<C-k>',
+      '*',
+      'b',
+    ]);
+    assertEqualLines(['aaβb']);
+  });
+
   newTest({
     title: 'Can insert last inserted text',
     start: ['test|'],


### PR DESCRIPTION

<!--
Yay! Thanks for sending us a PR! 🎊

Please ensure your PR adheres to:

- [ ] Commit messages has a short & issue references when necessary
- [ ] Each commit does a logical chunk of work.
- [ ] It builds and tests pass (e.g `gulp`)
-->

**What this PR does / why we need it**:
The most important change in this PR is to support digraphs in commandline and search, which vim 8.2 supports. To make digraphs more user-friendly, also report them in the 'ga' action (character code reporting) like vim. Finally, as a side-effect match digraphs in what seems to me a more intuitive order where user config always overrides defaults, and reverse digraphs are only used as a last resort.

**Which issue(s) this PR fixes**
No issue opened.

**Special notes for your reviewer**:
I have literally never written Javascript/Typescript before, let alone changed a Code extension.

Full disclosure, I also think it would be better to precompute user shadowing of defaults and (less importantly) reverse digraphs, but (a) it's not clear if it's possible to generally react to config changes; (b) it makes the big picture of digraph support harder to understand, even though it would entirely eliminate the growing complexity of individual functions. So for a first PR I avoided this.