### PR TITLE
Move to visual mode on mouse selection

### DIFF
--- a/src/mode/modeHandler.ts
+++ b/src/mode/modeHandler.ts
@@ -413,8 +413,7 @@ export class ModeHandler implements vscode.Disposable, IModeHandler {
 
         if (
           configuration.mouseSelectionGoesIntoVisualMode &&
-          !isVisualMode(this.vimState.currentMode) &&
-          this.currentMode !== Mode.Insert
+          !isVisualMode(this.vimState.currentMode)
         ) {
           await this.setCurrentMode(Mode.Visual);
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently, selecting text with mouse changes mode to Visual, unless we started from the insert mode. Multiple people [complained](https://github.com/VSCodeVim/Vim/issues/2410#issuecomment-574908393) about this departure from learned vim behavior. There is a setting that supposed to control it (#1871), but it doesn't address insert->visual for some reason.

**Which issue(s) this PR fixes**
#9214

**Special notes for your reviewer**:
