### PR TITLE
`cur[sor]`

### DIFF
--- a/src/cmd_line/commands/cursor.ts
+++ b/src/cmd_line/commands/cursor.ts
@@ -1,24 +1,24 @@
-import { optWhitespace, Parser, seq, whitespace } from "parsimmon";
-import { Position } from "vscode";
-import { Cursor } from "../../common/motion/cursor";
-import { VimState } from "../../state/vimState";
-import { ExCommand } from "../../vimscript/exCommand";
-import { numberParser } from "../../vimscript/parserUtils";
-import { Pattern, PatternMatch, SearchDirection } from "../../vimscript/pattern"
-
+import { optWhitespace, Parser, seq, whitespace } from 'parsimmon';
+import { Position } from 'vscode';
+import { Cursor } from '../../common/motion/cursor';
+import { VimState } from '../../state/vimState';
+import { ExCommand } from '../../vimscript/exCommand';
+import { numberParser } from '../../vimscript/parserUtils';
+import { Pattern, PatternMatch, SearchDirection } from '../../vimscript/pattern';
 
 export class CursorCommand extends ExCommand {
-  public static readonly CURSOR_HERE = "[$]{0}";
+  public static readonly CURSOR_HERE = '[$]{0}';
   public override isRepeatableWithDot: boolean = false;
   private readonly count: number | undefined; // undefined mean all matches.
   private readonly pattern: Pattern;
-  public static readonly argParser: Parser<CursorCommand> = optWhitespace.
-    then(
+  public static readonly argParser: Parser<CursorCommand> = optWhitespace
+    .then(
       seq(
         numberParser.skip(whitespace).fallback(-1),
         Pattern.parser({ direction: SearchDirection.Forward })
       )
-    ).map(([c, sp]) => new CursorCommand(c, sp));
+    )
+    .map(([c, sp]) => new CursorCommand(c, sp));
 
   constructor(count: number, pattern: Pattern) {
     super();
@@ -27,23 +27,33 @@ export class CursorCommand extends ExCommand {
   }
 
   async execute(vimState: VimState): Promise<void> {
-    const allMatches = this.pattern.allMatches(vimState, { fromPosition: vimState.editor.selection.active, maxResults: this.count });
+    const allMatches = this.pattern.allMatches(vimState, {
+      fromPosition: vimState.editor.selection.active,
+      maxResults: this.count,
+    });
     const pattern = this.pattern;
 
-    const matchToPosition = pattern.patternString.includes(CursorCommand.CURSOR_HERE) ?
-      (match: PatternMatch): Position[] => {
-        const splitted = pattern.patternString.split(CursorCommand.CURSOR_HERE).slice(undefined, -1);
-        const positions = splitted.reduce((acc: Position[], curr) => {
-          if (acc.length === 0) return [match.range.start.advancePositionByText(curr)];
-          else return [...acc, acc[acc.length - 1].advancePositionByText(curr)];
-        }, []);
-        return positions;
-      }
+    const matchToPosition = pattern.patternString.includes(CursorCommand.CURSOR_HERE)
+      ? (match: PatternMatch): Position[] => {
+          const groupedRegex = new RegExp(
+            pattern.patternString
+              .split(CursorCommand.CURSOR_HERE)
+              .slice(undefined, -1)
+              .map((s) => `(${s})`)
+              .join('')
+          );
+          const m = groupedRegex.exec(match.groups[0]);
+          const positions =
+            m?.slice(1).reduce((acc: Position[], v): Position[] => {
+              const pos = acc[acc.length - 1] ?? match.range.start;
+              return [...acc, pos.advancePositionByText(v)];
+            }, []) ?? [];
+          return positions;
+        }
       : (match: PatternMatch): Position[] => {
-        return [match.range.start];
-      }
+          return [match.range.start];
+        };
 
-    vimState.cursors = allMatches.flatMap(matchToPosition).map(p => new Cursor(p, p));
+    vimState.cursors = allMatches.flatMap(matchToPosition).map((p) => new Cursor(p, p));
   }
-
 }

--- a/src/cmd_line/commands/cursor.ts
+++ b/src/cmd_line/commands/cursor.ts
@@ -1,0 +1,49 @@
+import { optWhitespace, Parser, seq, whitespace } from "parsimmon";
+import { Position } from "vscode";
+import { Cursor } from "../../common/motion/cursor";
+import { VimState } from "../../state/vimState";
+import { ExCommand } from "../../vimscript/exCommand";
+import { numberParser } from "../../vimscript/parserUtils";
+import { Pattern, PatternMatch, SearchDirection } from "../../vimscript/pattern"
+
+
+export class CursorCommand extends ExCommand {
+  public static readonly CURSOR_HERE = "[$]{0}";
+  public override isRepeatableWithDot: boolean = false;
+  private readonly count: number | undefined; // undefined mean all matches.
+  private readonly pattern: Pattern;
+  public static readonly argParser: Parser<CursorCommand> = optWhitespace.
+    then(
+      seq(
+        numberParser.skip(whitespace).fallback(-1),
+        Pattern.parser({ direction: SearchDirection.Forward })
+      )
+    ).map(([c, sp]) => new CursorCommand(c, sp));
+
+  constructor(count: number, pattern: Pattern) {
+    super();
+    this.count = count === -1 ? undefined : count;
+    this.pattern = pattern;
+  }
+
+  async execute(vimState: VimState): Promise<void> {
+    const allMatches = this.pattern.allMatches(vimState, { fromPosition: vimState.editor.selection.active, maxResults: this.count });
+    const pattern = this.pattern;
+
+    const matchToPosition = pattern.patternString.includes(CursorCommand.CURSOR_HERE) ?
+      (match: PatternMatch): Position[] => {
+        const splitted = pattern.patternString.split(CursorCommand.CURSOR_HERE).slice(undefined, -1);
+        const positions = splitted.reduce((acc: Position[], curr) => {
+          if (acc.length === 0) return [match.range.start.advancePositionByText(curr)];
+          else return [...acc, acc[acc.length - 1].advancePositionByText(curr)];
+        }, []);
+        return positions;
+      }
+      : (match: PatternMatch): Position[] => {
+        return [match.range.start];
+      }
+
+    vimState.cursors = allMatches.flatMap(matchToPosition).map(p => new Cursor(p, p));
+  }
+
+}

--- a/src/vimscript/exCommandParser.ts
+++ b/src/vimscript/exCommandParser.ts
@@ -4,6 +4,7 @@ import { BangCommand } from '../cmd_line/commands/bang';
 import { BufferDeleteCommand } from '../cmd_line/commands/bufferDelete';
 import { CloseCommand } from '../cmd_line/commands/close';
 import { CopyCommand } from '../cmd_line/commands/copy';
+import { CursorCommand } from '../cmd_line/commands/cursor';
 import { DeleteCommand } from '../cmd_line/commands/delete';
 import { DigraphsCommand } from '../cmd_line/commands/digraph';
 import { FileCommand } from '../cmd_line/commands/file';
@@ -173,6 +174,7 @@ export const builtinExCommands: ReadonlyArray<[[string, string], ArgParser | und
   [['cu', 'nmap'], undefined],
   [['cuna', 'bbrev'], undefined],
   [['cunme', 'nu'], undefined],
+  [['cur', 'sor'], CursorCommand.argParser],
   [['cw', 'indow'], undefined],
   [['d', 'elete'], DeleteCommand.argParser],
   [['deb', 'ug'], undefined],

--- a/src/vimscript/pattern.ts
+++ b/src/vimscript/pattern.ts
@@ -65,9 +65,11 @@ export class Pattern {
     args:
       | {
           fromPosition: Position;
+          maxResults?: number;
         }
       | {
           lineRange: LineRange;
+          maxResults?: number;
         }
   ): PatternMatch[] {
     let fromPosition: Position;
@@ -137,6 +139,14 @@ export class Pattern {
           range: matchRange,
           groups: match,
         });
+
+        if (
+          args.maxResults !== undefined &&
+          matchRanges.beforeWrapping.length + matchRanges.afterWrapping.length >= args.maxResults
+        ) {
+          // TODO: Vim uses a timeout... we probably should too
+          break;
+        }
 
         if (
           matchRanges.beforeWrapping.length + matchRanges.afterWrapping.length >=

--- a/test/cmd_line/cursor.test.ts
+++ b/test/cmd_line/cursor.test.ts
@@ -1,0 +1,62 @@
+import { getAndUpdateModeHandler } from '../../extension';
+import { setupWorkspace, cleanUpWorkspace } from '../testUtils';
+import { newTest } from '../testSimplifier';
+import { CursorCommand } from '../../src/cmd_line/commands/cursor';
+
+function cursor(pattern: string, then: string, count?: number): string {
+  const countStr = count ? `${count}` : '';
+  return `:cur ${countStr} ${pattern}\n${then}`;
+}
+
+suite('cursor', () => {
+  const CH = CursorCommand.CURSOR_HERE;
+
+  setup(async () => {
+    await setupWorkspace();
+    await getAndUpdateModeHandler();
+  });
+
+  suiteTeardown(cleanUpWorkspace);
+
+  newTest({
+    title: 'All matches',
+    start: ['|abaa', 'aac'],
+    keysPressed: cursor('a', 'x'),
+    end: ['|b', 'c'],
+  });
+
+  newTest({
+    title: 'Limit to one match',
+    start: ['|aba'],
+    keysPressed: cursor('a', 'x', 1),
+    end: ['|ba'],
+  });
+
+  newTest({
+    title: 'Start at end of line',
+    start: ['abaa|', 'aac'],
+    keysPressed: cursor('a', 'x', 2),
+    end: ['abaa', '|c'],
+  });
+
+  newTest({
+    title: 'With cursor position indicator',
+    start: ['|abc'],
+    keysPressed: cursor(`a${CH}bc`, 'x'),
+    end: ['a|c'],
+  });
+
+  newTest({
+    title: 'With multiple cursor position indicators',
+    start: ['|abcde'],
+    keysPressed: cursor(`a${CH}bc${CH}d`, 'x'),
+    end: ['a|ce'],
+  });
+
+  newTest({
+    title: 'With multiple cursor position indicators with limit',
+    start: ['abc|de', 'abcde', 'abcde', 'abcde'],
+    keysPressed: cursor(`a${CH}bc${CH}d`, 'x', 2),
+    end: ['abcde', 'a|ce', 'ace', 'abcde'],
+  });
+});

--- a/test/cmd_line/cursor.test.ts
+++ b/test/cmd_line/cursor.test.ts
@@ -59,4 +59,11 @@ suite('cursor', () => {
     keysPressed: cursor(`a${CH}bc${CH}d`, 'x', 2),
     end: ['abcde', 'a|ce', 'ace', 'abcde'],
   });
+
+  newTest({
+    title: 'With multiple cursor position indicators with regex',
+    start: ['|abc!e', 'a123!e'],
+    keysPressed: cursor(`${CH}a\\w+${CH}!`, 'x'),
+    end: ['|bce', '123e'],
+  });
 });


### PR DESCRIPTION
<!--
Yay! Thanks for sending us a PR! 🎊

Please ensure your PR adheres to:

- [ ] Commit messages has a short & issue references when necessary
- [ ] Each commit does a logical chunk of work.
- [ ] It builds and tests pass (e.g `gulp`)
-->

**What this PR does / why we need it**:
Add cursors by search pattern.
Can add cursor at a specific location using special indicator. Currently I'm using `[$]{0}`.
We should discuss a better indicator. It has to be zero-length regex pattern, when searching. We can add to the search parser another special indicator, e.g. `<Cursor>` and replace it with a zero-length regex such that `[$]{0}` (or something more robust rather than `$`).

Feature:
Consider this example: (cursor indicated by `|`)
```python
def foo():
|def bar(): 
def bizbaz():
def moo():
```
1. `:cur def`    (all matches)
    ```python
    |def foo():
    |def bar():
    |def bizbaz():
    |def moo():
   ```
2. `:cur 2 def`   (limit number of cursors)
    ```python
    def foo():
    |def bar():
    |def bizbaz():
    def moo():
   ```
3. `:cur de[$]{0}f`   (at specified location)
    ```python
    de|f foo():
    de|f bar():
    de|f bizbaz():
    de|f moo():
   ```
4. `:cur [$]{0}de[$]{0}f`      (multiple cursor)
    ```python
    |de|f foo():
    |de|f bar():
    |de|f bizbaz():
    |de|f moo():
   ```
5. `:cur def \w+[$]{0}`     (using regex)
    ```python
    def foo|():
    def bar|():
    def bizbaz|():
    def moo|():
   ```
5. `vj :'<,'>cur def`     (in selection range)
    ```python
    def foo():
    |def bar():
    |def bizbaz():
    def moo():
   ```
**Which issue(s) this PR fixes**

<!--
Commits in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)
-->

**Special notes for your reviewer**:
