### PR TITLE
Add Rust's INNER_LINE_DOC to reflow list

### DIFF
--- a/src/actions/operator.ts
+++ b/src/actions/operator.ts
@@ -872,6 +872,7 @@ class ActionVisualReflowParagraph extends BaseOperator {
     { singleLine: false, start: '/*', inner: '*', final: '*/' },
     { singleLine: false, start: '{-', inner: '-', final: '-}' },
     { singleLine: true, start: '///' },
+    { singleLine: true, start: '//!' },
     { singleLine: true, start: '//' },
     { singleLine: true, start: '--' },
     { singleLine: true, start: '#' },


### PR DESCRIPTION
See https://doc.rust-lang.org/reference/comments.html

<!--
Yay! Thanks for sending us a PR! 🎊

Please ensure your PR adheres to:

- [x] Commit messages has a short & issue references when necessary
- [x] Each commit does a logical chunk of work.
- [x] It builds and tests pass (e.g `gulp`)
-->

**What this PR does / why we need it**:

Currently there's a problem where if you have:

```rust
//! A library for reading in Verilog $readmemb/$readmemh files formatted per IEEE Std. 1364-2005, §17.2.9
```

and the user goes onto the long line and does `gqq`, it will split it into two lines like this:

```rust
//! A library for reading in Verilog $readmemb/$readmemh files formatted per
//IEEE Std. 1364-2005, §17.2.9
```

This is incorrect. It should do this:

```
//! A library for reading in Verilog $readmemb/$readmemh files formatted per
//! IEEE Std. 1364-2005, §17.2.9
```

**Which issue(s) this PR fixes**:

<!--
Commits in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)
-->

**Special notes for your reviewer**:
