### PR TITLE
Add Toggle button to status bar

### DIFF
--- a/src/statusBar.ts
+++ b/src/statusBar.ts
@@ -24,6 +24,7 @@ class StatusBarImpl implements vscode.Disposable {
       Number.MIN_SAFE_INTEGER, // Furthest right on the left
     );
     this.statusBarItem.name = 'Vim Command Line';
+    this.statusBarItem.command = 'toggleVim';
     this.statusBarItem.show();
 
     this.recordedStateStatusBarItem = vscode.window.createStatusBarItem(


### PR DESCRIPTION
Converts the status bar icon (`--NORMAL--`) into a button. It can be clicked to quickly disable the extension.
The below gif shows it working in the environment

![Jun-06-2024_19-44-11](https://github.com/VSCodeVim/Vim/assets/57827758/cb0fda39-3764-4375-8223-fc1791e6b672)
