### PR TITLE
Fix CommandSearch throwing error in multicursor

### DIFF
--- a/src/actions/commands/actions.ts
+++ b/src/actions/commands/actions.ts
@@ -1012,6 +1012,9 @@ export class CommandSearchForwards extends BaseCommand {
   keys = ['/'];
   isMotion = true;
   isJump = true;
+  runsOnceForEveryCursor() {
+    return false;
+  }
 
   public async exec(position: Position, vimState: VimState): Promise<void> {
     globalState.searchState = new SearchState(
@@ -1034,6 +1037,9 @@ export class CommandSearchBackwards extends BaseCommand {
   keys = ['?'];
   isMotion = true;
   isJump = true;
+  runsOnceForEveryCursor() {
+    return false;
+  }
 
   public async exec(position: Position, vimState: VimState): Promise<void> {
     globalState.searchState = new SearchState(

--- a/test/multicursor.test.ts
+++ b/test/multicursor.test.ts
@@ -104,6 +104,20 @@ suite('Multicursor', () => {
     assertEqualLines(['<div></div> asd', '<div></div>']);
     assert.strictEqual(modeHandler.vimState.cursors.length, 2);
   });
+
+  newTest({
+    title: 'Can use "/" search with multicursors',
+    start: ['|line 1', 'line 2', 'line 3', 'line 4', 'line 5'],
+    keysPressed: '3<C-alt+down>v/ne \nd<Esc>',
+    end: ['|e 1', 'e 2', 'e 3', 'e 4', 'line 5'],
+  });
+
+  newTest({
+    title: 'Can use "?" search with multicursors',
+    start: ['line 1', 'line 2', 'line 3', 'line 4', 'line |5'],
+    keysPressed: '3<C-alt+up>v?ine\nd<Esc>',
+    end: ['line 1', '|l', 'l', 'l', 'l'],
+  });
 });
 
 suite('Multicursor with remaps', () => {


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix CommandSearch throwing error in multicursor
- Searching with `/` or  `?` no longer throws "Maximum call stack size exceeded"
- Set `runsOnceForEveryCursor` to false on `/` and `?` actions so that it doesn't try to run for every cursor when in multicursor.

<!--
Yay! Thanks for sending us a PR! 🎊

Please ensure your PR adheres to:

- [ ] Commit messages has a short & issue references when necessary
- [ ] Each commit does a logical chunk of work.
- [ ] It builds and tests pass (e.g `gulp`)
-->


**Which issue(s) this PR fixes**
fixes #5844
<!--
Commits in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)
-->

**Special notes for your reviewer**:
