### PR TITLE
Add debuggingForeground to colorCustomizations

### DIFF
--- a/src/statusBar.ts
+++ b/src/statusBar.ts
@@ -142,6 +142,7 @@ class StatusBarImpl implements vscode.Disposable {
 
     if (foreground !== undefined) {
       colorCustomizations['statusBar.foreground'] = foreground;
+      colorCustomizations['statusBar.debuggingForeground'] = foreground;
     }
 
     if (currentColorCustomizations !== colorCustomizations) {


### PR DESCRIPTION
If you chose to customize your modes under `vim.statusBarColor`, and since `statusBar.debuggingBackground` is registered to colorCustomizations so it uses your current mode background, using debugger can render the statusBar unreadable. I'm simply registering the missing `statusBar.debuggingForeground`, so the statusBar uses both your mode's background and foreground, not just the background.