### PR TITLE
add operation for generating a console log of targeted text object

### DIFF
--- a/package.json
+++ b/package.json
@@ -615,6 +615,16 @@
           "description": "Ignore case in search patterns.",
           "default": true
         },
+        "vim.logObject": {
+          "type": "boolean",
+          "markdownDescription": "Generate console log of targeted text object.",
+          "default": false
+        },
+        "vim.logObjectTemplate": {
+          "type": "string",
+          "markdownDescription": "The template for the console message. {object} will be replaced by the text object in the generated output. Default template is in JavaScript format. Please replace it if using another language.",
+          "default": "console.log(\"{object}\", {object});"
+        },
         "vim.smartcase": {
           "type": "boolean",
           "markdownDescription": "Override the `ignorecase` option if the search pattern contains upper case characters.",

--- a/src/actions/include-all.ts
+++ b/src/actions/include-all.ts
@@ -2,7 +2,6 @@ import './base';
 import './operator';
 import './motion';
 import '../textobject/textobject';
-
 // commands
 import './commands/insert';
 import './commands/replace';
@@ -11,11 +10,11 @@ import './commands/commandLine';
 import './commands/search';
 import './commands/put';
 import './commands/digraphs';
-
 // plugin
 import './plugins/camelCaseMotion';
 import './plugins/easymotion/easymotion.cmd';
 import './plugins/easymotion/registerMoveActions';
+import './plugins/logObject';
 import './plugins/sneak';
 import './plugins/replaceWithRegister';
 import './plugins/surround';

--- a/src/actions/include-plugins.ts
+++ b/src/actions/include-plugins.ts
@@ -2,6 +2,7 @@
 import './plugins/camelCaseMotion';
 import './plugins/easymotion/easymotion.cmd';
 import './plugins/easymotion/registerMoveActions';
+import './plugins/logObject';
 import './plugins/sneak';
 import './plugins/replaceWithRegister';
 import './plugins/surround';

--- a/src/actions/plugins/logObject.ts
+++ b/src/actions/plugins/logObject.ts
@@ -1,0 +1,54 @@
+import * as vscode from 'vscode';
+
+import { configuration } from '../../configuration/configuration';
+import { BaseOperator } from '../operator';
+import { Mode } from '../../mode/mode';
+import { Position } from 'vscode';
+import { RegisterAction } from '../base';
+import { TextEditor } from './../../textEditor';
+import { VimState } from '../../state/vimState';
+import { sorted } from './../../common/motion/position';
+
+function escapeRegExp(str: string) {
+  return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function replaceAll(str: string, find: string, replace: string) {
+  return str.replace(new RegExp(escapeRegExp(find), 'g'), replace);
+}
+@RegisterAction
+class LogObjectOperator extends BaseOperator {
+  public keys = ['<leader>', 'l'];
+  public modes = [Mode.Normal, Mode.Visual];
+
+  public override doesActionApply(vimState: VimState, keysPressed: string[]): boolean {
+    return configuration.logObject && super.doesActionApply(vimState, keysPressed);
+  }
+
+  public override couldActionApply(vimState: VimState, keysPressed: string[]): boolean {
+    return configuration.logObject && super.doesActionApply(vimState, keysPressed);
+  }
+
+  public async run(vimState: VimState, start: Position, end: Position): Promise<void> {
+    [start, end] = sorted(start, end);
+    const extendedEnd = new Position(end.line, end.character + 1);
+    const range = new vscode.Range(start, extendedEnd);
+    const text = vimState.document.getText(range);
+
+    await vimState.setCurrentMode(Mode.Normal);
+    await vscode.commands.executeCommand('editor.action.insertLineAfter');
+
+    vimState.cursorStopPosition = TextEditor.getFirstNonWhitespaceCharOnLine(
+      vimState.document,
+      start.line + 1
+    );
+
+    const logMessage = replaceAll(configuration.logObjectTemplate, '{object}', text);
+
+    if (vscode.window.activeTextEditor) {
+      await vscode.window.activeTextEditor.edit((editBuilder) => {
+        editBuilder.insert(new vscode.Position(start.line + 1, 0), logMessage);
+      });
+    }
+  }
+}

--- a/src/configuration/configuration.ts
+++ b/src/configuration/configuration.ts
@@ -235,6 +235,9 @@ class Configuration implements IConfiguration {
     enable: true,
   };
 
+  logObject = false;
+  logObjectTemplate = 'console.log("{object}", {object});';
+
   replaceWithRegister = false;
 
   smartRelativeLine = false;

--- a/src/configuration/iconfiguration.ts
+++ b/src/configuration/iconfiguration.ts
@@ -137,6 +137,16 @@ export interface IConfiguration {
   easymotion: boolean;
 
   /**
+   * Use LogObject plugin?
+   */
+  logObject: boolean;
+
+  /**
+   * Costmize logObject message template
+   */
+  logObjectTemplate: string;
+
+  /**
    * Use ReplaceWithRegister plugin?
    */
   replaceWithRegister: boolean;

--- a/test/plugins/logObject.test.ts
+++ b/test/plugins/logObject.test.ts
@@ -1,0 +1,73 @@
+import { cleanUpWorkspace, setupWorkspace } from '../testUtils';
+import { Configuration } from '../testConfiguration';
+import { newTest } from '../testSimplifier';
+
+function escapeRegExp(str: string) {
+  return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function replaceAll(str: string, find: string, replace: string) {
+  return str.replace(new RegExp(escapeRegExp(find), 'g'), replace);
+}
+
+suite('logObject plugin', () => {
+  const configuration = new Configuration();
+  setup(async () => {
+    configuration.logObject = true;
+    await setupWorkspace(configuration, '.js');
+  });
+
+  teardown(cleanUpWorkspace);
+
+  const logObjectTemplate = configuration.logObjectTemplate;
+  let logMessage = '';
+
+  logMessage = replaceAll(logObjectTemplate, '{object}', 'myIterator');
+  newTest({
+    title: "'<leader>liw' generates a console log from the target word",
+    start: ['<div>{getContent(myArray[myIte|rator].myProperty)}</div>'],
+    keysPressed: '<leader>liw',
+    end: ['<div>{getContent(myArray[myIterator].myProperty)}</div>', '|' + logMessage],
+  });
+
+  logMessage = replaceAll(logObjectTemplate, '{object}', 'myIterator');
+  newTest({
+    title: "'<leader>li[' generates a console log from the content of []",
+    start: ['<div>{getContent(myArray[myIte|rator].myProperty)}</div>'],
+    keysPressed: '<leader>li[',
+    end: ['<div>{getContent(myArray[myIterator].myProperty)}</div>', '|' + logMessage],
+  });
+
+  logMessage = replaceAll(logObjectTemplate, '{object}', 'myArray[myIterator].myProperty');
+  newTest({
+    title: "'<leader>li(' generates a console log from the content of ()",
+    start: ['<div>{getContent(myArray[myIte|rator].myProperty)}</div>'],
+    keysPressed: '<leader>li(',
+    end: ['<div>{getContent(myArray[myIterator].myProperty)}</div>', '|' + logMessage],
+  });
+
+  logMessage = replaceAll(
+    logObjectTemplate,
+    '{object}',
+    'getContent(myArray[myIterator].myProperty)'
+  );
+  newTest({
+    title: "'<leader>li{' generates a console log from the content of {}",
+    start: ['<div>{getContent(myArray[myIte|rator].myProperty)}</div>'],
+    keysPressed: '<leader>li{',
+    end: ['<div>{getContent(myArray[myIterator].myProperty)}</div>', '|' + logMessage],
+  });
+
+  logMessage = replaceAll(
+    logObjectTemplate,
+    '{object}',
+    '{getContent(myArray[myIterator].myProperty)}'
+  );
+  newTest({
+    title:
+      "'<leader>lit' generates a console log from the content between opening and closing tags",
+    start: ['<div>{getContent(myArray[myIte|rator].myProperty)}</div>'],
+    keysPressed: '<leader>lit',
+    end: ['<div>{getContent(myArray[myIterator].myProperty)}</div>', '|' + logMessage],
+  });
+});

--- a/test/testConfiguration.ts
+++ b/test/testConfiguration.ts
@@ -21,6 +21,8 @@ export class Configuration implements IConfiguration {
   camelCaseMotion = {
     enable: false,
   };
+  logObject = false;
+  logObjectTemplate = 'console.log("{object}", {object});';
   replaceWithRegister = false;
   smartRelativeLine = false;
   sneak = false;


### PR DESCRIPTION
<!--
Yay! Thanks for sending us a PR! 🎊

Please ensure your PR adheres to:

- [ ] Commit messages has a short & issue references when necessary
- [ ] Each commit does a logical chunk of work.
- [ ] It builds and tests pass (e.g `gulp`)
-->

**What this PR does / why we need it**:
Hi!

When coding I find myself using the snippet `clo` from [vscode-react-javascript-snippets](https://github.com/dsznajder/vscode-react-javascript-snippets) all the time. It pastes `console.log("<cursor>", <cursor>)` and thereby let you log a specific object (or array, variable etc...) while in the same time log the name of that object.

Having the double cursor helps speeding up the process since you typically will type simply the object name. However, autocomplete won't work since we're typing a string. This is a major hassle since a lot of times I want to type something like `myObject1.myObject2.myPropertyWithLongName`.

I therefore forked vscodevim and made a new operator that I call ”logObject”. It's mapped to `'<leader>l’` and lets you target a text object and then console logs that object on a new line below, in a similar fashion as the snippet mentioned above.

For example, I can place the cursor within the brackets of this line:

`headerImage = isImageEmpty(page.headerImage) ? null : page.headerImage;`

and then type this motion:

`'<leader>', 'l', 'i', '('`

It will then create a new line below with the following:

`console.log("page.headerImage", page.headerImage);`

The default template of the log message is for JavaScript, but this can be modified by setting `vim.logObjectTemplate` to a message of choice your.

**Which issue(s) this PR fixes**

There is no specific issue that it fixes.

<!--
Commits in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)
-->

**Special notes for your reviewer**:

This fork is made primarily because it speeds up the workflow for me personally. But I think other people might benefit from it as well, especially since it's possible to customize the log message. Please let me know if you think it would suit the project. I understand if you might want to keep to a minimal amount of well established plugins though.