### PR TITLE
Enable sourcemaps in dev builds

### DIFF
--- a/webpack.dev.js
+++ b/webpack.dev.js
@@ -4,6 +4,7 @@ const prod_configs = require('./webpack.config.js');
 module.exports = [
   merge.merge(prod_configs[0], {
     mode: 'development',
+    devtool: 'source-map',
     optimization: {
       minimize: false,
       removeAvailableModules: false,


### PR DESCRIPTION
**What this PR does / why we need it**:
Webpack sourcemaps were disabled in f02ed71ed848d8aca2e1fef77d8d2490a3b9e1e7, which inadvertedly also stopped vscode from picking up sourcemaps when debugging the extension. This resulted in vscode breakpoints not working at all.

**Which issue(s) this PR fixes**
Couldn't find any reported issues regarding this - I encountered it while working on https://github.com/VSCodeVim/Vim/pull/8077.