### PR TITLE
Fix 'cw' behavior on whitespace

### DIFF
--- a/src/actions/motion.ts
+++ b/src/actions/motion.ts
@@ -1287,7 +1287,7 @@ export class MoveWordBegin extends BaseMovement {
         return position;
       }
 
-      const char = line[position.character];
+      const char = line.text[position.character];
 
       /*
       From the Vim manual:

--- a/test/mode/modeNormal.test.ts
+++ b/test/mode/modeNormal.test.ts
@@ -250,6 +250,14 @@ suite('Mode Normal', () => {
   });
 
   newTest({
+    title: "Can handle 'cw' on white space",
+    start: ['|  const a = 1;'],
+    keysPressed: 'cw',
+    end: ['|const a = 1;'],
+    endMode: Mode.Insert,
+  });
+
+  newTest({
     title: "Can handle 'c2w'",
     start: ['|const a = 1;'],
     keysPressed: 'c2w',

--- a/test/mode/modeNormal.test.ts
+++ b/test/mode/modeNormal.test.ts
@@ -252,7 +252,7 @@ suite('Mode Normal', () => {
   newTest({
     title: "Can handle 'cw' on white space",
     start: ['|  const a = 1;'],
-    keysPressed: 'cw',
+    keysPressed: '0cw',
     end: ['|const a = 1;'],
     endMode: Mode.Insert,
   });


### PR DESCRIPTION
**What this PR does / why we need it**:
When `changeWordIncludesWhitespace` is `false`, 'cw' is supposed to act like 'ce' when the current character is a non-blank.  However, it is supposed to act like a regular 'w' motion when activated on a blank character.  This fixes a small typo for correctly detecting this case.  I also added a test to cover this case.

**Which issue(s) this PR fixes**
(haven't opened one, can do so if you wish)

**Special notes for your reviewer**:
* I'm surprised TypeScript allowed this bug.  I realized via `console.log` that `line[position.character]` was `undefined`.