### PR TITLE
Show Marks in Gutter

### DIFF
--- a/package.json
+++ b/package.json
@@ -1005,6 +1005,11 @@
           "type": "boolean",
           "markdownDescription": "When `true` the commands listed below move the cursor to the first non-blank of the line.  When `false` the cursor is kept in the same column (if possible).  This applies to the commands: `<C-d>`, `<C-u>`, `<C-b>`, `<C-f>`, `G`, `H`, `M`, `L`, `gg`, and to the commands `d`, `<<` and `>>` with a linewise operator.",
           "default": true
+        },
+        "vim.showMarksInGutter": {
+          "type": "boolean",
+          "description": "Show the currently set marks in the gutter.",
+          "default": false
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -1069,7 +1069,7 @@
     "typescript": "4.1.3",
     "vsce": "1.83.0",
     "vscode-test": "1.4.1",
-    "webpack": "5.10.3",
+    "webpack": "5.11.0",
     "webpack-cli": "4.2.0",
     "webpack-merge": "5.7.2",
     "webpack-stream": "6.1.1"

--- a/package.json
+++ b/package.json
@@ -1008,7 +1008,7 @@
         },
         "vim.showMarksInGutter": {
           "type": "boolean",
-          "description": "Show the currently set marks in the gutter.",
+          "description": "Show the currently set mark(s) in the gutter.",
           "default": false
         }
       }

