### PR TITLE
Implement normalization for 'Shift+Tab' key combo

### DIFF
--- a/src/actions/commands/actions.ts
+++ b/src/actions/commands/actions.ts
@@ -2594,11 +2594,11 @@ class ActionReplaceCharacter extends BaseCommand {
     const toReplace = this.keysPressed[1];
 
     /**
-     * <character> includes <BS>, <SHIFT+BS> and <TAB> but not any control keys,
+     * <character> includes <BS>, <S-BS> and <TAB> but not any control keys,
      * so we ignore the former two keys and have a special handle for <tab>.
      */
 
-    if (['<BS>', '<SHIFT+BS>'].includes(toReplace.toUpperCase())) {
+    if (['<BS>', '<S-BS>'].includes(toReplace.toUpperCase())) {
       return;
     }
 

--- a/src/actions/commands/commandLine.ts
+++ b/src/actions/commands/commandLine.ts
@@ -30,7 +30,7 @@ import { scrollView } from '../../util/util';
 @RegisterAction
 class CommandTabInCommandline extends BaseCommand {
   modes = [Mode.CommandlineInProgress];
-  keys = [['<tab>'], ['<shift+tab>']];
+  keys = [['<tab>'], ['<shift+tab>'], ['<s-tab>']];
   runsOnceForEveryCursor() {
     return this.keysPressed[0] === '\n';
   }

--- a/src/actions/commands/commandLine.ts
+++ b/src/actions/commands/commandLine.ts
@@ -225,7 +225,7 @@ class CommandInsertInCommandline extends BaseCommand {
     const key = this.keysPressed[0];
 
     // handle special keys first
-    if (key === '<BS>' || key === '<shift+BS>' || key === '<C-h>') {
+    if (key === '<BS>' || key === '<S-bs>' || key === '<C-h>') {
       if (vimState.statusBarCursorCharacterPos === 0) {
         await vimState.setCurrentMode(Mode.Normal);
         return;
@@ -331,7 +331,7 @@ class CommandInsertInSearchMode extends BaseCommand {
     const prevSearchList = globalState.searchStatePrevious;
 
     // handle special keys first
-    if (key === '<BS>' || key === '<shift+BS>' || key === '<C-h>') {
+    if (key === '<BS>' || key === '<S-bs>' || key === '<C-h>') {
       if (searchState.searchString.length === 0) {
         await new CommandEscInSearchMode().exec(position, vimState);
       }

--- a/src/actions/commands/commandLine.ts
+++ b/src/actions/commands/commandLine.ts
@@ -30,7 +30,7 @@ import { scrollView } from '../../util/util';
 @RegisterAction
 class CommandTabInCommandline extends BaseCommand {
   modes = [Mode.CommandlineInProgress];
-  keys = [['<tab>'], ['<shift+tab>'], ['<s-tab>']];
+  keys = [['<tab>'], ['<S-tab>']];
   runsOnceForEveryCursor() {
     return this.keysPressed[0] === '\n';
   }

--- a/src/actions/plugins/easymotion/easymotion.cmd.ts
+++ b/src/actions/plugins/easymotion/easymotion.cmd.ts
@@ -349,7 +349,7 @@ class EasyMotionCharInputMode extends BaseCommand {
     const action = vimState.easyMotion.searchAction;
     const oldSearchString = action.getSearchString();
     const newSearchString =
-      key === '<BS>' || key === '<shift+BS>' ? oldSearchString.slice(0, -1) : oldSearchString + key;
+      key === '<BS>' || key === '<S-bs>' ? oldSearchString.slice(0, -1) : oldSearchString + key;
     action.updateSearchString(newSearchString);
     if (action.shouldFire()) {
       // Skip Easymotion input mode to make sure not to back to it

--- a/src/configuration/notation.ts
+++ b/src/configuration/notation.ts
@@ -5,6 +5,7 @@ export class Notation {
   private static readonly _notationMap: Array<[RegExp, string]> = [
     [/ctrl\+|c\-/gi, 'C-'],
     [/cmd\+|d\-/gi, 'D-'],
+    [/shift\+|s\-/gi, 'S-'],
     [/escape|esc/gi, 'Esc'],
     [/backspace|bs/gi, 'BS'],
     [/delete|del/gi, 'Del'],
@@ -32,6 +33,7 @@ export class Notation {
       this.isSurroundedByAngleBrackets(key) &&
       key !== '<BS>' &&
       key !== '<SHIFT+BS>' &&
+      key !== '<S-BS>' &&
       key !== '<TAB>'
     );
   }

--- a/src/configuration/notation.ts
+++ b/src/configuration/notation.ts
@@ -30,11 +30,7 @@ export class Notation {
   public static IsControlKey(key: string): boolean {
     key = key.toLocaleUpperCase();
     return (
-      this.isSurroundedByAngleBrackets(key) &&
-      key !== '<BS>' &&
-      key !== '<SHIFT+BS>' &&
-      key !== '<S-BS>' &&
-      key !== '<TAB>'
+      this.isSurroundedByAngleBrackets(key) && key !== '<BS>' && key !== '<S-BS>' && key !== '<TAB>'
     );
   }
 

--- a/test/cmd_line/tabCompletion.test.ts
+++ b/test/cmd_line/tabCompletion.test.ts
@@ -34,7 +34,7 @@ suite('cmd_line tabComplete', () => {
     await modeHandler.handleKeyEvent('<tab>');
     const secondTab = StatusBar.getText();
 
-    await modeHandler.handleKeyEvent('<shift+tab>');
+    await modeHandler.handleKeyEvent('<S-tab>');
     const actual = StatusBar.getText();
 
     await modeHandler.handleKeyEvent('<Esc>');

--- a/test/configuration/notation.test.ts
+++ b/test/configuration/notation.test.ts
@@ -21,6 +21,7 @@ suite('Notation', () => {
       '<EnTeR>': '\n',
       '<space>': ' ',
       '<uP>': '<up>',
+      '<Shift+Tab>': '<S-tab>',
     };
 
     for (const test in testCases) {

--- a/test/mode/modeNormal.test.ts
+++ b/test/mode/modeNormal.test.ts
@@ -2374,9 +2374,9 @@ suite('Mode Normal', () => {
   });
 
   newTest({
-    title: '<S-BS> deletes the last character in search in progress mode',
+    title: '<S-bs> deletes the last character in search in progress mode',
     start: ['|foo', 'bar', 'abd'],
-    keysPressed: '/abc<shift+BS>d\n',
+    keysPressed: '/abc<S-bs>d\n',
     end: ['foo', 'bar', '|abd'],
     endMode: Mode.Normal,
   });


### PR DESCRIPTION
**What this PR does / why we need it**:
Implement normalization for 'Shift+Tab' key combo
- \<Shift+Tab\> key was being captured but had no normalization
 implemented, so only '\<shift+tab\>' would work.
- This commit, makes '\<s-tab\>' work as well

This basically makes it possible to use `<S-tab>` in remaps as well instead of only `<shift+tab>`.

<!--
Yay! Thanks for sending us a PR! 🎊

Please ensure your PR adheres to:

- [ ] Commit messages has a short & issue references when necessary
- [ ] Each commit does a logical chunk of work.
- [ ] It builds and tests pass (e.g `gulp`)
-->


**Which issue(s) this PR fixes**
fixes #4719
<!--
Commits in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)
-->

**Special notes for your reviewer**:
I've implemented only the `<S-tab>` notation since that is what normal Vim works and `<shift+tab>` to keep the same philosophy that was implemented for `<ctrl+...>` and `<cmd+...>`. This should allow for the normalization of any `shift+...` key combination, however currently we only capture `<Shift+Tab>` and `<Shift+BS>`.
I didn't implement `<Shift-Tab>` as suggested in #4719 because that doesn't work in normal Vim either.
