### PR TITLE
Explicitly assign new active editor to `vimState` before jumping to global marks

### DIFF
--- a/src/actions/motion.ts
+++ b/src/actions/motion.ts
@@ -615,6 +615,12 @@ class MarkMovementBOL extends BaseMovement {
       await ensureEditorIsActive(mark.document);
     }
 
+    const editor = vscode.window.activeTextEditor;
+    if (!editor) {
+      throw VimError.fromCode(ErrorCode.MarkNotSet);
+    }
+    vimState.editor = editor;
+
     return TextEditor.getFirstNonWhitespaceCharOnLine(vimState.document, mark.position.line);
   }
 }


### PR DESCRIPTION
<!--
Yay! Thanks for sending us a PR! 🎊

Please ensure your PR adheres to:

- [x] Commit messages has a short & issue references when necessary
- [x] Each commit does a logical chunk of work.
- [x] It builds and tests pass (e.g `gulp`)
-->

**What this PR does / why we need it**

When jumping to global marker across files, it awaits `showTextDocument()` switches active editor. However, even after the await, `vimState` sometimes has old editor (as far as I tested, it happens only when first `jump to global marker` across files for that name).
So this patch explicitly assigns new Editor to `vimState` before jumping to global marker.


**Which issue(s) this PR fixes**

- Fixes #7975 

<!--
Commits in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)
-->

**Special notes for your reviewer**:
