### PR TITLE
Fix sort unique bug

### DIFF
--- a/src/cmd_line/commands/sort.ts
+++ b/src/cmd_line/commands/sort.ts
@@ -43,6 +43,8 @@ export class SortCommand extends node.CommandBase {
       originalLines.push(vimState.document.lineAt(currentLine).text);
     }
 
+    const lastLineLength = originalLines[originalLines.length - 1].length;
+
     if (this.arguments.unique) {
       const seen = new Set<string>();
       const uniqueLines: string[] = [];
@@ -55,8 +57,6 @@ export class SortCommand extends node.CommandBase {
       }
       originalLines = uniqueLines;
     }
-
-    const lastLineLength = originalLines[originalLines.length - 1].length;
 
     const sortedLines = this.arguments.ignoreCase
       ? originalLines.sort((a: string, b: string) => a.localeCompare(b))


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR Fixes a bug where when you used `:sort u` on certain text it would cause it to not replace everything.
An example:

```
there
do
there
```

Would turn into:

```
do
thereere
```

**Which issue(s) this PR fixes**

<!--
Commits in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)
-->
#6825

**Special notes for your reviewer**:

If you are interested in what caused the bug:

In the [file that handles the command](https://github.com/VSCodeVim/Vim/blob/master/src/cmd_line/commands/sort.ts), the program modifies originalLines when the unique argument is specified:

```js
    if (this.arguments.unique) {
      const seen = new Set<string>();
      const uniqueLines: string[] = [];
      for (const line of originalLines) {
        const adjustedLine = this.arguments.ignoreCase ? line.toLowerCase() : line;
        if (!seen.has(adjustedLine)) {
          seen.add(adjustedLine);
          uniqueLines.push(line);
        }
      }
      originalLines = uniqueLines;
    }
```

The problem with this is when the program specifies the range of text to replace:

```js
 vimState.recordedState.transformer.addTransformation({
      type: 'replaceText',
      // this line in specific
      range: new vscode.Range(startLine, 0, endLine, lastLineLength),
      text: sortedContent,
      diff: PositionDiff.exactPosition(
        new vscode.Position(startLine, sortedLines[0].match(/\S/)?.index ?? 0)
      ),
 });
 ```
 The first 3 parameters are correct, but the fourth one is wrong. lastLineLength is defined by:
 
 ```js
 const lastLineLength = originalLines[originalLines.length - 1].length;
 ```
 
But this happens **after** the transformation on originalLines (line 46-57).  So lastLineLength is not actually getting the original text's last line length, it's getting the transformed originalLines (uniqueLines).

Here's a quick walkthrough if the text is `there\ndo\nthere`:

```
originalLines = ['there', 'do', 'there']

unique argument is provided so we get the unique lines and set it

originalLines is now ['there', 'do']

lastLineLength = 'do'.length = 2

// => ERROR: It should be 'there'.length which is 5.
```

In this case the range's end line character is only 2, so on the third line of 'there', it only replaces the starting two letters, and leaves 'ere' alone. So we get the result of:

```
do 
thereere
```
