### PR TITLE
Add `gB` keybinding for finding the previous match

### DIFF
--- a/src/actions/commands/actions.ts
+++ b/src/actions/commands/actions.ts
@@ -2498,6 +2498,27 @@ class ActionTriggerHover extends BaseCommand {
   }
 }
 
+@RegisterAction
+export class ActionPreviousFindMatch extends BaseCommand {
+  modes = [Mode.Normal, Mode.Visual];
+  keys = ['g', 'B'];
+  override runsOnceForEveryCursor() {
+    return false;
+  }
+  override runsOnceForEachCountPrefix = true;
+
+  public override async exec(position: Position, vimState: VimState): Promise<void> {
+    await vscode.commands.executeCommand('editor.action.addSelectionToPreviousFindMatch');
+    vimState.cursors = getCursorsAfterSync(vimState.editor);
+
+    // If this is the first cursor, select 1 character less
+    // so that only the word is selected, no extra character
+    vimState.cursors = vimState.cursors.map((x) => x.withNewStop(x.stop.getLeft()));
+
+    await vimState.setCurrentMode(Mode.Visual);
+  }
+}
+
 /**
  * Multi-Cursor Command Overrides
  *


### PR DESCRIPTION
Fix: https://github.com/VSCodeVim/Vim/issues/9000

<!--
Yay! Thanks for sending us a PR! 🎊

Please ensure your PR adheres to:

- [x] Commit messages has a short & issue references when necessary
- [x] Each commit does a logical chunk of work.
- [x] It builds and tests pass (e.g `gulp`)
-->

**What this PR does / why we need it**:

`gb` is a nice binding, so the inverse of it would be useful. 

You can bind `editor.action.addSelectionToPreviousFindMatch` in your config, but the nice thing about `gb` is that it aligns all the selection ends of the cursors.

**Which issue(s) this PR fixes**

fixes #9000

**Special notes for your reviewer**:
