### PR TITLE
Fix /\\c by requiring odd number of \'s before c for case (in)sensitivity

### DIFF
--- a/src/state/searchState.ts
+++ b/src/state/searchState.ts
@@ -26,7 +26,8 @@ export class SearchState {
   private static readonly MAX_SEARCH_RANGES = 1000;
 
   private static readonly specialCharactersRegex = /[\-\[\]{}()*+?.,\\\^$|#\s]/g;
-  private static readonly caseOverrideRegex = /\\[Cc]/g;
+  // c or C with an odd number of preceding \'s triggers "case override"
+  private static readonly caseOverrideRegex = /(?<=(?:^|[^\\])(?:\\\\)*)\\[Cc]/g;
   private static readonly notEscapedSlashRegex = supportsLookbehind
     ? new RegExp('(?<=[^\\\\])\\/', 'g')
     : /\//g;

--- a/test/mode/modeNormal.test.ts
+++ b/test/mode/modeNormal.test.ts
@@ -2334,6 +2334,20 @@ suite('Mode Normal', () => {
   });
 
   newTest({
+    title: '/\\\\c does not trigger case (in)sensitivity',
+    start: ['|__\\c__'],
+    keysPressed: '/\\\\c\n',
+    end: ['__|\\c__'],
+  });
+
+  newTest({
+    title: '/\\\\\\c triggers case insensitivity',
+    start: ['|__\\ASDF', 'asdf'],
+    keysPressed: '/\\\\\\c\n',
+    end: ['__|\\ASDF', 'asdf'],
+  });
+
+  newTest({
     title: '<C-l> adds the next character in the first match to search term',
     start: ['|foo', 'bar', 'abcd'],
     keysPressed: '/ab<C-l>d\n',


### PR DESCRIPTION

**What this PR does / why we need it**:
Require an odd number of `\`s before c for the case (in)sensitivity triggers `\c` and `\C`, enabling search for `\c` via `/\\c`.  This seems to match how vim works.

**Which issue(s) this PR fixes**
Fixes #6520.

**Special notes for your reviewer**:
* Thanks for the [pointer](https://github.com/VSCodeVim/Vim/pull/6891#issuecomment-883776019) to `searchState.ts`. I actually didn't know `\c` was a vim feature, which explains why it was just this particular case that was causing problems.
* I used lookbehind assertions which is not supported in all browsers, but seems to work fine in VSCode/Node.
* `/[\c]` is equivalent to `/c` in vim, but it still won't work with this patch. This seems less common, and I'm not sure how robustly I could fix it with a pure regular expression, and I don't think we really want to parse the whole regular expression...