### PR TITLE
fix: avoid escaping the exact word search twice

### DIFF
--- a/src/actions/commands/search.ts
+++ b/src/actions/commands/search.ts
@@ -36,9 +36,6 @@ async function searchCurrentWord(
       isExact = false;
     }
 
-    if (isExact) {
-      currentWord = _.escapeRegExp(currentWord);
-    }
     // If the search is going left then use `getWordLeft()` on position to start
     // at the beginning of the word. This ensures that any matches happen
     // outside of the currently selected word.


### PR DESCRIPTION
Apparently, on exact word search, the word is getting regexp-escaped twice - once in https://github.com/VSCodeVim/Vim/blob/ee4888ab3b18f11baf60e6ee44db84f2ba52c6f6/src/actions/commands/search.ts#L39-L41 and again in https://github.com/VSCodeVim/Vim/blob/ee4888ab3b18f11baf60e6ee44db84f2ba52c6f6/src/actions/commands/search.ts#L102-L103, so this PR just drop the former.

The impact for the user happens when the user configures for VSCode "what is a word". For example, my VSCode configuration on the R language is:
```json
"[r]": {
    // This makes sure that the "." character doesn't separate symbol.
    "editor.wordSeparators": "`~!@#$%^&*()-=+[{]}\\|;:'\",<>/?",
}
```
It's hard to notice, but the difference is that `.` isn't appear there, but appear in the following. The default value for this option is:
```json
"editor.wordSeparators": "`~!@#$%^&*()-=+[{]}\\|;:'\",.<>/?"
```

I do like that VSCodeVim treat my word correctly according to VSCode prefs, but I think that VSCodeVim should treat this word correctly on search (probably it was just a mistake in the code).