### PR TITLE
gq preserves whitespace between line breaks

### DIFF
--- a/src/actions/operator.ts
+++ b/src/actions/operator.ts
@@ -1011,6 +1011,7 @@ class ActionVisualReflowParagraph extends BaseOperator {
     for (const { commentType, content, indentLevelAfterComment } of chunksToReflow) {
       let lines: string[];
       const indentAfterComment = Array(indentLevelAfterComment + 1).join(' ');
+      const commentLength = commentType.start.length + indentAfterComment.length;
 
       // Start with a single empty content line.
       lines = [``];
@@ -1059,7 +1060,8 @@ class ActionVisualReflowParagraph extends BaseOperator {
           }
 
           // Consider appending separator and part of line to last line
-          const remaining = maximumLineLength - lastLine.length - separator.length;
+          const remaining =
+            maximumLineLength - separator.length - (lastLine.length || commentLength);
           const trimmedLine = line.trimStart();
           if (trimmedLine.length <= remaining) {
             // Entire line fits on last line

--- a/src/actions/operator.ts
+++ b/src/actions/operator.ts
@@ -1060,8 +1060,7 @@ class ActionVisualReflowParagraph extends BaseOperator {
           }
 
           // Consider appending separator and part of line to last line
-          const remaining =
-            maximumLineLength - separator.length - (lastLine.length || commentLength);
+          const remaining = maximumLineLength - separator.length - lastLine.length - commentLength;
           const trimmedLine = line.trimStart();
           if (trimmedLine.length <= remaining) {
             // Entire line fits on last line

--- a/src/actions/operator.ts
+++ b/src/actions/operator.ts
@@ -899,7 +899,7 @@ class ActionVisualReflowParagraph extends BaseOperator {
     for (const char of indent) {
       indentLevel += char === '\t' ? configuration.tabstop : 1;
     }
-    const maximumLineLength = configuration.textwidth - indentLevel - 2;
+    const maximumLineLength = configuration.textwidth - indentLevel;
 
     // Chunk the lines by commenting style.
 
@@ -913,7 +913,7 @@ class ActionVisualReflowParagraph extends BaseOperator {
 
     for (const line of s.split('\n')) {
       let lastChunk: Chunk | undefined = chunksToReflow[chunksToReflow.length - 1];
-      const trimmedLine = line.trim();
+      const trimmedLine = line.trimStart();
 
       // See what comment type they are using.
 
@@ -955,7 +955,7 @@ class ActionVisualReflowParagraph extends BaseOperator {
       if (!lastChunk || lastChunk.final || commentType.start !== lastChunk.commentType.start) {
         const chunk = {
           commentType,
-          content: `${trimmedLine.substr(commentType.start.length).trim()}`,
+          content: `${trimmedLine.substr(commentType.start.length).trimStart()}`,
           indentLevelAfterComment: 0,
           final: false,
         };
@@ -980,7 +980,9 @@ class ActionVisualReflowParagraph extends BaseOperator {
 
       if (lastChunk.commentType.singleLine) {
         // is it a continuation of a comment like "//"
-        lastChunk.content += `\n${trimmedLine.substr(lastChunk.commentType.start.length).trim()}`;
+        lastChunk.content += `\n${trimmedLine
+          .substr(lastChunk.commentType.start.length)
+          .trimStart()}`;
       } else if (!lastChunk.final) {
         // are we in the middle of a multiline comment like "/*"
         if (trimmedLine.endsWith(lastChunk.commentType.final)) {
@@ -992,9 +994,13 @@ class ActionVisualReflowParagraph extends BaseOperator {
             .substr(prefix, trimmedLine.length - lastChunk.commentType.final.length - prefix)
             .trim()}`;
         } else if (trimmedLine.startsWith(lastChunk.commentType.inner)) {
-          lastChunk.content += `\n${trimmedLine.substr(lastChunk.commentType.inner.length).trim()}`;
+          lastChunk.content += `\n${trimmedLine
+            .substr(lastChunk.commentType.inner.length)
+            .trimStart()}`;
         } else if (trimmedLine.startsWith(lastChunk.commentType.start)) {
-          lastChunk.content += `\n${trimmedLine.substr(lastChunk.commentType.start.length).trim()}`;
+          lastChunk.content += `\n${trimmedLine
+            .substr(lastChunk.commentType.start.length)
+            .trimStart()}`;
         }
       }
     }
@@ -1009,12 +1015,7 @@ class ActionVisualReflowParagraph extends BaseOperator {
       // Start with a single empty content line.
       lines = [``];
 
-      // This tracks what separator should be added before the next word.
-      // It's empty at the beginning of a paragraph, one space after most
-      // words, and two spaces after certain punctuation (via `joinspaces`).
-      let separator = '';
-
-      for (const line of content.split('\n')) {
+      for (let line of content.split('\n')) {
         // Preserve blank lines in output.
         if (line.trim() === '') {
           // Replace empty content line with blank line.
@@ -1027,30 +1028,69 @@ class ActionVisualReflowParagraph extends BaseOperator {
           // Add new empty content line for remaining content.
           lines.push(``);
 
-          separator = '';
           continue;
         }
 
-        // Add word by word, wrapping when necessary.
-        const words = line.split(/\s+/);
-        for (const word of words) {
-          if (word === '') {
-            continue;
-          }
+        // Repeatedly partition line into pieces that fit in maximumLineLength
+        while (line) {
+          const lastLine = lines[lines.length - 1];
 
-          if (lines[lines.length - 1].length + separator.length + word.length < maximumLineLength) {
-            lines[lines.length - 1] += `${separator}${word}`;
-          } else {
-            lines.push(`${word}`);
-          }
-
-          if (
+          // Determine the separator that we'd need to add to the last line
+          // in order to join onto this line.
+          let separator;
+          if (!lastLine) {
+            separator = '';
+          } else if (
             configuration.joinspaces &&
-            (word.endsWith('.') || word.endsWith('?') || word.endsWith('!'))
+            (lastLine.endsWith('.') || lastLine.endsWith('?') || lastLine.endsWith('!'))
           ) {
             separator = '  ';
+          } else if (lastLine.endsWith(' ')) {
+            if (
+              configuration.joinspaces &&
+              (lastLine.endsWith('. ') || lastLine.endsWith('? ') || lastLine.endsWith('! '))
+            ) {
+              separator = ' ';
+            } else {
+              separator = '';
+            }
           } else {
             separator = ' ';
+          }
+
+          // Consider appending separator and part of line to last line
+          const remaining = maximumLineLength - lastLine.length - separator.length;
+          const trimmedLine = line.trimStart();
+          if (trimmedLine.length <= remaining) {
+            // Entire line fits on last line
+            lines[lines.length - 1] += `${separator}${trimmedLine}`;
+            break;
+          } else {
+            // Find largest portion of line that fits on last line,
+            // by searching backward for a whitespace character (space or tab).
+            let breakpoint = Math.max(
+              trimmedLine.lastIndexOf(' ', remaining),
+              trimmedLine.lastIndexOf('\t', remaining)
+            );
+            if (breakpoint < 0) {
+              // Next word is too long to fit on the current line.
+              if (lastLine) {
+                // Start a new line and try again next round.
+                lines.push('');
+                continue;
+              } else {
+                // Next word is too long to fit on a line by itself.
+                // Break it at the next word boundary, if there is one.
+                breakpoint = trimmedLine.search(/[ \t]/);
+                if (breakpoint < 0) breakpoint = line.length;
+              }
+            }
+
+            // Split the line into the part that fits on the last line
+            // and the remainder.  Start a new line for the remainder.
+            lines[lines.length - 1] += `${separator}${trimmedLine.slice(0, breakpoint).trimEnd()}`;
+            line = line.slice(breakpoint + 1);
+            lines.push('');
           }
         }
       }

--- a/test/mode/modeNormal.test.ts
+++ b/test/mode/modeNormal.test.ts
@@ -1605,6 +1605,51 @@ suite('Mode Normal', () => {
   });
 
   newTest({
+    title: 'gq leaves alone whitespace within a line',
+    start: ["|Good morning, how are you?  I'm Dr. Worm.", "I'm interested", 'in      things.'],
+    keysPressed: 'gqG',
+    end: ["|Good morning, how are you?  I'm Dr. Worm.  I'm interested in      things."],
+  });
+
+  newTest({
+    title: 'gq breaks at exactly textwidth',
+    start: [
+      '|1 3 5 7 911 3 5 7 921 3 5 7 931 3 5 7 941 3 5 7 951 3 5 7 961 3 5 7 971 3 5 7 9x split',
+    ],
+    keysPressed: 'gqG',
+    end: [
+      '|1 3 5 7 911 3 5 7 921 3 5 7 931 3 5 7 941 3 5 7 951 3 5 7 961 3 5 7 971 3 5 7 9x',
+      'split',
+    ],
+  });
+
+  newTest({
+    title: 'gq breaks before textwidth',
+    start: [
+      '|1 3 5 7 911 3 5 7 921 3 5 7 931 3 5 7 941 3 5 7 951 3 5 7 961 3 5 7 971 3 5 7 9xs split',
+    ],
+    keysPressed: 'gqG',
+    end: [
+      '|1 3 5 7 911 3 5 7 921 3 5 7 931 3 5 7 941 3 5 7 951 3 5 7 961 3 5 7 971 3 5 7',
+      '9xs split',
+    ],
+  });
+
+  newTest({
+    title: 'gq breaks around long words',
+    start: [
+      '|this is a suuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuper long looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong                    word',
+    ],
+    keysPressed: 'gqG',
+    end: [
+      '|this is a',
+      'suuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuper',
+      'long looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong',
+      'word',
+    ],
+  });
+
+  newTest({
     title: '<Space> moves cursor one character right',
     start: ['|abc', 'def'],
     keysPressed: ' ',

--- a/test/mode/modeNormal.test.ts
+++ b/test/mode/modeNormal.test.ts
@@ -1510,8 +1510,8 @@ suite('Mode Normal', () => {
     ],
     keysPressed: 'Vgq',
     end: [
-      '    // We choose to write a vim extension, not because it is easy, but because',
-      '|    // it is hard.',
+      '    // We choose to write a vim extension, not because it is easy, but because it',
+      '|    // is hard.',
     ],
   });
 
@@ -1522,8 +1522,8 @@ suite('Mode Normal', () => {
     ],
     keysPressed: 'Vgq',
     end: [
-      '\t\t// We choose to write a vim extension, not because it is easy, but',
-      '|\t\t// because it is hard.',
+      '\t\t// We choose to write a vim extension, not because it is easy, but because',
+      '|\t\t// it is hard.',
     ],
   });
 
@@ -1536,8 +1536,8 @@ suite('Mode Normal', () => {
     keysPressed: 'gqj',
     end: [
       '|// We choose to write a vim extension, not because it is easy, but because it is',
-      '// hard.  We choose to write a vim extension, not because it is easy, but',
-      '// because it is hard.',
+      '// hard.  We choose to write a vim extension, not because it is easy, but because',
+      '// it is hard.',
     ],
   });
 

--- a/test/mode/modeNormal.test.ts
+++ b/test/mode/modeNormal.test.ts
@@ -1498,8 +1498,8 @@ suite('Mode Normal', () => {
     ],
     keysPressed: 'Vgq',
     end: [
-      '//    We choose to write a vim extension, not because it is easy, but because it is',
-      '|//    hard.',
+      '//    We choose to write a vim extension, not because it is easy, but because it',
+      '|//    is hard.',
     ],
   });
 
@@ -1510,8 +1510,8 @@ suite('Mode Normal', () => {
     ],
     keysPressed: 'Vgq',
     end: [
-      '    // We choose to write a vim extension, not because it is easy, but because it',
-      '|    // is hard.',
+      '    // We choose to write a vim extension, not because it is easy, but because',
+      '|    // it is hard.',
     ],
   });
 
@@ -1522,8 +1522,8 @@ suite('Mode Normal', () => {
     ],
     keysPressed: 'Vgq',
     end: [
-      '\t\t// We choose to write a vim extension, not because it is easy, but because',
-      '|\t\t// it is hard.',
+      '\t\t// We choose to write a vim extension, not because it is easy, but',
+      '|\t\t// because it is hard.',
     ],
   });
 
@@ -1632,6 +1632,20 @@ suite('Mode Normal', () => {
     end: [
       '|1 3 5 7 911 3 5 7 921 3 5 7 931 3 5 7 941 3 5 7 951 3 5 7 961 3 5 7 971 3 5 7',
       '9xs split',
+    ],
+  });
+
+  newTest({
+    title: 'gq breaks at exactly textwidth with indent and comment',
+    start: [
+      '| // 5 7 911 3 5 7 921 3 5 7 931 3 5 7 941 3 5 7 951 3 5 7 961 3 5 7 971 3 5 7 9 5 7 911 3 5 7 921 3 5 7 931 3 5 7 941 3 5 7 951 3 5 7 961 3 5 7 971 3 5 7 9 5 7 911 3 5 7 921 3 5 7 931 3 5 7 941 3 5 7 951 3 5 7 961 3 5 7 971 3 5 7 9xs split',
+    ],
+    keysPressed: 'gqG',
+    end: [
+      '| // 5 7 911 3 5 7 921 3 5 7 931 3 5 7 941 3 5 7 951 3 5 7 961 3 5 7 971 3 5 7 9',
+      ' // 5 7 911 3 5 7 921 3 5 7 931 3 5 7 941 3 5 7 951 3 5 7 961 3 5 7 971 3 5 7 9',
+      ' // 5 7 911 3 5 7 921 3 5 7 931 3 5 7 941 3 5 7 951 3 5 7 961 3 5 7 971 3 5 7',
+      ' // 9xs split',
     ],
   });
 

--- a/test/mode/modeNormal.test.ts
+++ b/test/mode/modeNormal.test.ts
@@ -1536,8 +1536,8 @@ suite('Mode Normal', () => {
     keysPressed: 'gqj',
     end: [
       '|// We choose to write a vim extension, not because it is easy, but because it is',
-      '// hard.  We choose to write a vim extension, not because it is easy, but because',
-      '// it is hard.',
+      '// hard.  We choose to write a vim extension, not because it is easy, but',
+      '// because it is hard.',
     ],
   });
 


### PR DESCRIPTION
<!--
Yay! Thanks for sending us a PR! 🎊

Please ensure your PR adheres to:

- [ ] Commit messages has a short & issue references when necessary
- [ ] Each commit does a logical chunk of work.
- [ ] It builds and tests pass (e.g `gulp`)
-->

**What this PR does / why we need it**:
* Rewrite 'gq' reflow to apply manual spacing (including `joinspaces` option) just when creating whitespace from what were linebreaks.
* Fix precision around `textwidth`. Now exactly fills lines to width `textwidth`, just like Vim. There's a test to verify this. This required modifying previous test outputs.

**Which issue(s) this PR fixes**
Fixes #6569

<!--
Commits in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)
-->

**Special notes for your reviewer**:
* I'm having trouble running the added tests locally, so I might need to tweak them slightly.