### PR TITLE
Revert TaskQueue removal

### DIFF
--- a/extensionBase.ts
+++ b/extensionBase.ts
@@ -16,6 +16,7 @@ import { globalState } from './src/state/globalState';
 import { Register } from './src/register/register';
 import { SpecialKeys } from './src/util/specialKeys';
 import { exCommandParser } from './src/vimscript/exCommandParser';
+import { taskQueue } from './src/taskQueue';
 
 let extensionContext: vscode.ExtensionContext;
 let previousActiveEditorUri: vscode.Uri | undefined;
@@ -246,13 +247,15 @@ export async function activate(context: vscode.ExtensionContext, handleLocal: bo
         return;
       }
 
-      const mh = await getAndUpdateModeHandler(true);
-      if (mh) {
-        globalState.jumpTracker.handleFileJump(
-          lastClosedModeHandler ? Jump.fromStateNow(lastClosedModeHandler.vimState) : null,
-          Jump.fromStateNow(mh.vimState),
-        );
-      }
+      taskQueue.enqueueTask(async () => {
+        const mh = await getAndUpdateModeHandler(true);
+        if (mh) {
+          globalState.jumpTracker.handleFileJump(
+            lastClosedModeHandler ? Jump.fromStateNow(lastClosedModeHandler.vimState) : null,
+            Jump.fromStateNow(mh.vimState),
+          );
+        }
+      });
     },
     true,
     true,
@@ -322,7 +325,7 @@ export async function activate(context: vscode.ExtensionContext, handleLocal: bo
         return;
       }
 
-      await mh.handleSelectionChange(e);
+      taskQueue.enqueueTask(() => mh.handleSelectionChange(e));
     },
     true,
     false,
@@ -335,15 +338,17 @@ export async function activate(context: vscode.ExtensionContext, handleLocal: bo
       if (e.textEditor !== vscode.window.activeTextEditor) {
         return;
       }
-      // Scrolling the viewport clears any status bar message, even errors.
-      const mh = await getAndUpdateModeHandler();
-      if (mh && StatusBar.lastMessageTime) {
-        // TODO: Using the time elapsed works most of the time, but is a bit of a hack
-        const timeElapsed = Date.now() - Number(StatusBar.lastMessageTime);
-        if (timeElapsed > 100) {
-          StatusBar.clear(mh.vimState, true);
+      taskQueue.enqueueTask(async () => {
+        // Scrolling the viewport clears any status bar message, even errors.
+        const mh = await getAndUpdateModeHandler();
+        if (mh && StatusBar.lastMessageTime) {
+          // TODO: Using the time elapsed works most of the time, but is a bit of a hack
+          const timeElapsed = Date.now() - Number(StatusBar.lastMessageTime);
+          if (timeElapsed > 100) {
+            StatusBar.clear(mh.vimState, true);
+          }
         }
-      }
+      });
     },
   );
 
