### PR TITLE
Fix bang command with ranges

### DIFF
--- a/src/cmd_line/commands/bang.ts
+++ b/src/cmd_line/commands/bang.ts
@@ -40,7 +40,7 @@ export class BangCommand extends ExCommand {
     const resolvedRange = range.resolveToRange(vimState);
 
     // pipe in stdin from lines in range
-    const input = vimState.document.getText();
+    const input = vimState.document.getText(resolvedRange);
     const output = await externalCommand.run(this._arguments.command, input);
 
     // place cursor at the start of the replaced text and first non-whitespace character

--- a/test/cmd_line/bang.test.ts
+++ b/test/cmd_line/bang.test.ts
@@ -31,8 +31,8 @@ suite('bang (!) cmd_line', () => {
 
     test('! with line range', async () => {
       await modeHandler.handleMultipleKeyEvents(['i', '123\n456\n789', '<Esc>']);
-      await modeHandler.handleMultipleKeyEvents(':1,3!echo hello world\n'.split(''));
-      assertEqualLines(['hello world']);
+      await modeHandler.handleMultipleKeyEvents(':2,3!echo hello world\n'.split(''));
+      assertEqualLines(['123', 'hello world']);
     });
   });
 
@@ -78,9 +78,9 @@ suite('bang (!) cmd_line', () => {
     });
 
     test(':{range}!{cmd} should pass in line range as stdin', async () => {
-      await modeHandler.handleMultipleKeyEvents(['i', '3\n2\n1', '<Esc>']);
-      await modeHandler.handleMultipleKeyEvents(':1,3!sort -n\n'.split(''));
-      assertEqualLines(['1', '2', '3']);
+      await modeHandler.handleMultipleKeyEvents(['i', '4\n3\n2\n1', '<Esc>']);
+      await modeHandler.handleMultipleKeyEvents(':2,4!sort -n\n'.split(''));
+      assertEqualLines(['4', '1', '2', '3']);
     });
 
     test('! with commands expecting stdin do not block when no stdin is supplied', async () => {


### PR DESCRIPTION
<!--
Yay! Thanks for sending us a PR! 🎊

Please ensure your PR adheres to:

- [ ] Commit messages has a short & issue references when necessary
- [ ] Each commit does a logical chunk of work.
- [ ] It builds and tests pass (e.g `gulp`)
-->

**What this PR does / why we need it**:
Fixes the bang `!` command when used with a range, which is currently broken since any bang commands with ranges operate on all lines since the range isn't passed in properly.

Also improved some tests which should've detected this regression, but didn't because they executed on all lines.

**Which issue(s) this PR fixes**
#3136 
<!--
Commits in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)
-->