### PR TITLE
Don't close editors in other groups with `:only`

### DIFF
--- a/src/cmd_line/commands/only.ts
+++ b/src/cmd_line/commands/only.ts
@@ -5,7 +5,7 @@ import { ExCommand } from '../../vimscript/exCommand';
 export class OnlyCommand extends ExCommand {
   async execute(vimState: VimState): Promise<void> {
     await Promise.allSettled([
-      vscode.commands.executeCommand('workbench.action.closeEditorsInOtherGroups'),
+      vscode.commands.executeCommand('workbench.action.joinAllGroups'),
       vscode.commands.executeCommand('workbench.action.maximizeEditor'),
       vscode.commands.executeCommand('workbench.action.closePanel'),
     ]);


### PR DESCRIPTION
<!--
Yay! Thanks for sending us a PR! 🎊

Please ensure your PR adheres to:

- [ ] Commit messages has a short & issue references when necessary
- [ ] Each commit does a logical chunk of work.
- [ ] It builds and tests pass (e.g `gulp`)
-->

**What this PR does / why we need it**:

Currently when running `:only` all editors from other groups are closed. This is surprising for a seasoned vim user because in vim all buffers would be kept open. It's especially annoying when there are terminal opened in editor area executing. some long-running tasks.

**Which issue(s) this PR fixes**

<!--
Commits in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)
-->

**Special notes for your reviewer**:
