### PR TITLE
Fix for pasting ragged blockwise text

### DIFF
--- a/src/actions/commands/actions.ts
+++ b/src/actions/commands/actions.ts
@@ -1830,7 +1830,8 @@ class ActionDeleteVisualBlock extends BaseCommand {
   }
 
   public override async exec(position: Position, vimState: VimState): Promise<void> {
-    let lines: string[] = [];
+    const lines: string[] = [];
+
     for (const { line, start, end } of TextEditor.iterateLinesInBlock(vimState)) {
       lines.push(line);
       vimState.recordedState.transformer.addTransformation({
@@ -1839,9 +1840,6 @@ class ActionDeleteVisualBlock extends BaseCommand {
         manuallySetCursorPositions: true,
       });
     }
-
-    const maxLineLength = Math.max(...lines.map((line) => line.length));
-    lines = lines.map((line) => line.padEnd(maxLineLength, ' '));
 
     const text = lines.length === 1 ? lines[0] : lines.join('\n');
     vimState.currentRegisterMode = RegisterMode.BlockWise;

--- a/src/actions/operator.ts
+++ b/src/actions/operator.ts
@@ -595,14 +595,11 @@ class YankVisualBlockMode extends BaseOperator {
 
   public async run(vimState: VimState, startPos: Position, endPos: Position): Promise<void> {
     const ranges: vscode.Range[] = [];
-    let lines: string[] = [];
+    const lines: string[] = [];
     for (const { line, start, end } of TextEditor.iterateLinesInBlock(vimState)) {
       lines.push(line);
       ranges.push(new vscode.Range(start, end));
     }
-
-    const maxLineLength = Math.max(...lines.map((line) => line.length));
-    lines = lines.map((line) => line.padEnd(maxLineLength, ' '));
 
     vimState.currentRegisterMode = RegisterMode.BlockWise;
 

--- a/test/operator/put.test.ts
+++ b/test/operator/put.test.ts
@@ -61,6 +61,13 @@ suite('put operator', () => {
       });
 
       newTest({
+        title: 'Yank ragged block-wise selection, <count>p',
+        start: ['|ABCDEFG', 'abcd', 'wxyz', 'WXYZ'],
+        keysPressed: '3l' + '<C-v>j$' + 'y' + 'jh' + '2p',
+        end: ['ABCDEFG', 'abc|DEFGDEFGd', 'wxyd   d   z', 'WXYZ'],
+      });
+
+      newTest({
         title: 'Yank block-wise, <count>p past last line',
         start: ['|[1]ABCD', '[2]abcd', 'wxyz', 'WXYZ'],
         keysPressed: '<C-v>llj' + 'd' + 'Gl' + '2p',
@@ -189,6 +196,13 @@ suite('put operator', () => {
         start: ['|[1]ABCD', '[2]abcd', 'wxyz', 'WXYZ'],
         keysPressed: '<C-v>llj' + 'd' + 'jl' + '2P',
         end: ['ABCD', 'a|[1][1]bcd', 'w[2][2]xyz', 'WXYZ'],
+      });
+
+      newTest({
+        title: 'Yank ragged block-wise selection, <count>P',
+        start: ['|ABCDEFG', 'abcd', 'wxyz', 'WXYZ'],
+        keysPressed: '3l' + '<C-v>j$' + 'y' + 'jh' + '2P',
+        end: ['ABCDEFG', 'ab|DEFGDEFGcd', 'wxd   d   yz', 'WXYZ'],
       });
 
       newTest({

--- a/test/operator/put.test.ts
+++ b/test/operator/put.test.ts
@@ -60,19 +60,6 @@ suite('put operator', () => {
         end: ['ABCD', 'ab|[1][1]cd', 'wx[2][2]yz', 'WXYZ'],
       });
 
-      // TODO: write ragged blockwise tests for other modes & put variants
-      newTest({
-        title: 'Yank block-wise (ragged), <count>p',
-        start: ['|longlonglong', 'shortshort', 'verylongverylong', 'veryshort'],
-        keysPressed: '<C-v>G$' + 'd' + '2p',
-        end: [
-          '|longlonglong    longlonglong    ',
-          'shortshort      shortshort      ',
-          'verylongverylongverylongverylong',
-          'veryshort       veryshort       ',
-        ],
-      });
-
       newTest({
         title: 'Yank block-wise, <count>p past last line',
         start: ['|[1]ABCD', '[2]abcd', 'wxyz', 'WXYZ'],


### PR DESCRIPTION
<!--
Yay! Thanks for sending us a PR! 🎊

Please ensure your PR adheres to:

- [ ] Commit messages has a short & issue references when necessary
- [ ] Each commit does a logical chunk of work.
- [ ] It builds and tests pass (e.g `gulp`)
-->

**What this PR does / why we need it**:
Previous fix for #7870 resulted in all blockwise text being right padded when yanked into a register, but text should only be right padded as necessary (based on surrounding document text) on put command execution.

**Which issue(s) this PR fixes**
Fixes #7870 "Text is not aligned when pasting a range yanked in blockwise"

<!--
Commits in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)
-->

**Special notes for your reviewer**:
The previous discussion we had is visible on d8c50a1.
I reverted the changes for d8c50a1 in this PR as well.
