### PR TITLE
Avoid needing two `MoveLeft`s if the current character is a low surrogate

### DIFF
--- a/src/actions/motion.ts
+++ b/src/actions/motion.ts
@@ -689,11 +689,20 @@ class MoveLeft extends BaseMovement {
   public override async execAction(position: Position, vimState: VimState): Promise<Position> {
     const getLeftWhile = (p: Position): Position => {
       const line = vimState.document.lineAt(p.line).text;
-      const newPosition = p.getLeft();
-      if (newPosition.character === 0) {
-        return newPosition;
+
+      if (p.character === 0) {
+        return p;
       }
       if (
+        isLowSurrogate(line.charCodeAt(p.character)) &&
+        isHighSurrogate(line.charCodeAt(p.character - 1))
+      ) {
+        p = p.getLeft();
+      }
+
+      const newPosition = p.getLeft();
+      if (
+        newPosition.character > 0 &&
         isLowSurrogate(line.charCodeAt(newPosition.character)) &&
         isHighSurrogate(line.charCodeAt(newPosition.character - 1))
       ) {

--- a/test/operator/surrogate.test.ts
+++ b/test/operator/surrogate.test.ts
@@ -46,4 +46,11 @@ suite('surrogate-pair', () => {
     keysPressed: 'i🐕🐕<ESC>',
     end: ['🐕🐕|'],
   });
+
+  newTest({
+    title: 'move left over cute dog',
+    start: ['|𩸽🐕', 'text'],
+    keysPressed: 'jlllkh',
+    end: ['|𩸽🐕', 'text'],
+  });
 });


### PR DESCRIPTION
<!--
Yay! Thanks for sending us a PR! 🎊

Please ensure your PR adheres to:

- [ ] Commit messages has a short & issue references when necessary
- [ ] Each commit does a logical chunk of work.
- [ ] It builds and tests pass (e.g `gulp`)
-->

**What this PR does / why we need it**:
It fixes an issue where you'll sometimes need to press 'h' twice to go to the next left char, if your current char is a surrogate pair. 

Happens when the character corresponding to the current cursor position is a low surrogate, so you'll only get to the next left char after you've moved to the high surrogate char (two `MoveLeft`s).

Before:
![before-moveleft](https://github.com/user-attachments/assets/57f5a84b-c2a7-430b-9224-dbeaaa892756)


After this PR:
![after-moveleft](https://github.com/user-attachments/assets/cfefb1e5-b19d-4dc6-b8cd-d365e0a21164)


**Which issue(s) this PR fixes**

<!--
Commits in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)
-->

**Special notes for your reviewer**: