### PR TITLE
Use timeout for search

### DIFF
--- a/src/vimscript/pattern.ts
+++ b/src/vimscript/pattern.ts
@@ -44,6 +44,7 @@ export class Pattern {
   public readonly closed: boolean; // was an ending delimiter present?
 
   private static readonly MAX_SEARCH_RANGES = 1000;
+  private static readonly MAX_SEARCH_TIME = 1000;
   private static readonly SPECIAL_CHARS_REGEX = /[\-\[\]{}()*+?.,\\\^$|#\s]/g;
 
   public nextMatch(document: TextDocument, fromPosition: Position): Range | undefined {
@@ -115,6 +116,11 @@ export class Pattern {
     while (true) {
       const match = this.regex.exec(haystack);
 
+      let searchTimeout = false;
+      setTimeout(() => {
+        searchTimeout = true;
+      }, Pattern.MAX_SEARCH_TIME);
+
       if (match) {
         if (wrappedOver && match.index >= startOffset) {
           // We've found our first match again
@@ -138,11 +144,7 @@ export class Pattern {
           groups: match,
         });
 
-        if (
-          matchRanges.beforeWrapping.length + matchRanges.afterWrapping.length >=
-          Pattern.MAX_SEARCH_RANGES
-        ) {
-          // TODO: Vim uses a timeout... we probably should too
+        if (searchTimeout) {
           break;
         }
 


### PR DESCRIPTION
<!--
Yay! Thanks for sending us a PR! 🎊

Please ensure your PR adheres to:

- [x] Commit messages has a short & issue references when necessary
- [x] Each commit does a logical chunk of work.
- [x] It builds and tests pass (e.g `gulp`)
-->

**What this PR does / why we need it**:
Using timeout is more correct then limiting the search results.

**Which issue(s) this PR fixes**
#6957

<!--
Commits in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)
-->

**Special notes for your reviewer**:
I think 1 second should be enough. We can finetune this value for better experience.
We can use both timeout and max number of ranges, but as a conjuction:
```ts
if (timeout && before.length + after.lenth > MAX_RANGES) {
    break;
}
```
This will keep the current behavior, while allowing more searches to be found.

