### PR TITLE
make getConfiguration use the document languageId (fixes #4503)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -279,9 +279,9 @@
       }
     },
     "@types/vscode": {
-      "version": "1.37.0",
-      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.37.0.tgz",
-      "integrity": "sha512-PRfeuqYuzk3vjf+puzxltIUWC+AhEGYpFX29/37w30DQSQnpf5AgMVf7GDBAdmTbWTBou+EMFz/Ne6XCM/KxzQ==",
+      "version": "1.42.0",
+      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.42.0.tgz",
+      "integrity": "sha512-ds6TceMsh77Fs0Mq0Vap6Y72JbGWB8Bay4DrnJlf5d9ui2RSe1wis13oQm+XhguOeH1HUfLGzaDAoupTUtgabw==",
       "dev": true
     },
     "@types/webpack": {
@@ -4900,9 +4900,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.19",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
-      "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ=="
+      "version": "4.17.20",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+      "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="
     },
     "lodash._reinterpolate": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "url": "https://github.com/VSCodeVim/Vim/issues"
   },
   "engines": {
-    "vscode": "^1.37.0"
+    "vscode": "^1.42.0"
   },
   "categories": [
     "Other",
@@ -1042,7 +1042,7 @@
   },
   "dependencies": {
     "diff-match-patch": "1.0.5",
-    "lodash": "^4.17.15",
+    "lodash": "^4.17.20",
     "neovim": "4.9.0",
     "untildify": "4.0.0",
     "winston": "3.3.3",
@@ -1057,7 +1057,7 @@
     "@types/mocha": "8.0.3",
     "@types/node": "12.12.31",
     "@types/sinon": "9.0.5",
-    "@types/vscode": "1.37.0",
+    "@types/vscode": "1.42.0",
     "clean-webpack-plugin": "3.0.0",
     "event-stream": "4.0.1",
     "gulp": "4.0.2",

--- a/src/configuration/configuration.ts
+++ b/src/configuration/configuration.ts
@@ -154,7 +154,9 @@ class Configuration implements IConfiguration {
 
   getConfiguration(section: string = ''): vscode.WorkspaceConfiguration {
     const activeTextEditor = vscode.window.activeTextEditor;
-    const resource = activeTextEditor ? activeTextEditor.document.uri : null;
+    const resource = activeTextEditor
+      ? { uri: activeTextEditor.document.uri, languageId: activeTextEditor.document.languageId }
+      : null;
     return vscode.workspace.getConfiguration(section, resource);
   }
 


### PR DESCRIPTION
Fixes #4503 by passing `languageId` in `getConfiguration`.  This required updating to `@types/vscode` 1.42, which appears to be the earliest version that supports this API.