### PR TITLE
Added "Improve Existing Issues" notes

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -14,6 +14,11 @@ When creating a new bug report do:
 - Search against existing issues to check if somebody else has already reported your problem or requested your idea
 - Fill out the issue template.
 
+### Improve Existing Issues
+- Search for [duplicate issues](https://github.com/VSCodeVim/Vim/issues?q=is%3Aissue+is%3Aopen+cursor). See which thread(s) are more mature, and recommend the duplicate be closed, or just provide links to related issues.
+- Find [old issues](https://github.com/VSCodeVim/Vim/issues?page=25&q=is%3Aissue+is%3Aopen) and test them in the latest version of VSCodeVim. If the issue has been resolved, comment & recommend OP to close (or provide more information if not resolved).
+- Give thumbs up / thumbs down to existing issues, to indicate your support (or not)
+
 ## Submitting Pull Requests
 
 Pull requests are _awesome_.


### PR DESCRIPTION
For the "duplicate" link, I provided a sample search for "cursor" which returns 200+ issues. Many of which probably aren't duplicates, but I thought that might be a good starting point. MIght be better to link to a blank search for open issues.

For the "old" link, I gave page 25. Currently there are 34 pages, so I thought that would be sufficient insulation to still be "old" but not get shwooped off later

I saw a few folks claim that VSCodeVIM Team gives precedence to issues with more thumbs up, so I included that recommendation. I didn't want to say that so explicitly though, since I don't actually know.

**What this PR does / why we need it**: Some folks may want to contribute outside of code.

**Which issue(s) this PR fixes** I didn't create an issue for this, though https://github.com/VSCodeVim/Vim/issues/5116 is what gave me the idea to add this PR

**Special notes for your reviewer**: I didn't run any tests or anything, cause it's just an .md file.
