### PR TITLE
Fix several dependency cycles

### DIFF
--- a/src/configuration/notation.ts
+++ b/src/configuration/notation.ts
@@ -1,5 +1,3 @@
-import { configuration } from './configuration';
-
 export class Notation {
   // Mapping from a regex to the normalized string that it should be converted to.
   private static readonly _notationMap: ReadonlyArray<[RegExp, string]> = [
@@ -79,8 +77,8 @@ export class Notation {
   /**
    * Converts a key to a form which will look nice when logged, etc.
    */
-  public static printableKey(key: string) {
-    const normalized = this.NormalizeKey(key, configuration.leader);
+  public static printableKey(key: string, leaderKey: string) {
+    const normalized = this.NormalizeKey(key, leaderKey);
     return normalized === ' ' ? '<space>' : normalized === '\n' ? '<enter>' : normalized;
   }
 

--- a/src/mode/mode.ts
+++ b/src/mode/mode.ts
@@ -1,9 +1,5 @@
 import * as vscode from 'vscode';
-import { VimState } from '../state/vimState';
-import { globalState } from '../state/globalState';
-import { SearchDirection } from '../state/searchState';
 import { Position } from 'vscode';
-import { Logger } from '../util/logger';
 
 export enum Mode {
   Normal,
@@ -44,117 +40,6 @@ export function isVisualMode(mode: Mode) {
  */
 export function isStatusBarMode(mode: Mode): boolean {
   return [Mode.SearchInProgressMode, Mode.CommandlineInProgress].includes(mode);
-}
-
-export function statusBarText(vimState: VimState) {
-  const cursorChar =
-    vimState.recordedState.actionKeys[vimState.recordedState.actionKeys.length - 1] === '<C-r>'
-      ? '"'
-      : '|';
-  switch (vimState.currentMode) {
-    case Mode.Normal:
-      return '-- NORMAL --';
-    case Mode.Insert:
-      return '-- INSERT --';
-    case Mode.Visual:
-      return '-- VISUAL --';
-    case Mode.VisualBlock:
-      return '-- VISUAL BLOCK --';
-    case Mode.VisualLine:
-      return '-- VISUAL LINE --';
-    case Mode.Replace:
-      return '-- REPLACE --';
-    case Mode.EasyMotionMode:
-      return '-- EASYMOTION --';
-    case Mode.EasyMotionInputMode:
-      return '-- EASYMOTION INPUT --';
-    case Mode.SurroundInputMode:
-      return '-- SURROUND INPUT --';
-    case Mode.Disabled:
-      return '-- VIM: DISABLED --';
-    case Mode.SearchInProgressMode:
-      if (globalState.searchState === undefined) {
-        const logger = Logger.get('StatusBar');
-        logger.warn(`globalState.searchState is undefined in SearchInProgressMode.`);
-        return '';
-      }
-      const leadingChar =
-        globalState.searchState.searchDirection === SearchDirection.Forward ? '/' : '?';
-
-      let searchWithCursor = globalState.searchState.searchString.split('');
-      searchWithCursor.splice(vimState.statusBarCursorCharacterPos, 0, cursorChar);
-
-      return `${leadingChar}${searchWithCursor.join('')}`;
-    case Mode.CommandlineInProgress:
-      let commandWithCursor = vimState.currentCommandlineText.split('');
-      commandWithCursor.splice(vimState.statusBarCursorCharacterPos, 0, cursorChar);
-
-      return `:${commandWithCursor.join('')}`;
-    default:
-      return '';
-  }
-}
-
-export function statusBarCommandText(vimState: VimState): string {
-  switch (vimState.currentMode) {
-    case Mode.SurroundInputMode:
-      return vimState.surround && vimState.surround.replacement
-        ? vimState.surround.replacement
-        : '';
-    case Mode.EasyMotionMode:
-      return `Target key: ${vimState.easyMotion.accumulation}`;
-    case Mode.EasyMotionInputMode:
-      if (!vimState.easyMotion) {
-        return '';
-      }
-
-      const searchCharCount = vimState.easyMotion.searchAction.searchCharCount;
-      const message =
-        searchCharCount > 0
-          ? `Search for ${searchCharCount} character(s): `
-          : 'Search for characters: ';
-      return message + vimState.easyMotion.searchAction.searchString;
-    case Mode.Visual: {
-      // TODO: holy shit, this is SO much more complicated than it should be because
-      // our representation of a visual selection is so weird and inconsistent
-      let [start, end] = [vimState.cursorStartPosition, vimState.cursorStopPosition];
-      let wentOverEOL = false;
-      if (start.isAfter(end)) {
-        start = start.getRightThroughLineBreaks();
-        [start, end] = [end, start];
-      } else if (end.isAfter(start) && end.character === 0) {
-        end = end.getLeftThroughLineBreaks(true);
-        wentOverEOL = true;
-      }
-      const lines = end.line - start.line + 1;
-      if (lines > 1) {
-        return `${lines} ${vimState.recordedState.pendingCommandString}`;
-      } else {
-        const chars = Math.max(end.character - start.character, 1) + (wentOverEOL ? 1 : 0);
-        return `${chars} ${vimState.recordedState.pendingCommandString}`;
-      }
-    }
-    case Mode.VisualLine:
-      return `${
-        Math.abs(vimState.cursorStopPosition.line - vimState.cursorStartPosition.line) + 1
-      } ${vimState.recordedState.pendingCommandString}`;
-    case Mode.VisualBlock: {
-      const lines =
-        Math.abs(vimState.cursorStopPosition.line - vimState.cursorStartPosition.line) + 1;
-      const chars =
-        Math.abs(vimState.cursorStopPosition.character - vimState.cursorStartPosition.character) +
-        1;
-      return `${lines}x${chars} ${vimState.recordedState.pendingCommandString}`;
-    }
-    case Mode.Insert:
-    case Mode.Replace:
-      return vimState.recordedState.pendingCommandString;
-    case Mode.Normal:
-    case Mode.Disabled:
-      return vimState.recordedState.commandString;
-    default:
-      return '';
-  }
 }
 
 export function getCursorStyle(cursorType: VSCodeVimCursorType) {

--- a/src/mode/modeHandler.ts
+++ b/src/mode/modeHandler.ts
@@ -30,7 +30,6 @@ import {
 import { isTextTransformation } from './../transformations/transformations';
 import { globalState } from '../state/globalState';
 import { Notation } from '../configuration/notation';
-import { ModeHandlerMap } from './modeHandlerMap';
 import { EditorIdentity } from '../editorIdentity';
 import { SpecialKeys } from '../util/specialKeys';
 import { BaseOperator } from '../actions/operator';
@@ -38,6 +37,10 @@ import { SearchByNCharCommand } from '../actions/plugins/easymotion/easymotion.c
 import { Position } from 'vscode';
 import { RemapState } from '../state/remapState';
 import * as process from 'process';
+
+interface IModeHandlerMap {
+  get(editorId: EditorIdentity): ModeHandler | undefined;
+}
 
 /**
  * ModeHandler is the extension's backbone. It listens to events and updates the VimState.
@@ -50,6 +53,7 @@ export class ModeHandler implements vscode.Disposable {
   public readonly remapState: RemapState;
 
   private _disposables: vscode.Disposable[] = [];
+  private _handlerMap: IModeHandlerMap;
   private _remappers: Remappers;
   private static readonly logger = Logger.get('ModeHandler');
 
@@ -65,15 +69,19 @@ export class ModeHandler implements vscode.Disposable {
     this._currentMode = modeName;
   }
 
-  public static async create(textEditor = vscode.window.activeTextEditor!): Promise<ModeHandler> {
-    const modeHandler = new ModeHandler(textEditor);
+  public static async create(
+    handlerMap: IModeHandlerMap,
+    textEditor = vscode.window.activeTextEditor!
+  ): Promise<ModeHandler> {
+    const modeHandler = new ModeHandler(handlerMap, textEditor);
     await modeHandler.vimState.load();
     await modeHandler.setCurrentMode(configuration.startInInsertMode ? Mode.Insert : Mode.Normal);
     modeHandler.syncCursors();
     return modeHandler;
   }
 
-  private constructor(textEditor: vscode.TextEditor) {
+  private constructor(handlerMap: IModeHandlerMap, textEditor: vscode.TextEditor) {
+    this._handlerMap = handlerMap;
     this._remappers = new Remappers();
 
     this.vimState = new VimState(textEditor);
@@ -360,7 +368,7 @@ export class ModeHandler implements vscode.Disposable {
 
   public async handleKeyEvent(key: string): Promise<void> {
     const now = Number(new Date());
-    const printableKey = Notation.printableKey(key);
+    const printableKey = Notation.printableKey(key, configuration.leader);
 
     // Check forceStopRemapping
     if (this.remapState.forceStopRecursiveRemapping) {
@@ -1532,7 +1540,9 @@ export class ModeHandler implements vscode.Disposable {
       (configuration.incsearch && this.currentMode === Mode.SearchInProgressMode) ||
       (configuration.hlsearch && globalState.hl);
     for (const editor of vscode.window.visibleTextEditors) {
-      ModeHandlerMap.get(EditorIdentity.fromEditor(editor))?.updateSearchHighlights(showHighlights);
+      this._handlerMap
+        .get(EditorIdentity.fromEditor(editor))
+        ?.updateSearchHighlights(showHighlights);
     }
 
     const easyMotionDimRanges =

--- a/src/mode/modeHandlerMap.ts
+++ b/src/mode/modeHandlerMap.ts
@@ -13,7 +13,7 @@ class ModeHandlerMapImpl {
 
     if (!modeHandler) {
       isNew = true;
-      modeHandler = await ModeHandler.create();
+      modeHandler = await ModeHandler.create(this);
       this.modeHandlerMap.set(editorId, modeHandler);
     }
     return [modeHandler, isNew];
@@ -51,4 +51,4 @@ class ModeHandlerMapImpl {
   }
 }
 
-export let ModeHandlerMap = new ModeHandlerMapImpl();
+export const ModeHandlerMap = new ModeHandlerMapImpl();

--- a/src/state/vimState.ts
+++ b/src/state/vimState.ts
@@ -1,6 +1,6 @@
 import * as vscode from 'vscode';
 
-import { BaseMovement } from '../actions/baseMotion';
+import { IMovement } from '../actions/baseMotion';
 import { configuration } from '../configuration/configuration';
 import { EasyMotion } from './../actions/plugins/easymotion/easymotion';
 import { EditorIdentity } from './../editorIdentity';
@@ -17,6 +17,14 @@ import { Position } from 'vscode';
 
 interface IInputMethodSwitcher {
   switchInputMethod(prevMode: Mode, newMode: Mode): Promise<void>;
+}
+
+interface IBaseMovement {
+  execActionWithCount(
+    position: Position,
+    vimState: VimState,
+    count: number
+  ): Promise<Position | IMovement>;
 }
 
 interface INVim {
@@ -76,12 +84,12 @@ export class VimState implements vscode.Disposable {
   /**
    * Tracks movements that can be repeated with ; (e.g. t, T, f, and F).
    */
-  public lastSemicolonRepeatableMovement: BaseMovement | undefined = undefined;
+  public lastSemicolonRepeatableMovement: IBaseMovement | undefined = undefined;
 
   /**
    * Tracks movements that can be repeated with , (e.g. t, T, f, and F).
    */
-  public lastCommaRepeatableMovement: BaseMovement | undefined = undefined;
+  public lastCommaRepeatableMovement: IBaseMovement | undefined = undefined;
 
   // TODO: move into ModeHandler
   public lastMovementFailed: boolean = false;

--- a/src/statusBar.ts
+++ b/src/statusBar.ts
@@ -1,7 +1,10 @@
 import * as vscode from 'vscode';
-import { Mode, statusBarText, statusBarCommandText } from './mode/mode';
+import { Mode } from './mode/mode';
+import { globalState } from './state/globalState';
+import { SearchDirection } from './state/searchState';
 import { configuration } from './configuration/configuration';
 import { VimState } from './state/vimState';
+import { Logger } from './util/logger';
 import { VimError } from './error';
 
 class StatusBarImpl implements vscode.Disposable {
@@ -145,3 +148,114 @@ class StatusBarImpl implements vscode.Disposable {
 }
 
 export const StatusBar = new StatusBarImpl();
+
+export function statusBarText(vimState: VimState) {
+  const cursorChar =
+    vimState.recordedState.actionKeys[vimState.recordedState.actionKeys.length - 1] === '<C-r>'
+      ? '"'
+      : '|';
+  switch (vimState.currentMode) {
+    case Mode.Normal:
+      return '-- NORMAL --';
+    case Mode.Insert:
+      return '-- INSERT --';
+    case Mode.Visual:
+      return '-- VISUAL --';
+    case Mode.VisualBlock:
+      return '-- VISUAL BLOCK --';
+    case Mode.VisualLine:
+      return '-- VISUAL LINE --';
+    case Mode.Replace:
+      return '-- REPLACE --';
+    case Mode.EasyMotionMode:
+      return '-- EASYMOTION --';
+    case Mode.EasyMotionInputMode:
+      return '-- EASYMOTION INPUT --';
+    case Mode.SurroundInputMode:
+      return '-- SURROUND INPUT --';
+    case Mode.Disabled:
+      return '-- VIM: DISABLED --';
+    case Mode.SearchInProgressMode:
+      if (globalState.searchState === undefined) {
+        const logger = Logger.get('StatusBar');
+        logger.warn(`globalState.searchState is undefined in SearchInProgressMode.`);
+        return '';
+      }
+      const leadingChar =
+        globalState.searchState.searchDirection === SearchDirection.Forward ? '/' : '?';
+
+      let searchWithCursor = globalState.searchState.searchString.split('');
+      searchWithCursor.splice(vimState.statusBarCursorCharacterPos, 0, cursorChar);
+
+      return `${leadingChar}${searchWithCursor.join('')}`;
+    case Mode.CommandlineInProgress:
+      let commandWithCursor = vimState.currentCommandlineText.split('');
+      commandWithCursor.splice(vimState.statusBarCursorCharacterPos, 0, cursorChar);
+
+      return `:${commandWithCursor.join('')}`;
+    default:
+      return '';
+  }
+}
+
+export function statusBarCommandText(vimState: VimState): string {
+  switch (vimState.currentMode) {
+    case Mode.SurroundInputMode:
+      return vimState.surround && vimState.surround.replacement
+        ? vimState.surround.replacement
+        : '';
+    case Mode.EasyMotionMode:
+      return `Target key: ${vimState.easyMotion.accumulation}`;
+    case Mode.EasyMotionInputMode:
+      if (!vimState.easyMotion) {
+        return '';
+      }
+
+      const searchCharCount = vimState.easyMotion.searchAction.searchCharCount;
+      const message =
+        searchCharCount > 0
+          ? `Search for ${searchCharCount} character(s): `
+          : 'Search for characters: ';
+      return message + vimState.easyMotion.searchAction.searchString;
+    case Mode.Visual: {
+      // TODO: holy shit, this is SO much more complicated than it should be because
+      // our representation of a visual selection is so weird and inconsistent
+      let [start, end] = [vimState.cursorStartPosition, vimState.cursorStopPosition];
+      let wentOverEOL = false;
+      if (start.isAfter(end)) {
+        start = start.getRightThroughLineBreaks();
+        [start, end] = [end, start];
+      } else if (end.isAfter(start) && end.character === 0) {
+        end = end.getLeftThroughLineBreaks(true);
+        wentOverEOL = true;
+      }
+      const lines = end.line - start.line + 1;
+      if (lines > 1) {
+        return `${lines} ${vimState.recordedState.pendingCommandString}`;
+      } else {
+        const chars = Math.max(end.character - start.character, 1) + (wentOverEOL ? 1 : 0);
+        return `${chars} ${vimState.recordedState.pendingCommandString}`;
+      }
+    }
+    case Mode.VisualLine:
+      return `${
+        Math.abs(vimState.cursorStopPosition.line - vimState.cursorStartPosition.line) + 1
+      } ${vimState.recordedState.pendingCommandString}`;
+    case Mode.VisualBlock: {
+      const lines =
+        Math.abs(vimState.cursorStopPosition.line - vimState.cursorStartPosition.line) + 1;
+      const chars =
+        Math.abs(vimState.cursorStopPosition.character - vimState.cursorStartPosition.character) +
+        1;
+      return `${lines}x${chars} ${vimState.recordedState.pendingCommandString}`;
+    }
+    case Mode.Insert:
+    case Mode.Replace:
+      return vimState.recordedState.pendingCommandString;
+    case Mode.Normal:
+    case Mode.Disabled:
+      return vimState.recordedState.commandString;
+    default:
+      return '';
+  }
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR starts cleaning up dependency cycles, which make code sensitive to the module initialization order.

**Which issue(s) this PR fixes**
#6177 (partially)

**Special notes for your reviewer**:
A very general plan is to make central types, such as vimState, globalState, recordedState and configuration to not depend on actions/commands and their parsers. Instead they will deal with commands/motions via interfaces.