### PR TITLE
Fix `Ctrl-o` behavior when cursor is behind last character in INSERT mode or when using `p` next

### DIFF
--- a/src/mode/modeHandler.ts
+++ b/src/mode/modeHandler.ts
@@ -908,7 +908,7 @@ export class ModeHandler implements vscode.Disposable, IModeHandler {
       const documentLineCount = this.vimState.document.lineCount;
 
       this.vimState.cursors = this.vimState.cursors.map((cursor: Cursor) => {
-        // adjust start/stop
+        // Adjust start/stop
         if (cursor.start.line >= documentLineCount) {
           cursor = cursor.withNewStart(documentEndPosition);
         }
@@ -916,8 +916,13 @@ export class ModeHandler implements vscode.Disposable, IModeHandler {
           cursor = cursor.withNewStop(documentEndPosition);
         }
 
-        // adjust column
-        if (this.vimState.currentMode === Mode.Normal || isVisualMode(this.vimState.currentMode)) {
+        // Adjust column. When getting from insert into normal mode with <C-o>,
+        // the cursor position should remain even if it is behind the last
+        // character in the line
+        if (
+          !this.vimState.returnToInsertAfterCommand &&
+          (this.vimState.currentMode === Mode.Normal || isVisualMode(this.vimState.currentMode))
+        ) {
           const currentLineLength = TextEditor.getLineLength(cursor.stop.line);
           const currentStartLineLength = TextEditor.getLineLength(cursor.start.line);
 

--- a/test/mode/modeInsert.test.ts
+++ b/test/mode/modeInsert.test.ts
@@ -11,7 +11,7 @@ import {
   reloadConfiguration,
 } from './../testUtils';
 import { Globals } from '../../src/globals';
-import { newTest } from '../testSimplifier';
+import { newTest, newTestOnly } from '../testSimplifier';
 
 suite('Mode Insert', () => {
   let modeHandler: ModeHandler;
@@ -324,34 +324,64 @@ suite('Mode Insert', () => {
   });
 
   newTest({
-    title: 'Can <Esc> after entering insert mode from <ctrl+o>',
-    start: ['|'],
-    keysPressed: 'i<C-o>i<Esc>',
-    end: ['|'],
-    endMode: Mode.Normal,
-  });
-
-  newTest({
-    title: 'Can perform <ctrl+o> to exit and perform one command in normal',
-    start: ['testtest|'],
-    keysPressed: 'a123<C-o>b123',
-    end: ['123|testtest123'],
-  });
-
-  newTest({
-    title: 'Can <ctrl-o> after entering insert mode from <ctrl-o>',
-    start: ['|'],
-    keysPressed: 'i<C-o>i<C-o>',
-    end: ['|'],
-    endMode: Mode.Normal,
-  });
-
-  newTest({
     title:
-      'Can perform <ctrl+o> to exit and perform one command in normal at the beginning of a row',
+      'Can perform <Esc> to exit and move cursor back one character from the most right position',
     start: ['|testtest'],
-    keysPressed: 'i<C-o>l123',
-    end: ['t123|esttest'],
+    keysPressed: 'A<Esc>',
+    end: ['testtes|t'],
+    endMode: Mode.Normal,
+  });
+
+  newTest({
+    title: 'Can perform <Esc> to exit and move cursor back one character from middle of text',
+    start: ['test|test'],
+    keysPressed: 'i<Esc>',
+    end: ['tes|ttest'],
+    endMode: Mode.Normal,
+  });
+
+  suite('<C-o>', () => {
+    newTest({
+      title: 'Can <Esc> after entering insert mode from <ctrl+o>',
+      start: ['|'],
+      keysPressed: 'i<C-o>i<Esc>',
+      end: ['|'],
+      endMode: Mode.Normal,
+    });
+
+    newTest({
+      title: 'Can perform <ctrl-o> after entering insert mode from <ctrl-o>',
+      start: ['test|test'],
+      keysPressed: 'i<C-o>i<C-o>',
+      end: ['test|test'],
+      endMode: Mode.Normal,
+    });
+
+    newTest({
+      title:
+        'Can perform <ctrl-o> to exit and perform one command in normal at the beginning of a line',
+      start: ['|testtest'],
+      keysPressed: 'i<C-o>l123',
+      end: ['t123|esttest'],
+      endMode: Mode.Insert,
+    });
+
+    newTest({
+      title:
+        'Can perform <ctrl-o> to exit and perform one command in normal at the middle of a row',
+      start: ['test|test'],
+      keysPressed: 'i<C-o>l123',
+      end: ['testt123|est'],
+      endMode: Mode.Insert,
+    });
+
+    newTest({
+      title: 'Can perform <ctrl-o> to exit and perform one command in normal at the end of a row',
+      start: ['testtest|'],
+      keysPressed: 'a123<C-o>zz',
+      end: ['testtest123|'],
+      endMode: Mode.Insert,
+    });
   });
 
   newTest({

--- a/test/mode/modeInsert.test.ts
+++ b/test/mode/modeInsert.test.ts
@@ -382,6 +382,22 @@ suite('Mode Insert', () => {
       end: ['testtest123|'],
       endMode: Mode.Insert,
     });
+
+    newTest({
+      title: 'Can perform <ctrl-o> to exit and paste',
+      start: ['|XXX', '123456'],
+      keysPressed: 'ye' + 'j' + 'A<C-o>p',
+      end: ['XXX', '123456XXX|'],
+      endMode: Mode.Insert,
+    });
+
+    newTest({
+      title: 'Can perform <ctrl-o> to exit and paste',
+      start: ['|XXX', '123456'],
+      keysPressed: 'ye' + 'j2|' + 'i<C-o>p',
+      end: ['XXX', '12XXX|3456'],
+      endMode: Mode.Insert,
+    });
   });
 
   newTest({

--- a/test/mode/modeInsert.test.ts
+++ b/test/mode/modeInsert.test.ts
@@ -11,7 +11,7 @@ import {
   reloadConfiguration,
 } from './../testUtils';
 import { Globals } from '../../src/globals';
-import { newTest, newTestOnly } from '../testSimplifier';
+import { newTest } from '../testSimplifier';
 
 suite('Mode Insert', () => {
   let modeHandler: ModeHandler;


### PR DESCRIPTION
<!--
Yay! Thanks for sending us a PR! 🎊

Please ensure your PR adheres to:

- [x] Commit messages has a short & issue references when necessary
- [x] Each commit does a logical chunk of work.
- [x] It builds and tests pass (e.g `gulp`)
-->

**What this PR does / why we need it**:
The pull request fixes several annoying issues with the positioning of the cursor when using `Ctrl-o` in INSERT mode.


**Which issue(s) this PR fixes**
1. https://github.com/VSCodeVim/Vim/issues/8948
2. https://github.com/VSCodeVim/Vim/issues/1791

<!--
Commits in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)
-->

**Special notes for your reviewer**:

Refactored interface in `BasePutCommand.getCursorPosition` method.
