### PR TITLE
Refactor `externalCommand.ts` to not use temporary files

### DIFF
--- a/src/util/child_process.ts
+++ b/src/util/child_process.ts
@@ -1,6 +1,9 @@
 import * as child_process from 'child_process';
 import { promisify } from 'util';
 
-export async function exec(command: string) {
-  return promisify(child_process.exec)(command);
+export function exec(
+  command: string,
+  options?: child_process.ExecOptions
+): child_process.PromiseWithChild<{ stdout: string | Buffer; stderr: string | Buffer }> {
+  return promisify(child_process.exec)(command, options);
 }

--- a/src/util/externalCommand.ts
+++ b/src/util/externalCommand.ts
@@ -1,19 +1,8 @@
-import { readFileAsync, writeFileAsync, unlink } from 'platform/fs';
-import { tmpdir } from '../util/os';
-import { join } from '../util/path';
 import { VimError, ErrorCode } from '../error';
-import { promisify } from 'util';
-import * as process from 'process';
+import { exec } from '../util/child_process';
 
 class ExternalCommand {
   private previousExternalCommand: string | undefined;
-
-  private getRandomFileName(): string {
-    return Math.random()
-      .toString(36)
-      .replace(/[^a-z]+/g, '')
-      .substr(0, 10);
-  }
 
   /**
    * Expands the given command by replacing any '!' with the previous external
@@ -47,35 +36,38 @@ class ExternalCommand {
   }
 
   /**
-   * Creates a shell command from a command string, and redirects stdin and
-   * stdout/stderr to the given input/output files.
-   *
-   * @param command the command to redirect
-   * @param inputFile path to the input file
-   * @param outputFile path to the output file
+   * Executes `command` and returns the output.
+   * @param command the command to run
+   * @param stdin string to pipe into stdin
    */
-  private redirectCommand(command: string, inputFile: string, outputFile: string): string {
-    let result: string;
-    if (process.platform === 'win32') {
-      // need to put the '<' redirection after the first command in the pipe
-      const pipeIndex = command.indexOf('|');
+  private async execute(command: string, stdin: string): Promise<string> {
+    const output: string[] = [];
 
-      if (pipeIndex !== -1) {
-        const firstCommand = command.slice(0, pipeIndex);
-        const restOfCommand = command.slice(pipeIndex);
-        result = `${firstCommand} < ${inputFile} ${restOfCommand} > ${outputFile}`;
-      } else {
-        result = `${command} < ${inputFile} > ${outputFile}`;
+    try {
+      const promise = exec(command);
+      const process = promise.child;
+
+      if (process.stdin !== null) {
+        process.stdin.on('error', () => {
+          // Make write EPIPE errors silent (e.g. when writing to program not expecting stdin)
+        });
+        process.stdin.write(stdin);
+        process.stdin.end();
       }
-    } else if (process.env.SHELL === 'fish') {
-      result = `begin; ${command}; end < ${inputFile} > ${outputFile}`;
-    } else {
-      result = `(${command}) < ${inputFile} > ${outputFile}`;
-    }
 
-    // combines stdout and stderr (compatible for all platforms)
-    result += ' 2>&1';
-    return result;
+      if (process.stdout !== null) {
+        process.stdout.on('data', (chunk) => output.push(chunk));
+      }
+      if (process.stderr !== null) {
+        process.stderr.on('data', (chunk) => output.push(chunk));
+      }
+
+      await promise;
+    } catch (e) {
+      // exec throws an error if exit code != 0
+      // keep going and read the output anyway (just like vim)
+    }
+    return output.join('');
   }
 
   /**
@@ -86,37 +78,18 @@ class ExternalCommand {
    * @param stdin string to pipe into stdin, by default the empty string
    */
   public async run(command: string, stdin: string = ''): Promise<string> {
-    const inputFile = join(tmpdir(), this.getRandomFileName());
-    const outputFile = join(tmpdir(), this.getRandomFileName());
-    let result = '';
+    command = this.expandCommand(command);
+    this.previousExternalCommand = command;
 
-    try {
-      await writeFileAsync(inputFile, stdin, 'utf8');
-
-      command = this.expandCommand(command);
-      this.previousExternalCommand = command;
-      command = this.redirectCommand(command, inputFile, outputFile);
-      try {
-        await import('child_process').then((cp) => {
-          return promisify(cp.exec)(command);
-        });
-      } catch (e) {
-        // exec throws an error if exit code != 0
-        // keep going and read the output anyway (just like vim)
-      }
-
-      result = await readFileAsync(outputFile, 'utf8');
-      // vim behavior: always trim newlines
-      if (result.endsWith('\n')) {
-        result = result.slice(0, -1);
-      }
-    } finally {
-      // always delete tmp files at the end
-      await unlink(inputFile);
-      await unlink(outputFile);
+    let output = await this.execute(command, stdin);
+    // vim behavior, trim newlines
+    if (output.endsWith('\r\n')) {
+      output = output.slice(0, -2);
+    } else if (output.endsWith('\n')) {
+      output = output.slice(0, -1);
     }
 
-    return result;
+    return output;
   }
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Refactors `externalCommand.ts` to use event emitters instead of temporary files to read the command output into the Vim buffer. This is much more cross-platform friendly. Creating temporary files and file paths are OS-dependent, which has made it difficult to build a `vim.shell` setting for #7100... so instead, this PR lets `exec`'s event emitters handle reading stdout/stderr for us. 

No change in behavior as this is an under-the-hood change, and existing tests in `bang.test.ts` and `filter.test.ts` pass.

**Which issue(s) this PR fixes**
N/A

