### PR TITLE
[Small Fix]: Fixed an issue with the foldfix setting

### DIFF
--- a/src/actions/motion.ts
+++ b/src/actions/motion.ts
@@ -276,7 +276,7 @@ class MoveDownFoldFix extends MoveByScreenLineMaintainDesiredColumn {
       prevChar = t.character;
       prevLine = t.line;
     } while (t.line === position.line);
-    return t;
+    return t.with({ character: position.character });
   }
 }
 
@@ -299,7 +299,10 @@ class MoveDown extends BaseMovement {
     }
 
     if (configuration.foldfix && vimState.currentMode !== Mode.VisualBlock) {
-      return new MoveDownFoldFix().execAction(position, vimState);
+      return new MoveDownFoldFix().execAction(
+        position.with({ character: vimState.desiredColumn }),
+        vimState,
+      );
     }
 
     if (position.line < vimState.document.lineCount - 1) {
@@ -337,7 +340,10 @@ class MoveUp extends BaseMovement {
     }
 
     if (configuration.foldfix && vimState.currentMode !== Mode.VisualBlock) {
-      return new MoveUpFoldFix().execAction(position, vimState);
+      return new MoveUpFoldFix().execAction(
+        position.with({ character: vimState.desiredColumn }),
+        vimState,
+      );
     }
 
     if (position.line > 0) {
@@ -373,7 +379,7 @@ class MoveUpFoldFix extends MoveByScreenLineMaintainDesiredColumn {
       t = await moveUpByScreenLine.execAction(position, vimState);
       t = t instanceof Position ? t : t.stop;
     } while (t.line === position.line);
-    return t;
+    return t.with({ character: position.character });
   }
 }
 


### PR DESCRIPTION
### What this PR does / why we need it:
It fixes an issue where the foldfix setting would cause the cursor to fail to remember the column position. The reason why it's needed is because the foldfix setting is very useful - but losing the ability to maintain column makes it unusable.

### Which issue(s) this PR fixes
Fixed an issue with the foldfix setting where the cursor fails to remember the column position and resets to the smallest line end it encounters.

### Special notes for your reviewer:
If this fix isn't done up to your standard, I would love to discuss how to fix it in a way that fits your standards. I hope you have a fantastic week ahead of you :).
