### PR TITLE
iskeyword is evaluated when a command is called (#7123)

### DIFF
--- a/src/textobject/word.ts
+++ b/src/textobject/word.ts
@@ -10,19 +10,17 @@ export enum WordType {
   FileName,
 }
 
-const nonWordCharRegex = makeUnicodeWordRegex(configuration.iskeyword);
 const nonBigWordCharRegex = makeWordRegex('');
-const nonCamelCaseWordCharRegex = makeCamelCaseWordRegex(configuration.iskeyword);
 const nonFileNameRegex = makeWordRegex('"\'`;<>{}[]()');
 
 function regexForWordType(wordType: WordType): RegExp {
   switch (wordType) {
     case WordType.Normal:
-      return nonWordCharRegex;
+      return makeUnicodeWordRegex(configuration.iskeyword);
     case WordType.Big:
       return nonBigWordCharRegex;
     case WordType.CamelCase:
-      return nonCamelCaseWordCharRegex;
+      return makeCamelCaseWordRegex(configuration.iskeyword);
     case WordType.FileName:
       return nonFileNameRegex;
   }


### PR DESCRIPTION
- [x] Commit messages has a short & issue references when necessary
- [x] Each commit does a logical chunk of work.
- [x] It builds and tests pass (e.g `gulp`)

**What this PR does / why we need it**:

`configuration.iskeyword` is evaluated only once when the extension is initialized. This means that `iskeyword` for a specific language is not respected when it's different from the language used for initialization. This PR solves the issue by evaluating it every time the word movement command is called.

**Which issue(s) this PR fixes**

#7123
