### PR TITLE
Do not revert to a single cursor when escape is pressed after a block selection

### DIFF
--- a/src/actions/commands/insert.ts
+++ b/src/actions/commands/insert.ts
@@ -109,7 +109,6 @@ export class CommandEscInsertMode extends BaseCommand {
     }
 
     if (vimState.isFakeMultiCursor) {
-      vimState.cursors = [vimState.cursors[0]];
       vimState.isFakeMultiCursor = false;
     }
   }

--- a/test/multicursor.test.ts
+++ b/test/multicursor.test.ts
@@ -166,4 +166,18 @@ suite('Multicursor selections', () => {
     keysPressed: 'gbgb<Esc>Vjjj<Esc><Esc>gg afd',
     end: ['| is a test', '1', '2', 'this is another test', '1', '2', '3', '4', '5'],
   });
+
+  newTest({
+    title: 'Multiple cursors are preserved after inserting before a block selection and then pressing escape once',
+    start: ['|testing', 'testing'],
+    keysPressed: 'gbgbI<Esc>ifoo',
+    end: ['foo|testing', 'footesting'],
+  });
+
+  newTest({
+    title: 'Multiple cursors are truncated to one cursor if you press escape twice',
+    start: ['|testing', 'testing'],
+    keysPressed: 'gbgbI<Esc><Esc>ifoo',
+    end: ['foo|testing', 'testing'],
+  });
 });


### PR DESCRIPTION
**What this PR does / why we need it**:
Previously, if you created a multicursor block selection, pressed `I`, and then pressed escape, all selections except the first would be deleted. This change updates the escape behavior to preserve these selections.

I've also added tests that confirm this behavior is fixed.

I'll admit I don't perfectly understand the purpose of `isFakeMultiCursor`, but I'm absolutely willing to put time into changes or improvements as suggested by a reviewer.

**Which issue(s) this PR fixes**
Fixes #8147
Fixes #7008

**Special notes for your reviewer**:
n/a