### PR TITLE
Support to `:sp`/`:vs` open non-existing files.

### DIFF
--- a/src/cmd_line/commands/file.ts
+++ b/src/cmd_line/commands/file.ts
@@ -68,9 +68,9 @@ function getLegacyArgs(args: IFileCommandArguments): LegacyArgs {
       createFileIfNotExists: true,
     };
   } else if (args.name === 'split') {
-    return { file: args.file, position: FilePosition.NewWindowHorizontalSplit };
+    return { file: args.file, position: FilePosition.NewWindowHorizontalSplit, createFileIfNotExists: true };
   } else if (args.name === 'vsplit') {
-    return { file: args.file, position: FilePosition.NewWindowVerticalSplit };
+    return { file: args.file, position: FilePosition.NewWindowVerticalSplit, createFileIfNotExists: true };
   } else {
     throw new Error(`Unexpected FileCommand.arguments.name: ${args.name}`);
   }

--- a/src/cmd_line/commands/file.ts
+++ b/src/cmd_line/commands/file.ts
@@ -68,9 +68,17 @@ function getLegacyArgs(args: IFileCommandArguments): LegacyArgs {
       createFileIfNotExists: true,
     };
   } else if (args.name === 'split') {
-    return { file: args.file, position: FilePosition.NewWindowHorizontalSplit, createFileIfNotExists: true };
+    return {
+      file: args.file,
+      position: FilePosition.NewWindowHorizontalSplit,
+      createFileIfNotExists: true,
+    };
   } else if (args.name === 'vsplit') {
-    return { file: args.file, position: FilePosition.NewWindowVerticalSplit, createFileIfNotExists: true };
+    return {
+      file: args.file,
+      position: FilePosition.NewWindowVerticalSplit,
+      createFileIfNotExists: true,
+    };
   } else {
     throw new Error(`Unexpected FileCommand.arguments.name: ${args.name}`);
   }


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes the use of `:sp`/`:vs` with non-existing files, opening a new split with the specified file and creating it right away (the file will need to be manually saved to apply changes).

**Which issue(s) this PR fixes**
Fixes #7283
Partially fixes #8671