### PR TITLE
Fix cursor position after visual block gp and gP operations

### DIFF
--- a/src/actions/commands/put.ts
+++ b/src/actions/commands/put.ts
@@ -494,12 +494,9 @@ function PlaceCursorAfterText<TBase extends new (...args: any[]) => PutCommand>(
           return new Position(line, 0);
         } else if (registerMode === RegisterMode.BlockWise) {
           const lines = text.split('\n');
-          return new Position(
-            rangeStart.line + lines.length - 1,
-            rangeStart.character +
-              lines[0].length +
-              (this.putBefore() && mode === Mode.Normal ? 1 : 0)
-          );
+          const lastLine = rangeStart.line + lines.length - 1;
+          const longestLineLength = Math.max(...lines.map((line) => line.length));
+          return new Position(lastLine, rangeStart.character + longestLineLength);
         }
       } else if (mode === Mode.VisualLine) {
         return new Position(rangeStart.line + text.split('\n').length, 0);

--- a/test/operator/put.test.ts
+++ b/test/operator/put.test.ts
@@ -330,6 +330,13 @@ suite('put operator', () => {
       });
 
       newTest({
+        title: 'Yank ragged block-wise selection, <count>gp',
+        start: ['|abcd', 'ABCDEFG', 'wxyz', 'WXYZ'],
+        keysPressed: '2l' + '<C-v>j$' + 'y' + '2gp',
+        end: ['abccd   cd   d', 'ABCCDEFGCDEFG|DEFG', 'wxyz', 'WXYZ'],
+      });
+
+      newTest({
         title: 'Yank block-wise, <count>gp past last line',
         start: ['|[1]ABCD', '[2]abcd', 'wxyz', 'WXYZ'],
         keysPressed: '<C-v>llj' + 'd' + 'Gl' + '2gp',
@@ -457,7 +464,14 @@ suite('put operator', () => {
         title: 'Yank block-wise, <count>gP',
         start: ['|[1]ABCD', '[2]abcd', 'wxyz', 'WXYZ'],
         keysPressed: '<C-v>llj' + 'd' + 'jl' + '2gP',
-        end: ['ABCD', 'a[1][1]bcd', 'w[2][2]x|yz', 'WXYZ'],
+        end: ['ABCD', 'a[1][1]bcd', 'w[2][2]|xyz', 'WXYZ'],
+      });
+
+      newTest({
+        title: 'Yank ragged block-wise selection, <count>gP',
+        start: ['|abcd', 'ABCDEFG', 'wxyz', 'WXYZ'],
+        keysPressed: '2l' + '<C-v>j$' + 'y' + '2gP',
+        end: ['abcd   cd   cd', 'ABCDEFGCDEFG|CDEFG', 'wxyz', 'WXYZ'],
       });
 
       newTest({


### PR DESCRIPTION
**What this PR does / why we need it**:
Cursor position may be incorrect after `gp` and `gP` operations. This PR correctly adjusts the cursor position and fixes one test case that was incorrect.

**Which issue(s) this PR fixes**
Related to the changes for #7870 
