### PR TITLE
Fix typo in `bug_report.md`

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -25,7 +25,7 @@ If remapping-related, please attach log output: https://github.com/VSCodeVim/Vim
 
 <!--
 Ensure you are on the latest VSCode + VSCodeVim
-You can use "Report Issue" by running "Developers: Show Running Extensions" from the Command Palette to prefill these.
+You can use "Report Issue" by running "Developer: Show Running Extensions" from the Command Palette to prefill these.
 -->
 
 - Extension (VsCodeVim) version:


### PR DESCRIPTION
<!--
Yay! Thanks for sending us a PR! 🎊

Please ensure your PR adheres to:

- [ ] Commit messages has a short & issue references when necessary
- [ ] Each commit does a logical chunk of work.
- [ ] It builds and tests pass (e.g `gulp`)
-->

**What this PR does / why we need it**:
This PR corrects a typo in `bug_report.md` in which there is a line that says to run "Developers: Show Running Extensions". There is no such command in VSCode. Rather the correct command is "Developer: Show Running Extensions"

**Which issue(s) this PR fixes**
fixes #8387
<!--
Commits in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)
-->

**Special notes for your reviewer**:
