### PR TITLE
Fix incorrect error message for :q in dirty file

### DIFF
--- a/src/error.ts
+++ b/src/error.ts
@@ -47,7 +47,7 @@ export const ErrorMessage: IErrorMessage = {
   33: 'No previous substitute regular expression',
   34: 'No previous command',
   35: 'No previous regular expression',
-  37: 'No write since last change (add ! to override)',
+  37: 'No write since last change (type :wq to override)',
   208: 'Error writing to file',
   211: 'File no longer available', // TODO: Should be `File "[file_name]" no longer available`
   223: 'Recursive mapping',


### PR DESCRIPTION
<!--
Yay! Thanks for sending us a PR! 🎊

Please ensure your PR adheres to:

- [ ] Commit messages has a short & issue references when necessary
- [ ] Each commit does a logical chunk of work.
- [ ] It builds and tests pass (e.g `gulp`)
-->

**What this PR does / why we need it**:
The error message for `:q` in dirty file was incorrect.

**Which issue(s) this PR fixes**
Fix #7544
