### PR TITLE
Only capture `<C-k>` when in Insert mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -231,7 +231,7 @@
       {
         "key": "ctrl+k",
         "command": "extension.vim_ctrl+k",
-        "when": "editorTextFocus && vim.active && vim.use<C-k> && !inDebugRepl"
+        "when": "editorTextFocus && vim.active && vim.use<C-k> && !inDebugRepl && vim.mode == 'Insert'"
       },
       {
         "key": "ctrl+l",


### PR DESCRIPTION
**What this PR does / why we need it**:
Makes the extension's `<C-k>` binding specific to Insert mode, by modifying the `when` condition to include `&& vim.mode == 'Insert'` as suggested in https://github.com/VSCodeVim/Vim/issues/7085#issuecomment-943571829. This is useful because many VSCode default bindings use `C-k` as a chord prefix, and Vim doesn't define behavior for `C-k` outside of Insert mode.

**Which issue(s) this PR fixes**
Fixes #7085

**Special notes for your reviewer**:
I didn't add any tests; let me know if this would be desired and/or you have ideas for good tests. I've tested by hand in the built extension.