### PR TITLE
update sentence definition to allow for closing quotes/parens/squarebrackets

### DIFF
--- a/src/textobject/sentence.ts
+++ b/src/textobject/sentence.ts
@@ -3,7 +3,7 @@ import { TextEditor } from '../textEditor';
 import { getCurrentParagraphBeginning, getCurrentParagraphEnd } from './paragraph';
 import { getAllPositions, getAllEndPositions } from './util';
 
-const sentenceEndRegex = /[\.!\?]{1}([ \n\t]+|$)/g;
+const sentenceEndRegex = /[\.!\?]["')\]]*?([ \n\t]+|$)/g;
 
 export function getSentenceBegin(position: Position, args: { forward: boolean }): Position {
   if (args.forward) {

--- a/test/motion.test.ts
+++ b/test/motion.test.ts
@@ -539,7 +539,6 @@ suite('sentence motion', () => {
       motion = motion.getSentenceBegin({ forward: true });
       assert.strictEqual(motion.line, 11);
       assert.strictEqual(motion.character, 96);
-
     });
   });
 

--- a/test/motion.test.ts
+++ b/test/motion.test.ts
@@ -492,6 +492,8 @@ suite('sentence motion', () => {
     '   ',
     'Wow!',
     'Another sentence inside one paragraph.',
+    '',
+    '"Sentence in quotes." Sentence out of quotes. \'Sentence in singlequotes.\' (Sentence in parens.) [Sentence in square brackets.]',
   ];
 
   suiteSetup(async () => {
@@ -515,10 +517,29 @@ suite('sentence motion', () => {
       assert.strictEqual(motion.character, 0);
     });
 
-    test('next sentence when paragraph contains a line of whilte spaces', () => {
+    test('next sentence when paragraph contains a line of white spaces', () => {
       const motion = new Position(6, 2).getSentenceBegin({ forward: true });
       assert.strictEqual(motion.line, 9);
       assert.strictEqual(motion.character, 0);
+    });
+
+    test('next sentence when sentences have closing punctuation', () => {
+      let motion = new Position(11, 0).getSentenceBegin({ forward: true });
+      assert.strictEqual(motion.line, 11);
+      assert.strictEqual(motion.character, 22);
+
+      motion = motion.getSentenceBegin({ forward: true });
+      assert.strictEqual(motion.line, 11);
+      assert.strictEqual(motion.character, 46);
+
+      motion = motion.getSentenceBegin({ forward: true });
+      assert.strictEqual(motion.line, 11);
+      assert.strictEqual(motion.character, 74);
+
+      motion = motion.getSentenceBegin({ forward: true });
+      assert.strictEqual(motion.line, 11);
+      assert.strictEqual(motion.character, 96);
+
     });
   });
 
@@ -529,13 +550,13 @@ suite('sentence motion', () => {
       assert.strictEqual(motion.character, 35);
     });
 
-    test('sentence forward when cursor is at the beginning of the second sentence', () => {
+    test('sentence backward when cursor is at the beginning of the second sentence', () => {
       const motion = new Position(0, 35).getSentenceBegin({ forward: false });
       assert.strictEqual(motion.line, 0);
       assert.strictEqual(motion.character, 0);
     });
 
-    test('current sentence begin with no concrete sentense inside', () => {
+    test('current sentence begin with no concrete sentence inside', () => {
       const motion = new Position(3, 0).getSentenceBegin({ forward: false });
       assert.strictEqual(motion.line, 2);
       assert.strictEqual(motion.character, 0);
@@ -550,6 +571,28 @@ suite('sentence motion', () => {
     test('current sentence begin when previous line ends with a concrete sentence', () => {
       const motion = new Position(9, 5).getSentenceBegin({ forward: false });
       assert.strictEqual(motion.line, 9);
+      assert.strictEqual(motion.character, 0);
+    });
+
+    test('sentence backward when sentences have closing punctuation', () => {
+      let motion = new Position(11, 125).getSentenceBegin({ forward: false });
+      assert.strictEqual(motion.line, 11);
+      assert.strictEqual(motion.character, 96);
+
+      motion = motion.getSentenceBegin({ forward: false });
+      assert.strictEqual(motion.line, 11);
+      assert.strictEqual(motion.character, 74);
+
+      motion = motion.getSentenceBegin({ forward: false });
+      assert.strictEqual(motion.line, 11);
+      assert.strictEqual(motion.character, 46);
+
+      motion = motion.getSentenceBegin({ forward: false });
+      assert.strictEqual(motion.line, 11);
+      assert.strictEqual(motion.character, 22);
+
+      motion = motion.getSentenceBegin({ forward: false });
+      assert.strictEqual(motion.line, 10);
       assert.strictEqual(motion.character, 0);
     });
   });

--- a/test/sentenceMotion.test.ts
+++ b/test/sentenceMotion.test.ts
@@ -51,6 +51,34 @@ suite('sentence motion', () => {
     });
 
     newTest({
+      title: 'move one sentence backward closing quotes',
+      start: ['"lorem ipsum." lorem ipsum|'],
+      keysPressed: '(',
+      end: ['"lorem ipsum." |lorem ipsum'],
+    });
+
+    newTest({
+      title: 'move one sentence backward closing singlequote',
+      start: ['\'lorem ipsum.\' lorem ipsum|'],
+      keysPressed: '(',
+      end: ['\'lorem ipsum.\' |lorem ipsum'],
+    });
+
+    newTest({
+      title: 'move one sentence backward closing paren',
+      start: ['(lorem ipsum.) lorem ipsum|'],
+      keysPressed: '(',
+      end: ['(lorem ipsum.) |lorem ipsum'],
+    });
+
+    newTest({
+      title: 'move one sentence backward closing square bracket',
+      start: ['[lorem ipsum.] lorem ipsum|'],
+      keysPressed: '(',
+      end: ['[lorem ipsum.] |lorem ipsum'],
+    });
+
+    newTest({
       title: 'move one sentence backward - multiline',
       start: ['lorem ipsum', 'lorem ipsum|'],
       keysPressed: '(',

--- a/test/sentenceMotion.test.ts
+++ b/test/sentenceMotion.test.ts
@@ -59,9 +59,9 @@ suite('sentence motion', () => {
 
     newTest({
       title: 'move one sentence backward closing singlequote',
-      start: ['\'lorem ipsum.\' lorem ipsum|'],
+      start: ["'lorem ipsum.' lorem ipsum|"],
       keysPressed: '(',
-      end: ['\'lorem ipsum.\' |lorem ipsum'],
+      end: ["'lorem ipsum.' |lorem ipsum"],
     });
 
     newTest({


### PR DESCRIPTION
<!--
Yay! Thanks for sending us a PR! 🎊

Please ensure your PR adheres to:

- [x] Commit messages has a short & issue references when necessary
- [x] Each commit does a logical chunk of work.
- [x] It builds and tests pass (e.g `gulp`)
-->

**What this PR does / why we need it**:

This change updates the definition of a sentence to be more in line with vim's definition.

Today, a sentence end is a punctuation character (`.`, `?`, `!`) followed by whitespace/line end - which means that something like `(potential sentence end.)` doesn't count as a sentence end (even though it does in vim).

With this change, we allow a sentence end to include any amount of closing: 1. single quotes; 2. double quotes; 3. parentheses; 4. square brackets.

**Which issue(s) this PR fixes**
#8390 

<!--
Commits in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)
-->

**Special notes for your reviewer**:
none
