### PR TITLE
Add task 'prepare-test' to tasks.json

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -17,6 +17,11 @@
       "type": "gulp",
       "task": "build-dev",
       "problemMatcher": []
+    },
+    {
+      "type": "gulp",
+      "task": "prepare-test",
+      "problemMatcher": []
     }
   ]
 }


### PR DESCRIPTION

**What this PR does / why we need it**:
Add task 'prepare-test' to tasks.json in order to do RUN AND DEBUG 'Run Tests'  on VS Code.

Before this PR, when select 'Run Tests' and press F5 key, this error was displayed.  
`Could not find the task 'gulp: prepare-test'.`


**Which issue(s) this PR fixes**
not yet

**Special notes for your reviewer**:
