### PR TITLE
Remove look behind for Safari

### DIFF
--- a/src/actions/languages/python/motion.ts
+++ b/src/actions/languages/python/motion.ts
@@ -19,6 +19,15 @@ interface StructureElement {
   end: Position;
 }
 
+// Older browsers don't support lookbehind - in this case, use an inferior regex rather than crashing
+let supportsLookbehind = true;
+try {
+  // tslint:disable-next-line
+  new RegExp('(?<=x)');
+} catch {
+  supportsLookbehind = false;
+}
+
 /*
  * Utility class used to parse the lines in the document and
  * determine class and function boundaries
@@ -31,7 +40,9 @@ export class PythonDocument {
   structure: StructureElement[];
 
   static readonly reOnlyWhitespace = /\S/;
-  static readonly reLastNonWhiteSpaceCharacter = /(?<=\S)\s*$/;
+  static readonly reLastNonWhiteSpaceCharacter = supportsLookbehind
+    ? new RegExp('/(?<=\\S)\\s*$/')
+    : /(\S)\s*$/;
   static readonly reDefOrClass = /^\s*(def|class) /;
 
   constructor(document: TextDocument) {

--- a/src/actions/languages/python/motion.ts
+++ b/src/actions/languages/python/motion.ts
@@ -41,7 +41,7 @@ export class PythonDocument {
 
   static readonly reOnlyWhitespace = /\S/;
   static readonly reLastNonWhiteSpaceCharacter = supportsLookbehind
-    ? new RegExp('/(?<=\\S)\\s*$/')
+    ? new RegExp('(?<=\\S)\\s*$')
     : /(\S)\s*$/;
   static readonly reDefOrClass = /^\s*(def|class) /;
 

--- a/src/state/searchState.ts
+++ b/src/state/searchState.ts
@@ -27,7 +27,9 @@ export class SearchState {
 
   private static readonly specialCharactersRegex = /[\-\[\]{}()*+?.,\\\^$|#\s]/g;
   // c or C with an odd number of preceding \'s triggers "case override"
-  private static readonly caseOverrideRegex = /(?<=(?:^|[^\\])(?:\\\\)*)\\[Cc]/g;
+  private static readonly caseOverrideRegex = supportsLookbehind
+    ? new RegExp('(?<=(?:^|[^\\\\])(?:\\\\\\\\)*)\\\\[Cc]', 'g')
+    : /\\[Cc]/g;
   private static readonly notEscapedSlashRegex = supportsLookbehind
     ? new RegExp('(?<=[^\\\\])\\/', 'g')
     : /\//g;


### PR DESCRIPTION
The newly introduced look behind regex breaks Vim in VS Code on Safari.