### PR TITLE
Fix #7159 bad handling of auto-surrounding selections

### DIFF
--- a/src/mode/modeHandler.ts
+++ b/src/mode/modeHandler.ts
@@ -1272,6 +1272,10 @@ export class ModeHandler implements vscode.Disposable, IModeHandler {
             }
             break;
 
+          case Mode.Insert:
+            // Don't collapse existing selections in insert mode
+            selections.push(new vscode.Selection(start, stop));
+            break;
           default:
             // Note that this collapses the selection onto one position
             selections.push(new vscode.Selection(stop, stop));

--- a/src/transformations/execute.ts
+++ b/src/transformations/execute.ts
@@ -241,13 +241,19 @@ export async function executeTransformations(
     }
   }
 
-  const selections = vimState.editor.selections.map((sel) => {
-    let range = Cursor.FromVSCodeSelection(sel);
-    if (range.start.isBefore(range.stop)) {
-      range = range.withNewStop(range.stop.getLeftThroughLineBreaks(true));
-    }
-    return new vscode.Selection(range.start, range.stop);
-  });
+  let selections;
+  if (vimState.currentMode === Mode.Insert) {
+    // Insert mode selections do not need to be modified
+    selections = vimState.editor.selections;
+  } else {
+    selections = vimState.editor.selections.map((sel) => {
+      let range = Cursor.FromVSCodeSelection(sel);
+      if (range.start.isBefore(range.stop)) {
+        range = range.withNewStop(range.stop.getLeftThroughLineBreaks(true));
+      }
+      return new vscode.Selection(range.start, range.stop);
+    });
+  }
   const firstTransformation = transformations[0];
   const manuallySetCursorPositions =
     (firstTransformation.type === 'deleteRange' ||


### PR DESCRIPTION
<!--
Yay! Thanks for sending us a PR! 🎊

Please ensure your PR adheres to:

- [ ] Commit messages has a short & issue references when necessary
- [x] Each commit does a logical chunk of work.
- [x] It builds and tests pass (e.g `gulp`)
-->

**What this PR does / why we need it**:
By default in VSCode with VSCodeVim disabled, selecting text and typing an opening bracket or quote will surround the selection, while *keeping the selection*, allowing for further non-surrounding keystrokes to overwrite the selected text.

Currently, with VSCodeVim enabled, in insert mode the functionality is still partially present, but broken.  
The text gets surrounded, but the selection is lost, and the cursor is placed one character short of the right end.

This is a pain when filling in snippet holes with strings.
I want to be able to just type my new text in, but when VSCodeVim is enabled, if I am inserting a string or bracketed expression, I have to delete the placeholder text first to prevent it from interfering.  
e.g. if the selected placeholder is `name` and I type in `"Jeff`, I get `"namJeffe"` when I wanted `"Jeff"`.

This PR fixes the behavior in insert mode to match the vim-disabled behavior.

**Which issue(s) this PR fixes**
Fixes #7159 

<!--
Commits in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)
-->

**Special notes for your reviewer**:
I did not get super familiar with the codebase. I hope you can pardon the tacked-on quality of the additions. They at least do not break existing tests, and I'm of course open to suggestions for restructuring.

Thanks :)