--- a/src/configuration/configuration.ts
+++ b/src/configuration/configuration.ts
@@ -390,6 +390,8 @@ class Configuration implements IConfiguration {
 
   startofline = true;
 
+  showMarksInGutter = false;
+
   report = 2;
   wrapscan = true;
 

--- a/src/configuration/decoration.ts
+++ b/src/configuration/decoration.ts
@@ -1,30 +1,34 @@
 import * as vscode from 'vscode';
 import { IConfiguration } from './iconfiguration';
 
-// TODO: move this to a helper file?
-const getMarkUri = (text: string) => {
-  const svg = [
-    '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 30 30" width="30px" height="30px">',
-    '<style>text { font-family: sans-serif; font-size: 0.8em; }</style>',
-    '<circle cx="15" cy="15" r="9" fill="rgb(3,102,214)" />',
-    `<text x="50%" y="50%" fill="rgb(255,255,255)" text-anchor="middle" dominant-baseline="middle">${text}</text>`,
-    '</svg>',
-  ].join('');
-
-  const uri = `data:image/svg+xml;utf8,${encodeURI(svg)}`;
-
-  return vscode.Uri.parse(uri, true);
-};
+interface IMarks {
+  [key: string]: vscode.TextEditorDecorationType;
+}
 
 class DecorationImpl {
   private _default: vscode.TextEditorDecorationType;
-  private _mark: vscode.TextEditorDecorationType;
+  private _marks: IMarks;
   private _searchHighlight: vscode.TextEditorDecorationType;
   private _easyMotionIncSearch: vscode.TextEditorDecorationType;
   private _easyMotionDimIncSearch: vscode.TextEditorDecorationType;
   private _insertModeVirtualCharacter: vscode.TextEditorDecorationType;
   private _operatorPendingModeCursor: vscode.TextEditorDecorationType;
   private _operatorPendingModeCursorChar: vscode.TextEditorDecorationType;
+
+  private _markNames = [...'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ'];
+
+  private getMarkUri(text: string) {
+    const svg = [
+      '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 30 30" width="30px" height="30px">',
+      '<style>text { font-family: sans-serif; font-size: 0.8em; }</style>',
+      '<circle cx="15" cy="15" r="9" fill="rgb(3,102,214)" />',
+      `<text x="50%" y="50%" fill="rgb(255,255,255)" text-anchor="middle" dominant-baseline="middle">${text}</text>`,
+      '</svg>',
+    ].join('');
+    const uri = `data:image/svg+xml;utf8,${encodeURI(svg)}`;
+
+    return vscode.Uri.parse(uri, true);
+  }
 
   public set default(value: vscode.TextEditorDecorationType) {
     if (this._default) {
@@ -37,12 +41,12 @@ class DecorationImpl {
     return this._default;
   }
 
-  public set mark(value: vscode.TextEditorDecorationType) {
-    this._mark = value;
+  public set marks(value: IMarks) {
+    this._marks = value;
   }
 
-  public get mark() {
-    return this._mark;
+  public get marks() {
+    return this._marks;
   }
 
   public set searchHighlight(value: vscode.TextEditorDecorationType) {
@@ -126,12 +130,17 @@ class DecorationImpl {
       borderWidth: '1px',
     });
 
-    // TODO: convert this to a function that passes along the mark name
-    this.mark = vscode.window.createTextEditorDecorationType({
-      isWholeLine: false,
-      gutterIconPath: getMarkUri('m'),
-      gutterIconSize: 'cover',
-    });
+    this.marks = this._markNames.reduce(
+      (marks, name) => ({
+        ...marks,
+        [name]: vscode.window.createTextEditorDecorationType({
+          isWholeLine: false,
+          gutterIconPath: this.getMarkUri(name),
+          gutterIconSize: 'cover',
+        }),
+      }),
+      {}
+    );
 
     const searchHighlightColor = configuration.searchHighlightColor
       ? configuration.searchHighlightColor

--- a/src/configuration/decoration.ts
+++ b/src/configuration/decoration.ts
@@ -21,8 +21,8 @@ class DecorationImpl {
     const svg = [
       '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 30 30" width="30px" height="30px">',
       '<style>text { font-family: sans-serif; font-size: 0.8em; }</style>',
-      '<circle cx="15" cy="15" r="9" fill="rgb(3,102,214)" />',
-      `<text x="50%" y="50%" fill="rgb(255,255,255)" text-anchor="middle" dominant-baseline="middle">${text}</text>`,
+      '<path fill="rgb(3,102,214)" d="M23,27l-8-7l-8,7V5c0-1.105,0.895-2,2-2h12c1.105,0,2,0.895,2,2V27z"/>',
+      `<text x="50%" y="40%" fill="rgb(255,255,255)" text-anchor="middle" dominant-baseline="middle">${text}</text>`,
       '</svg>',
     ].join('');
     const uri = `data:image/svg+xml;utf8,${encodeURI(svg)}`;

--- a/src/configuration/decoration.ts
+++ b/src/configuration/decoration.ts
@@ -22,7 +22,7 @@ class DecorationImpl {
       '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 30 30" width="30px" height="30px">',
       '<style>text { font-family: sans-serif; font-size: 0.8em; }</style>',
       '<path fill="rgb(3,102,214)" d="M23,27l-8-7l-8,7V5c0-1.105,0.895-2,2-2h12c1.105,0,2,0.895,2,2V27z"/>',
-      `<text x="50%" y="40%" fill="rgb(255,255,255)" text-anchor="middle" dominant-baseline="middle">${text}</text>`,
+      `<text x="50%" y="40%" fill="rgb(200,200,200)" text-anchor="middle" dominant-baseline="middle">${text}</text>`,
       '</svg>',
     ].join('');
     const uri = `data:image/svg+xml;utf8,${encodeURI(svg)}`;

--- a/src/configuration/decoration.ts
+++ b/src/configuration/decoration.ts
@@ -1,10 +1,6 @@
 import * as vscode from 'vscode';
 import { IConfiguration } from './iconfiguration';
 
-interface IMarkDecorations {
-  [key: string]: vscode.TextEditorDecorationType;
-}
-
 class DecorationImpl {
   private _default: vscode.TextEditorDecorationType;
   private _searchHighlight: vscode.TextEditorDecorationType;
@@ -14,7 +10,7 @@ class DecorationImpl {
   private _operatorPendingModeCursor: vscode.TextEditorDecorationType;
   private _operatorPendingModeCursorChar: vscode.TextEditorDecorationType;
 
-  private _markDecorationCache: IMarkDecorations = {};
+  private _markDecorationCache = new Map<string, vscode.TextEditorDecorationType>();
 
   private _createMarkDecoration(name: string): vscode.TextEditorDecorationType {
     const svg = [
@@ -78,16 +74,20 @@ class DecorationImpl {
     return this._easyMotionDimIncSearch;
   }
 
-  public getMarkDecoration(name: string): vscode.TextEditorDecorationType {
-    const cache = this._markDecorationCache[name];
+  public getOrCreateMarkDecoration(name: string): vscode.TextEditorDecorationType {
+    const decorationType = this.getMarkDecoration(name);
 
-    if (cache) {
-      return cache;
+    if (decorationType) {
+      return decorationType;
     } else {
       const type = this._createMarkDecoration(name);
-      this._markDecorationCache[name] = type;
+      this._markDecorationCache.set(name, type);
       return type;
     }
+  }
+
+  public getMarkDecoration(name: string): vscode.TextEditorDecorationType | undefined {
+    return this._markDecorationCache.get(name);
   }
 
   public set insertModeVirtualCharacter(value: vscode.TextEditorDecorationType) {

--- a/src/configuration/decoration.ts
+++ b/src/configuration/decoration.ts
@@ -1,8 +1,24 @@
 import * as vscode from 'vscode';
 import { IConfiguration } from './iconfiguration';
 
+// TODO: move this to a helper file?
+const getMarkUri = (text: string) => {
+  const svg = [
+    '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 30 30" width="30px" height="30px">',
+    '<style>text { font-family: sans-serif; font-size: 0.8em; }</style>',
+    '<circle cx="15" cy="15" r="9" fill="rgb(3,102,214)" />',
+    `<text x="50%" y="50%" fill="rgb(255,255,255)" text-anchor="middle" dominant-baseline="middle">${text}</text>`,
+    '</svg>',
+  ].join('');
+
+  const uri = `data:image/svg+xml;utf8,${encodeURI(svg)}`;
+
+  return vscode.Uri.parse(uri, true);
+};
+
 class DecorationImpl {
   private _default: vscode.TextEditorDecorationType;
+  private _mark: vscode.TextEditorDecorationType;
   private _searchHighlight: vscode.TextEditorDecorationType;
   private _easyMotionIncSearch: vscode.TextEditorDecorationType;
   private _easyMotionDimIncSearch: vscode.TextEditorDecorationType;
@@ -19,6 +35,14 @@ class DecorationImpl {
 
   public get default() {
     return this._default;
+  }
+
+  public set mark(value: vscode.TextEditorDecorationType) {
+    this._mark = value;
+  }
+
+  public get mark() {
+    return this._mark;
   }
 
   public set searchHighlight(value: vscode.TextEditorDecorationType) {
@@ -100,6 +124,13 @@ class DecorationImpl {
       },
       borderStyle: 'solid',
       borderWidth: '1px',
+    });
+
+    // TODO: convert this to a function that passes along the mark name
+    this.mark = vscode.window.createTextEditorDecorationType({
+      isWholeLine: false,
+      gutterIconPath: getMarkUri('m'),
+      gutterIconSize: 'cover',
     });
 
     const searchHighlightColor = configuration.searchHighlightColor

--- a/src/configuration/iconfiguration.ts
+++ b/src/configuration/iconfiguration.ts
@@ -398,4 +398,9 @@ export interface IConfiguration {
    * and `>>` with a linewise operator.
    */
   startofline: boolean;
+
+  /**
+   * Enable showing marks in the gutter.
+   */
+  showMarksInGutter: boolean;
 }

--- a/src/configuration/iconfiguration.ts
+++ b/src/configuration/iconfiguration.ts
@@ -400,7 +400,7 @@ export interface IConfiguration {
   startofline: boolean;
 
   /**
-   * Enable showing mark(s) in the gutter.
+   * Show the currently set mark(s) in the gutter.
    */
   showMarksInGutter: boolean;
 }

--- a/src/configuration/iconfiguration.ts
+++ b/src/configuration/iconfiguration.ts
@@ -400,7 +400,7 @@ export interface IConfiguration {
   startofline: boolean;
 
   /**
-   * Enable showing marks in the gutter.
+   * Enable showing mark(s) in the gutter.
    */
   showMarksInGutter: boolean;
 }

--- a/src/mode/modeHandler.ts
+++ b/src/mode/modeHandler.ts
@@ -1510,12 +1510,14 @@ export class ModeHandler implements vscode.Disposable {
       opCursorCharDecorations
     );
 
-    for (const { position, name } of this.vimState.historyTracker.getMarks()) {
-      const markLine = position.getLineBegin();
-      const markRange = new vscode.Range(markLine, markLine);
-      const markDecoration = decoration.marks[name];
+    if (configuration.showMarksInGutter) {
+      for (const { position, name } of this.vimState.historyTracker.getMarks()) {
+        const markLine = position.getLineBegin();
+        const markRange = new vscode.Range(markLine, markLine);
+        const markDecoration = decoration.marks[name];
 
-      this.vimState.editor.setDecorations(markDecoration, [markRange]);
+        this.vimState.editor.setDecorations(markDecoration, [markRange]);
+      }
     }
 
     const showHighlights =

--- a/src/mode/modeHandler.ts
+++ b/src/mode/modeHandler.ts
@@ -1516,7 +1516,9 @@ export class ModeHandler implements vscode.Disposable {
         const markRange = new vscode.Range(markLine, markLine);
         const markDecoration = decoration.marks[name];
 
-        this.vimState.editor.setDecorations(markDecoration, [markRange]);
+        if (this.vimState.editor.hasOwnProperty('setDecorations')) {
+          this.vimState.editor.setDecorations(markDecoration, [markRange]);
+        }
       }
     }
 

--- a/src/mode/modeHandler.ts
+++ b/src/mode/modeHandler.ts
@@ -1510,15 +1510,16 @@ export class ModeHandler implements vscode.Disposable {
       opCursorCharDecorations
     );
 
-    if (configuration.showMarksInGutter) {
-      for (const { position, name } of this.vimState.historyTracker.getMarks()) {
+    for (const { position, name } of this.vimState.historyTracker.getMarks()) {
+      const markDecoration = decoration.getMarkDecoration(name);
+
+      if (configuration.showMarksInGutter) {
         const markLine = position.getLineBegin();
         const markRange = new vscode.Range(markLine, markLine);
-        const markDecoration = decoration.marks[name];
 
-        if (this.vimState.editor.hasOwnProperty('setDecorations')) {
-          this.vimState.editor.setDecorations(markDecoration, [markRange]);
-        }
+        this.vimState.editor.setDecorations(markDecoration, [markRange]);
+      } else {
+        this.vimState.editor.setDecorations(markDecoration, []);
       }
     }
 

--- a/src/mode/modeHandler.ts
+++ b/src/mode/modeHandler.ts
@@ -1510,7 +1510,13 @@ export class ModeHandler implements vscode.Disposable {
       opCursorCharDecorations
     );
 
-    // TODO: draw marks (#3963)
+    // TODO: loop over marks and pass along
+    const markRanges = this.vimState.historyTracker.getMarks().map((mark) => {
+      const position = mark.position.getLineBegin();
+      return new vscode.Range(position, position);
+    });
+
+    this.vimState.editor.setDecorations(decoration.mark, markRanges);
 
     const showHighlights =
       (configuration.incsearch && this.currentMode === Mode.SearchInProgressMode) ||

--- a/src/mode/modeHandler.ts
+++ b/src/mode/modeHandler.ts
@@ -1510,13 +1510,13 @@ export class ModeHandler implements vscode.Disposable {
       opCursorCharDecorations
     );
 
-    // TODO: loop over marks and pass along
-    const markRanges = this.vimState.historyTracker.getMarks().map((mark) => {
-      const position = mark.position.getLineBegin();
-      return new vscode.Range(position, position);
-    });
+    for (const { position, name } of this.vimState.historyTracker.getMarks()) {
+      const markLine = position.getLineBegin();
+      const markRange = new vscode.Range(markLine, markLine);
+      const markDecoration = decoration.marks[name];
 
-    this.vimState.editor.setDecorations(decoration.mark, markRanges);
+      this.vimState.editor.setDecorations(markDecoration, [markRange]);
+    }
 
     const showHighlights =
       (configuration.incsearch && this.currentMode === Mode.SearchInProgressMode) ||

--- a/src/mode/modeHandler.ts
+++ b/src/mode/modeHandler.ts
@@ -1511,15 +1511,18 @@ export class ModeHandler implements vscode.Disposable {
     );
 
     for (const { position, name } of this.vimState.historyTracker.getMarks()) {
-      const markDecoration = decoration.getMarkDecoration(name);
-
       if (configuration.showMarksInGutter) {
+        const markDecoration = decoration.getOrCreateMarkDecoration(name);
+
         const markLine = position.getLineBegin();
         const markRange = new vscode.Range(markLine, markLine);
 
         this.vimState.editor.setDecorations(markDecoration, [markRange]);
       } else {
-        this.vimState.editor.setDecorations(markDecoration, []);
+        const markDecoration = decoration.getMarkDecoration(name);
+        if (markDecoration) {
+          this.vimState.editor.setDecorations(markDecoration, []);
+        }
       }
     }
 

--- a/test/testConfiguration.ts
+++ b/test/testConfiguration.ts
@@ -127,4 +127,5 @@ export class Configuration implements IConfiguration {
   wrapscan = true;
   scroll = 20;
   startofline = true;
+  showMarksInGutter = true;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5912,10 +5912,10 @@ webpack-stream@6.1.1:
     vinyl "^2.1.0"
     webpack "^4.26.1"
 
-webpack@5.10.3:
-  version "5.10.3"
-  resolved "https://registry.yarnpkg.com/webpack/-/webpack-5.10.3.tgz#933cbd5e79d62040d988049ff0f515a6dc333006"
-  integrity sha512-KFPEbpNKfNU4t2CDsUZJ7KpuUbzDqGUCZqLmz4667KSUWMc9BuR3a8jpa72Emv7JUbdGwISD9OZjoI9S5BnHig==
+webpack@5.11.0:
+  version "5.11.0"
+  resolved "https://registry.yarnpkg.com/webpack/-/webpack-5.11.0.tgz#1647abc060441d86d01d8835b8f0fc1dae2fe76f"
+  integrity sha512-ubWv7iP54RqAC/VjixgpnLLogCFbAfSOREcSWnnOlZEU8GICC5eKmJSu6YEnph2N2amKqY9rvxSwgyHxVqpaRw==
   dependencies:
     "@types/eslint-scope" "^3.7.0"
     "@types/estree" "^0.0.45"


### PR DESCRIPTION
## What this PR does / why we need it:
Adds the ability to see what marks you have set in the gutter.

This PR expands on the great work @gamcoh has in #4715 and adds the mark name to the "bookmark" icon (see screenshots below). Since this might not be everyone's cup of tea, I've added a new setting to enable / disable this (defaults to disabled).

This is my first PR in this project; let me know if I missed anything!

## Which issue(s) this PR fixes
* Closes #3963
* Closes #5119
* Relates to #4710

## Special notes for your reviewer:
![Screen Shot 2020-12-23 at 10 22 24 AM](https://user-images.githubusercontent.com/1946433/103026862-a4fd0680-4509-11eb-9e02-06751e1970ce.png)
_NOTE: the default is currently set to **off**_
![Screen Shot 2020-12-23 at 10 22 35 AM](https://user-images.githubusercontent.com/1946433/103026879-ad554180-4509-11eb-832e-675cf136c401.png)
