### PR TITLE
Fix gq to preserve blank lines like Vim does (fix #2393)

### DIFF
--- a/src/actions/operator.ts
+++ b/src/actions/operator.ts
@@ -923,7 +923,7 @@ class ActionVisualReflowParagraph extends BaseOperator {
       let commentType: CommentType | undefined;
 
       for (const type of ActionVisualReflowParagraph.CommentTypes) {
-        if (line.trim().startsWith(type.start)) {
+        if (trimmedLine.startsWith(type.start)) {
           commentType = type;
 
           break;
@@ -931,13 +931,13 @@ class ActionVisualReflowParagraph extends BaseOperator {
 
         // If they're currently in a multiline comment, see if they continued it.
         if (lastChunk && type.start === lastChunk.commentType.start && !type.singleLine) {
-          if (line.trim().startsWith(type.inner)) {
+          if (trimmedLine.startsWith(type.inner)) {
             commentType = type;
 
             break;
           }
 
-          if (line.trim().endsWith(type.final)) {
+          if (trimmedLine.endsWith(type.final)) {
             commentType = type;
 
             break;

--- a/src/actions/operator.ts
+++ b/src/actions/operator.ts
@@ -1008,7 +1008,7 @@ class ActionVisualReflowParagraph extends BaseOperator {
       // don't want to add an extra space. In addition, when there's a blank
       // line, this needs to be reset.
       let curIndex = 0;
-      for (const line of content.trim().split('\n')) {
+      for (const line of content.split('\n')) {
         // Preserve newlines.
 
         if (line.trim() === '') {

--- a/src/actions/operator.ts
+++ b/src/actions/operator.ts
@@ -8,7 +8,7 @@ import { Register, RegisterMode } from './../register/register';
 import { VimState } from './../state/vimState';
 import { TextEditor } from './../textEditor';
 import { BaseAction, RegisterAction } from './base';
-import { CommandNumber } from './commands/actions';
+import { CommandNumber, DocumentContentChangeAction } from './commands/actions';
 import { TextObjectMovement } from '../textobject/textobject';
 import { reportLinesChanged, reportLinesYanked } from '../util/statusBarTextUtils';
 import { commandLine } from './../cmd_line/commandLine';
@@ -907,15 +907,16 @@ class ActionVisualReflowParagraph extends BaseOperator {
 
     // Chunk the lines by commenting style.
 
-    let chunksToReflow: {
+    interface Chunk {
       commentType: CommentType;
       content: string;
       indentLevelAfterComment: number;
-    }[] = [];
+      final: boolean;
+    }
+    let chunksToReflow: Chunk[] = [];
 
     for (const line of s.split('\n')) {
-      let lastChunk: { commentType: CommentType; content: string } | undefined =
-        chunksToReflow[chunksToReflow.length - 1];
+      let lastChunk: Chunk | undefined = chunksToReflow[chunksToReflow.length - 1];
       const trimmedLine = line.trim();
 
       // See what comment type they are using.
@@ -930,7 +931,12 @@ class ActionVisualReflowParagraph extends BaseOperator {
         }
 
         // If they're currently in a multiline comment, see if they continued it.
-        if (lastChunk && type.start === lastChunk.commentType.start && !type.singleLine) {
+        if (
+          lastChunk &&
+          !lastChunk.final &&
+          type.start === lastChunk.commentType.start &&
+          !type.singleLine
+        ) {
           if (trimmedLine.startsWith(type.inner)) {
             commentType = type;
 
@@ -950,15 +956,22 @@ class ActionVisualReflowParagraph extends BaseOperator {
       } // will never happen, just to satisfy typechecker.
 
       // Did they start a new comment type?
-      if (!lastChunk || commentType.start !== lastChunk.commentType.start) {
+      if (!lastChunk || lastChunk.final || commentType.start !== lastChunk.commentType.start) {
         let chunk = {
           commentType,
           content: `${trimmedLine.substr(commentType.start.length).trim()}`,
           indentLevelAfterComment: 0,
+          final: false,
         };
         if (commentType.singleLine) {
           chunk.indentLevelAfterComment =
             trimmedLine.substr(commentType.start.length).length - chunk.content.length;
+        } else if (chunk.content.endsWith(commentType.final)) {
+          // Multiline comment started and ended on one line
+          chunk.content = chunk.content
+            .substr(0, chunk.content.length - commentType.final.length)
+            .trim();
+          chunk.final = true;
         }
         chunksToReflow.push(chunk);
 
@@ -972,17 +985,16 @@ class ActionVisualReflowParagraph extends BaseOperator {
       if (lastChunk.commentType.singleLine) {
         // is it a continuation of a comment like "//"
         lastChunk.content += `\n${trimmedLine.substr(lastChunk.commentType.start.length).trim()}`;
-      } else {
+      } else if (!lastChunk.final) {
         // are we in the middle of a multiline comment like "/*"
         if (trimmedLine.endsWith(lastChunk.commentType.final)) {
-          if (trimmedLine.length > lastChunk.commentType.final.length) {
-            lastChunk.content += `\n${trimmedLine
-              .substr(
-                lastChunk.commentType.inner.length,
-                trimmedLine.length - lastChunk.commentType.final.length
-              )
-              .trim()}`;
-          }
+          lastChunk.final = true;
+          const prefix = trimmedLine.startsWith(lastChunk.commentType.inner)
+            ? lastChunk.commentType.inner.length
+            : 0;
+          lastChunk.content += `\n${trimmedLine
+            .substr(prefix, trimmedLine.length - lastChunk.commentType.final.length - prefix)
+            .trim()}`;
         } else if (trimmedLine.startsWith(lastChunk.commentType.inner)) {
           lastChunk.content += `\n${trimmedLine.substr(lastChunk.commentType.inner.length).trim()}`;
         } else if (trimmedLine.startsWith(lastChunk.commentType.start)) {
@@ -998,25 +1010,27 @@ class ActionVisualReflowParagraph extends BaseOperator {
       let lines: string[];
       const indentAfterComment = Array(indentLevelAfterComment + 1).join(' ');
 
-      if (commentType.singleLine) {
-        lines = [``];
-      } else {
-        lines = [``, ``];
-      }
+      // Start with a single empty content line.
+      lines = [``];
 
       // This tracks if we're pushing the first line of a chunk. If so, then we
       // don't want to add an extra space. In addition, when there's a blank
       // line, this needs to be reset.
       let curIndex = 0;
       for (const line of content.split('\n')) {
-        // Preserve newlines.
-
+        // Preserve blank lines in output.
         if (line.trim() === '') {
-          for (let i = 0; i < 2; i++) {
-            lines.push(``);
+          // Replace empty content line with blank line.
+          if (lines[lines.length - 1] === '') {
+            lines.pop();
           }
-          curIndex = 0;
 
+          lines.push(line);
+
+          // Add new empty content line for remaining content.
+          lines.push(``);
+
+          curIndex = 0;
           continue;
         }
 
@@ -1041,37 +1055,45 @@ class ActionVisualReflowParagraph extends BaseOperator {
         curIndex++;
       }
 
-      if (!commentType.singleLine) {
-        lines.push(``);
+      // Drop final empty content line.
+      if (lines[lines.length - 1] === '') {
+        lines.pop();
       }
 
-      if (commentType.singleLine) {
-        if (lines.length > 1 && lines[0].trim() === '') {
-          lines = lines.slice(1);
-        }
-        if (lines.length > 1 && lines[lines.length - 1].trim() === '') {
-          lines = lines.slice(0, -1);
-        }
-      }
-
+      console.log('before', lines, commentType.singleLine);
       for (let i = 0; i < lines.length; i++) {
         if (commentType.singleLine) {
           lines[i] = `${indent}${commentType.start}${indentAfterComment}${lines[i]}`;
         } else {
           if (i === 0) {
-            lines[i] = `${indent}${commentType.start} ${lines[i]}`;
+            if (lines[i] === '') {
+              lines[i] = `${indent}${commentType.start}`;
+            } else {
+              lines[i] = `${indent}${commentType.start} ${lines[i]}`;
+            }
+            if (i === lines.length - 1) {
+              lines[i] += ` ${commentType.final}`;
+            }
           } else if (i === lines.length - 1) {
-            lines[i] = `${indent} ${commentType.final}`;
+            if (lines[i] === '') {
+              lines[i] = `${indent} ${commentType.final}`;
+            } else {
+              lines[i] = `${indent} ${commentType.inner} ${lines[i]} ${commentType.final}`;
+            }
           } else {
-            lines[i] = `${indent} ${commentType.inner} ${lines[i]}`;
+            if (lines[i] === '') {
+              lines[i] = `${indent} ${commentType.inner}`;
+            } else {
+              lines[i] = `${indent} ${commentType.inner} ${lines[i]}`;
+            }
           }
         }
       }
+      console.log('after', lines);
 
-      result = result.concat(lines);
+      result.push(...lines);
     }
 
-    // Gather up multiple empty lines into single empty lines.
     return result.join('\n');
   }
 

--- a/test/mode/modeNormal.test.ts
+++ b/test/mode/modeNormal.test.ts
@@ -1495,6 +1495,69 @@ suite('Mode Normal', () => {
   });
 
   newTest({
+    title: 'gq preserves newlines',
+    start: ['|abc', '', '', '', 'def'],
+    keysPressed: 'gqG',
+    end: ['|abc', '', '', '', 'def'],
+  });
+
+  newTest({
+    title: 'gq handles single-line comments',
+    start: ['|// abc', '// def'],
+    keysPressed: 'gqG',
+    end: ['|// abc def'],
+  });
+
+  newTest({
+    title: 'gq handles multiline comments',
+    start: ['|/*', ' * abc', ' * def', ' */'],
+    keysPressed: 'gqG',
+    end: ['|/*', ' * abc def', ' */'],
+  });
+
+  newTest({
+    title: 'gq handles multiline comments with inner and final on same line',
+    start: ['|/*', ' * abc', ' * def */'],
+    keysPressed: 'gqG',
+    end: ['|/*', ' * abc def */'],
+  });
+
+  newTest({
+    title: 'gq handles multiline comments with content on start line',
+    start: ['|/* abc', ' * def', '*/'],
+    keysPressed: 'gqG',
+    end: ['|/* abc def', ' */'],
+  });
+
+  newTest({
+    title: 'gq handles multiline comments with start and final on same line',
+    start: ['|/* abc def */'],
+    keysPressed: 'gqG',
+    end: ['|/* abc def */'],
+  });
+
+  newTest({
+    title: 'gq preserves blank lines in multiline comments',
+    start: ['|/* abc', ' *', ' *', ' * def */'],
+    keysPressed: 'gqG',
+    end: ['|/* abc', ' *', ' *', ' * def */'],
+  });
+
+  newTest({
+    title: 'gq does not merge adjacent multiline comments',
+    start: ['|/* abc */', '/* def */'],
+    keysPressed: 'gqG',
+    end: ['|/* abc */', '/* def */'],
+  });
+
+  newTest({
+    title: 'gq does not merge adjacent multiline comments',
+    start: ['|/* abc', ' */', '/* def', ' */'],
+    keysPressed: 'gqG',
+    end: ['|/* abc', ' */', '/* def', ' */'],
+  });
+
+  newTest({
     title: 'Can handle space',
     start: ['|abc', 'def'],
     keysPressed: '  ',


### PR DESCRIPTION
<!--
Yay! Thanks for sending us a PR! 🎊

Please ensure your PR adheres to:

- [x] Commit messages has a short & issue references when necessary
- [x] Each commit does a logical chunk of work.
- [x] It builds and tests pass (e.g `gulp`)
-->

**What this PR does / why we need it**:
Fixes the `gq` operator to not discard blank lines at the beginning or end of a chunk, like Vim does. This turned out to be a one-line change: blank lines at the beginning and end of a chunk were getting accidentally removed via an extra `.trim()` call. There was already code to properly deal with blank lines (which previously handled cases like reformatting two paragraphs separated by blank lines, but now also handle initial and final blank lines).

#2393 shows examples of the bad behavior.  Open any text document with multiple paragraphs (separated by blank lines), such as the repository's `README.md`.  Type `gqap` on a long-line paragraph (e.g. `VSCodeVim is a Vim emulator...`) and the newline(s) after that paragraph will disappear with the old code, but not disappear with this PR (as in Vim).

**Which issue(s) this PR fixes**: Fixes #2393

<!--
Commits in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)
-->

**Special notes for your reviewer**:
* I confirmed that the current implementation of `ap` (a-paragraph) motion matches that of Vim. In particular, `yap` (yank a-paragraph) *does* yank the blank lines that follow a paragraph. So the issue was with `gq`, not `ap`.
* In a second commit, I added some minor optimization that seemed to be intended, replacing repeated calls to `line.trim()` with an already existing `trimmedLine`.
* I'm new to this repository (and VSCode development in general), and didn't succeed in running the automatic tests. I did test `gqap` by hand using a built `.vsix`. (It would have been nice to have a `CONTRIBUTING.md` file to get me started [`yarn`, `yarn run build`, `yarn run vsce package --web`]. Happy to write one assuming there's interest.)