### PR TITLE
Fix remaps when entering chinese input mode (composition state)

### DIFF
--- a/extensionBase.ts
+++ b/extensionBase.ts
@@ -378,21 +378,16 @@ export async function activate(
 
   overrideCommand(context, 'compositionStart', async () => {
     taskQueue.enqueueTask(async () => {
-      const mh = await getAndUpdateModeHandler();
-      if (mh.vimState.currentMode !== Mode.Insert) {
-        compositionState.isInComposition = true;
-      }
+      compositionState.isInComposition = true;
     });
   });
 
   overrideCommand(context, 'compositionEnd', async () => {
     taskQueue.enqueueTask(async () => {
       const mh = await getAndUpdateModeHandler();
-      if (mh.vimState.currentMode !== Mode.Insert) {
-        let text = compositionState.composingText;
-        compositionState.reset();
-        mh.handleMultipleKeyEvents(text.split(''));
-      }
+      let text = compositionState.composingText;
+      compositionState.reset();
+      mh.handleMultipleKeyEvents(text.split(''));
     });
   });
 


### PR DESCRIPTION
<!--
Yay! Thanks for sending us a PR! 🎊

Please ensure your PR adheres to:

- [ ] Commit messages has a short & issue references when necessary
- [ ] Each commit does a logical chunk of work.
- [ ] It builds and tests pass (e.g `gulp`)
-->

**What this PR does / why we need it**:
When entering composition state to enter Chinese characters we now don't send the characters to Vim even in insert mode, we only send them after composition end. This should also allow to use Chinese characters in remaps on insert mode.

**Which issue(s) this PR fixes**
fixes #4815 
fixes #5237 

<!--
Commits in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)
-->

**Special notes for your reviewer**:
