### PR TITLE
Granular Status Bar item color control

### DIFF
--- a/package.json
+++ b/package.json
@@ -1152,6 +1152,116 @@
         }
       }
     },
+    "colors": [
+      {
+        "id": "statusBarItem.vimMode.Normal",
+        "description": "Vim status bar color for normal mode.",
+        "defaults": {
+          "dark": "statusBar.foreground",
+          "light": "statusBar.foreground",
+          "highContrast": "statusBar.foreground"
+        }
+      },
+      {
+        "id": "statusBarItem.vimMode.Insert",
+        "description": "Vim status bar color for insert mode.",
+        "defaults": {
+          "dark": "statusBar.foreground",
+          "light": "statusBar.foreground",
+          "highContrast": "statusBar.foreground"
+        }
+      },
+      {
+        "id": "statusBarItem.vimMode.Visual",
+        "description": "Vim status bar color for visual mode.",
+        "defaults": {
+          "dark": "statusBar.foreground",
+          "light": "statusBar.foreground",
+          "highContrast": "statusBar.foreground"
+        }
+      },
+      {
+        "id": "statusBarItem.vimMode.VisualBlock",
+        "description": "Vim status bar color for visual block mode.",
+        "defaults": {
+          "dark": "statusBar.foreground",
+          "light": "statusBar.foreground",
+          "highContrast": "statusBar.foreground"
+        }
+      },
+      {
+        "id": "statusBarItem.vimMode.VisualLine",
+        "description": "Vim status bar color for visual line mode.",
+        "defaults": {
+          "dark": "statusBar.foreground",
+          "light": "statusBar.foreground",
+          "highContrast": "statusBar.foreground"
+        }
+      },
+      {
+        "id": "statusBarItem.vimMode.Replace",
+        "description": "Vim status bar color for replace mode.",
+        "defaults": {
+          "dark": "statusBar.foreground",
+          "light": "statusBar.foreground",
+          "highContrast": "statusBar.foreground"
+        }
+      },
+      {
+        "id": "statusBarItem.vimMode.EasyMotionMode",
+        "description": "Vim status bar color for easy motion mode.",
+        "defaults": {
+          "dark": "statusBar.foreground",
+          "light": "statusBar.foreground",
+          "highContrast": "statusBar.foreground"
+        }
+      },
+      {
+        "id": "statusBarItem.vimMode.EasyMotionInputMode",
+        "description": "Vim status bar color for easy motion input mode.",
+        "defaults": {
+          "dark": "statusBar.foreground",
+          "light": "statusBar.foreground",
+          "highContrast": "statusBar.foreground"
+        }
+      },
+      {
+        "id": "statusBarItem.vimMode.SurroundInputMode",
+        "description": "Vim status bar color for surround input mode.",
+        "defaults": {
+          "dark": "statusBar.foreground",
+          "light": "statusBar.foreground",
+          "highContrast": "statusBar.foreground"
+        }
+      },
+      {
+        "id": "statusBarItem.vimMode.Disabled",
+        "description": "Vim status bar color for disabled mode.",
+        "defaults": {
+          "dark": "statusBar.foreground",
+          "light": "statusBar.foreground",
+          "highContrast": "statusBar.foreground"
+        }
+      },
+      {
+        "id": "statusBarItem.vimMode.SearchInProgressMode",
+        "description": "Vim status bar color for when a search is in progress.",
+        "defaults": {
+          "dark": "statusBar.foreground",
+          "light": "statusBar.foreground",
+          "highContrast": "statusBar.foreground"
+        }
+      },
+      {
+        "id": "statusBarItem.vimMode.CommandlineInProgress",
+        "description": "Vim status bar color for when entering a command.",
+        "defaults": {
+          "dark": "statusBar.foreground",
+          "light": "statusBar.foreground",
+          "highContrast": "statusBar.foreground"
+        }
+      }
+    ],
     "languages": [
       {
         "id": "Vimscript",

--- a/src/statusBar.ts
+++ b/src/statusBar.ts
@@ -70,11 +70,7 @@ class StatusBarImpl implements vscode.Disposable {
     }
 
     // StatusBar color
-    const shouldUpdateColor =
-      configuration.statusBarColorControl && vimState.currentMode !== this.previousMode;
-    if (shouldUpdateColor) {
-      this.updateColor(vimState.currentMode);
-    }
+    this.updateColor(vimState.currentMode);
 
     this.previousMode = vimState.currentMode;
     this.showingDefaultMessage = false;
@@ -123,6 +119,23 @@ class StatusBarImpl implements vscode.Disposable {
   }
 
   private updateColor(mode: Mode) {
+    // original color update method - applies to the whole line by modifying the user's settings
+    if (configuration.statusBarColorControl && mode !== this.previousMode) {
+      this.updateWholeStatusBarColor(mode);
+    }
+
+    // narrow color update method - applies to the Vim status bar items based on color settings
+    this.updateVimStatusItemColor(mode);
+  }
+
+  private updateVimStatusItemColor(mode: Mode) {
+    const modeName = Mode[mode];
+    const foregroundColor = new vscode.ThemeColor(`statusBarItem.vimMode.${modeName}`);
+    this.statusBarItem.color = foregroundColor;
+    this.recordedStateStatusBarItem.color = foregroundColor;
+  }
+
+  private updateWholeStatusBarColor(mode: Mode) {
     let foreground: string | undefined;
     let background: string | undefined;
 

--- a/src/statusBar.ts
+++ b/src/statusBar.ts
@@ -125,10 +125,10 @@ class StatusBarImpl implements vscode.Disposable {
     }
 
     // narrow color update method - applies to the Vim status bar items based on color settings
-    this.updateVimStatusItemColor(mode);
+    this.updateVimStatusBarItemColor(mode);
   }
 
-  private updateVimStatusItemColor(mode: Mode) {
+  private updateVimStatusBarItemColor(mode: Mode) {
     const modeName = Mode[mode];
     const foregroundColor = new vscode.ThemeColor(`statusBarItem.vimMode.${modeName}`);
     this.statusBarItem.color = foregroundColor;


### PR DESCRIPTION
<!--
Yay! Thanks for sending us a PR! 🎊

Please ensure your PR adheres to:

- [x] Commit messages has a short & issue references when necessary
- [x] Each commit does a logical chunk of work.
- [x] It builds and tests pass (e.g `gulp`)
-->

**What this PR does / why we need it**:
This PR adds the ability to specify colors for the extension's status bar item text directly via theme settings with different colors for each mode. Example:

![vim-mode-color-demo](https://github.com/user-attachments/assets/e8fa71ae-bb65-4357-955b-09d6abe8abb3)

This is a nice feature for those who would like to have some easy visual indication of the current mode without having to color the entire status bar. 

The approach provides customization options in a more idiomatic way for VS Code; allowing users to specify the color options as part of a theme or under the standard `"workbench.colorCustomizations"` setting. 

The original method of coloring the status bar is unchanged and unaffected by this PR - this is only an additional option that users can take advantage of by specifying color values for any of:
```json
        "statusBarItem.vimMode.Normal"
        "statusBarItem.vimMode.Insert"
        "statusBarItem.vimMode.Visual"
        "statusBarItem.vimMode.VisualBlock"
        "statusBarItem.vimMode.VisualLine"
        "statusBarItem.vimMode.Replace"
        "statusBarItem.vimMode.EasyMotionMode"
        "statusBarItem.vimMode.EasyMotionInputMode"
        "statusBarItem.vimMode.SurroundInputMode"
        "statusBarItem.vimMode.Disabled"
        "statusBarItem.vimMode.SearchInProgressMode"
        "statusBarItem.vimMode.CommandlineInProgress"
```
under `"workbench.colorCustomizations"` in their settings. 

All of the colors default to `"statusBar.foreground"` if unspecified. 

**Which issue(s) this PR fixes**
#8741 

<!--
Commits in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)
-->

**Special notes for your reviewer**:
I can add a section to the readme if desired.