### PR TITLE
Fix escaping in :s substitutions

### DIFF
--- a/src/cmd_line/subparsers/substitute.ts
+++ b/src/cmd_line/subparsers/substitute.ts
@@ -8,49 +8,70 @@ function isValidDelimiter(char: string): boolean {
   return !!/^[^\w\s\\|"]{1}$/g.exec(char);
 }
 
-function parsePattern(pattern: string, scanner: Scanner, delimiter: string): [string, boolean] {
-  if (scanner.isAtEof) {
-    return [pattern, false];
-  } else {
+function parsePattern(scanner: Scanner, delimiter: string): [string, boolean] {
+  let pattern = '';
+  while (!scanner.isAtEof) {
     let currentChar = scanner.next();
 
     if (currentChar === delimiter) {
-      // TODO skip delimiter
-      return [pattern, true];
+      return [pattern, true]; // found second delimiter
     } else if (currentChar === '\\') {
       if (!scanner.isAtEof) {
         currentChar = scanner.next();
-
-        if (currentChar !== delimiter) {
-          switch (currentChar) {
-            case 'r':
-              pattern += '\r';
-              break;
-            case 'n':
-              pattern += '\n';
-              break;
-            case 't':
-              pattern += '\t';
-              break;
-            case '\\':
-              pattern += '\\';
-              break;
-            default:
-              pattern += '\\';
-              pattern += currentChar;
-              break;
-          }
-        } else {
-          pattern += currentChar;
-        }
+        pattern += '\\' + currentChar;
+      } else {
+        pattern += '\\\\'; // :s/\ is treated like :s/\\
       }
-
-      return parsePattern(pattern, scanner, delimiter);
     } else {
       pattern += currentChar;
-      return parsePattern(pattern, scanner, delimiter);
     }
   }
+  return [pattern, false];
+}
+
+// See Vim's sub-replace-special documentation
+// TODO: \u, \U, \l, \L, \e, \E
+const replaceEscapes = {
+  b: '\b',
+  r: '\r',
+  n: '\n',
+  t: '\t',
+  '&': '$&',
+  '0': '$0',
+  '1': '$1',
+  '2': '$2',
+  '3': '$3',
+  '4': '$4',
+  '5': '$5',
+  '6': '$6',
+  '7': '$7',
+  '8': '$8',
+  '9': '$9',
+};
+
+function parseReplace(scanner: Scanner, delimiter: string): string {
+  let replace = '';
+  while (!scanner.isAtEof) {
+    let currentChar = scanner.next();
+
+    if (currentChar === delimiter) {
+      return replace; // found second delimiter
+    } else if (currentChar === '\\') {
+      if (!scanner.isAtEof) {
+        currentChar = scanner.next();
+        if (replaceEscapes.hasOwnProperty(currentChar)) {
+          replace += replaceEscapes[currentChar];
+        } else {
+          replace += currentChar;
+        }
+      } else {
+        replace += '\\'; // :s/.../\ is treated like :s/.../\\
+      }
+    } else {
+      replace += currentChar;
+    }
+  }
+  return replace;
 }
 
 function parseSubstituteFlags(scanner: Scanner): number {
@@ -165,7 +186,7 @@ export function parseSubstituteCommandArgs(args: string): node.SubstituteCommand
       let secondDelimiterFound: boolean;
 
       scanner = new Scanner(args.substr(1, args.length - 1));
-      [searchPattern, secondDelimiterFound] = parsePattern('', scanner, delimiter);
+      [searchPattern, secondDelimiterFound] = parsePattern(scanner, delimiter);
 
       if (!secondDelimiterFound) {
         // special case for :s/search
@@ -175,7 +196,7 @@ export function parseSubstituteCommandArgs(args: string): node.SubstituteCommand
           flags: node.SubstituteFlags.None,
         });
       }
-      replaceString = parsePattern('', scanner, delimiter)[0];
+      replaceString = parseReplace(scanner, delimiter);
     } else {
       // if it's not a valid delimiter, it must be flags, so start parsing from here
       searchPattern = undefined;

--- a/src/cmd_line/subparsers/substitute.ts
+++ b/src/cmd_line/subparsers/substitute.ts
@@ -18,7 +18,11 @@ function parsePattern(scanner: Scanner, delimiter: string): [string, boolean] {
     } else if (currentChar === '\\') {
       if (!scanner.isAtEof) {
         currentChar = scanner.next();
-        pattern += '\\' + currentChar;
+        if (currentChar === delimiter) {
+          pattern += delimiter;
+        } else {
+          pattern += '\\' + currentChar;
+        }
       } else {
         pattern += '\\\\'; // :s/\ is treated like :s/\\
       }
@@ -59,7 +63,9 @@ function parseReplace(scanner: Scanner, delimiter: string): string {
     } else if (currentChar === '\\') {
       if (!scanner.isAtEof) {
         currentChar = scanner.next();
-        if (replaceEscapes.hasOwnProperty(currentChar)) {
+        if (currentChar === delimiter) {
+          replace += delimiter;
+        } else if (replaceEscapes.hasOwnProperty(currentChar)) {
           replace += replaceEscapes[currentChar];
         } else {
           replace += currentChar;

--- a/test/cmd_line/subparser.substitute.test.ts
+++ b/test/cmd_line/subparser.substitute.test.ts
@@ -28,6 +28,18 @@ suite(':substitute args parser', () => {
     assert.strictEqual(args.arguments.replace, 'b');
   });
 
+  test('can use pattern escapes', () => {
+    const args = commandParsers.substitute.parser('/\\ba/b/');
+    assert.strictEqual(args.arguments.pattern, '\\ba');
+    assert.strictEqual(args.arguments.replace, 'b');
+  });
+
+  test('can escape replacement', () => {
+    const args = commandParsers.substitute.parser('/a/\\b/');
+    assert.strictEqual(args.arguments.pattern, 'a');
+    assert.strictEqual(args.arguments.replace, '\b');
+  });
+
   test('can parse flag KeepPreviousFlags', () => {
     const args = commandParsers.substitute.parser('/a/b/&');
     assert.strictEqual(args.arguments.flags, 1);

--- a/test/cmd_line/substitute.test.ts
+++ b/test/cmd_line/substitute.test.ts
@@ -175,6 +175,13 @@ suite('Basic substitute', () => {
   });
 
   newTest({
+    title: 'Replace trailing \\ with \\',
+    start: ['one |two three'],
+    keysPressed: sub('t', '\\'),
+    end: ['|one \\wo three'],
+  });
+
+  newTest({
     title: 'Replace specific single equal lines',
     start: ['|aba', 'ab'],
     keysPressed: sub('a', 'd', { lineRange: '1,1', flags: 'g' }),

--- a/test/cmd_line/substitute.test.ts
+++ b/test/cmd_line/substitute.test.ts
@@ -154,6 +154,20 @@ suite('Basic substitute', () => {
   });
 
   newTest({
+    title: 'Preserve \\b in regular expression',
+    start: ['one |two three thirteen'],
+    keysPressed: sub('\\bt', 'x', { flags: 'g' }),
+    end: ['|one xwo xhree xhirteen'],
+  });
+
+  newTest({
+    title: 'Preserve \\\\ in regular expression',
+    start: ['one |\\two \\three thirteen'],
+    keysPressed: sub('\\\\t', 'x', { flags: 'g' }),
+    end: ['|one xwo xhree thirteen'],
+  });
+
+  newTest({
     title: 'Replace with \\n',
     start: ['one |two three'],
     keysPressed: sub('t', '\\n', { flags: 'g' }),


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix `\` escaping in `:s` substitution commands. The pattern and replacement need to be processed differently, because `\`s need to be preserved in the pattern for passing to `RegExp`, whereas they need to actually be processed in the replacement.

* `parsePattern` generally leaves backslashes alone, passing them on  to the regular expression parser.
* New `parseReplace` interprets backslashes.  New definitions for `\b`  (backspace), `\&` (same as `$&`), and `\0` through `\9` (same as  `$1` through `$9`).
* Rewrite these parsers in imperative style to avoid any stack overflow.


**Which issue(s) this PR fixes**
Fixes #6890

**Special notes for your reviewer**:
I'd like to change how search (`/`) works as well, for #6520. But I'm finding `src/actions/commands/search.ts` hard to follow. If you could point me in the right direction, I can try to fix that similarly.