### PR TITLE
Set scroll option with <C-u> and <C-d>

### DIFF
--- a/src/actions/commands/scroll.ts
+++ b/src/actions/commands/scroll.ts
@@ -157,7 +157,7 @@ class CommandMoveFullPageDown extends CommandScrollAndMoveCursor {
 }
 
 @RegisterAction
-class CommandMoveHalfPageDown extends CommandScrollAndMoveCursor {
+class CommandCtrlD extends CommandScrollAndMoveCursor {
   keys = ['<C-d>'];
   to: EditorScrollDirection = 'down';
   override setScroll = true;
@@ -168,7 +168,7 @@ class CommandMoveHalfPageDown extends CommandScrollAndMoveCursor {
 }
 
 @RegisterAction
-class CommandMoveHalfPageUp extends CommandScrollAndMoveCursor {
+class CommandCtrlU extends CommandScrollAndMoveCursor {
   keys = ['<C-u>'];
   to: EditorScrollDirection = 'up';
   override setScroll = true;

--- a/src/actions/commands/scroll.ts
+++ b/src/actions/commands/scroll.ts
@@ -74,6 +74,8 @@ abstract class CommandScrollAndMoveCursor extends BaseCommand {
   modes = [Mode.Normal, Mode.Visual, Mode.VisualLine, Mode.VisualBlock];
   override runsOnceForEachCountPrefix = false;
   abstract to: EditorScrollDirection;
+  /** if true, set scroll option instead of repeating command */
+  setScroll = false;
 
   /**
    * @returns the number of lines this command should move the cursor
@@ -90,7 +92,9 @@ abstract class CommandScrollAndMoveCursor extends BaseCommand {
       .getConfiguration('editor')
       .get<boolean>('smoothScrolling', false);
 
-    const timesToRepeat = vimState.recordedState.count || 1;
+    if (this.setScroll && vimState.recordedState.count)
+      configuration.scroll = vimState.recordedState.count;
+    const timesToRepeat = (!this.setScroll && vimState.recordedState.count) || 1;
     const moveLines = timesToRepeat * this.getNumLines(visibleRanges);
 
     let scrollLines = moveLines;
@@ -156,6 +160,7 @@ class CommandMoveFullPageDown extends CommandScrollAndMoveCursor {
 class CommandMoveHalfPageDown extends CommandScrollAndMoveCursor {
   keys = ['<C-d>'];
   to: EditorScrollDirection = 'down';
+  override setScroll = true;
 
   protected getNumLines(visibleRanges: vscode.Range[]) {
     return configuration.getScrollLines(visibleRanges);
@@ -166,6 +171,7 @@ class CommandMoveHalfPageDown extends CommandScrollAndMoveCursor {
 class CommandMoveHalfPageUp extends CommandScrollAndMoveCursor {
   keys = ['<C-u>'];
   to: EditorScrollDirection = 'up';
+  override setScroll = true;
 
   protected getNumLines(visibleRanges: vscode.Range[]) {
     return configuration.getScrollLines(visibleRanges);

--- a/test/mode/modeNormal.test.ts
+++ b/test/mode/modeNormal.test.ts
@@ -2737,25 +2737,41 @@ suite('Mode Normal', () => {
     endMode: Mode.Normal,
   });
 
-  newTest({
-    title: 'can handle <C-u> when first line is visible and starting column is at the beginning',
-    start: ['\t hello world', 'hello', 'hi hello', '|foo'],
-    keysPressed: '<C-u>',
-    end: ['\t |hello world', 'hello', 'hi hello', 'foo'],
-  });
+  suite('<C-u> / <C-d>', () => {
+    newTest({
+      title: 'can handle <C-u> when first line is visible and starting column is at the beginning',
+      start: ['\t hello world', 'hello', 'hi hello', '|foo'],
+      keysPressed: '<C-u>',
+      end: ['\t |hello world', 'hello', 'hi hello', 'foo'],
+    });
 
-  newTest({
-    title: 'can handle <C-u> when first line is visible and starting column is at the end',
-    start: ['\t hello world', 'hello', 'hi hello', 'very long line at the bottom|'],
-    keysPressed: '<C-u>',
-    end: ['\t |hello world', 'hello', 'hi hello', 'very long line at the bottom'],
-  });
+    newTest({
+      title: 'can handle <C-u> when first line is visible and starting column is at the end',
+      start: ['\t hello world', 'hello', 'hi hello', 'very long line at the bottom|'],
+      keysPressed: '<C-u>',
+      end: ['\t |hello world', 'hello', 'hi hello', 'very long line at the bottom'],
+    });
 
-  newTest({
-    title: 'can handle <C-u> when first line is visible and starting column is in the middle',
-    start: ['\t hello world', 'hello', 'hi hello', 'very long line |at the bottom'],
-    keysPressed: '<C-u>',
-    end: ['\t |hello world', 'hello', 'hi hello', 'very long line at the bottom'],
+    newTest({
+      title: 'can handle <C-u> when first line is visible and starting column is in the middle',
+      start: ['\t hello world', 'hello', 'hi hello', 'very long line |at the bottom'],
+      keysPressed: '<C-u>',
+      end: ['\t |hello world', 'hello', 'hi hello', 'very long line at the bottom'],
+    });
+
+    newTest({
+      title: '[count]<C-u> sets and adheres to scroll option',
+      start: ['abc', 'def', 'ghi', 'jkl', 'mno', 'pqr', 'st|u'],
+      keysPressed: '2<C-u><C-u>',
+      end: ['abc', 'def', '|ghi', 'jkl', 'mno', 'pqr', 'stu'],
+    });
+
+    newTest({
+      title: '[count]<C-d> sets and adheres to scroll option',
+      start: ['ab|c', 'def', 'ghi', 'jkl', 'mno', 'pqr', 'stu'],
+      keysPressed: '2<C-d><C-d>',
+      end: ['abc', 'def', 'ghi', 'jkl', '|mno', 'pqr', 'stu'],
+    });
   });
 
   suite('<C-g>', () => {

--- a/test/testSimplifier.ts
+++ b/test/testSimplifier.ts
@@ -149,7 +149,7 @@ class DocState {
 }
 
 /**
- * Tokenize a string like "abc<Esc>d<C-c>" into ["a", "b", "c", "<Esc>", "d", "<C-c>"]
+ * Tokenize a string like `"abc<Esc>d<C-c>"` into `["a", "b", "c", "<Esc>", "d", "<C-c>"]`
  */
 function tokenizeKeySequence(sequence: string): string[] {
   let isBracketedKey = false;


### PR DESCRIPTION
<!--
Yay! Thanks for sending us a PR! 🎊

Please ensure your PR adheres to:

- [ ] Commit messages has a short & issue references when necessary
- [ ] Each commit does a logical chunk of work.
- [ ] It builds and tests pass (e.g `gulp`)
-->

**What this PR does / why we need it**:
Set scroll option with `[count]<C-u>` and `[count]<C-d>`.

Rename `CommandMoveHalfPageDown` to `CommandCtrlD` and `CommandMoveHalfPageUp` to `CommandCtrlU`, since HalfPage is only true when `scroll=0`. This also aligns with `CommandCtrlE` and `CommandCtrlY`.

Wrap a docstring with \` since `<` and `>` need escaping in rendered format.

**Which issue(s) this PR fixes**
Fixes  #8984

<!--
Commits in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)
-->
