### PR TITLE
Fix incorrect expand selection in VisualLine mode(#8773)

### DIFF
--- a/src/mode/modeHandler.ts
+++ b/src/mode/modeHandler.ts
@@ -245,7 +245,7 @@ export class ModeHandler implements vscode.Disposable, IModeHandler {
         if (e.kind === vscode.TextEditorSelectionChangeKind.Command) {
           // This 'Command' kind is triggered when using a command like 'editor.action.smartSelect.grow'
           // but it is also triggered when we set the 'editor.selections' on 'updateView'.
-          const allowedModes = [Mode.Normal, Mode.Visual];
+          const allowedModes = [Mode.Normal, Mode.Visual, Mode.VisualLine];
           if (!isSnippetSelectionChange()) {
             // if we just inserted a snippet then don't allow insert modes to go to visual mode
             allowedModes.push(Mode.Insert, Mode.Replace);

--- a/test/mode/modeVisual.test.ts
+++ b/test/mode/modeVisual.test.ts
@@ -1869,5 +1869,45 @@ suite('Mode Visual', () => {
       ],
       endMode: Mode.Normal,
     });
+
+    newTest({
+      title: 'Command editor.action.smartSelect.expand on visual mode linewise',
+      config: {
+        visualModeKeyBindings: [
+          {
+            before: ['J'],
+            commands: ['editor.action.smartSelect.expand'],
+          },
+        ],
+        leader: ' ',
+      },
+      start: [
+        `{`,
+        `  "vim.visualModeKeyBindingsNonRecursive": [`,
+        `    {|`,
+        `      "before": ["J"],`,
+        `      "commands": ["editor.action.smartSelect.expand"]`,
+        `    },`,
+        `    {`,
+        `      "before": ["K"],`,
+        `      "commands": ["editor.action.smartSelect.shrink"]`,
+        `    }`,
+        `  ],`,
+        `}`
+      ],
+      keysPressed: 'VJd',
+      end: [
+        `{`,
+        `  "vim.visualModeKeyBindingsNonRecursive": [`,
+        `|`,
+        `    {`,
+        `      "before": ["K"],`,
+        `      "commands": ["editor.action.smartSelect.shrink"]`,
+        `    }`,
+        `  ],`,
+        `}`
+      ],
+      endMode: Mode.Normal,
+    })
   });
 });

--- a/test/mode/modeVisual.test.ts
+++ b/test/mode/modeVisual.test.ts
@@ -1893,7 +1893,7 @@ suite('Mode Visual', () => {
         `      "commands": ["editor.action.smartSelect.shrink"]`,
         `    }`,
         `  ],`,
-        `}`
+        `}`,
       ],
       keysPressed: 'VJd',
       end: [
@@ -1905,9 +1905,9 @@ suite('Mode Visual', () => {
         `      "commands": ["editor.action.smartSelect.shrink"]`,
         `    }`,
         `  ],`,
-        `}`
+        `}`,
       ],
       endMode: Mode.Normal,
-    })
+    });
   });
 });


### PR DESCRIPTION
**What this PR does / why we need it**:
The selectin can't correct sync when use 'editor.action.smartSelection.expand' in VisualLine mode.
The sync problem has fixed in pr #5015, but VisualLine is not included.

Now, If you use 'editor.action.smartSelection.expand' in VisualLine mode,  the mode will change to Visual mode. The behavior is the same as nvim-treesitter and ideavim
**Which issue(s) this PR fixes**
fixes #8773
