### PR TITLE
Remove zombie data creator

### DIFF
--- a/src/jumps/jumpTracker.ts
+++ b/src/jumps/jumpTracker.ts
@@ -4,7 +4,6 @@ import { FileCommand } from './../cmd_line/commands/file';
 import { VimState } from '../state/vimState';
 
 import { Jump } from './jump';
-import { getCursorsAfterSync } from '../util/util';
 import { existsAsync } from 'platform/fs';
 import { Position } from 'vscode';
 
@@ -169,7 +168,6 @@ export class JumpTracker {
 
     if (jumpedFiles) {
       await this.performFileJump(jump, vimState);
-      vimState.cursors = getCursorsAfterSync();
     } else {
       vimState.cursorStopPosition = jump.position;
     }


### PR DESCRIPTION
**What this PR does / why we need it**:
Remove zombie data creator
- When we perform a file jump (with \<C-o\> or \<C-i\> for example), the 'activeTextEditorChangedEvent' will already take care of getting the correct cursors to that new editor's `modeHandler`. Then we would call this 'getCursorsAfterSync' that would get the cursors of that new editor and apply them to the previous editor's `modeHandler` (which makes no sense)
- In this case we don't need to change cursors at all.

This would add an expected selection change that would never come (because it was from another file), thus leaving that "zombie" data). All further selection changes would then be ignored.

<!--
Yay! Thanks for sending us a PR! 🎊

Please ensure your PR adheres to:

- [ ] Commit messages has a short & issue references when necessary
- [ ] Each commit does a logical chunk of work.
- [ ] It builds and tests pass (e.g `gulp`)
-->


**Which issue(s) this PR fixes**
fixes #5813 
Might fix a bunch of the other issues we have with cursors failing or being invalid. Because if we were getting the cursors from one file and trying to apply them to other different file, issues are bound to happen when they don't have the same dimensions!


<!--
Commits in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)
-->

**Special notes for your reviewer**:
@J-Fields Do you think this sort of fixes could be pushed directly upstream or do you prefer that I create a PR first?