### PR TITLE
More consistent behavior of C-d

### DIFF
--- a/package.json
+++ b/package.json
@@ -177,7 +177,7 @@
       {
         "key": "ctrl+d",
         "command": "extension.vim_ctrl+d",
-        "when": "editorTextFocus && vim.active && !inDebugRepl"
+        "when": "editorTextFocus && vim.active && vim.use<C-d> && !inDebugRepl"
       },
       {
         "key": "ctrl+d",


### PR DESCRIPTION
<!--
Yay! Thanks for sending us a PR! 🎊

Please ensure your PR adheres to:

- [X] Commit messages has a short & issue references when necessary
- [X] Each commit does a logical chunk of work.
- [X] It builds and tests pass (e.g `gulp`)
-->

**What this PR does / why we need it**: <kbd>C-d</kbd> behavior is inconsistent with vim.use.