### PR TITLE
Fix default hanldeKeys' type and value at configuration

### DIFF
--- a/src/configuration/configuration.ts
+++ b/src/configuration/configuration.ts
@@ -209,7 +209,7 @@ class Configuration implements IConfiguration {
     this.operatorPendingModeKeyBindingsMap = new Map<string, IKeyRemapping>();
   }
 
-  handleKeys: IHandleKeys[] = [];
+  handleKeys: IHandleKeys = {};
 
   useSystemClipboard = false;
 


### PR DESCRIPTION
<!--
Yay! Thanks for sending us a PR! 🎊

Please ensure your PR adheres to:

- [ ] Commit messages has a short & issue references when necessary
- [ ] Each commit does a logical chunk of work.
- [ ] It builds and tests pass (e.g `gulp`)
-->

**Special notes for your reviewer**:

Default hanldeKeys' value at configuration seems to be an object.