### PR TITLE
Exclude map files from extension bundle

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -4,6 +4,7 @@
 .vscode-test/**
 
 **/*.ts
+*.map
 *.yml
 
 src/**


### PR DESCRIPTION
**What this PR does / why we need it**:

The extension currently contains the following `*.map` files:
```
 20K    vscodevim.vim-1.24.3/extension/out/extensionBase.js.map
2.4M    vscodevim.vim-1.24.3/extension/out/extensionWeb.js.map
4.0M    vscodevim.vim-1.24.3/extension/out/extension.js.map
6.4M    total
```

These  should generally not be shipped in extensions as they increase the extension download and install size