### PR TITLE
Fix `set tw=N`

### DIFF
--- a/src/configuration/configuration.ts
+++ b/src/configuration/configuration.ts
@@ -470,14 +470,28 @@ class Configuration implements IConfiguration {
   visualModeKeyBindingsMap: Map<string, IKeyRemapping> = new Map();
   commandLineModeKeyBindingsMap: Map<string, IKeyRemapping> = new Map();
 
+  _textwidth = 80;
+
   get textwidth(): number {
-    const textwidth = this.getConfiguration('vim').get('textwidth', 80);
+    const textwidth = this.getConfiguration('vim').get('textwidth', this._textwidth);
 
     if (typeof textwidth !== 'number') {
-      return 80;
+      return this._textwidth;
     }
 
     return textwidth;
+  }
+
+  set textwidth(textwidth: number) {
+    // If in a workspace, update the workspace configuration. Otherwise update
+    // the global configuration.
+    if (vscode.workspace.name) {
+      this.getConfiguration('vim').update('textwidth', textwidth, undefined, true);
+    } else {
+      this.getConfiguration('vim').update('textwidth', textwidth, true, true);
+    }
+
+    this._textwidth = textwidth;
   }
 
   private static unproxify(obj: object): object {

--- a/test/configuration/configuration.test.ts
+++ b/test/configuration/configuration.test.ts
@@ -38,6 +38,14 @@ suite('Configuration', () => {
     assert.deepStrictEqual(normalizedKeybinds[0].after, ['o', '<Esc>', 'k']);
   });
 
+  newTest({
+    title: 'textwidth can be overridden with the set command',
+    config: { textwidth: 80 },
+    start: ['|1 12 1 1'],
+    keysPressed: ':set tw=2\ngqq',
+    end: ['|1', '12', '1', '1'],
+  });
+
   test('textwidth is configurable per-language', async () => {
     const globalVimConfig = vscode.workspace.getConfiguration('vim');
     const jsVimConfig = vscode.workspace.getConfiguration('vim', { languageId: 'javascript' });


### PR DESCRIPTION
- Fixes `set tw=N` command
- Add test for `set tw=N`

<!--
Yay! Thanks for sending us a PR! 🎊

Please ensure your PR adheres to:

- [ ] Commit messages has a short & issue references when necessary
- [ ] Each commit does a logical chunk of work.
- [ ] It builds and tests pass (e.g `gulp`)
-->

**What this PR does / why we need it**:
Since the v1.23.0 release, setting 'textwidth' on the fly with `set tw=100` has
been broken and would cause the following error:

```
CommandLine: Error executing cmd=set textwidth=100.
err=TypeError: Cannot set property textwidth of #<f> which has only a getter.
```

This PR provides a fix and also adds a test so we can tell if the
command breaks again.

**Which issue(s) this PR fixes**
Fixes #7809

<!--
Commits in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)
-->

