### PR TITLE
[Bug Fix] revert back the ctrl-p function for vscode file navigation

### DIFF
--- a/package.json
+++ b/package.json
@@ -257,7 +257,7 @@
       {
         "key": "ctrl+p",
         "command": "extension.vim_ctrl+p",
-        "when": "editorTextFocus && vim.active && vim.use<C-p> && !inDebugRepl || vim.mode == 'CommandlineInProgress' && vim.active && vim.use<C-p> && !inDebugRepl || vim.mode == 'SearchInProgressMode' && vim.active && vim.use<C-p> && !inDebugRepl"
+        "when": "suggestWidgetVisible && vim.active && vim.use<C-p> && !inDebugRepl || vim.mode == 'CommandlineInProgress' && vim.active && vim.use<C-p> && !inDebugRepl || vim.mode == 'SearchInProgressMode' && vim.active && vim.use<C-p> && !inDebugRepl"
       },
       {
         "key": "ctrl+q",


### PR DESCRIPTION
<!--
Yay! Thanks for sending us a PR! 🎊

Please ensure your PR adheres to:

- [ ] Commit messages has a short & issue references when necessary
- [ ] Each commit does a logical chunk of work.
- [ ] It builds and tests pass (e.g `gulp`)
-->

**What this PR does / why we need it**:
Previous PR #7261 brought in a severe bug, which is complained by issue #8574, #8581, #8587, #8588. 
#7261 change hot-key ctrl-p's original function that allows for easily file navigation. So this PR is aimed to revert the #7261 change. And it does not affect the ctrl-p's vim function that move upward in suggestion. 

**Which issue(s) this PR fixes**
#8574, #8581, #8587, #8588. 
<!--
Commits in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)
-->

**Special notes for your reviewer**:
@grosssoftware can you help explain why you do this in #7261? IMO, it did not fix anything but broke an important and basic feature of VSCode. 
