### PR TITLE
Implement :vsc to run VSCode commands

### DIFF
--- a/src/cmd_line/commands/vsc.ts
+++ b/src/cmd_line/commands/vsc.ts
@@ -1,0 +1,27 @@
+import * as vscode from 'vscode';
+import { VimState } from '../../state/vimState';
+import { CommandBase } from '../node';
+import { Scanner } from '../scanner';
+
+export class VscCommand extends CommandBase {
+  private command?: string;
+
+  constructor(command?: string) {
+    super();
+    this.command = command;
+  }
+
+  public static parse(args: string): VscCommand {
+    const scanner = new Scanner(args);
+    scanner.skipWhiteSpace();
+    return new VscCommand(scanner.isAtEof ? undefined : scanner.nextWord());
+  }
+
+  private async vsc() {
+    await vscode.commands.executeCommand(this.command ?? '');
+  }
+
+  async execute(_vimState: VimState): Promise<void> {
+    await this.vsc();
+  }
+}

--- a/src/cmd_line/commands/vscode.ts
+++ b/src/cmd_line/commands/vscode.ts
@@ -3,7 +3,7 @@ import { VimState } from '../../state/vimState';
 import { CommandBase } from '../node';
 import { Scanner } from '../scanner';
 
-export class VscCommand extends CommandBase {
+export class VsCodeCommand extends CommandBase {
   private command?: string;
 
   constructor(command?: string) {
@@ -11,10 +11,10 @@ export class VscCommand extends CommandBase {
     this.command = command;
   }
 
-  public static parse(args: string): VscCommand {
+  public static parse(args: string): VsCodeCommand {
     const scanner = new Scanner(args);
     scanner.skipWhiteSpace();
-    return new VscCommand(scanner.isAtEof ? undefined : scanner.nextWord());
+    return new VsCodeCommand(scanner.isAtEof ? undefined : scanner.nextWord());
   }
 
   private async vsc() {

--- a/src/cmd_line/commands/vscode.ts
+++ b/src/cmd_line/commands/vscode.ts
@@ -1,3 +1,5 @@
+import { ErrorCode, VimError } from '../../error';
+import { StatusBar } from '../../statusBar';
 import * as vscode from 'vscode';
 import { VimState } from '../../state/vimState';
 import { CommandBase } from '../node';
@@ -17,11 +19,15 @@ export class VsCodeCommand extends CommandBase {
     return new VsCodeCommand(scanner.isAtEof ? undefined : scanner.nextWord());
   }
 
-  private async vsc() {
-    await vscode.commands.executeCommand(this.command ?? '');
+  private async vsc(vimState: VimState) {
+    if (!this.command) {
+      StatusBar.displayError(vimState, VimError.fromCode(ErrorCode.ArgumentRequired));
+      return;
+    }
+    await vscode.commands.executeCommand(this.command);
   }
 
-  async execute(_vimState: VimState): Promise<void> {
-    await this.vsc();
+  async execute(vimState: VimState): Promise<void> {
+    await this.vsc(vimState);
   }
 }

--- a/src/cmd_line/subparser.ts
+++ b/src/cmd_line/subparser.ts
@@ -30,6 +30,7 @@ import { StatusBar } from '../statusBar';
 import { ShCommand } from './commands/sh';
 import { GotoCommand } from './commands/goto';
 import { YankCommand } from './commands/yank';
+import { VscCommand } from './commands/vsc';
 
 // Associates a name and an abbreviation with a command parser
 export type CommandParserMapping = {
@@ -346,6 +347,11 @@ export const commandParsers = {
   vnew: {
     abbrev: 'vne',
     parser: fileCmd.parseEditNewFileInNewVerticalWindowCommandArgs,
+  },
+
+  vsc: {
+    abbrev: 'vsc',
+    parser: VscCommand.parse,
   },
 
   vsplit: {

--- a/src/cmd_line/subparser.ts
+++ b/src/cmd_line/subparser.ts
@@ -30,7 +30,7 @@ import { StatusBar } from '../statusBar';
 import { ShCommand } from './commands/sh';
 import { GotoCommand } from './commands/goto';
 import { YankCommand } from './commands/yank';
-import { VscCommand } from './commands/vsc';
+import { VsCodeCommand } from './commands/vscode';
 
 // Associates a name and an abbreviation with a command parser
 export type CommandParserMapping = {
@@ -349,9 +349,9 @@ export const commandParsers = {
     parser: fileCmd.parseEditNewFileInNewVerticalWindowCommandArgs,
   },
 
-  vsc: {
+  vscode: {
     abbrev: 'vsc',
-    parser: VscCommand.parse,
+    parser: VsCodeCommand.parse,
   },
 
   vsplit: {


### PR DESCRIPTION
<!--
Yay! Thanks for sending us a PR! 🎊

Please ensure your PR adheres to:

- [ ] Commit messages has a short & issue references when necessary
- [ ] Each commit does a logical chunk of work.
- [ ] It builds and tests pass (e.g `gulp`)
-->

**What this PR does / why we need it**:
Add a `:vsc` command to run VSCode commands, including extension commands. 

Examples: 

```
:vsc editor.action.organizeImports
:vsc gitlens.toggleFileBlame
```

As a bonus, we can now map extension commands in vimrc. 

```
noremap <leader>glf :vsc gitlens.showFileHistoryView<CR>
```

**Which issue(s) this PR fixes**
#4463, #4733, probably others. While PR #4750 is another attempt at solving these issues, adding a new command is more in-line with approaches by other Vim emulators. e.g. VSVim uses `:vsc` and Ideavim uses `:action`. 

<!--
Commits in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)
-->

**Special notes for your reviewer**:
