### PR TITLE
Fix remap bug with '<' and special keys remaps

### DIFF
--- a/src/configuration/remapper.ts
+++ b/src/configuration/remapper.ts
@@ -594,9 +594,15 @@ export class Remapper implements IRemapper {
     countRemapAsPotential: boolean = false
   ): boolean {
     const keysAsString = keys.join('');
+    const re = /^<([^>]+)>/;
     if (keysAsString !== '') {
       for (let remap of remappings.keys()) {
         if (remap.startsWith(keysAsString) && (remap !== keysAsString || countRemapAsPotential)) {
+          // Don't confuse a key combination starting with '<' that is not a special key like '<C-a>'
+          // with a remap that starts with a special key.
+          if (keysAsString.startsWith('<') && !re.test(keysAsString) && re.test(remap)) {
+            continue;
+          }
           return true;
         }
       }

--- a/src/mode/modeHandler.ts
+++ b/src/mode/modeHandler.ts
@@ -1630,11 +1630,10 @@ export class ModeHandler implements vscode.Disposable {
           virtualKey = '"';
         } else if (virtualKey === '<C-k>') {
           virtualKey = '?';
-        } else {
-          // Don't show keys with `<` like `<C-x>` but show everything else
-          virtualKey = virtualKey.indexOf('<') >= 0 ? undefined : virtualKey;
         }
       }
+      // Don't show keys with `<` like `<C-x>` but show everything else
+      virtualKey = virtualKey && /<[^>]+>/.test(virtualKey) ? undefined : virtualKey;
 
       if (virtualKey) {
         // Normal Render Options with the key to overlap on the next character

--- a/test/configuration/remaps.test.ts
+++ b/test/configuration/remaps.test.ts
@@ -1202,4 +1202,20 @@ suite('Remaps', () => {
       },
     ],
   });
+
+  newTestWithRemaps({
+    title: `Don't confuse a '<' keystroke with a potential special key like '<C-e>'`,
+    remaps: ['inoremap <C-e> <C-o>$'],
+    start: ['|test'],
+    steps: [
+      {
+        // Step 0:
+        keysPressed: 'i<',
+        stepResult: {
+          end: ['<|test'],
+          endMode: Mode.Insert,
+        },
+      },
+    ],
+  });
 });


### PR DESCRIPTION

<!--
Yay! Thanks for sending us a PR! 🎊

Please ensure your PR adheres to:

- [ ] Commit messages has a short & issue references when necessary
- [ ] Each commit does a logical chunk of work.
- [ ] It builds and tests pass (e.g `gulp`)
-->

**What this PR does / why we need it**:
Fix remap bug with '<' and special keys remaps
- Fix remaps confusing '<' as potential remap to special keys like '\<C-x\>'
- Add test for this situation
- Prevent showing special keys like '\<C-x\>' with virtual key decoration

**Which issue(s) this PR fixes**
I don't think anyone has reported this yet
<!--
Commits in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)
-->

**Special notes for your reviewer**:
