### PR TITLE
Fix going into visual mode when filling out snippets with adjacent placeholders etc

### DIFF
--- a/src/mode/modeHandler.ts
+++ b/src/mode/modeHandler.ts
@@ -214,7 +214,11 @@ export class ModeHandler implements vscode.Disposable, IModeHandler {
     // must have been inserted.
     const isSnippetSelectionChange = () => {
       return e.selections.every((s) => {
-        return this.vimState.cursors.every((c) => !s.contains(new vscode.Range(c.start, c.stop)));
+        return this.vimState.cursors
+          .filter((c) => !c.start.isEqual(c.stop))
+          .every((c) => {
+            return !s.contains(new vscode.Range(c.start, c.stop));
+          });
       });
     };
 


### PR DESCRIPTION
<!--
Yay! Thanks for sending us a PR! 🎊

Please ensure your PR adheres to:

- [ ] Commit messages has a short & issue references when necessary
- [ ] Each commit does a logical chunk of work.
- [ ] It builds and tests pass (e.g `gulp`)
-->

**What this PR does / why we need it**:

Fixes going into visual mode on certain placeholders when you fill out vscode user snippets. Particularly this occurs when the placeholders are placed adjacent to each other (not seperated by a character, see Issue #9236), or when the snippet starts from a placeholder (see Issues #5969, #7068).

Note on the fix:

I noticed that in each of these placeholder cases where the cursor goes into visual mode, `isSnippetSelectionChange()` inside `ModeHandler.handleSelectionChange()`  returns `false` even though it is a snippet selection. 

I modified the `isSnippetSelectionChange()` to only consider comparing the previous cursors that represent a selection (`c.start` and `c.stop` are not equal) with `e.selections`. 

**Which issue(s) this PR fixes**

Fixes #9236, #7068, #6465, #5969 

<!--
Commits in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)
-->

**Special notes for your reviewer**: