### PR TITLE
Publish VSCodeVim to OpenVSX

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,3 +62,10 @@ jobs:
         run: yarn run vsce publish --yarn
         env:
           VSCE_PAT: ${{ secrets.VSCE_PAT }}
+          
+      - name: Publish to Open VSX Registry
+        uses: HaaLeo/publish-vscode-extension@v1
+        id: publishToOpenVSX
+        with:
+          pat: ${{ secrets.OPEN_VSX_TOKEN }}
+


### PR DESCRIPTION
Hey there VS Code Vim team 👋!

**What this PR does / why we need it**:
This PR adds automatic publishing to the OpenVSX registry and therefore fixes #7183.

**Special notes for your reviewer**:

There are some more steps to take:

1. Add a repo secret for GitHub Actions called `OPEN_VSX_TOKEN` with a PAT obtained via following [this guide](https://github.com/eclipse/openvsx/wiki/Publishing-Extensions) (steps 1-4)
2. After merging, try publishing for the first time 🚀
3. (Optional) claim the namespace by following [this doc](https://github.com/eclipse/openvsx/wiki/Namespace-Access#how-to-claim-a-namespace) so that the extension is verified on the registry.

cc @J-Fields 