### PR TITLE
feat(extensionBase.ts): support simple command and ex-command at string for vim.remap command

### DIFF
--- a/extensionBase.ts
+++ b/extensionBase.ts
@@ -24,7 +24,7 @@ let lastClosedModeHandler: ModeHandler | null = null;
 
 interface ICodeKeybinding {
   after?: string[];
-  commands?: Array<{ command: string; args: any[] }>;
+  commands?: Array<{ command: string; args: any[] } | string>;
 }
 
 export async function getAndUpdateModeHandler(
@@ -452,18 +452,12 @@ export async function activate(context: vscode.ExtensionContext, handleLocal: bo
           await mh.handleKeyEvent(Notation.NormalizeKey(key, configuration.leader));
         }
       }
-
       if (args.commands) {
         for (const command of args.commands) {
-          // Check if this is a vim command by looking for :
-          if (command.command.startsWith(':')) {
-            await new ExCommandLine(
-              command.command.slice(1, command.command.length),
-              mh.vimState.currentMode
-            ).run(mh.vimState);
-            mh.updateView();
+          if (typeof command === 'string') {
+            executeRemapCommand({ command }, mh);
           } else {
-            vscode.commands.executeCommand(command.command, command.args);
+            executeRemapCommand(command, mh);
           }
         }
       }
@@ -629,4 +623,22 @@ function handleContentChangedFromDisk(document: vscode.TextDocument): void {
     .forEach((modeHandler) => {
       modeHandler.vimState.historyTracker = new HistoryTracker(modeHandler.vimState);
     });
+}
+
+async function executeRemapCommand(
+  cmd: { command: string; args?: object },
+  mh: ModeHandler
+) {
+  // Check if this is a vim command by looking for :
+  if (cmd.command.startsWith(':')) {
+    await new ExCommandLine(cmd.command.slice(1, cmd.command.length), mh.vimState.currentMode).run(
+      mh.vimState
+    );
+    mh.updateView();
+  } else {
+    const commandArgs: [string, object] | [string] = cmd.args
+      ? [cmd.command, cmd.args]
+      : [cmd.command];
+    await vscode.commands.executeCommand.apply(null, commandArgs);
+  }
 }


### PR DESCRIPTION
<!--
Yay! Thanks for sending us a PR! 🎊

Please ensure your PR adheres to:

- [ ] Commit messages has a short & issue references when necessary
- [ ] Each commit does a logical chunk of work.
- [ ] It builds and tests pass (e.g `gulp`)
-->

**What this PR does / why we need it**:

Currently when we execute `vim.remap` command, we need to pass entire command object for [simple command](https://code.visualstudio.com/api/references/commands#simple-commands) ( Command that do not require parameters) and ExCommand.

There's an example:

https://vspacecode.github.io/docs/bonus/#execute-vim-command

If we can pass string with ExCommand or simple command's commandID, it will be more elegant.

**Which issue(s) this PR fixes**

None

<!--
Commits in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)
-->

**Special notes for your reviewer**:

With this pr, we set below config at `keybindings.json`, it works well at my environment.

```
  {
    "key": "alt+0",
    "command": "vim.remap",
    "args": {
      "after": ["<Esc>", "i", "w", "o", "r", "k", "<Esc>"],
      "commands": [
        ":undo",
        "workbench.action.toggleSidebarVisibility",
        {
          "command": "default:type",
          "args": { "text": "test_word" }
        }
      ]
    }
  }
```   

Thanks for mantainer's effort and all of the contributors, vscodevim is doing a very good job for all of vscode's users!
