### PR TITLE
Implement previous context marks (add to jump list on m' / m`)

### DIFF
--- a/src/history/historyTracker.ts
+++ b/src/history/historyTracker.ts
@@ -18,6 +18,8 @@ import { TextEditor } from './../textEditor';
 import { StatusBar } from '../statusBar';
 import { Mode } from '../mode/mode';
 import { Position } from 'vscode';
+import { Jump } from '../jumps/jump';
+import { globalState } from '../state/globalState';
 
 const diffEngine = new DiffMatchPatch.diff_match_patch();
 diffEngine.Diff_Timeout = 1; // 1 second
@@ -467,6 +469,12 @@ export class HistoryTracker {
    * Adds a mark.
    */
   public addMark(position: Position, markName: string): void {
+    // Sets previous context mark (adds current position to jump list).
+
+    if (markName === "'" || markName === '`') {
+      return globalState.jumpTracker.recordJump(Jump.fromStateNow(this.vimState));
+    }
+
     const isUppercaseMark = markName.toUpperCase() === markName;
     const newMark: IMark = {
       position,

--- a/src/jumps/jumpTracker.ts
+++ b/src/jumps/jumpTracker.ts
@@ -69,8 +69,8 @@ export class JumpTracker {
    * @param from - File/position jumped from
    * @param to - File/position jumped to
    */
-  public recordJump(from: Jump, to: Jump) {
-    if (from.isSamePosition(to)) {
+  public recordJump(from: Jump, to?: Jump) {
+    if (to && from.isSamePosition(to)) {
       return;
     }
 
@@ -293,12 +293,12 @@ export class JumpTracker {
     this._currentJumpNumber = 0;
   }
 
-  private pushJump(from: Jump | null, to: Jump) {
+  private pushJump(from: Jump | null, to?: Jump) {
     if (from) {
       this.clearJumpsOnSamePosition(from);
     }
 
-    if (from && !from.isSamePosition(to)) {
+    if (from && (!to || !from.isSamePosition(to))) {
       this._jumps.push(from);
     }
 

--- a/test/historyTracker.test.ts
+++ b/test/historyTracker.test.ts
@@ -4,6 +4,8 @@ import * as vscode from 'vscode';
 import { Position } from 'vscode';
 
 import { HistoryTracker, IMark } from '../src/history/historyTracker';
+import { Jump } from '../src/jumps/jump';
+import { globalState } from '../src/state/globalState';
 import { VimState } from '../src/state/vimState';
 
 suite('historyTracker unit tests', () => {
@@ -40,6 +42,27 @@ suite('historyTracker unit tests', () => {
     setup(() => {
       setupVSCode();
       historyTracker = setupHistoryTracker();
+    });
+
+    test('can set previous context mark from single quote', () => {
+      const spy = sandbox.spy(globalState.jumpTracker, 'recordJump');
+      const position = buildMockPosition();
+      const mockJump = new Jump({ editor: null, fileName: 'file name', position });
+      sandbox.stub(Jump, 'fromStateNow').returns(mockJump);
+
+      historyTracker.addMark(position, "'");
+
+      sinon.assert.calledWith(spy, mockJump);
+    });
+    test('can set previous context mark from backtick', () => {
+      const spy = sandbox.spy(globalState.jumpTracker, 'recordJump');
+      const position = buildMockPosition();
+      const mockJump = new Jump({ editor: null, fileName: 'file name', position });
+      sandbox.stub(Jump, 'fromStateNow').returns(mockJump);
+
+      historyTracker.addMark(position, '`');
+
+      sinon.assert.calledWith(spy, mockJump);
     });
 
     test('can create lowercase mark', () => {

--- a/test/jumpTracker.test.ts
+++ b/test/jumpTracker.test.ts
@@ -133,6 +133,23 @@ suite('Record and navigate jumps', () => {
       );
     });
 
+    test('Can handle recording "from" jump with no corresponding "to" jump', () => {
+      const jumpTracker = new JumpTracker();
+
+      jumpTracker.recordJump(jump(0, 0));
+
+      assert.strictEqual(
+        jumpTracker.jumps.length,
+        1,
+        'Jump tracker failed to record "from"-only jump'
+      );
+      assert.deepEqual(
+        jumpTracker.jumps.map((j) => [j.position.line, j.position.character, j.fileName]),
+        [[0, 0, 'Untitled']],
+        `Jump tracker doesn't contain expected jumps after recording "from"-only jump`
+      );
+    });
+
     test('Can handle text deleted from a file', async () => {
       const jumpTracker = new JumpTracker();
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Implements previous context marks as described in Vim's `help m'` / `` help m` ``.

**Which issue(s) this PR fixes**
https://github.com/VSCodeVim/Vim/issues/4873

**Special notes for your reviewer**:
First contribution to the project, so please let me know if there's anything I can do differently. Thanks! 