### PR TITLE
fixes #7022

### DIFF
--- a/src/actions/operator.ts
+++ b/src/actions/operator.ts
@@ -675,7 +675,7 @@ export class ChangeOperator extends BaseOperator {
       vimState.recordedState.transformer.delete(deleteRange);
     }
 
-    vimState.setCurrentMode(Mode.Insert);
+    await vimState.setCurrentMode(Mode.Insert);
   }
 }
 


### PR DESCRIPTION

related oprations/actions: 
- s
- c

issue: #7022

<!--
Yay! Thanks for sending us a PR! 🎊

Please ensure your PR adheres to:

- [ ] Commit messages has a short & issue references when necessary
- [ ] Each commit does a logical chunk of work.
- [ ] It builds and tests pass (e.g `gulp`)
-->

**What this PR does / why we need it**:

Fix ChangeOperators not enter InsertMode when autoSwitchInputMethod is enabled.

**Which issue(s) this PR fixes**

#7022

<!--
Commits in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)
-->

**Special notes for your reviewer**:

I found that there are other codes that use the `vimState.setCurrentMode` / `vimState.setModeData` interface, and don't write the `await` keyword, but I don't know whether it needs to be modified, such as:

https://github.com/VSCodeVim/Vim/blob/2d703280762663e8d8567e603f1e178f8ead0453/src/actions/commands/actions.ts#L2349
https://github.com/VSCodeVim/Vim/blob/2d703280762663e8d8567e603f1e178f8ead0453/src/actions/commands/insert.ts#L246
https://github.com/VSCodeVim/Vim/blob/2d703280762663e8d8567e603f1e178f8ead0453/src/actions/commands/insert.ts#L258
