### PR TITLE
Tab completion of file names is case insensitive on Windows

### DIFF
--- a/src/actions/commands/commandLine.ts
+++ b/src/actions/commands/commandLine.ts
@@ -115,9 +115,14 @@ class CommandLineTab extends CommandLineAction {
         isRemote,
         shouldAddDotItems
       );
+      const startWithBaseNameRegex = new RegExp(
+        `^${baseName}`,
+        process.platform === 'win32' ? 'i' : ''
+      );
       newCompletionItems = dirItems
-        .filter((name) => name.startsWith(baseName))
-        .map((name) => name.slice(name.search(baseName) + baseName.length))
+        .map((name): [RegExpExecArray | null, string] => [startWithBaseNameRegex.exec(name), name])
+        .filter(([isMatch]) => isMatch !== null)
+        .map(([match, name]) => name.slice(match![0].length))
         .sort();
     }
 

--- a/test/cmd_line/tabCompletion.test.ts
+++ b/test/cmd_line/tabCompletion.test.ts
@@ -282,8 +282,7 @@ suite('cmd_line tabComplete', () => {
 
   test('command line file tab completion case-sensitivity platform dependent', async () => {
     const dirPath = await t.createRandomDir();
-    const basename = 'testfile';
-    const filePath = await t.createEmptyFile(join(dirPath, basename));
+    const filePath = await t.createEmptyFile(join(dirPath, 'testfile'));
     const fileAsTyped = join(dirPath, 'TESTFIL');
     const cmd = `:e ${fileAsTyped}`.split('');
 


### PR DESCRIPTION
<!--
Yay! Thanks for sending us a PR! 🎊

Please ensure your PR adheres to:

- [x] Commit messages has a short & issue references when necessary
- [x] Each commit does a logical chunk of work.
- [x] It builds and tests pass (e.g `gulp`)
-->

**What this PR does / why we need it**:
Tab completion of file names should be case insensitive on Windows

**Which issue(s) this PR fixes**
fixes #7160 

<!--
Commits in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)
-->

**Special notes for your reviewer**:
