### PR TITLE
Simulate cursor "disappearing" on CommandLineMode

### DIFF
--- a/src/mode/mode.ts
+++ b/src/mode/mode.ts
@@ -27,6 +27,7 @@ export enum VSCodeVimCursorType {
   Underline,
   TextDecoration,
   Native,
+  UnderlineThin,
 }
 
 /**
@@ -164,6 +165,8 @@ export function getCursorStyle(cursorType: VSCodeVimCursorType) {
       return vscode.TextEditorCursorStyle.LineThin;
     case VSCodeVimCursorType.Underline:
       return vscode.TextEditorCursorStyle.Underline;
+    case VSCodeVimCursorType.UnderlineThin:
+      return vscode.TextEditorCursorStyle.UnderlineThin;
     case VSCodeVimCursorType.TextDecoration:
       return vscode.TextEditorCursorStyle.LineThin;
     case VSCodeVimCursorType.Native:

--- a/src/mode/modeHandler.ts
+++ b/src/mode/modeHandler.ts
@@ -1611,9 +1611,9 @@ function getCursorType(vimState: VimState, mode: Mode): VSCodeVimCursorType {
     case Mode.VisualLine:
       return VSCodeVimCursorType.TextDecoration;
     case Mode.SearchInProgressMode:
-      return getCursorType(vimState, globalState.searchState!.previousMode);
+      return VSCodeVimCursorType.UnderlineThin;
     case Mode.CommandlineInProgress:
-      return getCursorType(vimState, commandLine.previousMode);
+      return VSCodeVimCursorType.UnderlineThin;
     case Mode.Replace:
       return VSCodeVimCursorType.Underline;
     case Mode.EasyMotionMode:
@@ -1623,7 +1623,7 @@ function getCursorType(vimState: VimState, mode: Mode): VSCodeVimCursorType {
     case Mode.SurroundInputMode:
       return getCursorType(vimState, vimState.surround!.previousMode);
     case Mode.OperatorPendingMode:
-      return VSCodeVimCursorType.Underline;
+      return VSCodeVimCursorType.UnderlineThin;
     case Mode.Disabled:
     default:
       return VSCodeVimCursorType.Line;


### PR DESCRIPTION
**What this PR does / why we need it**:
Simulate cursor "disappearing" on CommandLineMode
- Change the cursor in both command line modes to be 'UnderlineThin'.
I don't think we can actually make it disappear so this is the closest
to it. It at least allows the user to have a feedback that they are now
typing on a different place.

<!--
Yay! Thanks for sending us a PR! 🎊

Please ensure your PR adheres to:

- [ ] Commit messages has a short & issue references when necessary
- [ ] Each commit does a logical chunk of work.
- [ ] It builds and tests pass (e.g `gulp`)
-->


**Which issue(s) this PR fixes**
fixes #5198 
<!--
Commits in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)
-->

**Special notes for your reviewer**:
