### PR TITLE
Handle unicode surrogate pairs in `DeleteOperator`

### DIFF
--- a/src/actions/operator.ts
+++ b/src/actions/operator.ts
@@ -127,6 +127,23 @@ export class DeleteOperator extends BaseOperator {
       end = new Position(end.line + 1, 0);
     }
 
+    const sLine = vimState.document.lineAt(start.line).text;
+    const eLine = vimState.document.lineAt(end.line).text;
+    if (
+      start.character !== 0 &&
+      isLowSurrogate(sLine.charCodeAt(start.character)) &&
+      isHighSurrogate(sLine.charCodeAt(start.character - 1))
+    ) {
+      start = start.getLeft();
+    }
+    if (
+      end.character !== 0 &&
+      isLowSurrogate(eLine.charCodeAt(end.character)) &&
+      isHighSurrogate(eLine.charCodeAt(end.character - 1))
+    ) {
+      end = end.getRight();
+    }
+
     // Yank the text
     let text = vimState.document.getText(new vscode.Range(start, end));
     if (vimState.currentRegisterMode === RegisterMode.LineWise) {


### PR DESCRIPTION
<!--
Yay! Thanks for sending us a PR! 🎊

Please ensure your PR adheres to:

- [ ] Commit messages has a short & issue references when necessary
- [ ] Each commit does a logical chunk of work.
- [ ] It builds and tests pass (e.g `gulp`)
-->

**What this PR does / why we need it**:

Checks if the `start` and `end` character in `DeleteOperator` is a low surrogate. If it is, then we extend them by using `.getLeft()` and `.getRight()` respectively. Here's a comparison (when doing 'x' & 'p' in normal mode):

Behavior before:

![before](https://github.com/user-attachments/assets/6e599582-2e79-4fcc-8537-72d365106a7d)

After this PR:

![after](https://github.com/user-attachments/assets/d23acd09-2cdb-44ea-8aa9-a82fb62f0ad4)


**Which issue(s) this PR fixes**

#3070 (step 4 in the issue)

<!--
Commits in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)
-->

**Special notes for your reviewer**:

This is already done in `YankOperator`, I've just added the same check to `DeleteOperator`