### PR TITLE
[TEST] Silence failing tests on Windows and add Windows build step

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,10 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout VSCodeVim
         uses: actions/checkout@v2
@@ -27,6 +30,7 @@ jobs:
         run: yarn install
 
       - name: Prettier
+        if: matrix.os != 'windows-latest'
         uses: creyD/prettier_action@v3.3
         with:
           prettier_options: '--write **/*.{ts,js,json,md,yml}'
@@ -41,7 +45,14 @@ jobs:
       - name: Build
         run: gulp webpack
 
-      - name: Test
+      - name: Test on ubuntu-latest
+        if: matrix.os != 'windows-latest'
         run: |
           gulp prepare-test
           xvfb-run -a yarn test
+
+      - name: Test on windows-latest
+        if: matrix.os == 'windows-latest'
+        run: |
+          gulp prepare-test
+          yarn test

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,13 +45,13 @@ jobs:
       - name: Build
         run: gulp webpack
 
-      - name: Test on ubuntu-latest
+      - name: Test on Ubuntu
         if: matrix.os != 'windows-latest'
         run: |
           gulp prepare-test
           xvfb-run -a yarn test
 
-      - name: Test on windows-latest
+      - name: Test on Windows
         if: matrix.os == 'windows-latest'
         run: |
           gulp prepare-test

--- a/test/cmd_line/bang.test.ts
+++ b/test/cmd_line/bang.test.ts
@@ -4,7 +4,12 @@ import { getAndUpdateModeHandler } from '../../extension';
 import { ModeHandler } from '../../src/mode/modeHandler';
 import { assertEqualLines, cleanUpWorkspace, setupWorkspace } from './../testUtils';
 
+// TODO(#4844): this fails on Windows
 suite('bang (!) cmd_line', () => {
+  if (process.platform === 'win32') {
+    return;
+  }
+
   let modeHandler: ModeHandler;
 
   setup(async () => {

--- a/test/completion/lineCompletion.test.ts
+++ b/test/completion/lineCompletion.test.ts
@@ -30,7 +30,11 @@ suite('Provide line completions', () => {
   };
 
   suite('Line Completion Provider unit tests', () => {
+    // TODO(#4844): this fails on Windows
     test('Can complete lines in file, prioritizing above cursor, near cursor', async () => {
+      if (process.platform === 'win32') {
+        return;
+      }
       const lines = ['a1', 'a2', 'a', 'a3', 'b1', 'a4'];
       await setupTestWithLines(lines);
       const expectedCompletions = ['a2', 'a1', 'a3', 'a4'];
@@ -42,7 +46,11 @@ suite('Provide line completions', () => {
       assert.deepStrictEqual(topCompletions, expectedCompletions, 'Unexpected completions found');
     });
 
+    // TODO(#4844): this fails on Windows
     test('Can complete lines in file with different indentation', async () => {
+      if (process.platform === 'win32') {
+        return;
+      }
       const lines = ['a1', '   a 2', 'a', 'a3  ', 'b1', 'a4'];
       await setupTestWithLines(lines);
       const expectedCompletions = ['a 2', 'a1', 'a3  ', 'a4'];

--- a/test/configuration/validators/neovimValidator.test.ts
+++ b/test/configuration/validators/neovimValidator.test.ts
@@ -39,7 +39,12 @@ suite('Neovim Validator', () => {
     assert.strictEqual(configuration.enableNeovim, false);
   });
 
+  // TODO(#4844): this fails on Windows
   test('neovim enabled with nvim in path', async () => {
+    if (process.platform === 'win32') {
+      return;
+    }
+
     // setup
     const configuration = new Configuration();
     configuration.enableNeovim = true;

--- a/test/jumpTracker.test.ts
+++ b/test/jumpTracker.test.ts
@@ -5,7 +5,7 @@ import { Jump } from './../src/jumps/jump';
 import { JumpTracker } from '../src/jumps/jumpTracker';
 import { cleanUpWorkspace, setupWorkspace } from './testUtils';
 import { Position } from 'vscode';
-import { ITestObject, newTest } from './testSimplifier';
+import { ITestObject, newTest, newTestSkip } from './testSimplifier';
 
 suite('Record and navigate jumps', () => {
   setup(async () => {
@@ -19,6 +19,16 @@ suite('Record and navigate jumps', () => {
       title: `Can track jumps for keys: ${options.keysPressed.replace(/\n/g, '<CR>')}`,
       ...options,
     });
+  };
+
+  const newJumpTestSkipOnWindows = (options: ITestObject | Omit<ITestObject, 'title'>) => {
+    return newTestSkip(
+      {
+        title: `Can track jumps for keys: ${options.keysPressed.replace(/\n/g, '<CR>')}`,
+        ...options,
+      },
+      process.platform === 'win32'
+    );
   };
 
   suite('Jump Tracker unit tests', () => {
@@ -307,7 +317,8 @@ suite('Record and navigate jumps', () => {
         end: ['|start', '{', 'a1', 'b1', 'a2', 'b2', '}', 'end'],
         jumps: ['{', '}'],
       });
-      newJumpTest({
+      // TODO(#4844): this fails on Windows
+      newJumpTestSkipOnWindows({
         start: ['|start', '{', 'a1', 'b1', 'a2', 'b2', '}', 'end'],
         keysPressed: '/^\nnnn<C-o><C-o><C-o><C-i>gg',
         end: ['|start', '{', 'a1', 'b1', 'a2', 'b2', '}', 'end'],
@@ -358,19 +369,22 @@ suite('Record and navigate jumps', () => {
     });
 
     suite('Can shifts jump lines up after deleting a line with Visual Line Mode', () => {
-      newJumpTest({
+      // TODO(#4844): this fails on Windows
+      newJumpTestSkipOnWindows({
         start: ['|start', 'a1', 'a2', 'a3', 'a4', 'a5', 'end'],
         keysPressed: '/^\nnnnkkdd',
         end: ['start', 'a1', '|a3', 'a4', 'a5', 'end'],
         jumps: ['start', 'a1', 'a3'],
       });
-      newJumpTest({
+      // TODO(#4844): this fails on Windows
+      newJumpTestSkipOnWindows({
         start: ['|start', 'a1', 'a2', 'a3', 'a4', 'a5', 'end'],
         keysPressed: '/^\nnnnkdd',
         end: ['start', 'a1', 'a2', '|a4', 'a5', 'end'],
         jumps: ['start', 'a1', 'a2', 'a4'],
       });
-      newJumpTest({
+      // TODO(#4844): this fails on Windows
+      newJumpTestSkipOnWindows({
         start: ['|start', 'a1', 'a2', 'a3', 'a4', 'a5', 'end'],
         keysPressed: '/^\nnnnnn<C-o><C-o><C-o><C-o>dd',
         end: ['start', 'a1', '|a3', 'a4', 'a5', 'end'],
@@ -385,7 +399,8 @@ suite('Record and navigate jumps', () => {
     });
 
     suite('Can shifts jump lines up after deleting a line with Visual Mode', () => {
-      newJumpTest({
+      // TODO(#4844): this fails on Windows
+      newJumpTestSkipOnWindows({
         start: ['|start', 'a1', 'a2', 'a3', 'a4', 'a5', 'end'],
         keysPressed: '/^\nnnnkklvjjhx',
         end: ['start', 'a1', 'a|4', 'a5', 'end'],
@@ -394,19 +409,22 @@ suite('Record and navigate jumps', () => {
     });
 
     suite('Can shift jump lines down after inserting a line', () => {
-      newJumpTest({
+      // TODO(#4844): this fails on Windows
+      newJumpTestSkipOnWindows({
         start: ['|start', 'a1', 'a2', 'a3', 'a4', 'a5', 'end'],
         keysPressed: '/^\nnnnkkoINSERTED<Esc>0',
         end: ['start', 'a1', 'a2', '|INSERTED', 'a3', 'a4', 'a5', 'end'],
         jumps: ['start', 'a1', 'a2', 'a3'],
       });
-      newJumpTest({
+      // TODO(#4844): this fails on Windows
+      newJumpTestSkipOnWindows({
         start: ['|start', 'a1', 'a2', 'a3', 'a4', 'a5', 'end'],
         keysPressed: '/^\nnnnkoINSERTED<Esc>0',
         end: ['start', 'a1', 'a2', 'a3', '|INSERTED', 'a4', 'a5', 'end'],
         jumps: ['start', 'a1', 'a2', 'a3'],
       });
-      newJumpTest({
+      // TODO(#4844): this fails on Windows
+      newJumpTestSkipOnWindows({
         start: ['|start', 'a1', 'a2', 'a3', 'a4', 'a5', 'end'],
         keysPressed: '/^\nnnnkOINSERTED<Esc>0',
         end: ['start', 'a1', 'a2', '|INSERTED', 'a3', 'a4', 'a5', 'end'],
@@ -430,7 +448,8 @@ suite('Record and navigate jumps', () => {
     });
 
     suite('Can track jumps from macros', () => {
-      newJumpTest({
+      // TODO(#4844): this fails on Windows
+      newJumpTestSkipOnWindows({
         start: ['|start', 'a1', 'a2', 'a3', 'a4', 'a5', 'a6', 'a7', 'a8', 'a9', 'end'],
         keysPressed: 'qq/^\nnq@q@q<C-o><C-o>',
         end: ['start', 'a1', 'a2', 'a3', '|a4', 'a5', 'a6', 'a7', 'a8', 'a9', 'end'],

--- a/test/mode/modeNormal.test.ts
+++ b/test/mode/modeNormal.test.ts
@@ -4,7 +4,7 @@ import { getAndUpdateModeHandler } from '../../extension';
 import { Mode } from '../../src/mode/mode';
 import { ModeHandler } from '../../src/mode/modeHandler';
 import { Configuration } from '../testConfiguration';
-import { newTest } from '../testSimplifier';
+import { newTest, newTestSkip } from '../testSimplifier';
 import { cleanUpWorkspace, setupWorkspace } from './../testUtils';
 
 suite('Mode Normal', () => {
@@ -1674,19 +1674,23 @@ suite('Mode Normal', () => {
     ],
   });
 
-  newTest({
-    title: 'gq work correctly with cursor in the middle of a line',
-    start: [
-      '// We choose to write a vim extension, not |because it is easy, but because it is hard.',
-      '// We choose to write a vim extension, not because it is easy, but because it is hard.',
-    ],
-    keysPressed: 'gqj',
-    end: [
-      '|// We choose to write a vim extension, not because it is easy, but because it is',
-      '// hard.  We choose to write a vim extension, not because it is easy, but',
-      '// because it is hard.',
-    ],
-  });
+  // TODO(#4844): this fails on Windows
+  newTestSkip(
+    {
+      title: 'gq work correctly with cursor in the middle of a line',
+      start: [
+        '// We choose to write a vim extension, not |because it is easy, but because it is hard.',
+        '// We choose to write a vim extension, not because it is easy, but because it is hard.',
+      ],
+      keysPressed: 'gqj',
+      end: [
+        '|// We choose to write a vim extension, not because it is easy, but because it is',
+        '// hard.  We choose to write a vim extension, not because it is easy, but',
+        '// because it is hard.',
+      ],
+    },
+    process.platform === 'win32'
+  );
 
   newTest({
     title: 'gq preserves newlines',
@@ -1695,33 +1699,49 @@ suite('Mode Normal', () => {
     end: ['|abc', '', '', '', 'def'],
   });
 
-  newTest({
-    title: 'gq handles single-line comments',
-    start: ['|// abc', '// def'],
-    keysPressed: 'gqG',
-    end: ['|// abc def'],
-  });
+  // TODO(#4844): this fails on Windows
+  newTestSkip(
+    {
+      title: 'gq handles single-line comments',
+      start: ['|// abc', '// def'],
+      keysPressed: 'gqG',
+      end: ['|// abc def'],
+    },
+    process.platform === 'win32'
+  );
 
-  newTest({
-    title: 'gq handles multiline comments',
-    start: ['|/*', ' * abc', ' * def', ' */'],
-    keysPressed: 'gqG',
-    end: ['|/*', ' * abc def', ' */'],
-  });
+  // TODO(#4844): this fails on Windows
+  newTestSkip(
+    {
+      title: 'gq handles multiline comments',
+      start: ['|/*', ' * abc', ' * def', ' */'],
+      keysPressed: 'gqG',
+      end: ['|/*', ' * abc def', ' */'],
+    },
+    process.platform === 'win32'
+  );
 
-  newTest({
-    title: 'gq handles multiline comments with inner and final on same line',
-    start: ['|/*', ' * abc', ' * def */'],
-    keysPressed: 'gqG',
-    end: ['|/*', ' * abc def */'],
-  });
+  // TODO(#4844): this fails on Windows
+  newTestSkip(
+    {
+      title: 'gq handles multiline comments with inner and final on same line',
+      start: ['|/*', ' * abc', ' * def */'],
+      keysPressed: 'gqG',
+      end: ['|/*', ' * abc def */'],
+    },
+    process.platform === 'win32'
+  );
 
-  newTest({
-    title: 'gq handles multiline comments with content on start line',
-    start: ['|/* abc', ' * def', '*/'],
-    keysPressed: 'gqG',
-    end: ['|/* abc def', ' */'],
-  });
+  // TODO(#4844): this fails on Windows
+  newTestSkip(
+    {
+      title: 'gq handles multiline comments with content on start line',
+      start: ['|/* abc', ' * def', '*/'],
+      keysPressed: 'gqG',
+      end: ['|/* abc def', ' */'],
+    },
+    process.platform === 'win32'
+  );
 
   newTest({
     title: 'gq handles multiline comments with start and final on same line',
@@ -1737,26 +1757,38 @@ suite('Mode Normal', () => {
     end: ['|/* abc', ' *', ' *', ' * def */'],
   });
 
-  newTest({
-    title: 'gq does not merge adjacent multiline comments',
-    start: ['|/* abc */', '/* def */'],
-    keysPressed: 'gqG',
-    end: ['|/* abc */', '/* def */'],
-  });
+  // TODO(#4844): this fails on Windows
+  newTestSkip(
+    {
+      title: 'gq does not merge adjacent multiline comments',
+      start: ['|/* abc */', '/* def */'],
+      keysPressed: 'gqG',
+      end: ['|/* abc */', '/* def */'],
+    },
+    process.platform === 'win32'
+  );
 
-  newTest({
-    title: 'gq does not merge adjacent multiline comments',
-    start: ['|/* abc', ' */', '/* def', ' */'],
-    keysPressed: 'gqG',
-    end: ['|/* abc', ' */', '/* def', ' */'],
-  });
+  // TODO(#4844): this fails on Windows
+  newTestSkip(
+    {
+      title: 'gq does not merge adjacent multiline comments',
+      start: ['|/* abc', ' */', '/* def', ' */'],
+      keysPressed: 'gqG',
+      end: ['|/* abc', ' */', '/* def', ' */'],
+    },
+    process.platform === 'win32'
+  );
 
-  newTest({
-    title: 'gq leaves alone whitespace within a line',
-    start: ["|Good morning, how are you?  I'm Dr. Worm.", "I'm interested", 'in      things.'],
-    keysPressed: 'gqG',
-    end: ["|Good morning, how are you?  I'm Dr. Worm.  I'm interested in      things."],
-  });
+  // TODO(#4844): this fails on Windows
+  newTestSkip(
+    {
+      title: 'gq leaves alone whitespace within a line',
+      start: ["|Good morning, how are you?  I'm Dr. Worm.", "I'm interested", 'in      things.'],
+      keysPressed: 'gqG',
+      end: ["|Good morning, how are you?  I'm Dr. Worm.  I'm interested in      things."],
+    },
+    process.platform === 'win32'
+  );
 
   newTest({
     title: 'gq breaks at exactly textwidth',

--- a/test/mode/normalModeTests/motions.test.ts
+++ b/test/mode/normalModeTests/motions.test.ts
@@ -936,13 +936,16 @@ suite('Motions in Normal Mode', () => {
       end: ['ab|c', 'def', 'ghi'],
     });
 
-    // TODO: this fails on Windows due to \r\n
-    newTest({
-      title: '`[count]go` goes to offset <count>, newlines disregarded',
-      start: ['abc', 'de|f', 'ghi'],
-      keysPressed: '10go',
-      end: ['abc', 'def', 'g|hi'],
-    });
+    // TODO(#4844): this fails on Windows due to \r\n
+    newTestSkip(
+      {
+        title: '`[count]go` goes to offset <count>, newlines disregarded',
+        start: ['abc', 'de|f', 'ghi'],
+        keysPressed: '10go',
+        end: ['abc', 'def', 'g|hi'],
+      },
+      process.platform === 'win32'
+    );
   });
 
   newTest({

--- a/test/operator/filter.test.ts
+++ b/test/operator/filter.test.ts
@@ -1,7 +1,12 @@
 import { newTest } from '../testSimplifier';
 import { cleanUpWorkspace, setupWorkspace } from '../testUtils';
 
+// TODO(#4844): this fails on Windows
 suite('filter operator', () => {
+  if (process.platform === 'win32') {
+    return;
+  }
+
   setup(async () => {
     await setupWorkspace();
   });

--- a/test/testSimplifier.ts
+++ b/test/testSimplifier.ts
@@ -61,7 +61,8 @@ export const newTestOnly = (testObj: ITestObject) => {
   return newTestGeneric(testObj, test.only, testIt);
 };
 
-export const newTestSkip = (testObj: ITestObject) => newTestGeneric(testObj, test.skip, testIt);
+export const newTestSkip = (testObj: ITestObject, skipCondition: boolean = true) =>
+  newTestGeneric(testObj, skipCondition ? test.skip : test, testIt);
 
 export const newTestWithRemaps = (testObj: ITestWithRemapsObject) =>
   newTestGeneric(testObj, test, testItWithRemaps);


### PR DESCRIPTION
<!--
Yay! Thanks for sending us a PR! 🎊

Please ensure your PR adheres to:

- [ ] Commit messages has a short & issue references when necessary
- [ ] Each commit does a logical chunk of work.
- [ ] It builds and tests pass (e.g `gulp`)
-->

**What this PR does / why we need it**:
While working on the bang/filter command feature, I've noticed that quite a few tests are failing only on Windows. This PR proposes we temporarily silence those tests on Windows and document them with TODO comments, which I hope should be helpful towards fixing #4844 (and #4079).

Additionally, I propose we add a Windows build step to our Github Actions workflow to encourage cross-platform compatibility for future PRs. However, this may affect this repo's Github Actions minutes limit - [jobs that run on Windows consume minutes at twice the rate of Linux-based jobs](https://docs.github.com/en/billing/managing-billing-for-github-actions/about-billing-for-github-actions#:~:text=Jobs%20that%20run%20on%20Windows%20and,10%2C000%20minutes%20included%20in%20your%20account.). This multiplier means that this would probably cause the minutes consumption to triple. I'm not sure what the minutes limit is for VSCodeVim nor if we currently run near that limit, so if this would cause problems, I can omit this change. Lemme know your thoughts!

**Which issue(s) this PR fixes**
N/A, but progresses towards fixing #4844 and #4079.

<!--
Commits in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)
-->