### PR TITLE
Persist global marks on disk

### DIFF
--- a/extensionBase.ts
+++ b/extensionBase.ts
@@ -16,6 +16,7 @@ import { globalState } from './src/state/globalState';
 import { Register } from './src/register/register';
 import { SpecialKeys } from './src/util/specialKeys';
 import { exCommandParser } from './src/vimscript/exCommandParser';
+import { HistoryStep } from './src/history/historyTracker';
 
 let extensionContext: vscode.ExtensionContext;
 let previousActiveEditorUri: vscode.Uri | undefined;
@@ -107,7 +108,7 @@ export async function activate(context: vscode.ExtensionContext, handleLocal: bo
 
   // Load state
   Register.loadFromDisk(handleLocal);
-  await Promise.all([ExCommandLine.loadHistory(context), SearchCommandLine.loadHistory(context)]);
+  await Promise.all([ExCommandLine.loadHistory(context), SearchCommandLine.loadHistory(context), HistoryStep.loadHistory(context)]);
 
   if (vscode.window.activeTextEditor) {
     const filepathComponents = vscode.window.activeTextEditor.document.fileName.split(/\\|\//);

--- a/src/history/historyFile.ts
+++ b/src/history/historyFile.ts
@@ -27,6 +27,10 @@ export class HistoryFile {
     this.base.clear();
   }
 
+  public filter(predicate: (value: string) => boolean) {
+    this.base.filter(predicate);
+  }
+
   public async load(): Promise<void> {
     await this.base.load();
   }
@@ -41,5 +45,11 @@ export class SearchHistory extends HistoryFile {
 export class CommandLineHistory extends HistoryFile {
   constructor(context: ExtensionContext) {
     super(context, '.cmdline_history');
+  }
+}
+
+export class MarkHistory extends HistoryFile {
+  constructor(context: ExtensionContext) {
+    super(context, '.mark_history');
   }
 }

--- a/src/history/historyTracker.ts
+++ b/src/history/historyTracker.ts
@@ -22,6 +22,8 @@ import { Mode } from '../mode/mode';
 import { ErrorCode, VimError } from '../error';
 import { Logger } from '../util/logger';
 import { earlierOf } from '../common/motion/position';
+import { MarkHistory } from './historyFile';
+import { ExtensionContext } from 'vscode';
 
 const diffEngine = new DiffMatchPatch.diff_match_patch();
 diffEngine.Diff_Timeout = 1; // 1 second
@@ -106,7 +108,7 @@ export interface IMark {
 /**
  * An undo's worth of changes; generally corresponds to a single action.
  */
-class HistoryStep {
+export class HistoryStep {
   /**
    * The insertions and deletions that occured in this history step.
    */
@@ -144,6 +146,32 @@ class HistoryStep {
    * "global" marks which operate across files. (when IMark.name is uppercase)
    */
   static globalMarks: IMark[] = [];
+
+  /**
+   * all the local marks which were restored from the history file
+   */
+  static historyLocalMarks: IMark[] = [];
+
+  public static markHistory: MarkHistory;
+
+  public static async loadHistory(context: ExtensionContext): Promise<void> {
+    HistoryStep.markHistory = new MarkHistory(context);
+    await HistoryStep.markHistory.load();
+    HistoryStep.markHistory.get().forEach((row) => {
+      const parsed = JSON.parse(row);
+      const newMark: IMark = {
+        position: parsed.position,
+        name: parsed.name,
+        isUppercaseMark: parsed.isUppercaseMark,
+        document: parsed.document,
+      };
+      if (newMark.isUppercaseMark) {
+        HistoryStep.globalMarks.push(newMark);
+      } else {
+        this.historyLocalMarks.push(newMark);
+      }
+    });
+  }
 
   constructor(init: { marks: IMark[]; changes?: DocumentChange[]; cameFromU?: boolean }) {
     this.changes = init.changes ?? [];
@@ -228,7 +256,11 @@ class UndoStack {
   private currentStepIndex = -1;
 
   // The marks as they existed before the first HistoryStep
-  private initialMarks: IMark[] = [];
+  private initialMarks: IMark[];
+
+  constructor(initialMarks: IMark[]) {
+    this.initialMarks = initialMarks;
+  }
 
   public getHistoryStepAtIndex(idx: number): HistoryStep | undefined {
     return this.historySteps[idx];
@@ -400,7 +432,12 @@ export class HistoryTracker {
 
   constructor(vimState: VimState) {
     this.vimState = vimState;
-    this.undoStack = new UndoStack();
+
+    // get all the local marks which belong to this document and set these as the initial marks
+    const initialMarks = HistoryStep.historyLocalMarks.filter((mark) => {
+      return !mark.isUppercaseMark && mark.document?.uri.path === vimState.document.uri.path;
+    });
+    this.undoStack = new UndoStack(initialMarks);
     this.changeList = new ChangeList();
     this.previousDocumentState = {
       text: this.getDocumentText(),
@@ -539,19 +576,38 @@ export class HistoryTracker {
       isUppercaseMark,
       document: isUppercaseMark ? document : undefined,
     };
-    this.putMarkInList(newMark);
+    this.putMarkInList(newMark, document);
   }
 
   /**
    * Puts the mark into either the global or local marks array depending on mark.isUppercaseMark.
    */
-  private putMarkInList(mark: IMark): void {
+  private putMarkInList(mark: IMark, document: vscode.TextDocument): void {
     const marks = this.getMarkList(mark.isUppercaseMark);
     const previousIndex = marks.findIndex((existingMark) => existingMark.name === mark.name);
     if (previousIndex !== -1) {
       marks[previousIndex] = mark;
+      if (mark.isUppercaseMark) {
+        // remove old entry frmo history by finding a mark with the same name before adding this mark
+        HistoryStep.markHistory.filter((value) => JSON.parse(value).name !== mark.name);
+      } else {
+        // remove marks which with this name which belong to this document
+        HistoryStep.markHistory.filter((value) => {
+          const parsed = JSON.parse(value);
+          return !(parsed.name === mark.name && parsed.document?.uri.path === document.uri.path);
+        });
+      }
     } else {
       marks.push(mark);
+    }
+
+    // add the entry to the history to persist it over sessions
+    if (mark.isUppercaseMark) {
+      HistoryStep.markHistory.add(JSON.stringify(mark));
+    } else {
+      // local marks do not store the path, but we still need to include it in the
+      // history file so we know which file it belongs to
+      HistoryStep.markHistory.add(JSON.stringify({ ...mark, document }));
     }
   }
 

--- a/src/platform/node/history.ts
+++ b/src/platform/node/history.ts
@@ -62,6 +62,11 @@ export class HistoryBase {
     }
   }
 
+  // filter history based on predicate
+  public filter(predicate: (value: string) => boolean) {
+    this.history = this.history.filter(predicate);
+  }
+
   public async load(): Promise<void> {
     // await this._base.load();
     let data = '';


### PR DESCRIPTION
Fixes #3841

<!--
Yay! Thanks for sending us a PR! 🎊

Please ensure your PR adheres to:

- [X] Commit messages has a short & issue references when necessary
- [X] Each commit does a logical chunk of work.
- [X] It builds and tests pass (e.g `gulp`)
-->

**What this PR does / why we need it**:
This PR ensures that marks are persisted between sessions through a new history file. This makes marks much more usable as marks set before the editor was closed/loaded will still work. This persists local and global marks. Also includes duplicate dedection, so when old marks are overriden the history file also removes the old mark from the file.

**Which issue(s) this PR fixes**
#3841 
<!--
Commits in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)
-->

**Special notes for your reviewer**:
