### PR TITLE
Fix bug where <C-i> <C-o> do not work after easy motion movement #5730

### DIFF
--- a/src/actions/plugins/easymotion/easymotion.cmd.ts
+++ b/src/actions/plugins/easymotion/easymotion.cmd.ts
@@ -384,6 +384,7 @@ class CommandEscEasyMotionCharInputMode extends BaseCommand {
 class MoveEasyMotion extends BaseCommand {
   modes = [Mode.EasyMotionMode];
   keys = ['<character>'];
+  isJump = true;
 
   public async exec(position: Position, vimState: VimState): Promise<void> {
     const key = this.keysPressed[0];


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes bug where `<C-o>` and `<C-i>` do not work after an easy motion movement.

**Which issue(s) this PR fixes**

Fixes #5730

**Special notes for your reviewer**:
The bug is due to isJump not being set on the BaseCommand class which means it's not recorded in the movement history.

Really great plugin. I use it every day. Thanks for all the hard work and effort put into this. 