### PR TITLE
Folding visual selected lines (`zf`)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
 - Yanking block-wise now pads shorter lines with spaces ([@J-Fields](https://github.com/J-Fields)).
 - `<C-]>` now goes to definition, not declaration ([@J-Fields](https://github.com/J-Fields)).
 
+### Added
+
+- Support for `zf` and `zd` commands, for folding and unfolding custom code blocks ([@elazarcoh](https://github.com/elazarcoh)).
+
 ## [v1.23.2](https://github.com/vscodevim/vim/tree/v1.23.2) (2022-08-01)
 
 ### Fixed

--- a/src/actions/commands/fold.ts
+++ b/src/actions/commands/fold.ts
@@ -87,9 +87,9 @@ class AddFold extends BaseOperator {
     const previousSelections = vimState.lastVisualSelection;  // keep in case of Normal mode
     vimState.editor.selection = new vscode.Selection(start, end);
     await vscode.commands.executeCommand(this.commandName);
-    await new CommandCloseFold().exec(start, vimState);
     vimState.lastVisualSelection = previousSelections;
     vimState.cursors = [new Cursor(start, start)];
+    await vimState.setCurrentMode(Mode.Normal);  // Vim behavior
   }
 }
 

--- a/src/actions/commands/fold.ts
+++ b/src/actions/commands/fold.ts
@@ -101,16 +101,12 @@ class RemoveFold extends BaseCommand {
 
   override async exec(position: Position, vimState: VimState): Promise<void> {
 
-    const selectionForFold = vimState.currentMode === Mode.Visual
-      ? vimState.editor.selection
-      : new vscode.Selection(position, position);
-
-    const previousSelections = vimState.lastVisualSelection;  // keep in case of Normal mode
-    vimState.editor.selection = selectionForFold;
     await vscode.commands.executeCommand(this.commandName);
-    vimState.lastVisualSelection = previousSelections;
-    const start = selectionForFold.start;
-    vimState.cursors = [new Cursor(start, start)];
+
+    const newCursorPosition = vimState.currentMode === Mode.Visual
+      ? vimState.editor.selection.start
+      : position;
+    vimState.cursors = [new Cursor(newCursorPosition, newCursorPosition)];
     await vimState.setCurrentMode(Mode.Normal);  // Vim behavior
   }
 }


### PR DESCRIPTION
<!--
Yay! Thanks for sending us a PR! 🎊

Please ensure your PR adheres to:

- [ ] Commit messages has a short & issue references when necessary
- [ ] Each commit does a logical chunk of work.
- [ ] It builds and tests pass (e.g `gulp`)
-->

**What this PR does / why we need it**:
Add folds using the new vscode commands "editor.createFoldingRangeFromSelection" and "editor.removeManualFoldingRanges".

Everything seems to work fine except for the cursor position in some cases. For some reason setting `vimState.cursors` does not work.

**Which issue(s) this PR fixes**
fixes: #4865

<!--
Commits in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)
-->

**Special notes for your reviewer**:
Testing is in WIP.
