### PR TITLE
Set vim.command in VSCodeContext on key press.

### DIFF
--- a/src/mode/modeHandler.ts
+++ b/src/mode/modeHandler.ts
@@ -640,6 +640,7 @@ export class ModeHandler implements vscode.Disposable, IModeHandler {
 
     const recordedState = this.vimState.recordedState;
     recordedState.actionKeys.push(key);
+    VSCodeContext.set('vim.command', recordedState.commandString);
 
     const action = getRelevantAction(recordedState.actionKeys, this.vimState);
     switch (action) {
@@ -651,6 +652,7 @@ export class ModeHandler implements vscode.Disposable, IModeHandler {
         }
         // Since there is no possible action we are no longer waiting any action keys
         this.vimState.recordedState.waitingForAnotherActionKey = false;
+        VSCodeContext.set('vim.command', '');
 
         return false;
       case KeypressState.WaitingOnKeys:


### PR DESCRIPTION
<!--
Yay! Thanks for sending us a PR! 🎊

Please ensure your PR adheres to:

- [x] Commit messages has a short & issue references when necessary
- [x] Each commit does a logical chunk of work.
- [x] It builds and tests pass (e.g `gulp`)
-->

**What this PR does / why we need it**:

This PR sets `vim.command` in VSCodeContext to `recordedState.commandString`. This allows pending actions that are waiting for a movement argument (e.g. `d` or `y`) to be read in the `when` clause of keyboard shortcuts.

There is currently no change to VSCodeContext in such a pending state, making it impossible to correctly configure some keyboard shortcuts, such as commands that should be activated in Normal mode, but *not* if a command is started. Making that information available in VS Code's context gives users greater flexibility and precision in setting up custom keyboard shortcuts.

**Which issue(s) this PR fixes**

<!--
Commits in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)
-->

Fixes #7833 by allowing users to add `!vim.command` to the `when` clause of the keyboard shortcut.

**Special notes for your reviewer**:

I didn't see a good way to add a unit test for this, as I am not sure how to access VSCodeContext within a test, but I did build and debug the change with `Inspect context keys` and confirm that `vim.command` gets updated as the user types and properly reset when their command completes.