### PR TITLE
Make vim.textwidth configurable per-language

### DIFF
--- a/package.json
+++ b/package.json
@@ -595,6 +595,7 @@
           "type": "number",
           "markdownDescription": "Width to word-wrap to when using `gq`.",
           "default": 80,
+          "scope": "language-overridable",
           "minimum": 1
         },
         "vim.timeout": {

--- a/src/configuration/configuration.ts
+++ b/src/configuration/configuration.ts
@@ -219,8 +219,6 @@ class Configuration implements IConfiguration {
 
   overrideCopy = true;
 
-  textwidth = 80;
-
   hlsearch = false;
 
   ignorecase = true;
@@ -471,6 +469,16 @@ class Configuration implements IConfiguration {
   operatorPendingModeKeyBindingsMap: Map<string, IKeyRemapping> = new Map();
   visualModeKeyBindingsMap: Map<string, IKeyRemapping> = new Map();
   commandLineModeKeyBindingsMap: Map<string, IKeyRemapping> = new Map();
+
+  get textwidth(): number {
+    const textwidth = this.getConfiguration('vim').get('textwidth', 80);
+
+    if (typeof textwidth !== 'number') {
+      return 80;
+    }
+
+    return textwidth;
+  }
 
   private static unproxify(obj: object): object {
     const result = {};

--- a/test/configuration/configuration.test.ts
+++ b/test/configuration/configuration.test.ts
@@ -1,9 +1,11 @@
 import * as assert from 'assert';
 import * as srcConfiguration from '../../src/configuration/configuration';
 import * as testConfiguration from '../testConfiguration';
-import { cleanUpWorkspace, setupWorkspace } from './../testUtils';
+import * as vscode from 'vscode';
+import { cleanUpWorkspace, setupWorkspace, createRandomFile } from './../testUtils';
 import { Mode } from '../../src/mode/mode';
 import { newTest } from '../testSimplifier';
+import { utils } from 'mocha';
 
 suite('Configuration', () => {
   const configuration = new testConfiguration.Configuration();
@@ -35,6 +37,27 @@ suite('Configuration', () => {
     assert.strictEqual(normalizedKeybinds.length, normalizedKeybindsMap.size);
     assert.deepStrictEqual(normalizedKeybinds[0].before, [' ', 'o']);
     assert.deepStrictEqual(normalizedKeybinds[0].after, ['o', '<Esc>', 'k']);
+  });
+
+  test.only('textwidth is configurable per-language', async () => {
+    const globalVimConfig = vscode.workspace.getConfiguration('vim');
+    const jsVimConfig = vscode.workspace.getConfiguration('vim', { languageId: 'javascript' });
+
+    try {
+      assert.equal(jsVimConfig.get('textwidth'), 80);
+      await jsVimConfig.update('textwidth', 120, vscode.ConfigurationTarget.Global);
+
+      const updatedGlobalVimConfig = vscode.workspace.getConfiguration('vim');
+      assert.equal(globalVimConfig.get('textwidth'), 80);
+
+      const updatedJsVimConfig = vscode.workspace.getConfiguration('vim', {
+        languageId: 'javascript',
+      });
+      assert.equal(updatedJsVimConfig.get('textwidth'), 120);
+    } finally {
+      await globalVimConfig.update('textwidth', undefined, vscode.ConfigurationTarget.Global);
+      await jsVimConfig.update('textwidth', undefined, vscode.ConfigurationTarget.Global);
+    }
   });
 
   newTest({

--- a/test/configuration/configuration.test.ts
+++ b/test/configuration/configuration.test.ts
@@ -47,7 +47,7 @@ suite('Configuration', () => {
       await jsVimConfig.update('textwidth', 120, vscode.ConfigurationTarget.Global);
 
       const updatedGlobalVimConfig = vscode.workspace.getConfiguration('vim');
-      assert.strictEqual(globalVimConfig.get('textwidth'), 80);
+      assert.strictEqual(updatedGlobalVimConfig.get('textwidth'), 80);
 
       const updatedJsVimConfig = vscode.workspace.getConfiguration('vim', {
         languageId: 'javascript',

--- a/test/configuration/configuration.test.ts
+++ b/test/configuration/configuration.test.ts
@@ -39,7 +39,7 @@ suite('Configuration', () => {
     assert.deepStrictEqual(normalizedKeybinds[0].after, ['o', '<Esc>', 'k']);
   });
 
-  test.only('textwidth is configurable per-language', async () => {
+  test('textwidth is configurable per-language', async () => {
     const globalVimConfig = vscode.workspace.getConfiguration('vim');
     const jsVimConfig = vscode.workspace.getConfiguration('vim', { languageId: 'javascript' });
 

--- a/test/configuration/configuration.test.ts
+++ b/test/configuration/configuration.test.ts
@@ -44,7 +44,7 @@ suite('Configuration', () => {
 
     try {
       assert.strictEqual(jsVimConfig.get('textwidth'), 80);
-      await jsVimConfig.update('textwidth', 120, vscode.ConfigurationTarget.Global);
+      await jsVimConfig.update('textwidth', 120, vscode.ConfigurationTarget.Global, true);
 
       const updatedGlobalVimConfig = vscode.workspace.getConfiguration('vim');
       assert.strictEqual(updatedGlobalVimConfig.get('textwidth'), 80);

--- a/test/configuration/configuration.test.ts
+++ b/test/configuration/configuration.test.ts
@@ -43,16 +43,16 @@ suite('Configuration', () => {
     const jsVimConfig = vscode.workspace.getConfiguration('vim', { languageId: 'javascript' });
 
     try {
-      assert.equal(jsVimConfig.get('textwidth'), 80);
+      assert.strictEqual(jsVimConfig.get('textwidth'), 80);
       await jsVimConfig.update('textwidth', 120, vscode.ConfigurationTarget.Global);
 
       const updatedGlobalVimConfig = vscode.workspace.getConfiguration('vim');
-      assert.equal(globalVimConfig.get('textwidth'), 80);
+      assert.strictEqual(globalVimConfig.get('textwidth'), 80);
 
       const updatedJsVimConfig = vscode.workspace.getConfiguration('vim', {
         languageId: 'javascript',
       });
-      assert.equal(updatedJsVimConfig.get('textwidth'), 120);
+      assert.strictEqual(updatedJsVimConfig.get('textwidth'), 120);
     } finally {
       await globalVimConfig.update('textwidth', undefined, vscode.ConfigurationTarget.Global);
       await jsVimConfig.update('textwidth', undefined, vscode.ConfigurationTarget.Global);

--- a/test/configuration/configuration.test.ts
+++ b/test/configuration/configuration.test.ts
@@ -5,7 +5,6 @@ import * as vscode from 'vscode';
 import { cleanUpWorkspace, setupWorkspace, createRandomFile } from './../testUtils';
 import { Mode } from '../../src/mode/mode';
 import { newTest } from '../testSimplifier';
-import { utils } from 'mocha';
 
 suite('Configuration', () => {
   const configuration = new testConfiguration.Configuration();

--- a/test/configuration/configuration.test.ts
+++ b/test/configuration/configuration.test.ts
@@ -2,7 +2,7 @@ import * as assert from 'assert';
 import * as srcConfiguration from '../../src/configuration/configuration';
 import * as testConfiguration from '../testConfiguration';
 import * as vscode from 'vscode';
-import { cleanUpWorkspace, setupWorkspace, createRandomFile } from './../testUtils';
+import { cleanUpWorkspace, setupWorkspace } from './../testUtils';
 import { Mode } from '../../src/mode/mode';
 import { newTest } from '../testSimplifier';
 


### PR DESCRIPTION


<!--
Yay! Thanks for sending us a PR! 🎊

Please ensure your PR adheres to:

- [ ] Commit messages has a short & issue references when necessary
- [ ] Each commit does a logical chunk of work.
- [ ] It builds and tests pass (e.g `gulp`)
-->

**What this PR does / why we need it**:

Currently the vim.textwidth setting is global which means that all
languages must share the same value. This works most of the time but
for some cases like git commits it can be useful to have a custom value
to adhere to specific guidelines.

This updates setting configuration to be "language-overridable" which
allows VSCode to autocomplete the value in the settings page for
languages. This allows us to update the `textwidth` property to a getter
where VSCode will automatically return the correct value.

**Which issue(s) this PR fixes**

Fixes https://github.com/VSCodeVim/Vim/issues/4993

**Special notes for your reviewer**:
I don't typically work on VSCode extensions so if there's a better way to test this I'd appreciate any feedback on how to improve it.