### PR TITLE
fixes #9006 easymotionDimColor has no effect

### DIFF
--- a/src/actions/plugins/easymotion/easymotion.ts
+++ b/src/actions/plugins/easymotion/easymotion.ts
@@ -23,9 +23,16 @@ export class EasyMotion implements IEasyMotion {
   private visibleMarkers: Marker[]; // Array of currently showing markers
   private decorations: vscode.DecorationOptions[][];
 
-  private static readonly fade = vscode.window.createTextEditorDecorationType({
-    color: configuration.easymotionDimColor,
-  });
+  private static fade: vscode.TextEditorDecorationType | null = null;
+  private static getFadeDecorationType(): vscode.TextEditorDecorationType {
+    if (this.fade === null) {
+      this.fade = vscode.window.createTextEditorDecorationType({
+        color: configuration.easymotionDimColor,
+      });
+    }
+    return this.fade;
+  }
+
   private static readonly hide = vscode.window.createTextEditorDecorationType({
     color: 'transparent',
   });
@@ -79,7 +86,7 @@ export class EasyMotion implements IEasyMotion {
       editor.setDecorations(EasyMotion.getDecorationType(i), []);
     }
 
-    editor.setDecorations(EasyMotion.fade, []);
+    editor.setDecorations(EasyMotion.getFadeDecorationType(), []);
     editor.setDecorations(EasyMotion.hide, []);
   }
 
@@ -421,7 +428,7 @@ export class EasyMotion implements IEasyMotion {
     editor.setDecorations(EasyMotion.hide, hiddenChars);
 
     if (configuration.easymotionDimBackground) {
-      editor.setDecorations(EasyMotion.fade, dimmingZones);
+      editor.setDecorations(EasyMotion.getFadeDecorationType(), dimmingZones);
     }
   }
 }


### PR DESCRIPTION
<!--
Yay! Thanks for sending us a PR! 🎊

Please ensure your PR adheres to:

- [ ] Commit messages has a short & issue references when necessary
- [ ] Each commit does a logical chunk of work.
- [ ] It builds and tests pass (e.g `gulp`)
-->

**What this PR does / why we need it**:

fixes #9006 easymotionDimColor has no effect

**Which issue(s) this PR fixes**

#9006 

<!--
Commits in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)
-->

**Special notes for your reviewer**:

This static property is initialized immediately when the class is loaded (due to the nature of static properties in TypeScript/JavaScript), not when an instance of the class is created. it only depends on the file containing the class (easymotion.ts) being processed by the JavaScript runtime.

https://github.com/VSCodeVim/Vim/blob/0e1e48797c5205df914f79a08b6e773be3c6feb0/src/actions/plugins/easymotion/easymotion.ts#L26-L28

So, when we used import, this value is initialized

https://github.com/VSCodeVim/Vim/blob/0e1e48797c5205df914f79a08b6e773be3c6feb0/src/mode/modeHandler.ts#L8

But at this time, the configuration.asymotionDimColor has not been loaded yet

https://github.com/VSCodeVim/Vim/blob/0e1e48797c5205df914f79a08b6e773be3c6feb0/extensionBase.ts#L101-L102