### PR TITLE
Fix H L motion

### DIFF
--- a/src/actions/motion.ts
+++ b/src/actions/motion.ts
@@ -1275,12 +1275,33 @@ class MoveScreenToLeftHalf extends MoveByScreenLine {
 }
 
 @RegisterAction
-class MoveToLineFromViewPortTop extends MoveByScreenLine {
+class MoveToLineFromViewPortTop extends BaseMovement {
   keys = ['H'];
-  movementType: CursorMovePosition = 'viewPortTop';
-  override by: CursorMoveByUnit = 'line';
-  override value = 1;
+  movementType: CursorMovePosition = 'up';
   override isJump = true;
+
+  public override async execActionWithCount(
+    position: Position,
+    vimState: VimState,
+    count: number,
+  ): Promise<Position | IMovement> {
+    vimState.currentRegisterMode = RegisterMode.LineWise;
+
+    let line = clamp(count, 1, vimState.document.lineCount) - 1;
+
+    const scrolloff = configuration
+      .getConfiguration('editor')
+      .get<number>('cursorSurroundingLines', 0);
+
+    let topLine = vscode.window.activeTextEditor?.visibleRanges[0].start.line;
+    topLine = topLine ? topLine : 0;
+    line = topLine + scrolloff;
+
+    return {
+      start: vimState.cursorStartPosition,
+      stop: position.with({ line }),
+    };
+  }
 }
 
 @RegisterAction

--- a/src/actions/motion.ts
+++ b/src/actions/motion.ts
@@ -1287,15 +1287,18 @@ class MoveToLineFromViewPortTop extends BaseMovement {
   ): Promise<Position | IMovement> {
     vimState.currentRegisterMode = RegisterMode.LineWise;
 
-    let line = clamp(count, 1, vimState.document.lineCount) - 1;
+    const topLine = vimState.editor.visibleRanges[0].start.line ?? 0;
+    if (topLine === 0) {
+      return {
+        start: vimState.cursorStartPosition,
+        stop: position.with({ line: topLine }),
+      };
+    }
 
     const scrolloff = configuration
       .getConfiguration('editor')
       .get<number>('cursorSurroundingLines', 0);
-
-    let topLine = vscode.window.activeTextEditor?.visibleRanges[0].start.line;
-    topLine = topLine ? topLine : 0;
-    line = topLine + scrolloff;
+    const line = topLine + scrolloff;
 
     return {
       start: vimState.cursorStartPosition,

--- a/src/actions/motion.ts
+++ b/src/actions/motion.ts
@@ -1277,7 +1277,6 @@ class MoveScreenToLeftHalf extends MoveByScreenLine {
 @RegisterAction
 class MoveToLineFromViewPortTop extends BaseMovement {
   keys = ['H'];
-  movementType: CursorMovePosition = 'up';
   override isJump = true;
 
   public override async execActionWithCount(
@@ -1310,7 +1309,6 @@ class MoveToLineFromViewPortTop extends BaseMovement {
 @RegisterAction
 class MoveToLineFromViewPortBottom extends BaseMovement {
   keys = ['L'];
-  movementType: CursorMovePosition = 'down';
   override isJump = true;
 
   public override async execActionWithCount(

--- a/test/configuration/remaps.test.ts
+++ b/test/configuration/remaps.test.ts
@@ -483,7 +483,7 @@ suite('Remaps', () => {
           'Lfillr typed via remap with a wrong user pressed key after should not handle the keys after failed action but should handle the user pressed key',
         keysPressed: ' lFdl',
         stepResult: {
-          end: ['    Hello World again!', '|llo World!'],
+          end: ['    Hello World again!', 'c|lo World!'],
           endMode: Mode.Normal,
         },
       },
@@ -493,7 +493,7 @@ suite('Remaps', () => {
           'Lfill typed via remap with multiple right user pressed keys after should run the corresponding remap and the rest of the keys',
         keysPressed: ' lfrsl',
         stepResult: {
-          end: ['    Hello World again!', '  |llo World!'],
+          end: ['    Hello World again!', '  |clo World!'],
           endMode: Mode.Normal,
         },
       },

--- a/test/mode/modeVisualBlock.test.ts
+++ b/test/mode/modeVisualBlock.test.ts
@@ -245,7 +245,7 @@ suite('VisualBlock mode', () => {
       assert.strictEqual(modeHandler.currentMode, Mode.Normal);
 
       // test copy by pasting back
-      await modeHandler.handleMultipleKeyEvents(['H', '"', '+', 'P']);
+      await modeHandler.handleMultipleKeyEvents(['H', '0', '"', '+', 'P']);
 
       // TODO: should be
       // assertEqualLines(['oneone two three', 'oneone two three', 'oneone two three']);


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes H and L behavior to be faithful to how vanilla Vim behaves. Prior to this, H and L would jump to the top and bottom visible lines in the editor, not respecting the `editor.cursorSurroundingLines` (`scrolloff` in vanilla Vim) setting. It would also move the cursor to the first non whitespace character on the line (either backwards or forwards) which was not faithful to vanilla Vim.

It also fixes tests that were written with the assumption of this incorrect behavior.

**Which issue(s) this PR fixes**
Fixes #4912 and #8837.

**Special notes for your reviewer**:
Let me know if you'd like more tests written.
