### PR TITLE
Fix the behavior of `ga` with respect to digraph

### DIFF
--- a/src/actions/commands/actions.ts
+++ b/src/actions/commands/actions.ts
@@ -40,6 +40,7 @@ import { reportLinesChanged, reportFileInfo, reportSearch } from '../../util/sta
 import { globalState } from '../../state/globalState';
 import { VimError, ErrorCode } from '../../error';
 import _ = require('lodash');
+import { DefaultDigraphs } from './digraphs';
 
 export class DocumentContentChangeAction extends BaseAction {
   private contentChanges: vscode.TextDocumentContentChangeEvent[] = [];
@@ -4214,12 +4215,25 @@ class CommandUnicodeName extends BaseCommand {
   public async exec(position: Position, vimState: VimState): Promise<VimState> {
     const char = vimState.editor.document.getText(new vscode.Range(position, position.getRight()));
     const charCode = char.charCodeAt(0);
+    const digraphChars = this.findDigraphChars(char);
+    let text = `<${char}>  ${charCode},  Hex ${charCode.toString(16)},  Octal ${charCode.toString(
+      8
+    )}`;
+    if (digraphChars) {
+      text += `,  Digr ${digraphChars}`;
+    }
     // TODO: Handle charCode > 127 by also including <M-x>
-    StatusBar.setText(
-      vimState,
-      `<${char}>  ${charCode},  Hex ${charCode.toString(16)},  Octal ${charCode.toString(8)}`
-    );
+    StatusBar.setText(vimState, text);
     return vimState;
+  }
+
+  private findDigraphChars(c: string) {
+    for (const [k, v] of Object.entries(DefaultDigraphs)) {
+      if (v[0] === c) {
+        return k;
+      }
+    }
+    return undefined;
   }
 }
 

--- a/test/mode/modeNormal.test.ts
+++ b/test/mode/modeNormal.test.ts
@@ -5,7 +5,7 @@ import { ModeHandler } from '../../src/mode/modeHandler';
 import { TextEditor } from '../../src/textEditor';
 import { Configuration } from '../testConfiguration';
 import { getTestingFunctions } from '../testSimplifier';
-import { cleanUpWorkspace, setupWorkspace } from './../testUtils';
+import { cleanUpWorkspace, setupWorkspace, assertStatusBarEqual } from './../testUtils';
 
 suite('Mode Normal', () => {
   let modeHandler: ModeHandler;
@@ -3366,5 +3366,17 @@ suite('Mode Normal', () => {
       end: ['hello |world and mars'],
       endMode: Mode.Normal,
     });
+  });
+
+  test('Can handle ga', async () => {
+    await modeHandler.handleMultipleKeyEvents(['i', 'R', '<Esc>']);
+    await modeHandler.handleMultipleKeyEvents(['g', 'a']);
+    assertStatusBarEqual('<R>  82,  Hex 52,  Octal 122');
+  });
+
+  test('Can handle ga if the character can be inserted as a digraph', async () => {
+    await modeHandler.handleMultipleKeyEvents(['i', 'ö', '<Esc>']);
+    await modeHandler.handleMultipleKeyEvents(['g', 'a']);
+    assertStatusBarEqual('<ö>  246,  Hex f6,  Octal 366,  Digr o:');
   });
 });


### PR DESCRIPTION
<!--
Yay! Thanks for sending us a PR! 🎊

Please ensure your PR adheres to:

- [ ] Commit messages has a short & issue references when necessary
- [ ] Each commit does a logical chunk of work.
- [ ] It builds and tests pass (e.g `gulp`)
-->

**What this PR does / why we need it**:

As the following help document, `ga` print the ascii value of the character under the cursor.
And, if the character can be inserted as a digraph, should print the two characters that can be used to create.

But this is not implemented.

```
:as[cii]	or					*ga* *:as* *:ascii*
ga			Print the ascii value of the character under the
			cursor in decimal, hexadecimal and octal.
			Mnemonic: Get Ascii value.

			For example, when the cursor is on a 'R':
				<R>  82,  Hex 52,  Octal 122
			When the character is a non-standard ASCII character,
			but printable according to the 'isprint' option, the
			non-printable version is also given.
			
			When the character is larger than 127, the <M-x> form
			is also printed.  For example:
				<~A>  <M-^A>  129,  Hex 81,  Octal 201
				<p>  <|~>  <M-~>  254,  Hex fe,  Octal 376
			(where <p> is a special character)

			The <Nul> character in a file is stored internally as
			<NL>, but it will be shown as:
				<^@>  0,  Hex 00,  Octal 000

			If the character has composing characters these are
			also shown.  The value of 'maxcombine' doesn't matter.

			If the character can be inserted as a digraph, also
			output the two characters that can be used to create
			the character:
			    <ö> 246, Hex 00f6, Oct 366, Digr o:
			This shows you can type CTRL-K o : to insert ö.
```

And also, since there was no test for `ga`, I added it.

**Which issue(s) this PR fixes**

<!--
Commits in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)
-->

**Special notes for your reviewer**:

The format of the `Hex` is partly different from the help, but this seems to be another problem originally exists.