### PR TITLE
Fix issue with shift + mouse selection from bottom to top

### DIFF
--- a/src/mode/modeHandler.ts
+++ b/src/mode/modeHandler.ts
@@ -371,7 +371,7 @@ export class ModeHandler implements vscode.Disposable, IModeHandler {
         // If we prevented from clicking past eol but it is part of this selection, include the last char
         if (this.lastClickWasPastEol) {
           const newStart = new Position(selection.anchor.line, selection.anchor.character + 1);
-          this.vimState.editor.selection = new vscode.Selection(newStart, selection.end);
+          this.vimState.editor.selection = new vscode.Selection(newStart, selection.active);
           this.vimState.cursorStartPosition = selectionStart;
           this.lastClickWasPastEol = false;
         }


### PR DESCRIPTION
When the cursor is at the end of a line, and I use the shift key and mouse to select an area above it, I encounter a problem where the selection cannot be made. The reason for this is that the selection range in the code is covering the wrong direction. This commit fixes this issue.