### PR TITLE
set selection=exclusive

### DIFF
--- a/package.json
+++ b/package.json
@@ -1171,6 +1171,16 @@
         "vim.langmap": {
           "type": "string",
           "description": "Language map for alternate keyboard layouts. When you are typing text in Insert (or Replace, etc.) mode, the characters are inserted derectly. Otherwise, they are translated based on the provided map."
+        },
+        "vim.selection": {
+          "type": "string",
+          "enum": [
+            "old",
+            "inclusive",
+            "exclusive"
+          ],
+          "description": "Controls whether the final character of a Visual mode selection is included in an operation.",
+          "default": "inclusive"
         }
       }
     },

--- a/src/configuration/configuration.ts
+++ b/src/configuration/configuration.ts
@@ -53,6 +53,7 @@ export const optionAliases: ReadonlyMap<string, string> = new Map<string, string
   ['scr', 'scroll'],
   ['so', 'scrolloff'],
   ['scs', 'smartcase'],
+  ['sel', 'selection'],
   ['smd', 'showmode'],
   ['sol', 'startofline'],
   ['to', 'timeout'],
@@ -419,6 +420,8 @@ class Configuration implements IConfiguration {
   visualstar = false;
 
   mouseSelectionGoesIntoVisualMode = true;
+
+  selection: 'old' | 'inclusive' | 'exclusive' = 'inclusive';
 
   changeWordIncludesWhitespace = false;
 

--- a/src/configuration/iconfiguration.ts
+++ b/src/configuration/iconfiguration.ts
@@ -332,6 +332,9 @@ export interface IConfiguration {
    */
   mouseSelectionGoesIntoVisualMode: boolean;
 
+  /** Controls whether the final character of a Visual mode selection is included. */
+  selection: 'old' | 'inclusive' | 'exclusive';
+
   /**
    * Includes trailing whitespace when changing word.
    */

--- a/src/mode/modeHandler.ts
+++ b/src/mode/modeHandler.ts
@@ -1102,6 +1102,17 @@ export class ModeHandler implements vscode.Disposable, IModeHandler {
         [start, stop] = [stop, start];
       }
 
+      // Character-wise Visual selections are represented internally as inclusive ranges.
+      // Vim's selection=exclusive instead treats the ordered range as half-open. Keep a
+      // one-character selection inclusive, as Vim does, so Visual mode can never be empty.
+      if (
+        startingMode === Mode.Visual &&
+        configuration.selection === 'exclusive' &&
+        !start.isEqual(stop)
+      ) {
+        stop = stop.getLeftThroughLineBreaks(true);
+      }
+
       if (!isVisualMode(startingMode) && startingRegisterMode !== RegisterMode.LineWise) {
         stop = stop.getLeftThroughLineBreaks(true);
       }
@@ -1325,7 +1336,13 @@ export class ModeHandler implements vscode.Disposable, IModeHandler {
              * but if we hit b we expect to select abcd, so we need to getRight() on the
              * start of the selection when it precedes where we started visual mode.
              */
-            if (start.isAfterOrEqual(stop)) {
+            if (configuration.selection === 'exclusive' && start.isBefore(stop)) {
+              const exclusiveStop = stop.getLeftThroughLineBreaks(true);
+              // Vim treats a one-character Visual selection as inclusive.
+              if (!exclusiveStop.isEqual(start)) {
+                stop = exclusiveStop;
+              }
+            } else if (start.isAfterOrEqual(stop)) {
               start = start.getRight();
             }
 

--- a/test/mode/modeVisual.test.ts
+++ b/test/mode/modeVisual.test.ts
@@ -51,11 +51,59 @@ suite('Mode Visual', () => {
     assert.strictEqual(sel.end.line, 0);
   });
 
+  test('selection=exclusive renders a half-open, nonempty selection', async () => {
+    await reloadConfiguration(new Configuration({ selection: 'exclusive' }));
+    await modeHandler.handleMultipleKeyEvents('iHello world!'.split(''));
+    await modeHandler.handleMultipleKeyEvents(['<Esc>', '^', 'v']);
+
+    let selection = modeHandler.vimState.editor.selection;
+    assert.strictEqual(selection.start.character, 0);
+    assert.strictEqual(selection.end.character, 1);
+
+    await modeHandler.handleKeyEvent('w');
+
+    selection = modeHandler.vimState.editor.selection;
+    assert.strictEqual(selection.start.character, 0);
+    assert.strictEqual(selection.end.character, 6);
+  });
+
   test('Can handle wd', async () => {
     await modeHandler.handleMultipleKeyEvents('ione two three'.split(''));
     await modeHandler.handleMultipleKeyEvents(['<Esc>', '^', 'v', 'w', 'd']);
 
     assertEqualLines(['wo three']);
+  });
+
+  newTest({
+    title: 'selection=exclusive excludes the final character from a forward selection',
+    config: { selection: 'exclusive' },
+    start: ['|Hello world!'],
+    keysPressed: 'vwd',
+    end: ['|world!'],
+  });
+
+  newTest({
+    title: 'selection=exclusive excludes the final character from a backward selection',
+    config: { selection: 'exclusive' },
+    start: ['abc|def'],
+    keysPressed: 'vbd',
+    end: ['|def'],
+  });
+
+  newTest({
+    title: 'selection=exclusive keeps a one-character selection inclusive',
+    config: { selection: 'exclusive' },
+    start: ['|abc'],
+    keysPressed: 'vx',
+    end: ['|bc'],
+  });
+
+  newTest({
+    title: ':set selection=exclusive changes Visual selection semantics',
+    config: { selection: 'inclusive' },
+    start: ['|Hello world!'],
+    keysPressed: ':set selection=exclusive\nvwd',
+    end: ['|world!'],
   });
 
   test('Can handle x', async () => {

--- a/test/testConfiguration.ts
+++ b/test/testConfiguration.ts
@@ -107,6 +107,7 @@ export class Configuration implements IConfiguration {
   matchpairs = '(:),{:},[:]';
   visualstar = false;
   mouseSelectionGoesIntoVisualMode = true;
+  selection: 'old' | 'inclusive' | 'exclusive' = 'inclusive';
   changeWordIncludesWhitespace = false;
   foldfix = false;
   disableExtension = false;


### PR DESCRIPTION
In answer to feature request https://github.com/VSCodeVim/Vim/issues/2747

**What this PR does / why we need it**: Because visual selection in vim is _retarded_ without `set selection=exclusive`.

~**Special notes for your reviewer**: This PR only partially fixes the issue.  It correctly alters the start of the selection as per traditional vim in `selection=exclusive` mode and *appears* to alter the end of the selection also, but that appearance is deceptive.  Can someone with more experience offer an opinion?~

~TL;DR:
`stop = stop.getLeft();` change the visual appearance of the selection, but not the actual selection.~

~postnote:  this has all been implemented as `"vim.selectionExclusive": true`, rather than the true vim selection=inclusive|exclusive|old`.  Would be happy to rectify that, if/when above issue is resolved.~
