### PR TITLE
Stop user forced stop remap from throwing error

### DIFF
--- a/extensionBase.ts
+++ b/extensionBase.ts
@@ -441,6 +441,7 @@ export async function activate(
     registerCommand(context, boundKey.command, () => {
       if (['<Esc>', '<C-c>'].includes(boundKey.key)) {
         checkIfRecursiveRemapping(`${boundKey.key}`);
+        handleKeyEvent(`${boundKey.key}`);
       } else {
         handleKeyEvent(`${boundKey.key}`);
       }

--- a/src/configuration/remapper.ts
+++ b/src/configuration/remapper.ts
@@ -415,6 +415,7 @@ export class Remapper implements IRemapper {
             vimState.wasPerformingRemapThatFinishedWaitingForTimeout = { ...remapping };
           }
           vimState.isCurrentlyPerformingRecursiveRemapping = false;
+          vimState.forceStopRecursiveRemapping = false;
         }
 
         if (!hasParentRemapping) {

--- a/src/mode/modeHandler.ts
+++ b/src/mode/modeHandler.ts
@@ -363,8 +363,7 @@ export class ModeHandler implements vscode.Disposable {
 
     // Check forceStopRemapping
     if (this.vimState.forceStopRecursiveRemapping) {
-      this.vimState.forceStopRecursiveRemapping = false;
-      throw new ForceStopRemappingError('Forced by user');
+      return;
     }
 
     ModeHandler.logger.debug(`handling key=${printableKey}.`);

--- a/test/configuration/remaps.test.ts
+++ b/test/configuration/remaps.test.ts
@@ -1218,4 +1218,28 @@ suite('Remaps', () => {
       },
     ],
   });
+
+  newTestWithRemaps({
+    title:
+      'Forced stop recursive remaps that are not infinite remaps should stop without throwing error',
+    remaps: {
+      insertModeKeyBindings: [
+        {
+          before: ['i', 'i'],
+          commands: ['extension.vim_escape'],
+        },
+      ],
+    },
+    start: ['|test'],
+    steps: [
+      {
+        // Step 0:
+        keysPressed: 'aii<Esc>l',
+        stepResult: {
+          end: ['t|est'],
+          endMode: Mode.Normal,
+        },
+      },
+    ],
+  });
 });


### PR DESCRIPTION
<!--
Yay! Thanks for sending us a PR! 🎊

Please ensure your PR adheres to:

- [ ] Commit messages has a short & issue references when necessary
- [ ] Each commit does a logical chunk of work.
- [ ] It builds and tests pass (e.g `gulp`)
-->

**What this PR does / why we need it**:
Stop user forced stop remap from throwing error
- When the user force stops a recursive remapping it shouldn't throw an
error, it should just set the 'vimState.forceStopRecursiveRemapping'
which will then make all the remaining keys be ignored until the
recursive remap finishes.
- Add test for forced stop remaps on non infinite recursive remaps.


**Which issue(s) this PR fixes**
fixes #5419 
fixes #5347 
fixes #5219 

<!--
Commits in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)
-->

**Special notes for your reviewer**:
Some of the fixed issues are closed, but they were closed because the user changed remap to use `"after": ["<Esc>"]` instead of `"commands": ["extension.vim_escape"]` and the 'after' approach is still the preferred one, however the error shouldn't be thrown when using the command approach either, so this fix will allow for both approaches.