### PR TITLE
Show command and search when showmodename is disabled

### DIFF
--- a/src/statusBar.ts
+++ b/src/statusBar.ts
@@ -99,7 +99,11 @@ class StatusBarImpl implements vscode.Disposable {
 
     const text: string[] = [];
 
-    if (configuration.showmodename) {
+    if (
+      configuration.showmodename ||
+      vimState.currentMode === Mode.CommandlineInProgress ||
+      vimState.currentMode === Mode.SearchInProgressMode
+    ) {
       text.push(statusBarText(vimState));
       if (vimState.isMultiCursor) {
         text.push(' MULTI CURSOR ');


### PR DESCRIPTION
**What this PR does / why we need it**:

When `showmodename` is disabled the mode is hidden but the search and
in-progress command text is also hidden.

This change updates the logic to take the command line and search
progress into account when determining if the status should be updated.

The old behavior of hiding all the text can be achieved by right
clicking the status bar and hiding the "Vim Command Line" entry. The
only difference is that macro information will also be hidden.

**Which issue(s) this PR fixes**
N/A. This was a quick change to make so I didn't open an issue. Happy to open one if preferred/necessary though!

**Special notes for your reviewer**:
N/A