### PR TITLE
Add pane resize keybindings

### DIFF
--- a/src/actions/commands/actions.ts
+++ b/src/actions/commands/actions.ts
@@ -1777,6 +1777,58 @@ class EvenPaneWidths extends BaseCommand {
 }
 
 @RegisterAction
+class IncreasePaneWidth extends BaseCommand {
+  modes = [Mode.Normal, Mode.Visual, Mode.VisualLine];
+  keys = ['<C-w>', '>'];
+
+  public override async exec(position: Position, vimState: VimState): Promise<void> {
+    vimState.postponedCodeViewChanges.push({
+      command: 'workbench.action.increaseViewWidth',
+      args: {},
+    });
+  }
+}
+
+@RegisterAction
+class DecreasePaneWidth extends BaseCommand {
+  modes = [Mode.Normal, Mode.Visual, Mode.VisualLine];
+  keys = ['<C-w>', '<'];
+
+  public override async exec(position: Position, vimState: VimState): Promise<void> {
+    vimState.postponedCodeViewChanges.push({
+      command: 'workbench.action.decreaseViewWidth',
+      args: {},
+    });
+  }
+}
+
+@RegisterAction
+class IncreasePaneHeight extends BaseCommand {
+  modes = [Mode.Normal, Mode.Visual, Mode.VisualLine];
+  keys = ['<C-w>', '+'];
+
+  public override async exec(position: Position, vimState: VimState): Promise<void> {
+    vimState.postponedCodeViewChanges.push({
+      command: 'workbench.action.increaseViewHeight',
+      args: {},
+    });
+  }
+}
+
+@RegisterAction
+class DecreasePaneHeight extends BaseCommand {
+  modes = [Mode.Normal, Mode.Visual, Mode.VisualLine];
+  keys = ['<C-w>', '-'];
+
+  public override async exec(position: Position, vimState: VimState): Promise<void> {
+    vimState.postponedCodeViewChanges.push({
+      command: 'workbench.action.decreaseViewHeight',
+      args: {},
+    });
+  }
+}
+
+@RegisterAction
 class CommandTabNext extends BaseCommand {
   modes = [Mode.Normal, Mode.Visual, Mode.VisualLine];
   keys = [['g', 't'], ['<C-pagedown>']];


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds `Ctrl-W +, -` and `Ctrl-W >, <` Vim-like keybindings to increase pane height and width, respectively.

**Which issue(s) this PR fixes**
Fixes #2044, fixes #4597

<!--
Commits in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)
-->

**Special notes for your reviewer**:
