### PR TITLE
Fix history navigation in VS Code interactive window

### DIFF
--- a/src/actions/motion.ts
+++ b/src/actions/motion.ts
@@ -299,6 +299,7 @@ class MoveDown extends BaseMovement {
     vimState: VimState
   ): Promise<Position | IMovement> {
     if (
+      vimState.currentMode === Mode.Insert &&
       this.keysPressed[0] === '<down>' &&
       vimState.editor.document.uri.scheme === 'vscode-interactive-input' &&
       position.line === vimState.document.lineCount - 1
@@ -340,6 +341,7 @@ class MoveUp extends BaseMovement {
     vimState: VimState
   ): Promise<Position | IMovement> {
     if (
+      vimState.currentMode === Mode.Insert &&
       this.keysPressed[0] === '<up>' &&
       vimState.editor.document.uri.scheme === 'vscode-interactive-input' &&
       position.line === 0

--- a/src/actions/motion.ts
+++ b/src/actions/motion.ts
@@ -302,7 +302,8 @@ class MoveDown extends BaseMovement {
       vimState.currentMode === Mode.Insert &&
       this.keysPressed[0] === '<down>' &&
       vimState.editor.document.uri.scheme === 'vscode-interactive-input' &&
-      position.line === vimState.document.lineCount - 1
+      position.line === vimState.document.lineCount - 1 &&
+      vimState.editor.selection.isEmpty
     ) {
       // navigate history in interactive window
       await vscode.commands.executeCommand('interactive.history.next');
@@ -344,7 +345,8 @@ class MoveUp extends BaseMovement {
       vimState.currentMode === Mode.Insert &&
       this.keysPressed[0] === '<up>' &&
       vimState.editor.document.uri.scheme === 'vscode-interactive-input' &&
-      position.line === 0
+      position.line === 0 &&
+      vimState.editor.selection.isEmpty
     ) {
       // navigate history in interactive window
       await vscode.commands.executeCommand('interactive.history.previous');

--- a/src/actions/motion.ts
+++ b/src/actions/motion.ts
@@ -298,6 +298,16 @@ class MoveDown extends BaseMovement {
     position: Position,
     vimState: VimState
   ): Promise<Position | IMovement> {
+    if (
+      this.keysPressed[0] === '<down>' &&
+      vimState.editor.document.uri.scheme === 'vscode-interactive-input' &&
+      position.line === vimState.document.lineCount - 1
+    ) {
+      // navigate history in interactive window
+      await vscode.commands.executeCommand('interactive.history.next');
+      return vimState.editor.selection.active;
+    }
+
     if (configuration.foldfix && vimState.currentMode !== Mode.VisualBlock) {
       return new MoveDownFoldFix().execAction(position, vimState);
     }
@@ -329,6 +339,16 @@ class MoveUp extends BaseMovement {
     position: Position,
     vimState: VimState
   ): Promise<Position | IMovement> {
+    if (
+      this.keysPressed[0] === '<up>' &&
+      vimState.editor.document.uri.scheme === 'vscode-interactive-input' &&
+      position.line === 0
+    ) {
+      // navigate history in interactive window
+      await vscode.commands.executeCommand('interactive.history.previous');
+      return vimState.editor.selection.active;
+    }
+
     if (configuration.foldfix && vimState.currentMode !== Mode.VisualBlock) {
       return new MoveUpFoldFix().execAction(position, vimState);
     }
@@ -399,10 +419,16 @@ export class ArrowsInInsertMode extends BaseMovement {
     let newPosition: Position;
     switch (this.keysPressed[0]) {
       case '<up>':
-        newPosition = (await new MoveUp().execAction(position, vimState)) as Position;
+        newPosition = (await new MoveUp(this.keysPressed).execAction(
+          position,
+          vimState
+        )) as Position;
         break;
       case '<down>':
-        newPosition = (await new MoveDown().execAction(position, vimState)) as Position;
+        newPosition = (await new MoveDown(this.keysPressed).execAction(
+          position,
+          vimState
+        )) as Position;
         break;
       case '<left>':
         newPosition = await new MoveLeft(this.keysPressed).execAction(position, vimState);


### PR DESCRIPTION
Fix microsoft/vscode#130425.

VS Code introduced a new Interactive Window editor whose input box is a regular editor with history support. However the history are navigated through arrow keys, which conflict with Vim. In this PR, we call VS Code's command to do history navigation when it's in insert mode and the cursor is at the first line or last line.