### PR TITLE
Remove "vim.remap" from the command palette

### DIFF
--- a/extensionBase.ts
+++ b/extensionBase.ts
@@ -411,11 +411,16 @@ export async function activate(context: vscode.ExtensionContext, handleLocal: bo
         return;
       }
 
+      if (!args) {
+        throw new Error(
+          "'args' is undefined. For this remap to work it needs to have 'args' with an '\"after\": string[]' and/or a '\"commands\": { command: string; args: any[] }[]'"
+        );
+      }
+
       if (args.after) {
         for (const key of args.after) {
           await mh.handleKeyEvent(Notation.NormalizeKey(key, configuration.leader));
         }
-        return;
       }
 
       if (args.commands) {

--- a/package.json
+++ b/package.json
@@ -46,10 +46,6 @@
   "contributes": {
     "commands": [
       {
-        "command": "vim.remap",
-        "title": "Vim: Remap any key combination that VS Code supports to Vim motions/operators/ExCommands/macro."
-      },
-      {
         "command": "toggleVim",
         "title": "Vim: Toggle Vim Mode"
       },


### PR DESCRIPTION

**What this PR does / why we need it**:
Remove "vim.remap" from the command palette
- This command is supposed to be used in keybindings, it can't be used
directly from the command palette


<!--
Yay! Thanks for sending us a PR! 🎊

Please ensure your PR adheres to:

- [ ] Commit messages has a short & issue references when necessary
- [ ] Each commit does a logical chunk of work.
- [ ] It builds and tests pass (e.g `gulp`)
-->


**Which issue(s) this PR fixes**
- fixes #5841
<!--
Commits in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)
-->

**Special notes for your reviewer**:
We should add an entry for this command explaining its use on the README file. I just don't know were or if we should even do it at all. I'm afraid it might create more confusion and future issues.

We really need a Wiki! 😄 Then we could add an advanced section inside a Remappings section where we could add this.

I also think this might be the cause of the issues related to #5306. But I'm not sure because no one as yet explained what they were doing...