### PR TITLE
Fix gulpfile updatePath on windows

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -146,6 +146,7 @@ function updatePath() {
         path.dirname(filePath),
         path.resolve(process.cwd(), 'out/src/platform/node')
       );
+      platformRelativepath = platformRelativepath.replace(/\\/g, '/');
       f.contents = Buffer.from(
         contents.replace(
           /\(\"platform\/([^"]*)\"\)/g,


### PR DESCRIPTION


<!--
Yay! Thanks for sending us a PR! 🎊

Please ensure your PR adheres to:

- [ ] Commit messages has a short & issue references when necessary
- [ ] Each commit does a logical chunk of work.
- [ ] It builds and tests pass (e.g `gulp`)
-->

**What this PR does / why we need it**:
It always changed to backslash, resulting in paths like 'out\src\platform\node' where the '\n' of '\node' would be considered a new line.

**Which issue(s) this PR fixes**
Build wasn't working on windows.
<!--
Commits in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)
-->

**Special notes for your reviewer**:
I've made this as a quick fix. It is what I've been doing manually every time. If there is a better way to fix this feel free to change it. I just wanted to get this fix in master so that I don't have to continuously add and remove this fix every time I change branches.