### PR TITLE
Revert "Set scope for `vim.autoSwitchInputMethod` to `machine` (#8051)"

### DIFF
--- a/package.json
+++ b/package.json
@@ -1064,20 +1064,17 @@
         "vim.autoSwitchInputMethod.defaultIM": {
           "type": "string",
           "markdownDescription": "The input method for your normal mode, find more information [here](https://github.com/VSCodeVim/Vim#input-method).",
-          "default": "",
-          "scope": "machine"
+          "default": ""
         },
         "vim.autoSwitchInputMethod.switchIMCmd": {
           "type": "string",
           "description": "The shell command to switch input method.",
-          "default": "/path/to/im-select {im}",
-          "scope": "machine"
+          "default": "/path/to/im-select {im}"
         },
         "vim.autoSwitchInputMethod.obtainIMCmd": {
           "type": "string",
           "description": "The shell command to get current input method.",
-          "default": "/path/to/im-select",
-          "scope": "machine"
+          "default": "/path/to/im-select"
         },
         "vim.whichwrap": {
           "type": "string",


### PR DESCRIPTION
This reverts commit 927ab3861e63c65817bf4a3f1bce4a1a129bdcb0.

Configuration settings like autoSwitchInputMethod.* shouldn't have a
"machine“ scope as this extension is running on the local machine.
