### PR TITLE
Make ts a synonym of tabstop (#5368)

### DIFF
--- a/src/configuration/configuration.ts
+++ b/src/configuration/configuration.ts
@@ -279,6 +279,9 @@ class Configuration implements IConfiguration {
   @overlapSetting({ settingName: 'tabSize', defaultValue: 8 })
   tabstop: number;
 
+  @overlapSetting({ settingName: 'tabSize', defaultValue: 8 })
+  ts: number;
+
   @overlapSetting({ settingName: 'cursorStyle', defaultValue: 'line' })
   private editorCursorStyleRaw: string;
 


### PR DESCRIPTION

**What this PR does / why we need it**:

Makes the `ts` configuration item a synonym for the `tabstop` configuration item.

**Which issue(s) this PR fixes**
Fixes #5368 

**Special notes for your reviewer**:
First time contributor to VsCodeVim, long time user. This is such a great tool! Thank you for the work you do maintaining it!

I hope that I followed all the proper processes! 
