### PR TITLE
ExecuteOperator doesn't need to change selections

### DIFF
--- a/src/mode/modeHandler.ts
+++ b/src/mode/modeHandler.ts
@@ -1035,9 +1035,6 @@ export class ModeHandler implements vscode.Disposable {
     } else {
       // Keep track of all cursors (in the case of multi-cursor).
       this.vimState.cursors = resultingCursors;
-      this.vimState.editor.selections = this.vimState.cursors.map(
-        (cursor: Range) => new vscode.Selection(cursor.start, cursor.stop)
-      );
     }
   }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Stops the 'executeOperator' function from changing the editor selections.
- These selections will be changed on 'updateView' using the logic to
ignore them if needed
- This was in some cases creating a selection change event after the end
of the action and after 'updateView' had already finished. This event
would then wrongfully update the cursors.

**Which issue(s) this PR fixes**
fixes #5257 

<!--
Commits in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)
-->

**Special notes for your reviewer**:
I think I had previously removed this already, but it might have leaked through again in some merge conflict without me noticing it.