### PR TITLE
Feat implementation leap plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ VSCodeVim is a Vim emulator for [Visual Studio Code](https://code.visualstudio.c
 - [🖱️ Multi-Cursor Mode](#️-multi-cursor-mode)
 - [🔌 Emulated Plugins](#-emulated-plugins)
   - [vim-airline](#vim-airline)
+  - [vim-leap](#vim-leap)
   - [vim-easymotion](#vim-easymotion)
   - [vim-surround](#vim-surround)
   - [vim-commentary](#vim-commentary)
@@ -521,6 +522,16 @@ Change the color of the status bar based on the current mode. Once enabled, conf
     "vim.statusBarColors.easymotioninputmode": "#007ACC",
     "vim.statusBarColors.surroundinputmode": "#007ACC",
 ```
+### vim-leap
+
+Based on [vim-leap](https://github.com/ggandor/leap.nvim) and configured through the following settings:
+
+| Setting                    | Description                                  | Type    | Default Value                  | Value              |
+| -------------------------- | -------------------------------------------- | ------- | ------------------------------ | ------------------ |
+| vim.leap                   | Enable/disable leap plugin                   | Boolean | false                          |                    |
+| vim.leapShowMarkerPosition | Set the position of the marker point display | String  | "after"                        | "after" , "target" |
+| vim.leapLabels               | The characters used for jump marker name     | String  | "sklyuiopnm,qwertzxcvbahdgjf;" |                    |
+| vim.leapCaseSensitive      | Whether to consider case in search patterns  | Boolean | false                          |                    |
 
 ### vim-easymotion
 

--- a/src/actions/commands/actions.ts
+++ b/src/actions/commands/actions.ts
@@ -902,11 +902,15 @@ class CommandClearLine extends BaseCommand {
 
   // Don't clash with sneak
   public override doesActionApply(vimState: VimState, keysPressed: string[]): boolean {
-    return super.doesActionApply(vimState, keysPressed) && !configuration.sneak;
+    return (
+      super.doesActionApply(vimState, keysPressed) && !configuration.sneak && !configuration.leap
+    );
   }
 
   public override couldActionApply(vimState: VimState, keysPressed: string[]): boolean {
-    return super.couldActionApply(vimState, keysPressed) && !configuration.sneak;
+    return (
+      super.couldActionApply(vimState, keysPressed) && !configuration.sneak && !configuration.leap
+    );
   }
 }
 
@@ -2214,6 +2218,7 @@ class ActionChangeChar extends BaseCommand {
     return (
       super.doesActionApply(vimState, keysPressed) &&
       !configuration.sneak &&
+      !configuration.leap &&
       !vimState.recordedState.operator
     );
   }
@@ -2222,6 +2227,7 @@ class ActionChangeChar extends BaseCommand {
     return (
       super.couldActionApply(vimState, keysPressed) &&
       !configuration.sneak &&
+      !configuration.leap &&
       !vimState.recordedState.operator
     );
   }

--- a/src/actions/include-all.ts
+++ b/src/actions/include-all.ts
@@ -23,3 +23,4 @@ import './plugins/sneak';
 import './plugins/replaceWithRegister';
 import './plugins/surround';
 import './plugins/targets/targets';
+import './plugins/leap/register';

--- a/src/actions/include-plugins.ts
+++ b/src/actions/include-plugins.ts
@@ -6,3 +6,4 @@ import './plugins/sneak';
 import './plugins/replaceWithRegister';
 import './plugins/surround';
 import './plugins/targets/targets';
+import './plugins/leap/register';

--- a/src/actions/plugins/leap/LeapAction.ts
+++ b/src/actions/plugins/leap/LeapAction.ts
@@ -1,0 +1,139 @@
+import { Mode } from '../../../mode/mode';
+import { BaseCommand, RegisterAction } from '../../base';
+import { Position } from 'vscode';
+import { VimState } from '../../../state/vimState';
+import { configuration } from '../../../configuration/configuration';
+import { LeapSearchDirection, createLeap } from './leap';
+import { getMatches, generateMarkerRegex, generatePrepareRegex } from './match';
+import { StatusBar } from '../../../statusBar';
+import { Marker } from './Marker';
+import { VimError, ErrorCode } from '../../../error';
+
+@RegisterAction
+export class LeapPrepareAction extends BaseCommand {
+  modes = [Mode.Normal];
+  keys = [
+    ['s', '<character>'],
+    ['S', '<character>'],
+  ];
+
+  public override doesActionApply(vimState: VimState, keysPressed: string[]) {
+    return super.doesActionApply(vimState, keysPressed) && configuration.leap;
+  }
+
+  public override async exec(cursorPosition: Position, vimState: VimState): Promise<void> {
+    if (!configuration.leap) return;
+
+    if (this.keysPressed[1] === '\n') {
+      this.execRepeatLastSearch(vimState);
+    } else {
+      await this.execPrepare(cursorPosition, vimState);
+    }
+  }
+
+  private async execPrepare(cursorPosition: Position, vimState: VimState) {
+    const direction = this.getDirection();
+    const firstSearchString = this.keysPressed[1];
+
+    const leap = createLeap(vimState, direction, firstSearchString);
+    vimState.leap = leap;
+    vimState.leap.previousMode = vimState.currentMode;
+
+    const matches = getMatches(
+      generatePrepareRegex(firstSearchString),
+      direction,
+      cursorPosition,
+      vimState.document
+    );
+
+    vimState.leap.createMarkers(matches);
+    vimState.leap.showMarkers();
+    await vimState.setCurrentMode(Mode.LeapPrepareMode);
+  }
+
+  private execRepeatLastSearch(vimState: VimState) {
+    if (vimState.leap?.leapAction) {
+      vimState.leap.isRepeatLastSearch = true;
+      vimState.leap.direction = this.getDirection();
+      vimState.leap.leapAction.fire();
+    } else {
+      StatusBar.displayError(vimState, VimError.fromCode(ErrorCode.LeapNoPreviousSearch));
+    }
+  }
+
+  private getDirection() {
+    return this.keysPressed[0] === 's' ? LeapSearchDirection.Backward : LeapSearchDirection.Forward;
+  }
+}
+
+@RegisterAction
+export class LeapAction extends BaseCommand {
+  modes = [Mode.LeapPrepareMode];
+  keys = ['<character>'];
+  override isJump = true;
+  private vimState!: VimState;
+  private searchString: string = '';
+  public override async exec(cursorPosition: Position, vimState: VimState): Promise<void> {
+    if (!configuration.leap) return;
+    this.vimState = vimState;
+    this.searchString = vimState.leap.firstSearchString + this.keysPressed[0];
+    const markers: Marker[] = this.getMarkers(cursorPosition);
+
+    if (markers.length === 0) {
+      await this.handleNoFoundMarkers();
+      return;
+    }
+
+    // When the leapAction is executed, it needs to be logged
+    // This is to repeat the last search command
+    // As long as it is recorded, it means that the search was successfully executed once.
+    // As long as the search has been executed successfully, it will be ok when we execute "repeat last search".
+    vimState.leap.leapAction = this;
+
+    if (markers.length === 1) {
+      await this.handleOneMarkers(markers[0]);
+      return;
+    }
+
+    await this.handleMultipleMarkers();
+  }
+  private async handleMultipleMarkers() {
+    this.vimState.leap.keepMarkersBySearchString(this.searchString);
+    await this.vimState.setCurrentMode(Mode.LeapMode);
+  }
+
+  private async handleOneMarkers(marker: Marker) {
+    this.vimState.cursorStopPosition = marker.matchPosition;
+    this.vimState.leap.cleanupMarkers();
+    await this.vimState.setCurrentMode(this.vimState.leap.previousMode);
+  }
+
+  private async handleNoFoundMarkers() {
+    StatusBar.displayError(
+      this.vimState,
+      VimError.fromCode(ErrorCode.LeapNoFoundSearchString, this.searchString)
+    );
+    this.vimState.leap.cleanupMarkers();
+    await this.vimState.setCurrentMode(this.vimState.leap.previousMode);
+  }
+
+  private getMarkers(cursorPosition: Position) {
+    if (this.vimState.leap.isRepeatLastSearch) {
+      const matches = getMatches(
+        generateMarkerRegex(this.searchString),
+        this.vimState.leap.direction!,
+        cursorPosition,
+        this.vimState.document
+      );
+      this.vimState.leap.createMarkers(matches);
+      this.vimState.leap.showMarkers();
+      return this.vimState.leap.markers;
+    } else {
+      return this.vimState.leap.findMarkersBySearchString(this.searchString);
+    }
+  }
+
+  public fire() {
+    this.exec(this.vimState.cursorStopPosition, this.vimState);
+  }
+}

--- a/src/actions/plugins/leap/Marker.ts
+++ b/src/actions/plugins/leap/Marker.ts
@@ -1,0 +1,147 @@
+import { Match } from './match';
+import * as vscode from 'vscode';
+import { configuration } from './../../../configuration/configuration';
+
+export class Marker {
+  private decoration!: MarkerDecoration;
+  label: string = '';
+  searchString: string;
+  matchPosition: vscode.Position;
+  constructor({ position, searchString }: Match, editor: vscode.TextEditor) {
+    this.matchPosition = position;
+    this.searchString = searchString;
+    this.decoration = new MarkerDecoration(editor, this);
+  }
+
+  get prefix() {
+    return this.label.length > 1 ? this.label[0] : '';
+  }
+
+  deletePrefix() {
+    this.label = this.label.slice(-1);
+  }
+
+  update() {
+    this.show();
+  }
+
+  show() {
+    this.decoration.show();
+  }
+
+  dispose() {
+    this.decoration.dispose();
+  }
+}
+
+class MarkerDecoration {
+  private range!: vscode.Range;
+  private editor!: vscode.TextEditor;
+  private marker!: Marker;
+  private textEditorDecorationType: vscode.TextEditorDecorationType;
+
+  private static backgroundColors = ['#ccff88', '#99ccff']; // TODO 基于配置来
+  constructor(editor: vscode.TextEditor, marker: Marker) {
+    this.editor = editor;
+    this.marker = marker;
+    this.textEditorDecorationType = vscode.window.createTextEditorDecorationType({});
+    this.createRange();
+  }
+
+  private createRange() {
+    let position = this.marker.matchPosition;
+    if (configuration.leapShowMarkerPosition === 'after') {
+      position = new vscode.Position(position.line, position.character + 2);
+    }
+    this.range = new vscode.Range(
+      position.line,
+      position.character,
+      position.line,
+      position.character
+    );
+  }
+
+  private calcDecorationBackgroundColor() {
+    const labels = configuration.leapLabels.split('').reverse().join('');
+
+    let index = 0;
+    if (this.marker.prefix) {
+      const prefixIndex = labels.indexOf(this.marker.prefix);
+      if (prefixIndex !== -1) {
+        index = (prefixIndex + 1) % 2 === 0 ? 0 : 1;
+      }
+    }
+
+    return MarkerDecoration.backgroundColors[index];
+  }
+
+  show() {
+    this.editor.setDecorations(this.textEditorDecorationType, this.getRangesOrOptions());
+  }
+
+  private getRangesOrOptions() {
+    const secondCharRenderOptions: vscode.ThemableDecorationInstanceRenderOptions = {
+      before: {
+        contentText: this.marker.label,
+        backgroundColor: this.calcDecorationBackgroundColor(),
+        color: '#000000',
+        margin: `0 -1ch 0 0;
+            position: absolute;
+            font-weight: normal;`,
+        height: '100%',
+      },
+    };
+
+    return [
+      {
+        range: this.range,
+        renderOptions: {
+          dark: secondCharRenderOptions,
+          light: secondCharRenderOptions,
+        },
+      },
+    ];
+  }
+
+  dispose() {
+    this.textEditorDecorationType.dispose();
+  }
+}
+
+export function generateMarkerNames(count: number) {
+  const leapLabels = configuration.leapLabels;
+  const result = [];
+
+  const prefixCount = Math.floor(count / leapLabels.length);
+  const prefixes = leapLabels
+    .slice(0 - prefixCount)
+    .split('')
+    .reverse()
+    .join('');
+
+  const firstGroupValues = leapLabels.slice(0, leapLabels.length - prefixCount);
+  const secondGroupValues = leapLabels;
+
+  for (let i = 0; i < count; i++) {
+    let value;
+    let prefixIndex;
+    const isFirstGroup = i < firstGroupValues.length;
+    if (isFirstGroup) {
+      value = firstGroupValues[i % firstGroupValues.length];
+      prefixIndex = Math.floor(i / firstGroupValues.length);
+    } else {
+      const ii = i - firstGroupValues.length;
+      value = secondGroupValues[ii % secondGroupValues.length];
+      prefixIndex = Math.floor(ii / secondGroupValues.length) + 1;
+    }
+
+    const prefixValue = prefixIndex === 0 ? '' : prefixes[prefixIndex - 1];
+    result.push(prefixValue + value);
+  }
+
+  return result;
+}
+
+export function createMarker(match: Match, editor: vscode.TextEditor) {
+  return new Marker(match, editor);
+}

--- a/src/actions/plugins/leap/MoveLeapAction.ts
+++ b/src/actions/plugins/leap/MoveLeapAction.ts
@@ -1,0 +1,66 @@
+import { Position } from 'vscode';
+import { BaseCommand, RegisterAction } from '../../base';
+import { VimState } from '../../../state/vimState';
+import { Mode } from '../../../mode/mode';
+import { Marker } from './Marker';
+
+@RegisterAction
+export class MoveLeapAction extends BaseCommand {
+  modes = [Mode.LeapMode];
+  keys = ['<character>'];
+  override isJump = true;
+
+  private vimState!: VimState;
+  public override async exec(position: Position, vimState: VimState): Promise<void> {
+    const searchString = this.keysPressed[0];
+    if (!searchString) return;
+    this.vimState = vimState;
+
+    const marker = vimState.leap.findMarkerByName(searchString);
+    if (marker) {
+      await this.handleDirectFoundMarker(marker);
+    } else if (vimState.leap.isPrefixOfMarker(searchString)) {
+      this.handleIsPrefixOfMarker(searchString);
+    } else {
+      await this.handleNoFoundMarker();
+    }
+  }
+
+  private async handleDirectFoundMarker(marker: Marker) {
+    this.vimState.leap.cleanupMarkers();
+    this.vimState.cursorStopPosition = marker.matchPosition;
+    await this.vimState.setCurrentMode(this.vimState.leap.previousMode);
+  }
+
+  private async handleIsPrefixOfMarker(searchString: string) {
+    this.vimState.leap.keepMarkersByPrefix(searchString);
+    this.vimState.leap.deletePrefixOfMarkers();
+  }
+
+  private async handleNoFoundMarker() {
+    this.vimState.leap.cleanupMarkers();
+    await this.vimState.setCurrentMode(this.vimState.leap.previousMode);
+  }
+}
+
+@RegisterAction
+class CommandEscLeapMode extends BaseCommand {
+  modes = [Mode.LeapMode];
+  keys = ['<Esc>'];
+
+  public override async exec(position: Position, vimState: VimState): Promise<void> {
+    vimState.leap.cleanupMarkers();
+    await vimState.setCurrentMode(vimState.leap.previousMode);
+  }
+}
+
+@RegisterAction
+class CommandEscLeapPrepareMode extends BaseCommand {
+  modes = [Mode.LeapPrepareMode];
+  keys = ['<Esc>'];
+
+  public override async exec(position: Position, vimState: VimState): Promise<void> {
+    vimState.leap.cleanupMarkers();
+    await vimState.setCurrentMode(vimState.leap.previousMode);
+  }
+}

--- a/src/actions/plugins/leap/leap.ts
+++ b/src/actions/plugins/leap/leap.ts
@@ -1,0 +1,129 @@
+import { Mode } from '../../../mode/mode';
+import { Match } from './match';
+import { Marker, createMarker, generateMarkerNames } from './Marker';
+import { VimState } from '../../../state/vimState';
+import { LeapAction } from './LeapAction';
+
+export enum LeapSearchDirection {
+  Forward = -1,
+  Backward = 1,
+}
+
+export class Leap {
+  markers: Marker[] = [];
+  vimState: VimState;
+  previousMode!: Mode;
+  isRepeatLastSearch: boolean = false;
+  direction?: LeapSearchDirection;
+  leapAction?: LeapAction;
+  firstSearchString?: string;
+
+  constructor(vimState: VimState) {
+    this.vimState = vimState;
+  }
+
+  public createMarkers(matches: Match[]) {
+    this.markers = matches.map((match) => {
+      return createMarker(match, this.vimState.editor);
+    });
+
+    this.setMarkersName();
+
+    return this.markers;
+  }
+
+  private setMarkersName() {
+    const map: { [key: string]: Marker[] } = {};
+
+    this.markers.forEach((marker) => {
+      const key = marker.searchString;
+      if (!map[key]) {
+        map[key] = [];
+      }
+
+      map[key].push(marker);
+    });
+
+    Object.keys(map).forEach((key) => {
+      const group = map[key];
+      const markerNames = generateMarkerNames(group.length);
+      group.forEach((marker, index) => {
+        marker.label = markerNames[index];
+      });
+    });
+  }
+
+  public findMarkerByName(name: string) {
+    return this.markers.find((marker: Marker) => {
+      return marker.label === name;
+    });
+  }
+
+  public findMarkersBySearchString(searchString: string) {
+    return this.markers.filter((marker) => {
+      return marker.searchString === searchString;
+    });
+  }
+
+  public keepMarkersByPrefix(prefix: string) {
+    this.markers = this.markers
+      .map((marker) => {
+        if (marker.prefix !== prefix) marker.dispose();
+        return marker;
+      })
+      .filter((marker) => {
+        return marker.prefix === prefix;
+      });
+  }
+
+  public keepMarkersBySearchString(searchString: string) {
+    this.markers = this.markers
+      .map((marker) => {
+        if (marker.searchString !== searchString) marker.dispose();
+        return marker;
+      })
+      .filter((marker) => {
+        return marker.searchString === searchString;
+      });
+  }
+
+  public deletePrefixOfMarkers() {
+    this.markers.forEach((marker: Marker) => {
+      marker.deletePrefix();
+      marker.update();
+    });
+  }
+
+  public isPrefixOfMarker(character: string) {
+    return this.markers.some((marker) => {
+      return marker.prefix === character;
+    });
+  }
+
+  public cleanupMarkers() {
+    if (this.markers.length === 0) return;
+    this.markers.forEach((marker) => {
+      marker.dispose();
+    });
+
+    this.markers = [];
+  }
+
+  public showMarkers() {
+    this.markers.forEach((marker) => {
+      marker.show();
+    });
+  }
+}
+
+export function createLeap(
+  vimState: VimState,
+  direction: LeapSearchDirection = LeapSearchDirection.Backward,
+  firstSearchString: string = ''
+) {
+  const leap = new Leap(vimState);
+  leap.direction = direction;
+  leap.firstSearchString = firstSearchString;
+
+  return leap;
+}

--- a/src/actions/plugins/leap/match.ts
+++ b/src/actions/plugins/leap/match.ts
@@ -1,0 +1,105 @@
+import { Position } from 'vscode';
+import { LeapSearchDirection } from './leap';
+import * as vscode from 'vscode';
+import { configuration } from '../../../configuration/configuration';
+
+export interface Match {
+  position: Position;
+  searchString: string;
+}
+
+const needEscapeStrings: string = '$()*+.[]?\\^{}|';
+function escapeString(str: string) {
+  return needEscapeStrings.includes(str) ? '\\' + str : str;
+}
+
+function getFlags() {
+  const caseSensitiveFlag = configuration.leapCaseSensitive ? '' : 'i';
+  return `g${caseSensitiveFlag}`;
+}
+
+export function generatePrepareRegex(rawSearchString: string) {
+  const searchCharacter = escapeString(rawSearchString);
+  const pattern = `${searchCharacter}[\\s\\S]|${searchCharacter}$`;
+  return new RegExp(pattern, getFlags());
+}
+
+export function generateMarkerRegex(searchString: string) {
+  function getPattern(rawSearchString: string) {
+    const searchChars = rawSearchString.split('').map(escapeString);
+
+    const firstChar = searchChars[0];
+    const secondChar = searchChars[1];
+    let pattern = '';
+    if (secondChar === ' ') {
+      pattern = firstChar + '\\s' + '|' + firstChar + '$';
+    } else {
+      pattern = firstChar + secondChar;
+    }
+
+    return pattern;
+  }
+
+  return new RegExp(getPattern(searchString), getFlags());
+}
+
+const MATCH_LINE_COUNT = 50;
+const MATCH_COUNT_LIMIT = 400;
+export function getMatches(
+  searchRegex: RegExp,
+  direction: LeapSearchDirection,
+  position: Position,
+  document: vscode.TextDocument
+) {
+  const matches: Match[] = [];
+
+  const lineStart = position.line;
+  const lineEnd =
+    direction === LeapSearchDirection.Backward
+      ? Math.min(position.line + MATCH_LINE_COUNT, document.lineCount - 1)
+      : Math.max(position.line - MATCH_LINE_COUNT, 0);
+
+  function checkPosition(lineCount: number, index: number) {
+    return (
+      (lineCount === lineStart &&
+        (direction === LeapSearchDirection.Forward
+          ? index < position.character - 1
+          : index > position.character)) ||
+      lineCount !== lineStart
+    );
+  }
+
+  function calcCurrentLineMatches(lineCount: number) {
+    const lineText = document.lineAt(lineCount).text;
+    let result = searchRegex.exec(lineText);
+    const lineMatches: Match[] = [];
+
+    while (result) {
+      if (checkPosition(lineCount, result.index)) {
+        const pos = new Position(lineCount, result.index);
+        const rawText = result[0].length === 1 ? result[0] + ' ' : result[0];
+        const searchString = configuration.leapCaseSensitive ? rawText : rawText.toLowerCase();
+        lineMatches.push({ position: pos, searchString });
+        if (searchString[0] === searchString[1]) {
+          searchRegex.lastIndex--;
+        }
+      }
+      result = searchRegex.exec(lineText);
+    }
+
+    return lineMatches;
+  }
+
+  const s = direction === LeapSearchDirection.Backward ? lineStart : lineEnd;
+  const e = direction === LeapSearchDirection.Backward ? lineEnd : lineStart;
+
+  for (let i = s; i <= e; i++) {
+    matches.push(...calcCurrentLineMatches(i));
+  }
+
+  if (direction === LeapSearchDirection.Forward) matches.reverse();
+
+  if (matches.length > MATCH_COUNT_LIMIT) matches.length = MATCH_COUNT_LIMIT;
+
+  return matches;
+}

--- a/src/actions/plugins/leap/register.ts
+++ b/src/actions/plugins/leap/register.ts
@@ -1,0 +1,2 @@
+import './LeapAction';
+import './MoveLeapAction';

--- a/src/actions/plugins/sneak.ts
+++ b/src/actions/plugins/sneak.ts
@@ -12,6 +12,10 @@ export class SneakForward extends BaseMovement {
   ];
   override isJump = true;
 
+  public override doesActionApply(vimState: VimState, keysPressed: string[]) {
+    return super.doesActionApply(vimState, keysPressed) && configuration.sneak;
+  }
+
   public override couldActionApply(vimState: VimState, keysPressed: string[]): boolean {
     const startingLetter = vimState.recordedState.operator === undefined ? 's' : 'z';
 
@@ -78,6 +82,10 @@ export class SneakBackward extends BaseMovement {
     ['Z', '<character>', '<character>'],
   ];
   override isJump = true;
+
+  public override doesActionApply(vimState: VimState, keysPressed: string[]) {
+    return super.doesActionApply(vimState, keysPressed) && configuration.sneak;
+  }
 
   public override couldActionApply(vimState: VimState, keysPressed: string[]): boolean {
     const startingLetter = vimState.recordedState.operator === undefined ? 'S' : 'Z';

--- a/src/configuration/configuration.ts
+++ b/src/configuration/configuration.ts
@@ -261,6 +261,11 @@ class Configuration implements IConfiguration {
   easymotionKeys = 'hklyuiopnm,qwertzxcvbasdgjf;';
   easymotionJumpToAnywhereRegex = '\\b[A-Za-z0-9]|[A-Za-z0-9]\\b|_.|#.|[a-z][A-Z]';
 
+  leap = false;
+  leapShowMarkerPosition = 'after';
+  leapLabels = 'sklyuiopnm,qwertzxcvbahdgjf;';
+  leapCaseSensitive = false;
+
   targets: ITargetsConfiguration = {
     enable: false,
 

--- a/src/error.ts
+++ b/src/error.ts
@@ -35,6 +35,8 @@ export enum ErrorCode {
   AtEndOfChangeList = 663,
   ChangeListIsEmpty = 664,
   NoPreviouslyUsedRegister = 748,
+  LeapNoPreviousSearch = 800,
+  LeapNoFoundSearchString = 801,
 }
 
 export const ErrorMessage: IErrorMessage = {
@@ -70,6 +72,8 @@ export const ErrorMessage: IErrorMessage = {
   663: 'At end of changelist',
   664: 'changelist is empty',
   748: 'No previously used register',
+  800: 'No previous search',
+  801: 'Not found',
 };
 
 export class VimError extends Error {

--- a/src/mode/mode.ts
+++ b/src/mode/mode.ts
@@ -15,6 +15,8 @@ export enum Mode {
   SurroundInputMode,
   OperatorPendingMode, // Pseudo-Mode, used only when remapping. DON'T SET TO THIS MODE
   Disabled,
+  LeapPrepareMode,
+  LeapMode,
 }
 
 export enum VSCodeVimCursorType {

--- a/src/mode/modeHandler.ts
+++ b/src/mode/modeHandler.ts
@@ -1645,6 +1645,10 @@ export class ModeHandler implements vscode.Disposable, IModeHandler {
       this.vimState.easyMotion.updateDecorations(this.vimState.editor);
     }
 
+    if (this.currentMode !== Mode.LeapPrepareMode && this.currentMode !== Mode.LeapMode) {
+      this.vimState.leap?.cleanupMarkers();
+    }
+
     StatusBar.clear(this.vimState, false);
 
     // NOTE: this is not being awaited to save the 15-20ms block - I think this is fine
@@ -1726,6 +1730,10 @@ function getCursorType(vimState: VimState, mode: Mode): VSCodeVimCursorType {
     case Mode.EasyMotionMode:
       return VSCodeVimCursorType.Block;
     case Mode.EasyMotionInputMode:
+      return VSCodeVimCursorType.Block;
+    case Mode.LeapPrepareMode:
+      return VSCodeVimCursorType.Block;
+    case Mode.LeapMode:
       return VSCodeVimCursorType.Block;
     case Mode.SurroundInputMode:
       return getCursorType(vimState, vimState.surround!.previousMode);

--- a/src/state/vimState.ts
+++ b/src/state/vimState.ts
@@ -3,6 +3,7 @@ import * as vscode from 'vscode';
 import { IMovement } from '../actions/baseMotion';
 import { configuration } from '../configuration/configuration';
 import { IEasyMotion } from '../actions/plugins/easymotion/types';
+import { Leap } from '../actions/plugins/leap/leap';
 import { HistoryTracker } from './../history/historyTracker';
 import { Logger } from '../util/logger';
 import { Mode } from '../mode/mode';
@@ -60,6 +61,8 @@ export class VimState implements vscode.Disposable {
   public historyTracker: HistoryTracker;
 
   public easyMotion: IEasyMotion;
+
+  public leap!: Leap;
 
   public readonly documentUri: vscode.Uri;
 

--- a/src/statusBar.ts
+++ b/src/statusBar.ts
@@ -185,6 +185,10 @@ export function statusBarText(vimState: VimState) {
       return '-- EASYMOTION --';
     case Mode.EasyMotionInputMode:
       return '-- EASYMOTION INPUT --';
+    case Mode.LeapMode:
+      return '-- LEAP --';
+    case Mode.LeapPrepareMode:
+      return '-- LEAP PREPARE --';
     case Mode.SurroundInputMode:
       return '-- SURROUND INPUT --';
     case Mode.Disabled:
@@ -252,6 +256,14 @@ export function statusBarCommandText(vimState: VimState): string {
     case Mode.Insert:
     case Mode.Replace:
       return vimState.recordedState.pendingCommandString;
+    case Mode.LeapPrepareMode:
+    case Mode.LeapMode:
+      if (vimState.leap?.isRepeatLastSearch) {
+        const searchString =
+          vimState.leap.firstSearchString + vimState.leap.leapAction!.keysPressed[0];
+        return 's' + searchString;
+      }
+      return vimState.recordedState.commandString;
     case Mode.Normal:
     case Mode.Disabled:
       return vimState.recordedState.commandString;

--- a/test/plugins/leap.test.ts
+++ b/test/plugins/leap.test.ts
@@ -1,0 +1,129 @@
+import { Configuration } from '../testConfiguration';
+import { newTest } from '../testSimplifier';
+import { cleanUpWorkspace, setupWorkspace } from '../testUtils';
+
+function leapCommand(key: 's' | 'S', searchStrings: string[], jumpKeys: string[] = []) {
+  return [key, ...searchStrings, ...jumpKeys].join('');
+}
+
+suite('leap plugin', () => {
+  setup(async () => {
+    const configuration = new Configuration();
+    configuration.leap = true;
+
+    await setupWorkspace(configuration);
+  });
+
+  teardown(cleanUpWorkspace);
+
+  suite('to backward', async () => {
+    newTest({
+      title: 'move first marker position',
+      start: ['|cccabcabfg'],
+      keysPressed: leapCommand('s', ['a', 'b'], ['s']),
+      end: ['ccc|abcabfg'],
+    });
+
+    newTest({
+      title: 'move second marker position',
+      start: ['|cccabcabfg'],
+      keysPressed: leapCommand('s', ['a', 'b'], ['k']),
+      end: ['cccabc|abfg'],
+    });
+
+    newTest({
+      title: 'marker name is not exist',
+      start: ['|cccabcabfg'],
+      keysPressed: leapCommand('s', ['a', 'b'], ['l']),
+      end: ['|cccabcabfg'],
+    });
+
+    newTest({
+      title: 'directly jump target position when only have one marker',
+      start: ['|cccabcabfg'],
+      keysPressed: leapCommand('s', ['f', 'g']),
+      end: ['cccabcab|fg'],
+    });
+
+    newTest({
+      title: 'cursor should not change when no marker',
+      start: ['|cccabcabfg'],
+      keysPressed: leapCommand('s', ['z', 'z']),
+      end: ['|cccabcabfg'],
+    });
+  });
+
+  suite('to forward', async () => {
+    newTest({
+      title: 'move first marker position',
+      start: ['cccabcabf|g'],
+      keysPressed: leapCommand('S', ['a', 'b'], ['s']),
+      end: ['cccabc|abfg'],
+    });
+
+    newTest({
+      title: 'move second marker position',
+      start: ['cccabcabf|g'],
+      keysPressed: leapCommand('S', ['a', 'b'], ['k']),
+      end: ['ccc|abcabfg'],
+    });
+
+    newTest({
+      title: 'marker name is not exist',
+      start: ['cccabcabf|g'],
+      keysPressed: leapCommand('S', ['a', 'b'], ['z']),
+      end: ['cccabcabf|g'],
+    });
+
+    newTest({
+      title: 'directly jump target position when only have one marker',
+      start: ['fgcccabca|b'],
+      keysPressed: leapCommand('S', ['f', 'g']),
+      end: ['|fgcccabcab'],
+    });
+
+    newTest({
+      title: 'cursor should not change when no marker',
+      start: ['cccabcabf|g'],
+      keysPressed: leapCommand('S', ['z', 'z']),
+      end: ['cccabcabf|g'],
+    });
+
+    newTest({
+      title: 'should not match when cursor position is search string',
+      start: ['lsdjaflonkdjfjo|n'],
+      keysPressed: leapCommand('S', ['o', 'n'], ['s']),
+      end: ['lsdjafl|onkdjfjon'],
+    });
+  });
+
+  suite('last repeat search', async () => {
+    newTest({
+      title: 'to forward',
+      start: ['onabonabc|d'],
+      keysPressed: [...leapCommand('S', ['o', 'n'], ['s']), ...leapCommand('S', ['\n'])].join(''),
+      end: ['|onabonabcd'],
+    });
+
+    newTest({
+      title: 'to backward',
+      start: ['|abonabonabcd'],
+      keysPressed: [...leapCommand('s', ['o', 'n'], ['s']), ...leapCommand('s', ['\n'])].join(''),
+      end: ['abonab|onabcd'],
+    });
+
+    newTest({
+      title: 'different direction',
+      start: ['|abonabonab'],
+      keysPressed: [...leapCommand('s', ['o', 'n'], ['k']), ...leapCommand('S', ['\n'])].join(''),
+      end: ['ab|onabonab'],
+    });
+  });
+
+  newTest({
+    title: 'continuous two matching characters',
+    start: ['|boolean'],
+    keysPressed: leapCommand('s', ['o', 'l']),
+    end: ['bo|olean'],
+  });
+});

--- a/test/testConfiguration.ts
+++ b/test/testConfiguration.ts
@@ -26,6 +26,10 @@ export class Configuration implements IConfiguration {
   sneak = false;
   sneakUseIgnorecaseAndSmartcase = false;
   sneakReplacesF = false;
+  leap = false;
+  leapShowMarkerPosition = 'after';
+  leapLabels = 'sklyuiopnm,qwertzxcvbahdgjf;';
+  leapCaseSensitive = false;
   surround = false;
   argumentObjectSeparators = [','];
   argumentObjectOpeningDelimiters = ['(', '['];


### PR DESCRIPTION
<!--
Yay! Thanks for sending us a PR! 🎊

Please ensure your PR adheres to:

- [ ] Commit messages has a short & issue references when necessary
- [ ] Each commit does a logical chunk of work.
- [ ] It builds and tests pass (e.g `gulp`)
-->

## **What this PR does / why we need it**:
hi @J-Fields 

I have implemented a leap-like functionality plugin in vscodevim

leap is currently a very popular mobile plugin in the neovim community, and it is really efficient. I believe there are many vscodevim users waiting for its arrival #8144 

### Functional Features
- s c c -> search down
- S c c -> Search up
- s c -> Show cue marker points
- s \<enter\> -> Execute the previous search
- s c \<space\> -> Search c + \\t

You can see how it behaves in vscodevim

![show-vscode-leap](https://user-images.githubusercontent.com/12064746/210962432-3e4a48fd-db24-4e4e-84a1-b75e0dd45146.gif)


## Compare the functional differences between leap.nvim

Because the implementation of vscodevim is different from neovim. So in some functions it is not the same as leap.nvim

- No automatic jumping to the first marker point
- Selection of multiple markers
- No support for using operators together

### Does not automatically jump to the first marker point

When matching multiple tag points, it does not automatically jump to the first tag point position.

In leap.nvim you can recognize that when you press a character that is the tag of a marker point then it will automatically jump to the marker point, otherwise it will execute the character as if it was a command in normal mode, but unfortunately this is not possible in vscodevim.

Another problem is that this feature can be confusing. Sometimes it jumps automatically and sometimes it doesn't (for example when there are multiple jump points, or you set the corresponding configuration). So I simply killed this feature in my implementation.

Instead of jumping to the first match point by default, the implementation now requires you to press an s. This s can be modified by the configuration

Of course, if only one marker is matched, then it will automatically jump over

### Multiple markers are selected in the following way

In leap.nvim, if there are too many matching tokens, then the selection method is to select the corresponding group by /.The problem with this method is that if three groups are matched, then needs to be pressed twice to select them. (Of course, this is a very extreme case, so you will not encounter it)

In my implementation, I refer to easymotion's jump implementation, which starts with one letter and uses two letters if it goes beyond that, so the advantage is that no matter how many matches are made, the two letters will directly locate the marker point.Of course, another reason is that this implementation is unified with easymotion. Because some mobile scenes use easymotion. So it would be difficult to have two sets of selections. (I believe many users of vscodeVim also use easymotion, so this behavior may be more preferable for them, but I'm not sure... haha... what do you think?)

![vim-leap-01](https://user-images.githubusercontent.com/12064746/210189372-d7da215a-8614-4099-9d5c-060c9d2ddfef.gif)

### Use with operators is not supported

Unfortunately, this feature is also not supported, again because of the underlying implementation of vscodevim. Currently there is no way to do this

But this feature scenario is not used very often

## Can I map other keys if I don't want to use s S?

You can refer to the following configuration

Replace s with f
```
"vim.normalModeKeyBindingsNonRecursive": [
  {

      "before":[
        "f"
      ],

      "after":[
        "s"
      ]
    },

    {

      "before":[
        "s"
      ],

      "after":[
        "c",
        "l"
      ]
    },
]
```

## How should I experience this feature before this pr merge?

You can install the experience locally based on my code branch

From time to time, I will merge new code from vscodevim into my branch until this pr is merged.

Here's how to do it: 

1. Download [my code branch](https://github.com/cuixiaorui/VSCodeVim/tree/leap)
2. yarn   
3. yarn package
4. code --install-extension vim-1.24.3.vsix --force
