### PR TITLE
Fixes for `viw` and whitespace at the beginning of the line

### DIFF
--- a/src/textobject/textobject.ts
+++ b/src/textobject/textobject.ts
@@ -273,7 +273,7 @@ export class SelectInnerWord extends TextObjectMovement {
     const currentChar = vimState.document.lineAt(position).text[position.character];
 
     if (/\s/.test(currentChar)) {
-      start = position.getLastWordEnd().getRight();
+      start = position.getWordLeft(true);
       stop = position.getWordRight().getLeftThroughLineBreaks();
     } else {
       start = position.getWordLeft(true);

--- a/src/textobject/word.ts
+++ b/src/textobject/word.ts
@@ -149,12 +149,7 @@ export function getLastWordEnd(pos: Position, wordType: WordType): Position {
     // reverse the list to find the biggest element smaller than pos.character
     positions = positions.reverse();
     let index = positions.findIndex((i) => i < pos.character || currentLine !== pos.line);
-    console.log({
-      'pos.character': pos.character,
-      currentLine,
-      positions,
-      index,
-    });
+
     let newCharacter = 0;
     if (index === -1) {
       if (currentLine > -1) {
@@ -334,10 +329,7 @@ function makeUnicodeWordRegex(keywordChars: string): RegExp {
   // - a keyword (vim.iskeyword)
   const wordSegment = `([^\\s${codePointRanges.join('')}]+)`;
 
-  const lineLeadingWhitespace = '^\\s*';
-
-  // https://regex101.com/r/X1agK6/2
-  // TODO: update regex
-  const segments = symbolSegments.concat(wordSegment, '$^', lineLeadingWhitespace);
+  // https://regex101.com/r/ZBoapq/1
+  const segments = symbolSegments.concat(wordSegment, '$^', '^\\s*');
   return new RegExp(segments.join('|'), 'ug');
 }

--- a/src/textobject/word.ts
+++ b/src/textobject/word.ts
@@ -149,7 +149,6 @@ export function getLastWordEnd(pos: Position, wordType: WordType): Position {
     // reverse the list to find the biggest element smaller than pos.character
     positions = positions.reverse();
     let index = positions.findIndex((i) => i < pos.character || currentLine !== pos.line);
-
     let newCharacter = 0;
     if (index === -1) {
       if (currentLine > -1) {

--- a/src/textobject/word.ts
+++ b/src/textobject/word.ts
@@ -149,6 +149,12 @@ export function getLastWordEnd(pos: Position, wordType: WordType): Position {
     // reverse the list to find the biggest element smaller than pos.character
     positions = positions.reverse();
     let index = positions.findIndex((i) => i < pos.character || currentLine !== pos.line);
+    console.log({
+      'pos.character': pos.character,
+      currentLine,
+      positions,
+      index,
+    });
     let newCharacter = 0;
     if (index === -1) {
       if (currentLine > -1) {
@@ -328,7 +334,10 @@ function makeUnicodeWordRegex(keywordChars: string): RegExp {
   // - a keyword (vim.iskeyword)
   const wordSegment = `([^\\s${codePointRanges.join('')}]+)`;
 
+  const lineLeadingWhitespace = '^\\s*';
+
   // https://regex101.com/r/X1agK6/2
-  const segments = symbolSegments.concat(wordSegment, '$^');
+  // TODO: update regex
+  const segments = symbolSegments.concat(wordSegment, '$^', lineLeadingWhitespace);
   return new RegExp(segments.join('|'), 'ug');
 }

--- a/test/mode/modeVisual.test.ts
+++ b/test/mode/modeVisual.test.ts
@@ -1719,7 +1719,7 @@ suite('Mode Visual', () => {
       title: 'viw at whitespace at the begining of a line',
       start: [' | foo'],
       keysPressed: 'viwx',
-      end: ['|foo']
+      end: ['|foo'],
     });
 
     newTest({

--- a/test/mode/modeVisual.test.ts
+++ b/test/mode/modeVisual.test.ts
@@ -1713,4 +1713,20 @@ suite('Mode Visual', () => {
       endMode: Mode.Normal,
     });
   });
+
+  suite('Can handle viw', () => {
+    newTest({
+      title: 'viw at whitespace at the begining of a line',
+      start: [' | foo'],
+      keysPressed: 'viwx',
+      end: ['|foo']
+    });
+
+    newTest({
+      title: 'viw at whitespace within an indented block',
+      start: ['foo:', ' | bar'],
+      keysPressed: 'viwx',
+      end: ['foo:', '|bar'],
+    });
+  });
 });


### PR DESCRIPTION
## What this PR does / why we need it:
VSCodeVim was not behaving like vim when the user selects the inner word (`viw`) and they are on leading space on a line.

### Scenario:

```python
if x is None:
 | y = 0
```

Typing `viwx` would result in the following:

```python
if x is None:y = 0
```

This PR ensures that VSCodeVim behaves like vim,  by _just_ selecting the leading space on the line, resulting in this:

```python
if x is None:
y = 0
```

## Which issue(s) this PR fixes
* Closes #5572 

## Special notes for your reviewer:
I've added two extra tests to cover the problems presented in the linked issue. I recognize that this PR interacts with a fairly core part of the extension, so let me know if I missed something!