### PR TITLE
Implement correct behavior for visual block indent operator

### DIFF
--- a/test/mode/modeVisualBlock.test.ts
+++ b/test/mode/modeVisualBlock.test.ts
@@ -151,6 +151,45 @@ suite('VisualBlock mode', () => {
     end: ['t123|est', 't123est'],
   });
 
+  suite('`>` (indent at left edge of block)', () => {
+    newTest({
+      title: 'Repeated multiline `[count]>` indent (2 spaces) top down selection',
+      editorOptions: { tabSize: 2 },
+      start: ['This is |a long line', 'Short', 'Another long line'],
+      keysPressed: '<C-v>jj3>jhh.',
+      end: ['This is       a long line', 'Sh|      ort', 'An      other       long line'],
+    });
+    newTest({
+      title: 'Repeated multiline `[count]>` indent (2 spaces) bottom up selection',
+      editorOptions: { tabSize: 2 },
+      start: ['This is a long line', 'Short', 'Another |long line'],
+      keysPressed: '<C-v>kk3>jhh.',
+      end: ['This is       a long line', 'Sh|      ort', 'An      other       long line'],
+    });
+    newTest({
+      title: 'Repeated multiline `[count]>` indent (4 spaces) top down selection',
+      editorOptions: { tabSize: 4 },
+      start: ['This is |a long line', 'Short', 'Another long line'],
+      keysPressed: '<C-v>jj3>jhh.',
+      end: [
+        'This is             a long line',
+        'Sh|            ort',
+        'An            other             long line',
+      ],
+    });
+    newTest({
+      title: 'Repeated multiline `[count]>` indent (4 spaces) bottom up selection',
+      editorOptions: { tabSize: 4 },
+      start: ['This is a long line', 'Short', 'Another |long line'],
+      keysPressed: '<C-v>kk3>jhh.',
+      end: [
+        'This is             a long line',
+        'Sh|            ort',
+        'An            other             long line',
+      ],
+    });
+  });
+
   suite('Non-darwin `<C-c>` tests', () => {
     if (process.platform === 'darwin') {
       return;


### PR DESCRIPTION
**What this PR does / why we need it**:
Visual block indent operator should have different behavior from visual and visual line indent operators, but they're all currently implemented the same way. This PR correctly implements the visual block indent operator.

**Which issue(s) this PR fixes**
Fixes #7640 

**Special notes for your reviewer**:
I noticed that the visual block outdent operator also doesn't work as expected, so I'll submit another PR later on to fix that issue.