### PR TITLE
fix 'db', 'dB', 'c' + backward/left motion at beginning of file

### DIFF
--- a/src/actions/operator.ts
+++ b/src/actions/operator.ts
@@ -104,6 +104,14 @@ export class DeleteOperator extends BaseOperator {
   public modes = [Mode.Normal, Mode.Visual, Mode.VisualLine];
 
   public async run(vimState: VimState, start: Position, end: Position): Promise<void> {
+    const hasNoTargetAtDocBegin =
+      vimState.desiredColumn === 0 && start.isAtDocumentBegin() && end.isAtDocumentBegin();
+    const dPressed = vimState.recordedState.actionsRunPressedKeys[0] === 'd';
+
+    if (hasNoTargetAtDocBegin && dPressed && vimState.currentMode === Mode.Normal) {
+      return;
+    }
+
     // TODO: this is off by one when character-wise and not including last EOL
     const numLinesDeleted = Math.abs(start.line - end.line) + 1;
 

--- a/src/actions/operator.ts
+++ b/src/actions/operator.ts
@@ -547,6 +547,23 @@ export class ChangeOperator extends BaseOperator {
   public modes = [Mode.Normal, Mode.Visual, Mode.VisualLine];
 
   public async run(vimState: VimState, start: Position, end: Position): Promise<void> {
+    const hasNoTargetAtDocBegin =
+      vimState.desiredColumn === 0 && start.isAtDocumentBegin() && end.isAtDocumentBegin();
+
+    if (hasNoTargetAtDocBegin && vimState.currentMode === Mode.Normal) {
+      const pressedActionKey = vimState.recordedState.actionKeys[0];
+      const moveBeginningWordKeys = ['b', 'B', '<C-left>'];
+      if (moveBeginningWordKeys.includes(pressedActionKey)) {
+        return;
+      }
+
+      const moveLeftKeys = ['h', '<left>'];
+      if (moveLeftKeys.includes(pressedActionKey)) {
+        vimState.setCurrentMode(Mode.Insert);
+        return;
+      }
+    }
+
     if (vimState.currentRegisterMode === RegisterMode.LineWise) {
       start = start.getLineBegin();
       end = end.getLineEnd();

--- a/test/mode/modeNormal.test.ts
+++ b/test/mode/modeNormal.test.ts
@@ -158,6 +158,13 @@ suite('Mode Normal', () => {
   });
 
   newTest({
+    title: "Cannot handle 'db' at beginning of file",
+    start: ['|hello'],
+    keysPressed: 'db',
+    end: ['|hello'],
+  });
+
+  newTest({
     title: "Can handle 'dl' at end of line",
     start: ['bla|h'],
     keysPressed: '$dldldl',

--- a/test/mode/modeNormal.test.ts
+++ b/test/mode/modeNormal.test.ts
@@ -305,6 +305,13 @@ suite('Mode Normal', () => {
     endMode: Mode.Insert,
   });
 
+  newTest({
+    title: "Cannot handle 'cb' at beginning of file",
+    start: ['|hello'],
+    keysPressed: 'cb',
+    end: ['|hello'],
+  });
+
   suite('`s` (synonym for `cl`)', () => {
     newTest({
       title: '`s` deletes a character and enters Insert mode',


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixed that when cursor is at the beginning of document and in Normal mode
* 'db', 'dB' don't delete anything and stay in Normal mode.
* 'c' + backward motion don't delete anything and stay in Normal mode.
* 'c' + left motion don't delete anything and in Insert mode.

**Which issue(s) this PR fixes**

fixes #6407

<!--
Commits in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)
-->

**Special notes for your reviewer**:
