### PR TITLE
Preserve case when inc/decrement (`<C-a>`/`<C-x>`) num

### DIFF
--- a/src/common/number/numericString.ts
+++ b/src/common/number/numericString.ts
@@ -35,6 +35,7 @@ export class NumericString {
   suffix: string;
   // If a negative sign should be manually added when converting to string.
   negative: boolean;
+  isCapital: boolean;
 
   // Map radix to number prefix
   private static numPrefix = {
@@ -108,8 +109,21 @@ export class NumericString {
       negative = true;
     }
 
+    let isCapital = false;
+    if (coreRadix === 16) {
+      for (const c of Array.from(input).reverse()) {
+        if ('A' <= c && c <= 'F') {
+          isCapital = true;
+          break;
+        } else if ('a' <= c && c <= 'f') {
+          isCapital = false;
+          break;
+        }
+      }
+    }
+
     return {
-      num: new NumericString(value, coreRadix, numLength, prefix, suffix, negative),
+      num: new NumericString(value, coreRadix, numLength, prefix, suffix, negative, isCapital),
       suffixOffset: coreEnd,
     };
   }
@@ -120,7 +134,8 @@ export class NumericString {
     numLength: number,
     prefix: string,
     suffix: string,
-    negative: boolean
+    negative: boolean,
+    isCapital: boolean
   ) {
     this.value = value;
     this.radix = radix;
@@ -128,6 +143,7 @@ export class NumericString {
     this.prefix = prefix;
     this.suffix = suffix;
     this.negative = negative;
+    this.isCapital = isCapital;
   }
 
   public toString(): string {
@@ -142,6 +158,9 @@ export class NumericString {
     // Gen num part
     const absValue = Math.abs(this.value);
     let num = absValue.toString(this.radix);
+    if (this.isCapital) {
+      num = num.toUpperCase();
+    }
     // numLength of decimal *should not* be preserved.
     if (this.radix !== 10) {
       const diff = this.numLength - num.length;

--- a/test/mode/modeNormal.test.ts
+++ b/test/mode/modeNormal.test.ts
@@ -2192,6 +2192,34 @@ suite('Mode Normal', () => {
   });
 
   newTest({
+    title: 'can ctrl-a can preserve uppercase',
+    start: ['|0xDEAD'],
+    keysPressed: '<C-a>',
+    end: ['0xDEA|E'],
+  });
+
+  newTest({
+    title: 'can ctrl-a can transform to lowercase',
+    start: ['|0xDEAd'],
+    keysPressed: '<C-a>',
+    end: ['0xdea|e'],
+  });
+
+  newTest({
+    title: 'can ctrl-a can transform to uppercase 1',
+    start: ['|0xdeaD'],
+    keysPressed: '<C-a>',
+    end: ['0xDEA|E'],
+  });
+
+  newTest({
+    title: 'can ctrl-a can transform to uppercase 2',
+    start: ['|0xDeaD1'],
+    keysPressed: '<C-a>',
+    end: ['0xDEAD|2'],
+  });
+
+  newTest({
     title: 'can ctrl-a preserve leading zeros of octal',
     start: ['|000007'],
     keysPressed: '<C-a>',

--- a/test/number/numericString.test.ts
+++ b/test/number/numericString.test.ts
@@ -14,6 +14,11 @@ suite('numeric string', () => {
     assert.strictEqual(input, NumericString.parse(input)?.num.toString());
   });
 
+  test('handles hex with capitals round trip', () => {
+    const input = '0xAb1';
+    assert.strictEqual('0xab1', NumericString.parse(input)?.num.toString());
+  });
+
   test('handles decimal round trip', () => {
     const input = '9';
     assert.strictEqual(input, NumericString.parse(input)?.num.toString());


### PR DESCRIPTION
<!--
Yay! Thanks for sending us a PR! 🎊

Please ensure your PR adheres to:

- [x] Commit messages has a short & issue references when necessary
- [x] Each commit does a logical chunk of work.
- [x] It builds and tests pass (e.g `gulp`)
-->

**What this PR does / why we need it**:

Current impl of `<C-a>` and `<C-x>` lowercases hex string even if original string is capital.

This PR preserves lowercase/uppercase in below strategy:

1. If the string is hex string, find the last alphabet in the word, check if it is lowercase/uppercase.
2. If the hex string doesn't have alphabet in it, think it as lowercase.
3. If the string is not hex, think it as lowercase.
4. Finally, when doing `toString()`, transform whole hex string to lowercase or uppercase. 

**Which issue(s) this PR fixes**

<!--
Commits in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)
-->

**Special notes for your reviewer**:
