### PR TITLE
off load vimrc module in web

### DIFF
--- a/extensionWeb.ts
+++ b/extensionWeb.ts
@@ -11,7 +11,6 @@ import './src/actions/include-main';
 
 import './src/configuration/validators/inputMethodSwitcherValidator';
 import './src/configuration/validators/remappingValidator';
-import './src/configuration/validators/vimrcValidator';
 
 import * as vscode from 'vscode';
 import { activate as activateFunc } from './extensionBase';

--- a/src/configuration/configuration.ts
+++ b/src/configuration/configuration.ts
@@ -5,7 +5,6 @@ import { ValidatorResults } from './iconfigurationValidator';
 import { VSCodeContext } from '../util/vscodeContext';
 import { configurationValidator } from './configurationValidator';
 import { decoration } from './decoration';
-import { vimrc } from './vimrc';
 import {
   IConfiguration,
   IKeyRemapping,
@@ -17,6 +16,7 @@ import {
 } from './iconfiguration';
 
 import * as packagejson from '../../package.json';
+import { SUPPORT_VIMRC } from 'platform/constants';
 
 export const extensionVersion = packagejson.version;
 
@@ -113,8 +113,10 @@ class Configuration implements IConfiguration {
       }
     }
 
-    if (this.vimrc.enable) {
-      await vimrc.load(this);
+    if (SUPPORT_VIMRC && this.vimrc.enable) {
+      await import('./vimrc').then((vimrcModel) => {
+        return vimrcModel.vimrc.load(this);
+      });
     }
 
     this.leader = Notation.NormalizeKey(this.leader, this.leaderDefault);

--- a/src/platform/browser/constants.ts
+++ b/src/platform/browser/constants.ts
@@ -1,3 +1,4 @@
+export const SUPPORT_VIMRC = false;
 export const SUPPORT_NVIM = false;
 export const SUPPORT_IME_SWITCHER = false;
 export const SUPPORT_READ_COMMAND = false;

--- a/src/platform/node/constants.ts
+++ b/src/platform/node/constants.ts
@@ -1,3 +1,4 @@
+export const SUPPORT_VIMRC = true;
 export const SUPPORT_NVIM = true;
 export const SUPPORT_IME_SWITCHER = true;
 export const SUPPORT_READ_COMMAND = true;

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -94,6 +94,9 @@ const nodelessConfig = {
       resourceRegExp: /\/imswitcher$/,
     }),
     new webpack.IgnorePlugin({
+      resourceRegExp: /\/vimrc$/,
+    }),
+    new webpack.IgnorePlugin({
       resourceRegExp: /child_process$/,
     }),
   ],


### PR DESCRIPTION
The Vimrc uses look back regex, which is not supported on Safari. Since we are not loading vimrc at all, instead of tweaking the regex, we can off load the vimrc module completely.