### PR TITLE
Exclude :w, :q, and :wq from dot command

### DIFF
--- a/src/actions/base.ts
+++ b/src/actions/base.ts
@@ -26,7 +26,7 @@ export abstract class BaseAction implements IBaseAction {
   /**
    * If true, the action will create an undo point.
    */
-  public readonly actionCreatesUndoPoint: boolean = false;
+  public readonly createsUndoPoint: boolean = false;
 
   /**
    * If this is being run in multi cursor mode, the index of the cursor

--- a/src/actions/base.ts
+++ b/src/actions/base.ts
@@ -24,10 +24,9 @@ export abstract class BaseAction implements IBaseAction {
   public readonly isJump: boolean = false;
 
   /**
-   * TODO: This property is a lie - it pertains to whether an action creates an undo point...
-   *       See #5058 and rationalize ASAP.
+   * If true, the action will create an undo point.
    */
-  public readonly canBeRepeatedWithDot: boolean = false;
+  public readonly actionCreatesUndoPoint: boolean = false;
 
   /**
    * If this is being run in multi cursor mode, the index of the cursor

--- a/src/actions/commands/actions.ts
+++ b/src/actions/commands/actions.ts
@@ -366,7 +366,7 @@ class CommandExecuteLastMacro extends BaseCommand {
   modes = [Mode.Normal, Mode.Visual, Mode.VisualLine];
   keys = ['@', '@'];
   override runsOnceForEachCountPrefix = true;
-  override actionCreatesUndoPoint = true;
+  override createsUndoPoint = true;
   override isJump = true;
 
   public override async exec(position: Position, vimState: VimState): Promise<void> {
@@ -389,7 +389,7 @@ class CommandExecuteMacro extends BaseCommand {
   modes = [Mode.Normal, Mode.Visual, Mode.VisualLine];
   keys = ['@', '<character>'];
   override runsOnceForEachCountPrefix = true;
-  override actionCreatesUndoPoint = true;
+  override createsUndoPoint = true;
 
   public override async exec(position: Position, vimState: VimState): Promise<void> {
     const register = this.keysPressed[1].toLocaleLowerCase();
@@ -841,7 +841,7 @@ class CommandDot extends BaseCommand {
 class CommandRepeatSubstitution extends BaseCommand {
   modes = [Mode.Normal];
   keys = ['&'];
-  override actionCreatesUndoPoint = true;
+  override createsUndoPoint = true;
 
   public override async exec(position: Position, vimState: VimState): Promise<void> {
     // Parsing the command from a string, while not ideal, is currently
@@ -1183,7 +1183,7 @@ class CommandRedo extends BaseCommand {
 class CommandDeleteToLineEnd extends BaseCommand {
   modes = [Mode.Normal];
   keys = ['D'];
-  override actionCreatesUndoPoint = true;
+  override createsUndoPoint = true;
   override runsOnceForEveryCursor() {
     return true;
   }
@@ -1863,7 +1863,7 @@ class CommandTabPrevious extends BaseCommand {
 export class ActionDeleteChar extends BaseCommand {
   modes = [Mode.Normal];
   keys = ['x'];
-  override actionCreatesUndoPoint = true;
+  override createsUndoPoint = true;
 
   public override async exec(position: Position, vimState: VimState): Promise<void> {
     // If line is empty, do nothing
@@ -1888,7 +1888,7 @@ export class ActionDeleteCharWithDeleteKey extends BaseCommand {
   modes = [Mode.Normal];
   keys = ['<Del>'];
   override runsOnceForEachCountPrefix = true;
-  override actionCreatesUndoPoint = true;
+  override createsUndoPoint = true;
 
   public override async execCount(position: Position, vimState: VimState): Promise<void> {
     // If <del> has a count in front of it, then <del> deletes a character
@@ -1911,7 +1911,7 @@ export class ActionDeleteCharWithDeleteKey extends BaseCommand {
 export class ActionDeleteLastChar extends BaseCommand {
   modes = [Mode.Normal];
   keys = ['X'];
-  override actionCreatesUndoPoint = true;
+  override createsUndoPoint = true;
 
   public override async exec(position: Position, vimState: VimState): Promise<void> {
     if (position.character === 0) {
@@ -1932,7 +1932,7 @@ export class ActionDeleteLastChar extends BaseCommand {
 class ActionJoin extends BaseCommand {
   modes = [Mode.Normal];
   keys = ['J'];
-  override actionCreatesUndoPoint = true;
+  override createsUndoPoint = true;
   override runsOnceForEachCountPrefix = false;
 
   private firstNonWhitespaceIndex(str: string): number {
@@ -2117,7 +2117,7 @@ class ActionJoinVisualBlockMode extends BaseCommand {
 class ActionJoinNoWhitespace extends BaseCommand {
   modes = [Mode.Normal];
   keys = ['g', 'J'];
-  override actionCreatesUndoPoint = true;
+  override createsUndoPoint = true;
 
   // gJ is essentially J without the edge cases. ;-)
 
@@ -2170,7 +2170,7 @@ class ActionJoinNoWhitespaceVisualMode extends BaseCommand {
 class ActionReplaceCharacter extends BaseCommand {
   modes = [Mode.Normal];
   keys = ['r', '<character>'];
-  override actionCreatesUndoPoint = true;
+  override createsUndoPoint = true;
   override runsOnceForEachCountPrefix = false;
 
   public override async exec(position: Position, vimState: VimState): Promise<void> {
@@ -2236,7 +2236,7 @@ class ActionReplaceCharacterVisual extends BaseCommand {
   override runsOnceForEveryCursor() {
     return false;
   }
-  override actionCreatesUndoPoint = true;
+  override createsUndoPoint = true;
 
   public override async exec(position: Position, vimState: VimState): Promise<void> {
     let toInsert = this.keysPressed[1];
@@ -2316,7 +2316,7 @@ class ActionReplaceCharacterVisualBlock extends BaseCommand {
   override runsOnceForEveryCursor() {
     return false;
   }
-  override actionCreatesUndoPoint = true;
+  override createsUndoPoint = true;
 
   public override async exec(position: Position, vimState: VimState): Promise<void> {
     let toInsert = this.keysPressed[1];
@@ -2351,7 +2351,7 @@ class ActionReplaceCharacterVisualBlock extends BaseCommand {
 class ActionDeleteVisualBlock extends BaseCommand {
   modes = [Mode.VisualBlock];
   keys = [['d'], ['x'], ['X']];
-  override actionCreatesUndoPoint = true;
+  override createsUndoPoint = true;
   override runsOnceForEveryCursor() {
     return false;
   }
@@ -2386,7 +2386,7 @@ class ActionDeleteVisualBlock extends BaseCommand {
 class ActionShiftDVisualBlock extends BaseCommand {
   modes = [Mode.VisualBlock];
   keys = ['D'];
-  override actionCreatesUndoPoint = true;
+  override createsUndoPoint = true;
   override runsOnceForEveryCursor() {
     return false;
   }
@@ -2712,7 +2712,7 @@ class ActionChangeChar extends BaseCommand {
 class ToggleCaseAndMoveForward extends BaseCommand {
   modes = [Mode.Normal];
   keys = ['~'];
-  override actionCreatesUndoPoint = true;
+  override createsUndoPoint = true;
 
   private toggleCase(text: string): string {
     let newText = '';
@@ -2746,7 +2746,7 @@ class ToggleCaseAndMoveForward extends BaseCommand {
 
 abstract class IncrementDecrementNumberAction extends BaseCommand {
   modes = [Mode.Normal, Mode.Visual, Mode.VisualLine, Mode.VisualBlock];
-  override actionCreatesUndoPoint = true;
+  override createsUndoPoint = true;
   abstract offset: number;
   abstract staircase: boolean;
 

--- a/src/actions/commands/actions.ts
+++ b/src/actions/commands/actions.ts
@@ -366,7 +366,7 @@ class CommandExecuteLastMacro extends BaseCommand {
   modes = [Mode.Normal, Mode.Visual, Mode.VisualLine];
   keys = ['@', '@'];
   override runsOnceForEachCountPrefix = true;
-  override canBeRepeatedWithDot = true;
+  override actionCreatesUndoPoint = true;
   override isJump = true;
 
   public override async exec(position: Position, vimState: VimState): Promise<void> {
@@ -389,7 +389,7 @@ class CommandExecuteMacro extends BaseCommand {
   modes = [Mode.Normal, Mode.Visual, Mode.VisualLine];
   keys = ['@', '<character>'];
   override runsOnceForEachCountPrefix = true;
-  override canBeRepeatedWithDot = true;
+  override actionCreatesUndoPoint = true;
 
   public override async exec(position: Position, vimState: VimState): Promise<void> {
     const register = this.keysPressed[1].toLocaleLowerCase();
@@ -841,7 +841,7 @@ class CommandDot extends BaseCommand {
 class CommandRepeatSubstitution extends BaseCommand {
   modes = [Mode.Normal];
   keys = ['&'];
-  override canBeRepeatedWithDot = true;
+  override actionCreatesUndoPoint = true;
 
   public override async exec(position: Position, vimState: VimState): Promise<void> {
     // Parsing the command from a string, while not ideal, is currently
@@ -1183,7 +1183,7 @@ class CommandRedo extends BaseCommand {
 class CommandDeleteToLineEnd extends BaseCommand {
   modes = [Mode.Normal];
   keys = ['D'];
-  override canBeRepeatedWithDot = true;
+  override actionCreatesUndoPoint = true;
   override runsOnceForEveryCursor() {
     return true;
   }
@@ -1863,7 +1863,7 @@ class CommandTabPrevious extends BaseCommand {
 export class ActionDeleteChar extends BaseCommand {
   modes = [Mode.Normal];
   keys = ['x'];
-  override canBeRepeatedWithDot = true;
+  override actionCreatesUndoPoint = true;
 
   public override async exec(position: Position, vimState: VimState): Promise<void> {
     // If line is empty, do nothing
@@ -1888,7 +1888,7 @@ export class ActionDeleteCharWithDeleteKey extends BaseCommand {
   modes = [Mode.Normal];
   keys = ['<Del>'];
   override runsOnceForEachCountPrefix = true;
-  override canBeRepeatedWithDot = true;
+  override actionCreatesUndoPoint = true;
 
   public override async execCount(position: Position, vimState: VimState): Promise<void> {
     // If <del> has a count in front of it, then <del> deletes a character
@@ -1911,7 +1911,7 @@ export class ActionDeleteCharWithDeleteKey extends BaseCommand {
 export class ActionDeleteLastChar extends BaseCommand {
   modes = [Mode.Normal];
   keys = ['X'];
-  override canBeRepeatedWithDot = true;
+  override actionCreatesUndoPoint = true;
 
   public override async exec(position: Position, vimState: VimState): Promise<void> {
     if (position.character === 0) {
@@ -1932,7 +1932,7 @@ export class ActionDeleteLastChar extends BaseCommand {
 class ActionJoin extends BaseCommand {
   modes = [Mode.Normal];
   keys = ['J'];
-  override canBeRepeatedWithDot = true;
+  override actionCreatesUndoPoint = true;
   override runsOnceForEachCountPrefix = false;
 
   private firstNonWhitespaceIndex(str: string): number {
@@ -2117,7 +2117,7 @@ class ActionJoinVisualBlockMode extends BaseCommand {
 class ActionJoinNoWhitespace extends BaseCommand {
   modes = [Mode.Normal];
   keys = ['g', 'J'];
-  override canBeRepeatedWithDot = true;
+  override actionCreatesUndoPoint = true;
 
   // gJ is essentially J without the edge cases. ;-)
 
@@ -2170,7 +2170,7 @@ class ActionJoinNoWhitespaceVisualMode extends BaseCommand {
 class ActionReplaceCharacter extends BaseCommand {
   modes = [Mode.Normal];
   keys = ['r', '<character>'];
-  override canBeRepeatedWithDot = true;
+  override actionCreatesUndoPoint = true;
   override runsOnceForEachCountPrefix = false;
 
   public override async exec(position: Position, vimState: VimState): Promise<void> {
@@ -2236,7 +2236,7 @@ class ActionReplaceCharacterVisual extends BaseCommand {
   override runsOnceForEveryCursor() {
     return false;
   }
-  override canBeRepeatedWithDot = true;
+  override actionCreatesUndoPoint = true;
 
   public override async exec(position: Position, vimState: VimState): Promise<void> {
     let toInsert = this.keysPressed[1];
@@ -2316,7 +2316,7 @@ class ActionReplaceCharacterVisualBlock extends BaseCommand {
   override runsOnceForEveryCursor() {
     return false;
   }
-  override canBeRepeatedWithDot = true;
+  override actionCreatesUndoPoint = true;
 
   public override async exec(position: Position, vimState: VimState): Promise<void> {
     let toInsert = this.keysPressed[1];
@@ -2351,7 +2351,7 @@ class ActionReplaceCharacterVisualBlock extends BaseCommand {
 class ActionDeleteVisualBlock extends BaseCommand {
   modes = [Mode.VisualBlock];
   keys = [['d'], ['x'], ['X']];
-  override canBeRepeatedWithDot = true;
+  override actionCreatesUndoPoint = true;
   override runsOnceForEveryCursor() {
     return false;
   }
@@ -2386,7 +2386,7 @@ class ActionDeleteVisualBlock extends BaseCommand {
 class ActionShiftDVisualBlock extends BaseCommand {
   modes = [Mode.VisualBlock];
   keys = ['D'];
-  override canBeRepeatedWithDot = true;
+  override actionCreatesUndoPoint = true;
   override runsOnceForEveryCursor() {
     return false;
   }
@@ -2712,7 +2712,7 @@ class ActionChangeChar extends BaseCommand {
 class ToggleCaseAndMoveForward extends BaseCommand {
   modes = [Mode.Normal];
   keys = ['~'];
-  override canBeRepeatedWithDot = true;
+  override actionCreatesUndoPoint = true;
 
   private toggleCase(text: string): string {
     let newText = '';
@@ -2746,7 +2746,7 @@ class ToggleCaseAndMoveForward extends BaseCommand {
 
 abstract class IncrementDecrementNumberAction extends BaseCommand {
   modes = [Mode.Normal, Mode.Visual, Mode.VisualLine, Mode.VisualBlock];
-  override canBeRepeatedWithDot = true;
+  override actionCreatesUndoPoint = true;
   abstract offset: number;
   abstract staircase: boolean;
 

--- a/src/actions/commands/put.ts
+++ b/src/actions/commands/put.ts
@@ -20,7 +20,7 @@ function firstNonBlankChar(text: string): number {
 
 abstract class BasePutCommand extends BaseCommand {
   modes = [Mode.Normal, Mode.Visual, Mode.VisualLine, Mode.VisualBlock];
-  override actionCreatesUndoPoint = true;
+  override createsUndoPoint = true;
 
   public override async exec(position: Position, vimState: VimState): Promise<void> {
     const register = await Register.get(vimState.recordedState.registerName, this.multicursorIndex);

--- a/src/actions/commands/put.ts
+++ b/src/actions/commands/put.ts
@@ -20,7 +20,7 @@ function firstNonBlankChar(text: string): number {
 
 abstract class BasePutCommand extends BaseCommand {
   modes = [Mode.Normal, Mode.Visual, Mode.VisualLine, Mode.VisualBlock];
-  override canBeRepeatedWithDot = true;
+  override actionCreatesUndoPoint = true;
 
   public override async exec(position: Position, vimState: VimState): Promise<void> {
     const register = await Register.get(vimState.recordedState.registerName, this.multicursorIndex);

--- a/src/actions/commands/replace.ts
+++ b/src/actions/commands/replace.ts
@@ -84,7 +84,7 @@ class BackspaceInReplaceMode extends BaseCommand {
 class ReplaceInReplaceMode extends BaseCommand {
   modes = [Mode.Replace];
   keys = ['<character>'];
-  override actionCreatesUndoPoint = true;
+  override createsUndoPoint = true;
 
   public override async exec(position: Position, vimState: VimState): Promise<void> {
     const char = this.keysPressed[0];

--- a/src/actions/commands/replace.ts
+++ b/src/actions/commands/replace.ts
@@ -84,7 +84,7 @@ class BackspaceInReplaceMode extends BaseCommand {
 class ReplaceInReplaceMode extends BaseCommand {
   modes = [Mode.Replace];
   keys = ['<character>'];
-  override canBeRepeatedWithDot = true;
+  override actionCreatesUndoPoint = true;
 
   public override async exec(position: Position, vimState: VimState): Promise<void> {
     const char = this.keysPressed[0];

--- a/src/actions/operator.ts
+++ b/src/actions/operator.ts
@@ -19,7 +19,7 @@ export abstract class BaseOperator extends BaseAction {
     super();
     this.multicursorIndex = multicursorIndex;
   }
-  override canBeRepeatedWithDot = true;
+  override actionCreatesUndoPoint = true;
 
   public override doesActionApply(vimState: VimState, keysPressed: string[]): boolean {
     if (this.doesRepeatedOperatorApply(vimState, keysPressed)) {
@@ -186,7 +186,7 @@ class DeleteOperatorVisual extends BaseOperator {
 export class YankOperator extends BaseOperator {
   public keys = ['y'];
   public modes = [Mode.Normal, Mode.Visual, Mode.VisualLine];
-  override canBeRepeatedWithDot = false;
+  override actionCreatesUndoPoint = false;
 
   public async run(vimState: VimState, start: Position, end: Position): Promise<void> {
     [start, end] = sorted(start, end);
@@ -568,7 +568,7 @@ export class ChangeOperator extends BaseOperator {
 class YankVisualBlockMode extends BaseOperator {
   public keys = ['y'];
   public modes = [Mode.VisualBlock];
-  override canBeRepeatedWithDot = false;
+  override actionCreatesUndoPoint = false;
   runsOnceForEveryCursor() {
     return false;
   }

--- a/src/actions/operator.ts
+++ b/src/actions/operator.ts
@@ -19,7 +19,7 @@ export abstract class BaseOperator extends BaseAction {
     super();
     this.multicursorIndex = multicursorIndex;
   }
-  override actionCreatesUndoPoint = true;
+  override createsUndoPoint = true;
 
   public override doesActionApply(vimState: VimState, keysPressed: string[]): boolean {
     if (this.doesRepeatedOperatorApply(vimState, keysPressed)) {
@@ -186,7 +186,7 @@ class DeleteOperatorVisual extends BaseOperator {
 export class YankOperator extends BaseOperator {
   public keys = ['y'];
   public modes = [Mode.Normal, Mode.Visual, Mode.VisualLine];
-  override actionCreatesUndoPoint = false;
+  override createsUndoPoint = false;
 
   public async run(vimState: VimState, start: Position, end: Position): Promise<void> {
     [start, end] = sorted(start, end);
@@ -568,7 +568,7 @@ export class ChangeOperator extends BaseOperator {
 class YankVisualBlockMode extends BaseOperator {
   public keys = ['y'];
   public modes = [Mode.VisualBlock];
-  override actionCreatesUndoPoint = false;
+  override createsUndoPoint = false;
   runsOnceForEveryCursor() {
     return false;
   }

--- a/src/actions/plugins/surround.ts
+++ b/src/actions/plugins/surround.ts
@@ -185,7 +185,7 @@ class CommandSurroundModeStartVisualLine extends SurroundOperator {
 
 abstract class CommandSurround extends BaseCommand {
   modes = [Mode.Normal];
-  override actionCreatesUndoPoint = true;
+  override createsUndoPoint = true;
   override runsOnceForEveryCursor() {
     return true;
   }

--- a/src/actions/plugins/surround.ts
+++ b/src/actions/plugins/surround.ts
@@ -185,7 +185,7 @@ class CommandSurroundModeStartVisualLine extends SurroundOperator {
 
 abstract class CommandSurround extends BaseCommand {
   modes = [Mode.Normal];
-  override canBeRepeatedWithDot = true;
+  override actionCreatesUndoPoint = true;
   override runsOnceForEveryCursor() {
     return true;
   }

--- a/src/cmd_line/commandLine.ts
+++ b/src/cmd_line/commandLine.ts
@@ -288,6 +288,9 @@ export class ExCommandLine extends CommandLine {
       }
     }
 
+    // Update state if this command is repeatable via dot command.
+    vimState.lastCommandDotRepeatable = !!this.command?.isRepeatableWithDot;
+
     await vimState.setCurrentMode(Mode.Normal);
   }
 

--- a/src/cmd_line/commandLine.ts
+++ b/src/cmd_line/commandLine.ts
@@ -289,7 +289,7 @@ export class ExCommandLine extends CommandLine {
     }
 
     // Update state if this command is repeatable via dot command.
-    vimState.lastCommandDotRepeatable = !!this.command?.isRepeatableWithDot;
+    vimState.lastCommandDotRepeatable = this.command?.isRepeatableWithDot ?? false;
 
     await vimState.setCurrentMode(Mode.Normal);
   }

--- a/src/cmd_line/commands/quit.ts
+++ b/src/cmd_line/commands/quit.ts
@@ -27,6 +27,8 @@ export class QuitCommand extends ExCommand {
         })
     );
 
+  public override isRepeatableWithDot = false;
+
   public arguments: IQuitCommandArguments;
   constructor(args: IQuitCommandArguments) {
     super();

--- a/src/cmd_line/commands/write.ts
+++ b/src/cmd_line/commands/write.ts
@@ -36,6 +36,8 @@ export class WriteCommand extends ExCommand {
     ).fallback({})
   ).map(([bang, opt, other]) => new WriteCommand({ bang, opt, bgWrite: true, ...other }));
 
+  public override isRepeatableWithDot = false;
+
   public readonly arguments: IWriteCommandArguments;
   private readonly logger = Logger.get('Write');
 

--- a/src/cmd_line/commands/writequit.ts
+++ b/src/cmd_line/commands/writequit.ts
@@ -22,6 +22,8 @@ export class WriteQuitCommand extends ExCommand {
     regexp(/\S+/).fallback(undefined)
   ).map(([bang, opt, file]) => new WriteQuitCommand(file ? { bang, opt, file } : { bang, opt }));
 
+  public override isRepeatableWithDot = false;
+
   private readonly args: IWriteQuitCommandArguments;
   constructor(args: IWriteQuitCommandArguments) {
     super();

--- a/src/cmd_line/commands/writequitall.ts
+++ b/src/cmd_line/commands/writequitall.ts
@@ -20,6 +20,8 @@ export class WriteQuitAllCommand extends ExCommand {
     whitespace.then(fileOptParser).fallback([])
   ).map(([bang, fileOpt]) => new WriteQuitAllCommand({ bang, fileOpt }));
 
+  public override isRepeatableWithDot = false;
+
   private readonly arguments: IWriteQuitAllCommandArguments;
   constructor(args: IWriteQuitAllCommandArguments) {
     super();

--- a/src/mode/modeHandler.ts
+++ b/src/mode/modeHandler.ts
@@ -771,13 +771,14 @@ export class ModeHandler implements vscode.Disposable, IModeHandler {
       this.createUndoPointForBrackets();
 
     // Record down previous action and flush temporary state
-    if (ranRepeatableAction) {
+    if (ranRepeatableAction && this.vimState.lastCommandDotRepeatable) {
       globalState.previousFullAction = this.vimState.recordedState;
 
       if (recordedState.isInsertion) {
         Register.setReadonlyRegister('.', recordedState);
       }
     }
+    this.vimState.lastCommandDotRepeatable = true;
 
     // Update desiredColumn
     const preservesDesiredColumn =

--- a/src/mode/modeHandler.ts
+++ b/src/mode/modeHandler.ts
@@ -719,7 +719,7 @@ export class ModeHandler implements vscode.Disposable, IModeHandler {
         ranAction = true;
       }
 
-      if (action.actionCreatesUndoPoint) {
+      if (action.createsUndoPoint) {
         ranRepeatableAction = true;
       }
     } else if (action instanceof BaseOperator) {
@@ -751,7 +751,7 @@ export class ModeHandler implements vscode.Disposable, IModeHandler {
       if (operator) {
         await this.executeOperator();
         this.vimState.recordedState.hasRunOperator = true;
-        ranRepeatableAction = operator.actionCreatesUndoPoint;
+        ranRepeatableAction = operator.createsUndoPoint;
         ranAction = true;
       }
     }

--- a/src/mode/modeHandler.ts
+++ b/src/mode/modeHandler.ts
@@ -719,7 +719,7 @@ export class ModeHandler implements vscode.Disposable, IModeHandler {
         ranAction = true;
       }
 
-      if (action.canBeRepeatedWithDot) {
+      if (action.actionCreatesUndoPoint) {
         ranRepeatableAction = true;
       }
     } else if (action instanceof BaseOperator) {
@@ -751,7 +751,7 @@ export class ModeHandler implements vscode.Disposable, IModeHandler {
       if (operator) {
         await this.executeOperator();
         this.vimState.recordedState.hasRunOperator = true;
-        ranRepeatableAction = operator.canBeRepeatedWithDot;
+        ranRepeatableAction = operator.actionCreatesUndoPoint;
         ranAction = true;
       }
     }

--- a/src/state/recordedState.ts
+++ b/src/state/recordedState.ts
@@ -282,7 +282,7 @@ export interface IBaseAction {
   readonly isOperator: boolean;
   readonly isCommand: boolean;
   readonly isJump: boolean;
-  readonly canBeRepeatedWithDot: boolean;
+  readonly actionCreatesUndoPoint: boolean;
 
   keysPressed: string[];
   multicursorIndex: number | undefined;

--- a/src/state/recordedState.ts
+++ b/src/state/recordedState.ts
@@ -282,7 +282,7 @@ export interface IBaseAction {
   readonly isOperator: boolean;
   readonly isCommand: boolean;
   readonly isJump: boolean;
-  readonly actionCreatesUndoPoint: boolean;
+  readonly createsUndoPoint: boolean;
 
   keysPressed: string[];
   multicursorIndex: number | undefined;

--- a/src/state/vimState.ts
+++ b/src/state/vimState.ts
@@ -95,6 +95,12 @@ export class VimState implements vscode.Disposable {
   // TODO: move into ModeHandler
   public lastMovementFailed: boolean = false;
 
+  /**
+   * Keep track of whether the last command that ran is able to be repeated
+   * with the dot command.
+   */
+  public lastCommandDotRepeatable: boolean = true;
+
   public isRunningDotCommand = false;
   public isReplayingMacro: boolean = false;
 

--- a/src/vimscript/exCommand.ts
+++ b/src/vimscript/exCommand.ts
@@ -10,6 +10,8 @@ export abstract class ExCommand {
     return false;
   }
 
+  public readonly isRepeatableWithDot: boolean = true;
+
   abstract execute(vimState: VimState): Promise<void>;
 
   async executeWithRange(vimState: VimState, range: LineRange): Promise<void> {


### PR DESCRIPTION
<!--
Yay! Thanks for sending us a PR! 🎊

Please ensure your PR adheres to:

- [ ] Commit messages has a short & issue references when necessary
- [ ] Each commit does a logical chunk of work.
- [ ] It builds and tests pass (e.g `gulp`)
-->

**What this PR does / why we need it**:

Adds a boolean property "isRepeatableWithDot" to exCommand to identify commands which should and should not be repeatable via dot command.

Adds a boolean property "lastCommandDotRepeatable" to vimState to keep track of if the last command executed is repeatable via dot command and should update the globalState.previousFullAction.

Resolves an issue where save, quit, and savequit commands would be treated as repeatable for the purpose of the dot command, making the dot command less effective.

**Which issue(s) this PR fixes**

<!--
Commits in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)
-->
fixes #6829 

**Special notes for your reviewer**:

New to the code base and new to open source, feedback appreciated!