### PR TITLE
Implement correct behavior for visual block outdent operator

### DIFF
--- a/test/mode/modeVisualBlock.test.ts
+++ b/test/mode/modeVisualBlock.test.ts
@@ -190,6 +190,44 @@ suite('VisualBlock mode', () => {
     });
   });
 
+  suite('`<` (outdent at left edge of block)', () => {
+    newTest({
+      title: '`[count]<` outdent (2 spaces) should have no effect on non-whitespace character',
+      editorOptions: { tabSize: 2 },
+      start: ['This is |a long line', 'Short', 'Another long line'],
+      keysPressed: '<C-v>2<',
+      end: ['This is |a long line', 'Short', 'Another long line'],
+    });
+    newTest({
+      title: 'Repeated multiline `[count]<` outdent (2 spaces) top down selection',
+      editorOptions: { tabSize: 2 },
+      start: ['This is |  a long line', 'Short', 'Another           long line'],
+      keysPressed: '<C-v>jj2<jj.',
+      end: ['This is a long line', 'Short', 'Another |  long line'],
+    });
+    newTest({
+      title: 'Repeated multiline `[count]<` outdent (2 spaces) bottom up selection',
+      editorOptions: { tabSize: 2 },
+      start: ['This is   a long line', 'Short', 'Another |          long line'],
+      keysPressed: '<C-v>kk2<jj.',
+      end: ['This is a long line', 'Short', 'Another |  long line'],
+    });
+    newTest({
+      title: 'Repeated multiline `[count]<` outdent (4 spaces) top down selection',
+      editorOptions: { tabSize: 4 },
+      start: ['This is |  a long line', 'Short', 'Another           long line'],
+      keysPressed: '<C-v>jj2<jj.',
+      end: ['This is a long line', 'Short', 'Another |long line'],
+    });
+    newTest({
+      title: 'Repeated multiline `[count]<` outdent (4 spaces) bottom up selection',
+      editorOptions: { tabSize: 4 },
+      start: ['This is   a long line', 'Short', 'Another |          long line'],
+      keysPressed: '<C-v>kk2<jj.',
+      end: ['This is a long line', 'Short', 'Another |long line'],
+    });
+  });
+
   suite('Non-darwin `<C-c>` tests', () => {
     if (process.platform === 'darwin') {
       return;


### PR DESCRIPTION
**What this PR does / why we need it**:
Visual block outdent operator has its own unique behavior in Vim/Neovim that's not currently emulated by VSCodeVim. This PR implements the operator correctly.

**Which issue(s) this PR fixes**
No issue had been posted concerning visual block outdent operator. See #8007 for previous discussion on visual block indent operator.
