### PR TITLE
Fix 7397 dot with numbered registers

### DIFF
--- a/src/mode/modeHandler.ts
+++ b/src/mode/modeHandler.ts
@@ -31,6 +31,7 @@ import {
   CommandInsertAtCursor,
   CommandNumber,
   CommandQuitRecordMacro,
+  CommandRegister,
   DocumentContentChangeAction,
 } from './../actions/commands/actions';
 import {
@@ -1182,6 +1183,12 @@ export class ModeHandler implements vscode.Disposable, IModeHandler {
       replayMode = ReplayMode.Insert;
     } else if (actions[0] instanceof ActionReplaceCharacter) {
       replayMode = ReplayMode.Replace;
+    } else if (actions[0] instanceof CommandRegister) {
+      // Increment numbered registers "1 to "9.
+      const keyPressed = Number(actions[0].keysPressed[1]);
+      if (!isNaN(keyPressed) && keyPressed > 0 && keyPressed < 9) {
+        actions[0].keysPressed[1] = String(keyPressed + 1);
+      }
     }
     for (let j = 0; j < transformation.count; j++) {
       recordedState = new RecordedState();

--- a/test/mode/normalModeTests/dot.test.ts
+++ b/test/mode/normalModeTests/dot.test.ts
@@ -230,6 +230,27 @@ suite('Repeat content change', () => {
     keysPressed: 'ciwxxx<Esc>' + 'bb.' + 'bbV<Esc>.' + 'bb<C-q><Esc>.',
     end: ['xx|x xxx xxx xxx'],
   });
+
+  newTest({
+    title: 'Can repeat insertion with increasing numbered register',
+    start: ['|1 2 3'],
+    keysPressed: '"1daw..' + '"1p..',
+    end: ['1 2 |3'],
+  });
+
+  newTest({
+    title: 'Does not increase the "0 register',
+    start: ['|lorem', 'ipsum'],
+    keysPressed: 'dd' + 'yy' + '"0p.',
+    end: ['ipsum', 'ipsum', '|ipsum'],
+  });
+
+  newTest({
+    title: 'Can repeat line insertion with 9 as highest numbered register',
+    start: ['|one', 'two', 'three', 'four', 'five', 'six', 'seven', 'eight', 'nine'],
+    keysPressed: 'dd' + 'dd' + 'dd' + 'dd' + 'dd' + 'dd' + 'dd' + 'dd' + 'dd' + '"1p.........',
+    end: ['', 'nine', 'eight', 'seven', 'six', 'five', 'four', 'three', 'two', 'one', '|one'],
+  });
 });
 
 suite('Dot Operator repeat with remap', () => {


### PR DESCRIPTION
**What this PR does / why we need it**:

It fixes #7397 and adds three tests for this.

**Which issue(s) this PR fixes**

#7397 

**Special notes for your reviewer**:
Hi there I am happy to make my first contribution to this amazing project!

I implemented the fix for all commands that start with a (numbered) `CommandRegister` action. I could not think of or find a dot repeatable command that has a numbered register in it but does not not start with it. If there is one, please let me know.

BTW: is there a way to filter tests? I do not want to run all tests _while_ I'm trying to fix a small bug 😉
