### PR TITLE
Fix .vimrc warning & more

### DIFF
--- a/extension.ts
+++ b/extension.ts
@@ -16,11 +16,15 @@ import './src/configuration/validators/neovimValidator';
 import './src/configuration/validators/vimrcValidator';
 
 import * as vscode from 'vscode';
-import { activate as activateFunc, registerCommand, registerEventListener } from './extensionBase';
+import {
+  activate as activateFunc,
+  loadConfiguration,
+  registerCommand,
+  registerEventListener,
+} from './extensionBase';
 import { Globals } from './src/globals';
 import { Register } from './src/register/register';
 import { vimrc } from './src/configuration/vimrc';
-import { configuration } from './src/configuration/configuration';
 import * as path from 'path';
 import { Logger } from './src/util/logger';
 
@@ -28,18 +32,13 @@ export { getAndUpdateModeHandler } from './extensionBase';
 
 export async function activate(context: vscode.ExtensionContext) {
   // Set the storage path to be used by history files
-  Globals.extensionStoragePath = context.globalStoragePath;
+  Globals.extensionStoragePath = context.globalStorageUri.fsPath;
 
   await activateFunc(context);
 
   registerEventListener(context, vscode.workspace.onDidSaveTextDocument, async (document) => {
-    if (
-      configuration.vimrc.enable &&
-      vimrc.vimrcPath &&
-      path.relative(document.fileName, vimrc.vimrcPath) === ''
-    ) {
-      // TODO: Should instead probably call `loadConfiguration` (in extensionBase.ts)
-      await configuration.load();
+    if (vimrc.vimrcPath && path.relative(document.fileName, vimrc.vimrcPath) === '') {
+      await loadConfiguration();
       Logger.info('Sourced new .vimrc');
     }
   });
@@ -52,7 +51,7 @@ export async function activate(context: vscode.ExtensionContext) {
         const document = await vscode.workspace.openTextDocument(vimrc.vimrcPath);
         await vscode.window.showTextDocument(document);
       } else {
-        await vscode.window.showWarningMessage('No .vimrc found. Please set `vim.vimrc.path.`');
+        await vscode.window.showWarningMessage('No .vimrc found. Please set `vim.vimrc.path`.');
       }
     },
     false,

--- a/extensionBase.ts
+++ b/extensionBase.ts
@@ -71,7 +71,7 @@ export async function getAndUpdateModeHandler(
 /**
  * Loads and validates the user's configuration
  */
-async function loadConfiguration() {
+export async function loadConfiguration() {
   const validatorResults = await configuration.load();
 
   Logger.debug(`${validatorResults.numErrors} errors found with vim configuration`);

--- a/src/configuration/vimrc.ts
+++ b/src/configuration/vimrc.ts
@@ -77,7 +77,7 @@ export class VimrcImpl {
       ? VimrcImpl.expandHome(config.vimrc.path)
       : await VimrcImpl.findDefaultVimrc();
     if (!_path) {
-      await window.showWarningMessage('No .vimrc found. Please set `vim.vimrc.path.`');
+      await window.showWarningMessage('No .vimrc found. Please set `vim.vimrc.path`.');
       return;
     }
     if (!(await fs.existsAsync(_path))) {


### PR DESCRIPTION
**What this PR does / why we need it**:
- Fix a typo in the warning message that appears when the .vimrc file fails to open.
- Now uses `loadConfiguration` from extension.ts instead of `configuration.load`.
- Now uses `context.globalStorageUri.fsPath` instead of `context.globalStoragePath` which is deprecated.
