### PR TITLE
Run showOpenDialog for empty `:e` command

### DIFF
--- a/src/cmd_line/commands/file.ts
+++ b/src/cmd_line/commands/file.ts
@@ -26,7 +26,7 @@ export type IFileCommandArguments =
       bang: boolean;
       opt: FileOpt;
       cmd?: FileCmd;
-      file?: string;
+      file: string;
       createFileIfNotExists?: boolean;
     }
   | {
@@ -84,7 +84,7 @@ export class FileCommand extends ExCommand {
       bangParser,
       optWhitespace.then(fileOptParser).fallback([]),
       optWhitespace.then(fileCmdParser).fallback(undefined),
-      optWhitespace.then(fileNameParser).fallback(undefined)
+      optWhitespace.then(fileNameParser).fallback('')
     ).map(([bang, opt, cmd, file]) => new FileCommand({ name: 'edit', bang, opt, cmd, file })),
     enew: bangParser.map((bang) => new FileCommand({ name: 'enew', bang })),
     new: seq(

--- a/test/vimscript/exCommandParse.test.ts
+++ b/test/vimscript/exCommandParse.test.ts
@@ -215,11 +215,11 @@ suite('Ex command parsing', () => {
   suite(':e[dit]', () => {
     exParseTest(
       ':edit',
-      new FileCommand({ name: 'edit', bang: false, opt: [], cmd: undefined, file: undefined })
+      new FileCommand({ name: 'edit', bang: false, opt: [], cmd: undefined, file: '' })
     );
     exParseTest(
       ':edit!',
-      new FileCommand({ name: 'edit', bang: true, opt: [], cmd: undefined, file: undefined })
+      new FileCommand({ name: 'edit', bang: true, opt: [], cmd: undefined, file: '' })
     );
 
     exParseTest(


### PR DESCRIPTION




<!--
Yay! Thanks for sending us a PR! 🎊

Please ensure your PR adheres to:

- [ ] Commit messages has a short & issue references when necessary
- [ ] Each commit does a logical chunk of work.
- [ ] It builds and tests pass (e.g `gulp`)
-->

**What this PR does / why we need it**:
I want to be able to open the "Open File" dialog by executing the `:e` command.
The code for this already exists, but was unreachable because the default value for `file` while parsing was `undefined`.
Set the default value to `''`, so that arguments for `:e` are distinguishable from the `:enew` command.

**Which issue(s) this PR fixes**
Fixes #8039

<!--
Commits in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)
-->

**Special notes for your reviewer**:
❤️ 
