### PR TITLE
Fix escaping of multiple forward slashes in visualstar search

### DIFF
--- a/src/actions/commands/search.ts
+++ b/src/actions/commands/search.ts
@@ -99,7 +99,7 @@ async function createSearchStateAndMoveToMatch(args: {
     return;
   }
 
-  const escapedNeedle = escapeRegExp(needle).replace('/', '\\/');
+  const escapedNeedle = escapeRegExp(needle).replaceAll('/', '\\/');
   const searchString = isExact ? `\\<${escapedNeedle}\\>` : escapedNeedle;
 
   // Start a search for the given term.

--- a/test/mode/modeVisual.test.ts
+++ b/test/mode/modeVisual.test.ts
@@ -1088,9 +1088,9 @@ suite('Mode Visual', () => {
 
     newTest({
       title: '`*` escapes `/` properly',
-      start: ['one |two/three four', 'one two/three four'],
+      start: ['one |two//three four', 'one two//three four'],
       keysPressed: 'vE*',
-      end: ['one two/three four', 'one |two/three four'],
+      end: ['one two//three four', 'one |two//three four'],
       endMode: Mode.Normal,
     });
 


### PR DESCRIPTION
<!--
Yay! Thanks for sending us a PR! 🎊

Please ensure your PR adheres to:

- [ ] Commit messages has a short & issue references when necessary
- [ ] Each commit does a logical chunk of work.
- [ ] It builds and tests pass (e.g `gulp`)
-->

**What this PR does / why we need it**:
Allows searching for visual selections that contain multiple forward slashes.

**Which issue(s) this PR fixes**
Fixes #9111

<!--
Commits in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)
-->