### PR TITLE
Fix: cW behaves incorrectly when the cursor is at the end of a word

### DIFF
--- a/src/actions/motion.ts
+++ b/src/actions/motion.ts
@@ -1492,7 +1492,9 @@ export class MoveFullWordBegin extends BaseMovement {
       // TODO use execForOperator? Or maybe dont?
 
       // See note for w
-      return position.nextWordEnd(vimState.document, { wordType: WordType.Big }).getRight();
+      return position
+        .nextWordEnd(vimState.document, { wordType: WordType.Big, inclusive: true })
+        .getRight();
     } else {
       return position.nextWordStart(vimState.document, { wordType: WordType.Big });
     }

--- a/test/mode/modeNormal.test.ts
+++ b/test/mode/modeNormal.test.ts
@@ -2056,6 +2056,13 @@ suite('Mode Normal', () => {
   });
 
   newTest({
+    title: "Can handle 'dW' on last character of word",
+    start: ['first secon|d third fourth'],
+    keysPressed: 'dW',
+    end: ['first secon|third fourth'],
+  });
+
+  newTest({
     title: 'can delete linewise with d2G',
     start: ['on|e', 'two', 'three'],
     keysPressed: 'd2G',

--- a/test/mode/modeNormal.test.ts
+++ b/test/mode/modeNormal.test.ts
@@ -259,6 +259,14 @@ suite('Mode Normal', () => {
   });
 
   newTest({
+    title: "Can handle 'cW' on last character of word",
+    start: ['first secon|d third fourth'],
+    keysPressed: 'cW',
+    end: ['first secon| third fourth'],
+    endMode: Mode.Insert,
+  });
+
+  newTest({
     title: "Can handle 'c2w'",
     start: ['|const a = 1;'],
     keysPressed: 'c2w',


### PR DESCRIPTION
<!--
Yay! Thanks for sending us a PR! 🎊

Please ensure your PR adheres to:

- [ ] Commit messages has a short & issue references when necessary
- [ ] Each commit does a logical chunk of work.
- [ ] It builds and tests pass (e.g `gulp`)
-->

**What this PR does / why we need it**:
Fix incorrect behavior of `cW` when the cursor is at the end of a word

**Which issue(s) this PR fixes**
fixes #7981 

<!--
Commits in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)
-->

**Special notes for your reviewer**:
