### PR TITLE
add a textobject:SelectAttrs i-r/a-r

### DIFF
--- a/src/textobject/textobject.ts
+++ b/src/textobject/textobject.ts
@@ -24,6 +24,8 @@ import { WordType } from './word';
 export abstract class TextObject extends BaseMovement {
   override modes = [Mode.Normal, Mode.Visual, Mode.VisualBlock];
 
+  public static readonly attrRegExp = /[\w.:@-]+=(["']).*?\1|[\w.:@-]+=\{.*?\}/;
+
   public override async execActionForOperator(
     position: Position,
     vimState: VimState,
@@ -585,6 +587,50 @@ export class SelectEntireIgnoringLeadingTrailing extends TextObject {
       stop = stop.getUp();
     }
     stop = stop.getLineEnd();
+
+    return {
+      start,
+      stop,
+    };
+  }
+}
+
+@RegisterAction
+export class SelectAttrs extends TextObject {
+  keys = ['a', 'r'];
+
+  public async execAction(position: Position, vimState: VimState): Promise<IMovement> {
+    let start = position;
+    let stop = position;
+
+    const range = vimState.document.getWordRangeAtPosition(position, TextObject.attrRegExp);
+
+    if (range) {
+      start = range.start;
+      stop = range.end;
+    }
+
+    return {
+      start,
+      stop,
+    };
+  }
+}
+
+@RegisterAction
+export class SelectInnerAttrs extends TextObject {
+  keys = ['i', 'r'];
+
+  public async execAction(position: Position, vimState: VimState): Promise<IMovement> {
+    let start = position;
+    let stop = position;
+
+    const range = vimState.document.getWordRangeAtPosition(position, TextObject.attrRegExp);
+
+    if (range) {
+      start = range.start;
+      stop = range.end.getLeft();
+    }
 
     return {
       start,


### PR DESCRIPTION
<!--
Yay! Thanks for sending us a PR! 🎊

Please ensure your PR adheres to:

- [ ] Commit messages has a short & issue references when necessary
- [ ] Each commit does a logical chunk of work.
- [ ] It builds and tests pass (e.g `gulp`)
-->

**What this PR does / why we need it**:

Currently, the VSCodeVim does not have a feature for quickly selecting HTML attributes, so I went ahead and developed one myself.

Usage: Place your cursor on the attribute you wish to select, then use the commands `i-r` to select the inner attribute or `a-r` to select the entire attribute, like cir / dar / vir

**Which issue(s) this PR fixes**

no

<!--
Commits in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)
-->

**Special notes for your reviewer**:

1. I haven't written any test cases for it, but I've manually tested the functionality and found it to be working well.
2. Currently, I'm using the keybinding `r`, and I'm unsure if this mapping is universally acceptable or might conflict with other Vim functionalities.