@@ -351,67 +356,75 @@ export async function activate(context: vscode.ExtensionContext, handleLocal: bo
 
   // Override VSCode commands
   overrideCommand(context, 'type', async (args) => {
-    const mh = await getAndUpdateModeHandler();
-    if (mh) {
-      if (compositionState.isInComposition) {
-        compositionState.composingText += args.text;
-        if (mh.vimState.currentMode === Mode.Insert) {
-          compositionState.insertedText = true;
-          vscode.commands.executeCommand('default:type', { text: args.text });
+    taskQueue.enqueueTask(async () => {
+      const mh = await getAndUpdateModeHandler();
+      if (mh) {
+        if (compositionState.isInComposition) {
+          compositionState.composingText += args.text;
+          if (mh.vimState.currentMode === Mode.Insert) {
+            compositionState.insertedText = true;
+            vscode.commands.executeCommand('default:type', { text: args.text });
+          }
+        } else {
+          await mh.handleKeyEvent(args.text);
         }
-      } else {
-        await mh.handleKeyEvent(args.text);
       }
-    }
+    });
   });
 
   overrideCommand(context, 'replacePreviousChar', async (args) => {
-    const mh = await getAndUpdateModeHandler();
-    if (mh) {
-      if (compositionState.isInComposition) {
-        compositionState.composingText =
-          compositionState.composingText.substr(
-            0,
-            compositionState.composingText.length - args.replaceCharCnt,
-          ) + args.text;
-      }
-      if (compositionState.insertedText) {
+    taskQueue.enqueueTask(async () => {
+      const mh = await getAndUpdateModeHandler();
+      if (mh) {
+        if (compositionState.isInComposition) {
+          compositionState.composingText =
+            compositionState.composingText.substr(
+              0,
+              compositionState.composingText.length - args.replaceCharCnt,
+            ) + args.text;
+        }
+        if (compositionState.insertedText) {
+          await vscode.commands.executeCommand('default:replacePreviousChar', {
+            text: args.text,
+            replaceCharCnt: args.replaceCharCnt,
+          });
+          mh.vimState.cursorStopPosition = mh.vimState.editor.selection.start;
+          mh.vimState.cursorStartPosition = mh.vimState.editor.selection.start;
+        }
+      } else {
         await vscode.commands.executeCommand('default:replacePreviousChar', {
           text: args.text,
           replaceCharCnt: args.replaceCharCnt,
         });
-        mh.vimState.cursorStopPosition = mh.vimState.editor.selection.start;
-        mh.vimState.cursorStartPosition = mh.vimState.editor.selection.start;
       }
-    } else {
-      await vscode.commands.executeCommand('default:replacePreviousChar', {
-        text: args.text,
-        replaceCharCnt: args.replaceCharCnt,
-      });
-    }
+    });
   });
 
   overrideCommand(context, 'compositionStart', async () => {
-    compositionState.isInComposition = true;
+    taskQueue.enqueueTask(async () => {
+      compositionState.isInComposition = true;
+    });
   });
 
   overrideCommand(context, 'compositionEnd', async () => {
-    const mh = await getAndUpdateModeHandler();
-    if (mh) {
-      if (compositionState.insertedText) {
-        mh.selectionsChanged.ignoreIntermediateSelections = true;
-        await vscode.commands.executeCommand('default:replacePreviousChar', {
-          text: '',
-          replaceCharCnt: compositionState.composingText.length,
-        });
-        mh.vimState.cursorStopPosition = mh.vimState.editor.selection.active;
-        mh.vimState.cursorStartPosition = mh.vimState.editor.selection.active;
-        mh.selectionsChanged.ignoreIntermediateSelections = false;
+    taskQueue.enqueueTask(async () => {
+      const mh = await getAndUpdateModeHandler();
+      if (mh) {
+        if (compositionState.insertedText) {
+          mh.selectionsChanged.ignoreIntermediateSelections = true;
+          await vscode.commands.executeCommand('default:replacePreviousChar', {
+            text: '',
+            replaceCharCnt: compositionState.composingText.length,
+          });
+          mh.vimState.cursorStopPosition = mh.vimState.editor.selection.active;
+          mh.vimState.cursorStartPosition = mh.vimState.editor.selection.active;
+          mh.selectionsChanged.ignoreIntermediateSelections = false;
+        }
+        const text = compositionState.composingText;
+        await mh.handleMultipleKeyEvents(text.split(''));
       }
-      const text = compositionState.composingText;
-      await mh.handleMultipleKeyEvents(text.split(''));
-    }
-    compositionState.reset();
+      compositionState.reset();
+    });
   });
 
   // Register extension commands
@@ -432,37 +445,39 @@ export async function activate(context: vscode.ExtensionContext, handleLocal: bo
   });
 
   registerCommand(context, 'vim.remap', async (args: ICodeKeybinding) => {
-    const mh = await getAndUpdateModeHandler();
-    if (mh === undefined) {
-      return;
-    }
-
-    if (!args) {
-      throw new Error(
-        "'args' is undefined. For this remap to work it needs to have 'args' with an '\"after\": string[]' and/or a '\"commands\": { command: string; args: any[] }[]'",
-      );
-    }
-
-    if (args.after) {
-      for (const key of args.after) {
-        await mh.handleKeyEvent(Notation.NormalizeKey(key, configuration.leader));
+    taskQueue.enqueueTask(async () => {
+      const mh = await getAndUpdateModeHandler();
+      if (mh === undefined) {
+        return;
       }
-    }
 
-    if (args.commands) {
-      for (const command of args.commands) {
-        // Check if this is a vim command by looking for :
-        if (command.command.startsWith(':')) {
-          await new ExCommandLine(
-            command.command.slice(1, command.command.length),
-            mh.vimState.currentMode,
-          ).run(mh.vimState);
-          mh.updateView();
-        } else {
-          vscode.commands.executeCommand(command.command, command.args);
+      if (!args) {
+        throw new Error(
+          "'args' is undefined. For this remap to work it needs to have 'args' with an '\"after\": string[]' and/or a '\"commands\": { command: string; args: any[] }[]'",
+        );
+      }
+
+      if (args.after) {
+        for (const key of args.after) {
+          await mh.handleKeyEvent(Notation.NormalizeKey(key, configuration.leader));
         }
       }
-    }
+
+      if (args.commands) {
+        for (const command of args.commands) {
+          // Check if this is a vim command by looking for :
+          if (command.command.startsWith(':')) {
+            await new ExCommandLine(
+              command.command.slice(1, command.command.length),
+              mh.vimState.currentMode,
+            ).run(mh.vimState);
+            mh.updateView();
+          } else {
+            vscode.commands.executeCommand(command.command, command.args);
+          }
+        }
+      }
+    });
   });
 
   registerCommand(context, 'toggleVim', async () => {
@@ -484,7 +499,9 @@ export async function activate(context: vscode.ExtensionContext, handleLocal: bo
             await mh.handleKeyEvent(`${boundKey.key}`);
           }
         };
-    registerCommand(context, boundKey.command, command);
+    registerCommand(context, boundKey.command, async () => {
+      taskQueue.enqueueTask(command);
+    });
   }
 
   {

--- a/package.json
+++ b/package.json
@@ -1156,6 +1156,7 @@
     "parsimmon": "^1.18.0",
     "path-browserify": "1.0.1",
     "process": "0.11.10",
+    "queue": "^6.0.2",
     "untildify": "4.0.0",
     "util": "0.12.5"
   },

--- a/src/taskQueue.ts
+++ b/src/taskQueue.ts
@@ -1,0 +1,22 @@
+import Queue from 'queue';
+import { Logger } from './util/logger';
+
+class TaskQueue {
+  private readonly taskQueue = new Queue({ autostart: true, concurrency: 1 });
+
+  constructor() {
+    this.taskQueue.addListener('error', (err, task) => {
+      // TODO: Report via telemetry API?
+      Logger.error(`Error running task: ${err}`);
+    });
+  }
+
+  /**
+   * Adds a task to the task queue.
+   */
+  public enqueueTask(task: () => Promise<void>): void {
+    this.taskQueue.push(task);
+  }
+}
+
+export let taskQueue = new TaskQueue();

--- a/yarn.lock
+++ b/yarn.lock
@@ -3,7 +3,7 @@
 
 
 "@babel/code-frame@^7.0.0":
-  version "7.11.0"
+  version "7.10.4"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.10.4.tgz#168da1a36e90da68ae8d49c0f1b48c7c6249213a"
   integrity sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg==
   dependencies:
@@ -4288,6 +4288,13 @@ qs@^6.9.1:
   integrity sha512-MvjoMCJwEarSbUYk5O+nmoSzSutSsTwF85zcHPQ9OrlFoZOYIjaqBAJIqIXjptyD5vThxGq52Xu/MaJzRkIk4Q==
   dependencies:
     side-channel "^1.0.4"
+
+queue@^6.0.2:
+  version "6.0.2"
+  resolved "https://registry.yarnpkg.com/queue/-/queue-6.0.2.tgz#b91525283e2315c7553d2efa18d83e76432fed65"
+  integrity sha512-iHZWu+q3IdFZFX36ro/lKBkSvfkztY5Y7HMiPlOUjhupPcG2JMfst2KKEpu5XndviX/3UhFbRngUPNKtgvtZiA==
+  dependencies:
+    inherits "~2.0.3"
 
 randombytes@^2.1.0:
   version "2.1.0"


### PR DESCRIPTION
<!--
Yay! Thanks for sending us a PR! 🎊

Please ensure your PR adheres to:

- [ ] Commit messages has a short & issue references when necessary
- [ ] Each commit does a logical chunk of work.
- [ ] It builds and tests pass (e.g `gulp`)
-->

**What this PR does / why we need it**:
The commit 50bc4fe1e32434cc15098173a5dfc42c7818ac8e removed `TaskQueue`. But some issues rised after this commit like: #8577 #8603

I have investigated this issue and foud that there are some nested event invocations. With `TaskQueue`, these events are added to a queue and processed event by event. But as of 1.26.0, some events are invoking other event processing immediately before finishing current event and this behaviour is different from pre 1.26.0 versions.

This commit is just a revert of 50bc4fe1e32434cc15098173a5dfc42c7818ac8e.

**Which issue(s) this PR fixes**
#8577 #8603

<!--
Commits in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)
-->

**Special notes for your reviewer**:

I think there are two ways to solve this problem:
- Find and fix all nesting issues case by case
- Task queue recovery

For this commit I choosed latter because of its simplicity.

Keep throwing off `queue` dependency and make (simple) self task queue implementation is also a option but I wanted to preserve the previous source state if possible.