### PR TITLE
Support `:set` in `.vimrc`

### DIFF
--- a/src/cmd_line/commands/set.ts
+++ b/src/cmd_line/commands/set.ts
@@ -13,7 +13,7 @@ type SetOperation =
       option: string | undefined;
     }
   | {
-      // :se[t] {option}?
+     // :se[t] {option}?
       type: 'show';
       option: string;
     }
@@ -153,7 +153,8 @@ export class SetCommand extends ExCommand {
     this.operation = operation;
   }
 
-  async execute(vimState: VimState): Promise<void> {
+  // We allow vimState to be `null` so we can use this command for vimrc loading (where vimState is not available).
+  async execute(vimState: VimState | null): Promise<void> {
     if (this.operation.option === undefined) {
       // TODO: Show all options that differ from their default value
       return;
@@ -179,13 +180,15 @@ export class SetCommand extends ExCommand {
           if (type === 'boolean') {
             configuration[option] = true;
           } else {
-            this.showOption(vimState, option, currentValue);
+            if(vimState)
+              this.showOption(vimState, option, currentValue);
           }
         }
         break;
       }
       case 'show': {
-        this.showOption(vimState, option, currentValue);
+        if(vimState)
+          this.showOption(vimState, option, currentValue);
         break;
       }
       case 'unset': {

--- a/src/configuration/vimrc.ts
+++ b/src/configuration/vimrc.ts
@@ -5,6 +5,7 @@ import * as path from 'path';
 import * as vscode from 'vscode';
 import { IConfiguration, IVimrcKeyRemapping } from './iconfiguration';
 import { vimrcKeyRemappingBuilder } from './vimrcKeyRemappingBuilder';
+import { vimrcSetOptionBuilder } from './vimrcToConfigurationBuilder';
 import { window } from 'vscode';
 import { configuration } from './configuration';
 import { Logger } from '../util/logger';
@@ -66,6 +67,11 @@ export class VimrcImpl {
         const clearRemap = await vimrcKeyRemappingBuilder.buildClearMapping(line);
         if (clearRemap) {
           VimrcImpl.clearRemapsFromConfig(config, clearRemap);
+          continue;
+        }
+        const setOptionAction = await vimrcSetOptionBuilder.buildSetAction(line);
+        if (setOptionAction) {
+          setOptionAction();
           continue;
         }
       }

--- a/src/configuration/vimrcToConfigurationBuilder.ts
+++ b/src/configuration/vimrcToConfigurationBuilder.ts
@@ -1,0 +1,21 @@
+import { SetCommand } from "../cmd_line/commands/set";
+
+class VimrcSetOptionBuilder {
+  public buildSetAction(line: string): (() => void) | undefined {
+    line = line.trim();
+
+    if (!line.startsWith("se")) {
+      return undefined;
+    }
+
+    const result = SetCommand.argParser.parse(line.replace(/set?/, ""));
+    if (result.status) {
+      const action = result.value;
+      return () => action.execute(null);
+    } else {
+      return undefined;
+    }
+  }
+}
+
+export const vimrcSetOptionBuilder = new VimrcSetOptionBuilder();


### PR DESCRIPTION
<!--
Yay! Thanks for sending us a PR! 🎊

Please ensure your PR adheres to:

- [x] Commit messages has a short & issue references when necessary
- [x] Each commit does a logical chunk of work.
- [ ] It builds and tests pass (e.g `gulp`)
-->

**What this PR does / why we need it**:
Add support for `set` in vimrc. 

**Which issue(s) this PR fixes**
fixes: #7055

<!--
Commits in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)
-->

**Special notes for your reviewer**:
To make use of the already existing `SetCommand`, I needed to allow passing a `null` as the `VimState`, which might not be the best solution to tackle this. 
The `SetCommand` not really needs the `vimState` to handle the vimrc usecase, I think.
An alternative approach is to parse the vimrc, and capture all the operations that needs `vimState` into a list, which we'll execute later when we have a `vimState`.
Something like:
```ts
class Vimrc {
  public load(vimrcPath) {
     const lines = ...
     for (const line in lines) {
       const action: ((_: VimState) => void) | undefined = parseLine(line);
       if (action) this.actions.push(action)
    }
  }
 public onStart(vimState) {
    for (const action in this.actions) {
      action(vimState);
    }
  } 
}

```