### PR TITLE
Fixed neovim newlines for Windows, and related cursor position bug

### DIFF
--- a/src/neovim/neovim.ts
+++ b/src/neovim/neovim.ts
@@ -126,20 +126,20 @@ export class NeovimWrapper implements vscode.Disposable {
     );
     await this.nvim.callFunction('setpos', [
       '.',
-      [0, vimState.cursorStopPosition.line + 1, vimState.cursorStopPosition.character, false],
+      [0, vimState.cursorStopPosition.line + 1, vimState.cursorStopPosition.character + 1, false],
     ]);
     await this.nvim.callFunction('setpos', [
       "'<",
-      [0, rangeStart.line + 1, rangeEnd.character, false],
+      [0, rangeStart.line + 1, rangeStart.character + 1, false],
     ]);
     await this.nvim.callFunction('setpos', [
       "'>",
-      [0, rangeEnd.line + 1, rangeEnd.character, false],
+      [0, rangeEnd.line + 1, rangeEnd.character + 1, false],
     ]);
     for (const mark of vimState.historyTracker.getLocalMarks()) {
       await this.nvim.callFunction('setpos', [
         `'${mark.name}`,
-        [0, mark.position.line + 1, mark.position.character, false],
+        [0, mark.position.line + 1, mark.position.character + 1, false],
       ]);
     }
 
@@ -170,14 +170,11 @@ export class NeovimWrapper implements vscode.Disposable {
 
     this.logger.debug(`${lines.length} lines in nvim. ${lineCount} in editor.`);
 
-    let [row, character] = ((await this.nvim.callFunction('getpos', ['.'])) as Array<number>).slice(
-      1,
-      3
-    );
-    vimState.editor.selection = new vscode.Selection(
-      new Position(row - 1, character),
-      new Position(row - 1, character)
-    );
+    let [newCursorLine, newCursorCol] = ((await this.nvim.callFunction('getpos', ['.'])) as Array<
+      number
+    >).slice(1, 3);
+    vimState.cursorStartPosition = new Position(newCursorLine - 1, newCursorCol - 1);
+    vimState.cursorStopPosition = new Position(newCursorLine - 1, newCursorCol - 1);
 
     if (configuration.expandtab) {
       await vscode.commands.executeCommand('editor.action.indentationToSpaces');


### PR DESCRIPTION

Related to issue #1914 and PR #1939
PR #1939 removed dangling \r's after the text buffer was returned from neovim, but I think it makes more sense to remove them on the way out from VSCode. Now neovim works with line commands as expected.
Also after finishing a neovim ex command, the new cursor position was being read from neovim but it wasn't actually being set in VSCode. Maybe it was using a deprecated method for setting the cursor. Also the cursor would have been off because the code didn't account for the fact that lines and columns start at 1 in neovim.