### PR TITLE
Refactor test setup/teardown, speeding tests up substantially

### DIFF
--- a/test/cmd_line/bang.test.ts
+++ b/test/cmd_line/bang.test.ts
@@ -1,7 +1,7 @@
 import { newTest } from '../../test/testSimplifier';
 import { getAndUpdateModeHandler } from '../../extension';
 import { ModeHandler } from '../../src/mode/modeHandler';
-import { assertEqualLines, cleanUpWorkspace, setupWorkspace } from './../testUtils';
+import { assertEqualLines, setupWorkspace } from './../testUtils';
 
 // TODO(#4844): this fails on Windows
 suite('bang (!) cmd_line', () => {
@@ -15,8 +15,6 @@ suite('bang (!) cmd_line', () => {
     await setupWorkspace();
     modeHandler = (await getAndUpdateModeHandler())!;
   });
-
-  teardown(cleanUpWorkspace);
 
   suite('parsing', () => {
     test('simple !', async () => {
@@ -120,7 +118,6 @@ suite('custom bang shell', () => {
           config: { shell: `/bin/${shell}` },
         });
       });
-      teardown(cleanUpWorkspace);
 
       newTest({
         title: `! supports /bin/${shell}`,

--- a/test/cmd_line/bufferDelete.test.ts
+++ b/test/cmd_line/bufferDelete.test.ts
@@ -16,8 +16,6 @@ suite('Buffer delete', () => {
     modeHandler = (await getAndUpdateModeHandler())!;
   });
 
-  teardown(t.cleanUpWorkspace);
-
   for (const cmd of ['bdelete', 'bdel', 'bd']) {
     test(`${cmd} deletes the current buffer`, async () => {
       await new ExCommandLine(cmd, modeHandler.vimState.currentMode).run(modeHandler.vimState);
@@ -46,7 +44,7 @@ suite('Buffer delete', () => {
   });
 
   test.skip("bd 'N' deletes the Nth buffer open", async () => {
-    const dirPath = await t.createRandomDir();
+    const dirPath = await t.createDir();
     const filePaths: string[] = [];
 
     try {

--- a/test/cmd_line/command.test.ts
+++ b/test/cmd_line/command.test.ts
@@ -2,7 +2,7 @@ import * as assert from 'assert';
 import { getAndUpdateModeHandler } from '../../extension';
 import { Mode } from '../../src/mode/mode';
 import { ModeHandler } from '../../src/mode/modeHandler';
-import { cleanUpWorkspace, setupWorkspace, assertStatusBarEqual } from '../testUtils';
+import { setupWorkspace, assertStatusBarEqual } from '../testUtils';
 
 suite('cmd_line/search command', () => {
   let modeHandler: ModeHandler;
@@ -11,8 +11,6 @@ suite('cmd_line/search command', () => {
     await setupWorkspace();
     modeHandler = (await getAndUpdateModeHandler())!;
   });
-
-  teardown(cleanUpWorkspace);
 
   test('command <C-w> can remove word in cmd line', async () => {
     await modeHandler.handleMultipleKeyEvents([':', 'a', 'b', 'c', '-', '1', '2', '3', '<C-w>']);

--- a/test/cmd_line/move.test.ts
+++ b/test/cmd_line/move.test.ts
@@ -1,10 +1,6 @@
 import { newTest } from '../testSimplifier';
-import { cleanUpWorkspace, setupWorkspace } from '../testUtils';
 
 suite(':[range]m[ove] [address] command', () => {
-  suiteSetup(setupWorkspace);
-  suiteTeardown(cleanUpWorkspace);
-
   newTest({
     title: ':move [address] will move the cursor line to below the line given by {address}',
     start: ['|one', 'two', 'three'],

--- a/test/cmd_line/only.test.ts
+++ b/test/cmd_line/only.test.ts
@@ -4,7 +4,7 @@ import * as vscode from 'vscode';
 import { getAndUpdateModeHandler } from '../../extension';
 import { ExCommandLine } from '../../src/cmd_line/commandLine';
 import { ModeHandler } from '../../src/mode/modeHandler';
-import { cleanUpWorkspace, setupWorkspace } from '../testUtils';
+import { cleanUpWorkspace, setupWorkspace, waitForEditorsToClose } from '../testUtils';
 
 const isPanelVisible = async () =>
   withinIsolatedEditor(async () => {
@@ -32,8 +32,7 @@ const withinIsolatedEditor = async (lambda: () => Thenable<unknown>) => {
 const getNumberOfVisibleLines = async () =>
   vscode.window.activeTextEditor!.visibleRanges[0].end.line;
 
-// TODO: Skipped!
-suite.skip(':only command', () => {
+suite(':only command', () => {
   let modeHandler: ModeHandler;
 
   setup(async () => {
@@ -46,6 +45,7 @@ suite.skip(':only command', () => {
   test('Run :only', async () => {
     // Ensure we have multiple editors in a split
     await vscode.commands.executeCommand('workbench.action.splitEditorRight');
+    await waitForEditorsToClose(2);
     assert.strictEqual(vscode.window.visibleTextEditors.length, 2, 'Editor did not split into 2');
 
     // Ensure panel is visible

--- a/test/cmd_line/put.test.ts
+++ b/test/cmd_line/put.test.ts
@@ -1,6 +1,6 @@
 import { getAndUpdateModeHandler } from '../../extension';
 import { ModeHandler } from '../../src/mode/modeHandler';
-import { assertEqualLines, cleanUpWorkspace, setupWorkspace } from './../testUtils';
+import { assertEqualLines, setupWorkspace } from './../testUtils';
 import * as assert from 'assert';
 import { Register, RegisterMode } from '../../src/register/register';
 
@@ -11,8 +11,6 @@ suite('put cmd_line', () => {
     await setupWorkspace();
     modeHandler = (await getAndUpdateModeHandler())!;
   });
-
-  teardown(cleanUpWorkspace);
 
   test('put in empty file', async () => {
     Register.put(modeHandler.vimState, 'abc');

--- a/test/cmd_line/redo.test.ts
+++ b/test/cmd_line/redo.test.ts
@@ -1,7 +1,7 @@
 import { getAndUpdateModeHandler } from '../../extension';
 import { ExCommandLine } from '../../src/cmd_line/commandLine';
 import { ModeHandler } from '../../src/mode/modeHandler';
-import { assertEqualLines, cleanUpWorkspace, setupWorkspace } from '../testUtils';
+import { assertEqualLines, setupWorkspace } from '../testUtils';
 
 suite('Redo command', () => {
   let modeHandler: ModeHandler;
@@ -10,8 +10,6 @@ suite('Redo command', () => {
     await setupWorkspace();
     modeHandler = (await getAndUpdateModeHandler())!;
   });
-
-  teardown(cleanUpWorkspace);
 
   test('redoes last undoed action after insert mode', async () => {
     await modeHandler.handleMultipleKeyEvents(['I', 'a', '<Esc>']);

--- a/test/cmd_line/retab.test.ts
+++ b/test/cmd_line/retab.test.ts
@@ -6,7 +6,6 @@ import * as testUtils from './../testUtils';
 
 suite(':retab', () => {
   suiteSetup(testUtils.setupWorkspace);
-  suiteTeardown(testUtils.cleanUpWorkspace);
 
   suite('Retab line segments', () => {
     test('replaceSpaces=false', () => {

--- a/test/cmd_line/smile.test.ts
+++ b/test/cmd_line/smile.test.ts
@@ -4,12 +4,7 @@ import * as vscode from 'vscode';
 import { getAndUpdateModeHandler } from '../../extension';
 import { ExCommandLine } from '../../src/cmd_line/commandLine';
 import { ModeHandler } from '../../src/mode/modeHandler';
-import {
-  assertEqualLines,
-  cleanUpWorkspace,
-  setupWorkspace,
-  waitForTabChange,
-} from './../testUtils';
+import { assertEqualLines, setupWorkspace, waitForTabChange } from './../testUtils';
 import { SmileCommand } from '../../src/cmd_line/commands/smile';
 
 suite('Smile command', () => {
@@ -19,7 +14,6 @@ suite('Smile command', () => {
     await setupWorkspace();
     modeHandler = (await getAndUpdateModeHandler())!;
   });
-  suiteTeardown(cleanUpWorkspace);
 
   test(':smile creates new tab', async () => {
     await new ExCommandLine('smile', modeHandler.vimState.currentMode).run(modeHandler.vimState);

--- a/test/cmd_line/sort.test.ts
+++ b/test/cmd_line/sort.test.ts
@@ -1,10 +1,6 @@
 import { newTest } from '../testSimplifier';
-import { cleanUpWorkspace, setupWorkspace } from './../testUtils';
 
 suite(':sort', () => {
-  suiteSetup(setupWorkspace);
-  suiteTeardown(cleanUpWorkspace);
-
   newTest({
     title: 'Sort whole file, ascending',
     start: ['Eggplant', 'dragonfruit', 'ap|ple', 'Banana', 'cabbage'],

--- a/test/cmd_line/split.test.ts
+++ b/test/cmd_line/split.test.ts
@@ -4,7 +4,7 @@ import * as vscode from 'vscode';
 import { getAndUpdateModeHandler } from '../../extension';
 import { ExCommandLine } from '../../src/cmd_line/commandLine';
 import { ModeHandler } from '../../src/mode/modeHandler';
-import { cleanUpWorkspace, setupWorkspace, waitForEditorsToClose } from './../testUtils';
+import { setupWorkspace, waitForEditorsToClose } from './../testUtils';
 
 suite('Horizontal split', () => {
   let modeHandler: ModeHandler;
@@ -13,8 +13,6 @@ suite('Horizontal split', () => {
     await setupWorkspace();
     modeHandler = (await getAndUpdateModeHandler())!;
   });
-
-  teardown(cleanUpWorkspace);
 
   for (const cmd of ['sp', 'split', 'new']) {
     test(`:${cmd} creates a second split`, async () => {

--- a/test/cmd_line/tab.test.ts
+++ b/test/cmd_line/tab.test.ts
@@ -4,7 +4,7 @@ import * as assert from 'assert';
 import { getAndUpdateModeHandler } from '../../extension';
 import { ExCommandLine } from '../../src/cmd_line/commandLine';
 import { ModeHandler } from '../../src/mode/modeHandler';
-import { createRandomFile, setupWorkspace, cleanUpWorkspace } from '../testUtils';
+import { createFile, setupWorkspace, cleanUpWorkspace } from '../testUtils';
 
 suite('cmd_line tab', () => {
   let modeHandler: ModeHandler;
@@ -33,7 +33,7 @@ suite('cmd_line tab', () => {
   });
 
   test('tabe with absolute path when not in workspace opens file', async () => {
-    const filePath = await createRandomFile('', '');
+    const filePath = await createFile();
     await new ExCommandLine(`tabe ${filePath}`, modeHandler.vimState.currentMode).run(
       modeHandler.vimState,
     );
@@ -55,7 +55,7 @@ suite('cmd_line tab', () => {
   });
 
   test('tabe with current file path does nothing', async () => {
-    const filePath = await createRandomFile('', '');
+    const filePath = await createFile();
     await new ExCommandLine(`tabe ${filePath}`, modeHandler.vimState.currentMode).run(
       modeHandler.vimState,
     );

--- a/test/cmd_line/tabCompletion.test.ts
+++ b/test/cmd_line/tabCompletion.test.ts
@@ -99,7 +99,7 @@ suite('cmd_line tabComplete', () => {
   });
 
   test('command line file tab completion directory with / at the end', async () => {
-    const dirPath = await t.createRandomDir();
+    const dirPath = await t.createDir();
 
     try {
       const baseCmd = `:e ${dirPath.slice(0, -1)}`.split('');
@@ -120,7 +120,7 @@ suite('cmd_line tabComplete', () => {
   test('command line file navigate tab completion', async () => {
     // tmpDir --- inner0
     //         |- inner1 --- inner10 --- inner100
-    const tmpDir = await t.createRandomDir();
+    const tmpDir = await t.createDir();
     const inner0 = await t.createDir(join(tmpDir, 'inner0'));
     const inner1 = await t.createDir(join(tmpDir, 'inner1'));
     const inner10 = await t.createDir(join(inner1, 'inner10'));
@@ -191,8 +191,8 @@ suite('cmd_line tabComplete', () => {
   });
 
   test('command line file tab completion with .', async () => {
-    const dirPath = await t.createRandomDir();
-    const testFilePath = await t.createEmptyFile(join(dirPath, '.testfile'));
+    const dirPath = await t.createDir();
+    const testFilePath = await t.createFile({ fsPath: join(dirPath, '.testfile') });
 
     try {
       // There should only be one auto-completion
@@ -239,7 +239,7 @@ suite('cmd_line tabComplete', () => {
 
   test('command line file tab completion with space in file path', async () => {
     // Create an random file in temp folder with a space in the file name
-    const spacedFilePath = await t.createRandomFile('', 'vscode-vim completion-test');
+    const spacedFilePath = await t.createFile({ fileExtension: 'vscode-vim completion-test' });
     try {
       // Get the base name of the path which is <random name>vscode-vim completion-test
       const baseName = basename(spacedFilePath);
@@ -277,8 +277,8 @@ suite('cmd_line tabComplete', () => {
   });
 
   test('command line file tab completion case-sensitivity platform dependent', async () => {
-    const dirPath = await t.createRandomDir();
-    const filePath = await t.createEmptyFile(join(dirPath, 'testfile'));
+    const dirPath = await t.createDir();
+    const filePath = await t.createFile({ fsPath: join(dirPath, 'testfile') });
     const fileAsTyped = join(dirPath, 'TESTFIL');
     const cmd = `:e ${fileAsTyped}`.split('');
 

--- a/test/cmd_line/undo.test.ts
+++ b/test/cmd_line/undo.test.ts
@@ -1,7 +1,7 @@
 import { getAndUpdateModeHandler } from '../../extension';
 import { ExCommandLine } from '../../src/cmd_line/commandLine';
 import { ModeHandler } from '../../src/mode/modeHandler';
-import { assertEqualLines, cleanUpWorkspace, setupWorkspace } from '../testUtils';
+import { assertEqualLines, setupWorkspace } from '../testUtils';
 
 suite('Undo command', () => {
   let modeHandler: ModeHandler;
@@ -10,8 +10,6 @@ suite('Undo command', () => {
     await setupWorkspace();
     modeHandler = (await getAndUpdateModeHandler())!;
   });
-
-  teardown(cleanUpWorkspace);
 
   test('undoes last action after insert mode', async () => {
     await modeHandler.handleMultipleKeyEvents(['i', 'a', '<Esc>']);

--- a/test/cmd_line/vsplit.test.ts
+++ b/test/cmd_line/vsplit.test.ts
@@ -4,7 +4,7 @@ import * as vscode from 'vscode';
 import { getAndUpdateModeHandler } from '../../extension';
 import { ExCommandLine } from '../../src/cmd_line/commandLine';
 import { ModeHandler } from '../../src/mode/modeHandler';
-import { cleanUpWorkspace, setupWorkspace, waitForEditorsToClose } from './../testUtils';
+import { setupWorkspace, waitForEditorsToClose } from './../testUtils';
 
 suite('Vertical split', () => {
   let modeHandler: ModeHandler;
@@ -13,8 +13,6 @@ suite('Vertical split', () => {
     await setupWorkspace();
     modeHandler = (await getAndUpdateModeHandler())!;
   });
-
-  teardown(cleanUpWorkspace);
 
   for (const cmd of ['vs', 'vsp', 'vsplit', 'vnew', 'vne']) {
     test(`:${cmd} creates a second split`, async () => {

--- a/test/cmd_line/yank.test.ts
+++ b/test/cmd_line/yank.test.ts
@@ -1,10 +1,6 @@
 import { newTest } from '../testSimplifier';
-import { cleanUpWorkspace, setupWorkspace } from '../testUtils';
 
 suite(':[range]y[ank] [count] command', () => {
-  suiteSetup(setupWorkspace);
-  suiteTeardown(cleanUpWorkspace);
-
   newTest({
     title: ':yank will yank a single line',
     start: ['|one', 'two', 'three'],

--- a/test/configuration/configuration.test.ts
+++ b/test/configuration/configuration.test.ts
@@ -1,7 +1,7 @@
 import * as assert from 'assert';
 import * as srcConfiguration from '../../src/configuration/configuration';
 import * as vscode from 'vscode';
-import { cleanUpWorkspace, setupWorkspace } from './../testUtils';
+import { setupWorkspace } from './../testUtils';
 import { Mode } from '../../src/mode/mode';
 import { newTest } from '../testSimplifier';
 import { IConfiguration } from '../../src/configuration/iconfiguration';
@@ -25,8 +25,6 @@ suite('Configuration', () => {
   setup(async () => {
     await setupWorkspace({ config: testConfig });
   });
-
-  teardown(cleanUpWorkspace);
 
   test('remappings are normalized', async () => {
     const normalizedKeybinds = srcConfiguration.configuration.normalModeKeyBindingsNonRecursive;

--- a/test/configuration/remapper.test.ts
+++ b/test/configuration/remapper.test.ts
@@ -10,7 +10,7 @@ import { IRegisterContent, Register } from '../../src/register/register';
 import { VimState } from '../../src/state/vimState';
 import { StatusBar } from '../../src/statusBar';
 import { Configuration } from '../testConfiguration';
-import { assertEqualLines, cleanUpWorkspace, setupWorkspace } from '../testUtils';
+import { assertEqualLines, setupWorkspace } from '../testUtils';
 
 suite('Remapper', () => {
   let modeHandler: ModeHandler;
@@ -114,8 +114,6 @@ suite('Remapper', () => {
     modeHandler = (await getAndUpdateModeHandler())!;
     vimState = modeHandler.vimState;
   };
-
-  teardown(cleanUpWorkspace);
 
   test('getLongestedRemappedKeySequence', async () => {
     // setup

--- a/test/configuration/remaps.test.ts
+++ b/test/configuration/remaps.test.ts
@@ -2,7 +2,7 @@ import { getAndUpdateModeHandler } from '../../extension';
 import { Mode } from '../../src/mode/mode';
 import { ModeHandler } from '../../src/mode/modeHandler';
 import { newTestWithRemaps, newTestWithRemapsSkip } from '../testSimplifier';
-import { cleanUpWorkspace, setupWorkspace } from '../testUtils';
+import { setupWorkspace } from '../testUtils';
 
 suite('Remaps', () => {
   let modeHandler: ModeHandler;
@@ -20,8 +20,6 @@ suite('Remaps', () => {
     });
     modeHandler = (await getAndUpdateModeHandler())!;
   });
-
-  teardown(cleanUpWorkspace);
 
   newTestWithRemaps({
     title: 'Can handle ambiguous remaps on different recursiveness mappings',

--- a/test/jumpTracker.test.ts
+++ b/test/jumpTracker.test.ts
@@ -3,13 +3,12 @@ import * as vscode from 'vscode';
 
 import { Jump } from './../src/jumps/jump';
 import { JumpTracker } from '../src/jumps/jumpTracker';
-import { cleanUpWorkspace, setupWorkspace } from './testUtils';
+import { setupWorkspace } from './testUtils';
 import { Position } from 'vscode';
 import { ITestObject, newTest, newTestSkip } from './testSimplifier';
 
 suite('Record and navigate jumps', () => {
   suiteSetup(setupWorkspace);
-  suiteTeardown(cleanUpWorkspace);
 
   const newJumpTest = (options: ITestObject | Omit<ITestObject, 'title'>) => {
     return newTest({

--- a/test/macro.test.ts
+++ b/test/macro.test.ts
@@ -1,6 +1,6 @@
 import { Mode } from '../src/mode/mode';
 import { newTest, newTestWithRemaps } from './testSimplifier';
-import { cleanUpWorkspace, setupWorkspace } from './testUtils';
+import { setupWorkspace } from './testUtils';
 
 suite('Record and execute a macro', () => {
   setup(async () => {
@@ -11,7 +11,6 @@ suite('Record and execute a macro', () => {
       },
     });
   });
-  teardown(cleanUpWorkspace);
 
   newTest({
     title: 'Can record and execute',

--- a/test/marks.test.ts
+++ b/test/marks.test.ts
@@ -25,7 +25,8 @@ suite('Marks', () => {
     return (await getAndUpdateModeHandler())!;
   };
 
-  test(`Capital marks can change the editor's active document`, async () => {
+  // TODO: Skipped
+  test.skip(`Capital marks can change the editor's active document`, async () => {
     const firstDocumentName = vscode.window.activeTextEditor!.document.fileName;
     await modeHandler.handleMultipleKeyEvents('mA'.split(''));
 

--- a/test/mode/modeInsert.test.ts
+++ b/test/mode/modeInsert.test.ts
@@ -4,12 +4,7 @@ import * as vscode from 'vscode';
 import { getAndUpdateModeHandler } from '../../extension';
 import { Mode } from '../../src/mode/mode';
 import { ModeHandler } from '../../src/mode/modeHandler';
-import {
-  assertEqualLines,
-  cleanUpWorkspace,
-  setupWorkspace,
-  reloadConfiguration,
-} from './../testUtils';
+import { assertEqualLines, setupWorkspace, reloadConfiguration } from './../testUtils';
 import { Globals } from '../../src/globals';
 import { newTest } from '../testSimplifier';
 
@@ -20,8 +15,6 @@ suite('Mode Insert', () => {
     await setupWorkspace();
     modeHandler = (await getAndUpdateModeHandler())!;
   });
-
-  teardown(cleanUpWorkspace);
 
   test('can be activated', async () => {
     const activationKeys = ['o', 'I', 'i', 'O', 'a', 'A', '<Insert>'];

--- a/test/mode/modeNormal.test.ts
+++ b/test/mode/modeNormal.test.ts
@@ -2778,6 +2778,8 @@ suite('Mode Normal', () => {
     // TODO: test with untitled file
     // TODO: test [count]<C-g>
 
+    suiteSetup(cleanUpWorkspace);
+
     newTest({
       title: '<C-g> displays info about the file in status bar (line 1 of 3)',
       start: ['o|ne', 'two', 'three'],

--- a/test/mode/modeReplace.test.ts
+++ b/test/mode/modeReplace.test.ts
@@ -1,11 +1,7 @@
 import { Mode } from '../../src/mode/mode';
 import { newTest } from '../testSimplifier';
-import { cleanUpWorkspace, setupWorkspace } from './../testUtils';
 
 suite('Mode Replace', () => {
-  suiteSetup(setupWorkspace);
-  suiteTeardown(cleanUpWorkspace);
-
   newTest({
     title: 'Can activate with <Insert> from Insert mode',
     start: ['|'],

--- a/test/mode/modeVisual.test.ts
+++ b/test/mode/modeVisual.test.ts
@@ -5,12 +5,7 @@ import { Globals } from '../../src/globals';
 import { Mode } from '../../src/mode/mode';
 import { ModeHandler } from '../../src/mode/modeHandler';
 import { newTest, newTestSkip } from '../testSimplifier';
-import {
-  assertEqualLines,
-  cleanUpWorkspace,
-  reloadConfiguration,
-  setupWorkspace,
-} from './../testUtils';
+import { assertEqualLines, reloadConfiguration, setupWorkspace } from './../testUtils';
 
 suite('Mode Visual', () => {
   let modeHandler: ModeHandler;
@@ -19,8 +14,6 @@ suite('Mode Visual', () => {
     await setupWorkspace();
     modeHandler = (await getAndUpdateModeHandler())!;
   });
-
-  teardown(cleanUpWorkspace);
 
   test('can be activated', async () => {
     await modeHandler.handleKeyEvent('v');

--- a/test/mode/modeVisualBlock.test.ts
+++ b/test/mode/modeVisualBlock.test.ts
@@ -4,7 +4,7 @@ import * as assert from 'assert';
 import { getAndUpdateModeHandler } from '../../extension';
 import { Mode } from '../../src/mode/mode';
 import { ModeHandler } from '../../src/mode/modeHandler';
-import { assertEqualLines, cleanUpWorkspace, setupWorkspace } from './../testUtils';
+import { assertEqualLines, setupWorkspace } from './../testUtils';
 import { newTest } from '../testSimplifier';
 
 suite('VisualBlock mode', () => {
@@ -14,8 +14,6 @@ suite('VisualBlock mode', () => {
     await setupWorkspace();
     modeHandler = (await getAndUpdateModeHandler())!;
   });
-
-  teardown(cleanUpWorkspace);
 
   test('can be activated', async () => {
     modeHandler.vimState.editor = vscode.window.activeTextEditor!;

--- a/test/mode/modeVisualLine.test.ts
+++ b/test/mode/modeVisualLine.test.ts
@@ -4,7 +4,7 @@ import { getAndUpdateModeHandler } from '../../extension';
 import { Mode } from '../../src/mode/mode';
 import { ModeHandler } from '../../src/mode/modeHandler';
 import { newTest } from '../testSimplifier';
-import { assertEqualLines, cleanUpWorkspace, setupWorkspace } from './../testUtils';
+import { assertEqualLines, setupWorkspace } from './../testUtils';
 
 suite('Mode Visual Line', () => {
   let modeHandler: ModeHandler;
@@ -13,8 +13,6 @@ suite('Mode Visual Line', () => {
     await setupWorkspace();
     modeHandler = (await getAndUpdateModeHandler())!;
   });
-
-  teardown(cleanUpWorkspace);
 
   test('can be activated', async () => {
     await modeHandler.handleKeyEvent('V');

--- a/test/mode/normalModeTests/commands.test.ts
+++ b/test/mode/normalModeTests/commands.test.ts
@@ -1,11 +1,7 @@
 import { Mode } from '../../../src/mode/mode';
 import { newTest } from '../../testSimplifier';
-import { cleanUpWorkspace, setupWorkspace } from '../../testUtils';
 
 suite('Mode Normal', () => {
-  suiteSetup(setupWorkspace);
-  suiteTeardown(cleanUpWorkspace);
-
   newTest({
     title: "Can handle 'x'",
     start: ['te|xt'],

--- a/test/mode/normalModeTests/dot.test.ts
+++ b/test/mode/normalModeTests/dot.test.ts
@@ -1,7 +1,6 @@
 import { Mode } from '../../../src/mode/mode';
-import { Configuration } from '../../testConfiguration';
 import { newTest } from '../../testSimplifier';
-import { cleanUpWorkspace, setupWorkspace } from './../../testUtils';
+import { setupWorkspace } from './../../testUtils';
 
 suite('Dot Operator', () => {
   suiteSetup(async () => {
@@ -12,7 +11,6 @@ suite('Dot Operator', () => {
       },
     });
   });
-  suiteTeardown(cleanUpWorkspace);
 
   newTest({
     title: "Can repeat '~' with <num>",
@@ -73,7 +71,6 @@ suite('Repeat content change', () => {
       },
     });
   });
-  suiteTeardown(cleanUpWorkspace);
 
   newTest({
     title: 'Can repeat `<BS>`',
@@ -256,7 +253,7 @@ suite('Repeat content change', () => {
 });
 
 suite('Dot Operator repeat with remap', () => {
-  setup(async () => {
+  suiteSetup(async () => {
     await setupWorkspace({
       config: {
         insertModeKeyBindings: [
@@ -275,8 +272,6 @@ suite('Dot Operator repeat with remap', () => {
       },
     });
   });
-
-  teardown(cleanUpWorkspace);
 
   newTest({
     title: "Can repeat content change using 'jjk' mapped to '<Esc>' without trailing characters",

--- a/test/mode/normalModeTests/matchingBracket.test.ts
+++ b/test/mode/normalModeTests/matchingBracket.test.ts
@@ -1,9 +1,8 @@
 import { newTest } from '../../testSimplifier';
-import { cleanUpWorkspace, setupWorkspace } from './../../testUtils';
+import { setupWorkspace } from './../../testUtils';
 
 suite('Matching Bracket (%)', () => {
   suiteSetup(setupWorkspace);
-  suiteTeardown(cleanUpWorkspace);
 
   newTest({
     title: 'before opening parenthesis',

--- a/test/mode/normalModeTests/motionMatchpairs.test.ts
+++ b/test/mode/normalModeTests/motionMatchpairs.test.ts
@@ -1,12 +1,10 @@
 import { newTest } from '../../testSimplifier';
-import { cleanUpWorkspace, setupWorkspace } from './../../testUtils';
+import { setupWorkspace } from './../../testUtils';
 
 suite('matchpair empty', () => {
   setup(async () => {
     await setupWorkspace({ config: { matchpairs: '' } });
   });
-
-  teardown(cleanUpWorkspace);
 
   newTest({
     title: "basic motion doesn't work",
@@ -20,7 +18,6 @@ suite('matchpairs enabled', () => {
   suiteSetup(async () => {
     await setupWorkspace({ config: { matchpairs: '<:>' } });
   });
-  suiteTeardown(cleanUpWorkspace);
 
   suite('Tests for % with matchpairs', () => {
     newTest({

--- a/test/mode/normalModeTests/motions.test.ts
+++ b/test/mode/normalModeTests/motions.test.ts
@@ -1,10 +1,9 @@
-import { cleanUpWorkspace, setupWorkspace } from './../../testUtils';
+import { setupWorkspace } from './../../testUtils';
 import { Mode } from '../../../src/mode/mode';
 import { newTest, newTestSkip } from '../../testSimplifier';
 
 suite('Motions in Normal Mode', () => {
   suiteSetup(setupWorkspace);
-  suiteTeardown(cleanUpWorkspace);
 
   suite('w', () => {
     newTest({

--- a/test/mode/normalModeTests/undo.test.ts
+++ b/test/mode/normalModeTests/undo.test.ts
@@ -1,9 +1,8 @@
 import { newTest, newTestSkip } from '../../testSimplifier';
-import { cleanUpWorkspace, setupWorkspace } from '../../testUtils';
+import { setupWorkspace } from '../../testUtils';
 
 suite('Undo', () => {
   suiteSetup(setupWorkspace);
-  suiteTeardown(cleanUpWorkspace);
 
   suite('u', () => {
     newTest({

--- a/test/motion.test.ts
+++ b/test/motion.test.ts
@@ -3,7 +3,7 @@ import { Position, window } from 'vscode';
 import { getCurrentParagraphBeginning, getCurrentParagraphEnd } from '../src/textobject/paragraph';
 import { WordType } from '../src/textobject/word';
 import { TextEditor } from './../src/textEditor';
-import { cleanUpWorkspace, setupWorkspace } from './testUtils';
+import { setupWorkspace } from './testUtils';
 
 suite('basic motion', () => {
   const text: string[] = ['mary had', 'a', 'little lamb', ' whose fleece was '];
@@ -14,7 +14,6 @@ suite('basic motion', () => {
       editBuilder.insert(new Position(0, 0), text.join('\n'));
     });
   });
-  suiteTeardown(cleanUpWorkspace);
 
   test('char right: should move one column right', () => {
     const position = new Position(0, 0);
@@ -153,7 +152,6 @@ suite('word motion', () => {
       editBuilder.insert(new Position(0, 0), text.join('\n'));
     });
   });
-  suiteTeardown(cleanUpWorkspace);
 
   suite('word right', () => {
     test('move to word right', () => {
@@ -397,7 +395,6 @@ suite('unicode word motion', () => {
       editBuilder.insert(new Position(0, 0), text.join('\n'));
     });
   });
-  suiteTeardown(cleanUpWorkspace);
 
   suite('word right', () => {
     test('move cursor word right stops at different kind of character (ideograph -> hiragana)', () => {
@@ -502,7 +499,6 @@ suite('sentence motion', () => {
       editBuilder.insert(new Position(0, 0), text.join('\n'));
     });
   });
-  suiteTeardown(cleanUpWorkspace);
 
   suite('sentence forward', () => {
     test('next concrete sentence', () => {
@@ -616,7 +612,6 @@ suite('paragraph motion', () => {
       editBuilder.insert(new Position(0, 0), text.join('\n'));
     });
   });
-  suiteTeardown(cleanUpWorkspace);
 
   suite('paragraph down', () => {
     test('move down normally', () => {

--- a/test/motionLineWrapping.test.ts
+++ b/test/motionLineWrapping.test.ts
@@ -1,9 +1,7 @@
 import { newTest } from './testSimplifier';
-import { cleanUpWorkspace, setupWorkspace } from './testUtils';
+import { setupWorkspace } from './testUtils';
 
 suite('motion line wrapping', () => {
-  suiteTeardown(cleanUpWorkspace);
-
   suite('whichwrap enabled', () => {
     suiteSetup(async () => {
       await setupWorkspace({

--- a/test/multicursor.test.ts
+++ b/test/multicursor.test.ts
@@ -1,7 +1,7 @@
 import * as assert from 'assert';
 import { getAndUpdateModeHandler } from '../extension';
 import { ModeHandler } from '../src/mode/modeHandler';
-import { assertEqualLines, cleanUpWorkspace, setupWorkspace } from './testUtils';
+import { assertEqualLines, setupWorkspace } from './testUtils';
 import { newTest } from './testSimplifier';
 
 suite('Multicursor', () => {
@@ -11,8 +11,6 @@ suite('Multicursor', () => {
     await setupWorkspace();
     modeHandler = (await getAndUpdateModeHandler())!;
   });
-
-  teardown(cleanUpWorkspace);
 
   test('can add multiple cursors below', async () => {
     await modeHandler.handleMultipleKeyEvents('i11\n22'.split(''));
@@ -133,8 +131,6 @@ suite('Multicursor with remaps', () => {
     });
   });
 
-  teardown(cleanUpWorkspace);
-
   newTest({
     title: "Using 'jjk' mapped to '<Esc>' doesn't leave trailing characters",
     start: ['o|ne', 'two'],
@@ -157,8 +153,6 @@ suite('Multicursor selections', () => {
       },
     });
   });
-
-  teardown(cleanUpWorkspace);
 
   newTest({
     title:

--- a/test/normalCommand.test.ts
+++ b/test/normalCommand.test.ts
@@ -1,11 +1,6 @@
 import { newTest, newTestSkip } from './testSimplifier';
-import { cleanUpWorkspace, setupWorkspace } from './testUtils';
 
 suite('Execute normal command', () => {
-  setup(setupWorkspace);
-
-  teardown(cleanUpWorkspace);
-
   newTest({
     title: 'One liner',
     start: ['foo =| bar = 1'],

--- a/test/number/incrementDecrement.test.ts
+++ b/test/number/incrementDecrement.test.ts
@@ -1,11 +1,7 @@
 import { Mode } from '../../src/mode/mode';
 import { newTest } from '../testSimplifier';
-import { setupWorkspace, cleanUpWorkspace } from '../testUtils';
 
 suite('Increment/decrement (<C-a> and <C-x>)', () => {
-  suiteSetup(setupWorkspace);
-  suiteTeardown(cleanUpWorkspace);
-
   newTest({
     title: 'can ctrl-a correctly behind a word',
     start: ['|one 9'],

--- a/test/operator/comment.test.ts
+++ b/test/operator/comment.test.ts
@@ -1,12 +1,11 @@
 import { Mode } from '../../src/mode/mode';
 import { newTest } from '../testSimplifier';
-import { cleanUpWorkspace, setupWorkspace } from './../testUtils';
+import { setupWorkspace } from './../testUtils';
 
 suite('comment operator', () => {
   suiteSetup(async () => {
     await setupWorkspace({ fileExtension: '.js' });
   });
-  suiteTeardown(cleanUpWorkspace);
 
   newTest({
     title: 'gcc comments out current line',

--- a/test/operator/filter.test.ts
+++ b/test/operator/filter.test.ts
@@ -1,14 +1,10 @@
 import { newTest } from '../testSimplifier';
-import { cleanUpWorkspace, setupWorkspace } from '../testUtils';
 
 // TODO(#4844): this fails on Windows
 suite('filter operator', () => {
   if (process.platform === 'win32') {
     return;
   }
-
-  suiteSetup(setupWorkspace);
-  suiteTeardown(cleanUpWorkspace);
 
   newTest({
     title: '!! with no count',

--- a/test/operator/format.test.ts
+++ b/test/operator/format.test.ts
@@ -1,11 +1,10 @@
 import { newTest } from '../testSimplifier';
-import { cleanUpWorkspace, setupWorkspace } from './../testUtils';
+import { setupWorkspace } from './../testUtils';
 
 suite('format operator', () => {
   suiteSetup(async () => {
     await setupWorkspace({ fileExtension: '.ts' });
   });
-  suiteTeardown(cleanUpWorkspace);
 
   newTest({
     title: '== formats current line',

--- a/test/operator/put.test.ts
+++ b/test/operator/put.test.ts
@@ -1,10 +1,6 @@
 import { newTest } from '../testSimplifier';
-import { cleanUpWorkspace, setupWorkspace } from '../testUtils';
 
 suite('put operator', () => {
-  suiteSetup(setupWorkspace);
-  suiteTeardown(cleanUpWorkspace);
-
   suite('p', () => {
     suite('Normal mode', () => {
       newTest({

--- a/test/operator/rot13.test.ts
+++ b/test/operator/rot13.test.ts
@@ -1,13 +1,9 @@
 import * as assert from 'assert';
 
-import { setupWorkspace, cleanUpWorkspace } from '../testUtils';
 import { ROT13Operator } from '../../src/actions/operator';
 import { newTest } from '../testSimplifier';
 
 suite('rot13 operator', () => {
-  suiteSetup(setupWorkspace);
-  suiteTeardown(cleanUpWorkspace);
-
   test('rot13() unit test', () => {
     const testCases = [
       ['abcdefghijklmnopqrstuvwxyz', 'nopqrstuvwxyzabcdefghijklm'],

--- a/test/operator/shift.test.ts
+++ b/test/operator/shift.test.ts
@@ -1,9 +1,8 @@
 import { newTest } from '../testSimplifier';
-import { cleanUpWorkspace, setupWorkspace } from '../testUtils';
+import { setupWorkspace } from '../testUtils';
 
 suite('shift operator', () => {
   suiteSetup(setupWorkspace);
-  suiteTeardown(cleanUpWorkspace);
 
   newTest({
     title: 'basic shift left test',

--- a/test/operator/surrogate.test.ts
+++ b/test/operator/surrogate.test.ts
@@ -1,10 +1,6 @@
 import { newTest } from '../testSimplifier';
-import { cleanUpWorkspace, setupWorkspace } from './../testUtils';
 
 suite('surrogate-pair', () => {
-  suiteSetup(setupWorkspace);
-  suiteTeardown(cleanUpWorkspace);
-
   newTest({
     title: 'yank single hokke',
     start: ['|𩸽'],

--- a/test/plugins/camelCaseMotion.test.ts
+++ b/test/plugins/camelCaseMotion.test.ts
@@ -1,11 +1,10 @@
-import { cleanUpWorkspace, setupWorkspace } from './../testUtils';
+import { setupWorkspace } from './../testUtils';
 import { newTest } from '../testSimplifier';
 
 suite('camelCaseMotion plugin if not enabled', () => {
   suiteSetup(async () => {
     await setupWorkspace({ config: { camelCaseMotion: { enable: false } } });
   });
-  suiteTeardown(cleanUpWorkspace);
 
   newTest({
     title: "basic motion doesn't work",
@@ -19,7 +18,6 @@ suite('camelCaseMotion plugin', () => {
   suiteSetup(async () => {
     await setupWorkspace({ config: { camelCaseMotion: { enable: true } } });
   });
-  suiteTeardown(cleanUpWorkspace);
 
   suite('handles <leader>w for camelCaseText', () => {
     newTest({

--- a/test/plugins/easymotion.test.ts
+++ b/test/plugins/easymotion.test.ts
@@ -3,7 +3,7 @@ import {
   EasymotionTrigger,
 } from '../../src/actions/plugins/easymotion/easymotion.cmd';
 import { newTest } from '../testSimplifier';
-import { cleanUpWorkspace, setupWorkspace } from './../testUtils';
+import { setupWorkspace } from './../testUtils';
 
 function easymotionCommand(trigger: EasymotionTrigger, searchWord: string, jumpKey: string) {
   return [...buildTriggerKeys(trigger), searchWord, jumpKey].join('');
@@ -15,7 +15,6 @@ suite('easymotion plugin', () => {
       config: { easymotion: true },
     });
   });
-  suiteTeardown(cleanUpWorkspace);
 
   newTest({
     title: 'Can handle s move',

--- a/test/plugins/imswitcher.test.ts
+++ b/test/plugins/imswitcher.test.ts
@@ -1,7 +1,7 @@
 import * as assert from 'assert';
 import { InputMethodSwitcher } from '../../src/actions/plugins/imswitcher';
 import { Mode } from '../../src/mode/mode';
-import { cleanUpWorkspace, setupWorkspace } from '../testUtils';
+import { setupWorkspace } from '../testUtils';
 
 suite('Input method plugin', () => {
   let savedCmd = '';
@@ -40,8 +40,6 @@ suite('Input method plugin', () => {
       },
     });
   });
-
-  teardown(cleanUpWorkspace);
 
   test('use default im in insert mode', async () => {
     savedCmd = '';

--- a/test/plugins/lastNextObject.test.ts
+++ b/test/plugins/lastNextObject.test.ts
@@ -1,5 +1,5 @@
 import { newTest } from '../testSimplifier';
-import { cleanUpWorkspace, setupWorkspace } from '../testUtils';
+import { setupWorkspace } from '../testUtils';
 
 suite('lastNextObject plugin', () => {
   suite('lastNextObject plugin disabled', () => {
@@ -8,7 +8,7 @@ suite('lastNextObject plugin', () => {
         fileExtension: '.js',
       });
     });
-    suiteTeardown(cleanUpWorkspace);
+
     // test next
     newTest({
       title: "next object - should not work as it's disabled",
@@ -46,7 +46,7 @@ suite('lastNextObject plugin', () => {
         fileExtension: '.js',
       });
     });
-    suiteTeardown(cleanUpWorkspace);
+
     // test next
     newTest({
       title: 'next object - 1',

--- a/test/plugins/replaceWithRegister.test.ts
+++ b/test/plugins/replaceWithRegister.test.ts
@@ -1,6 +1,6 @@
 import { Globals } from '../../src/globals';
 import { newTest } from '../testSimplifier';
-import { cleanUpWorkspace, setupWorkspace, reloadConfiguration } from '../testUtils';
+import { setupWorkspace, reloadConfiguration } from '../testUtils';
 
 suite('replaceWithRegister plugin', () => {
   const YankInnerWord = 'yiw';
@@ -11,7 +11,6 @@ suite('replaceWithRegister plugin', () => {
     Globals.mockConfiguration.replaceWithRegister = true;
     await reloadConfiguration();
   });
-  suiteTeardown(cleanUpWorkspace);
 
   newTest({
     title: 'Replaces within inner word',

--- a/test/plugins/smartQuotes.test.ts
+++ b/test/plugins/smartQuotes.test.ts
@@ -1,5 +1,5 @@
 import { newTest } from '../testSimplifier';
-import { cleanUpWorkspace, setupWorkspace } from '../testUtils';
+import { setupWorkspace } from '../testUtils';
 
 suite('smartQuotes plugin', () => {
   suite('smartQuotes.breakThroughLines = false', () => {
@@ -19,7 +19,7 @@ suite('smartQuotes plugin', () => {
         fileExtension: '.js',
       });
     });
-    suiteTeardown(cleanUpWorkspace);
+
     // test quotes types
     newTest({
       title: 'single quote - 1',
@@ -733,7 +733,6 @@ suite('smartQuotes plugin', () => {
         fileExtension: '.js',
       });
     });
-    suiteTeardown(cleanUpWorkspace);
 
     // test next
     newTest({

--- a/test/plugins/sneak.test.ts
+++ b/test/plugins/sneak.test.ts
@@ -1,6 +1,6 @@
 import { Globals } from '../../src/globals';
 import { newTest } from '../testSimplifier';
-import { cleanUpWorkspace, setupWorkspace, reloadConfiguration } from './../testUtils';
+import { setupWorkspace, reloadConfiguration } from './../testUtils';
 
 suite('sneak plugin', () => {
   suiteSetup(async () => {
@@ -8,7 +8,6 @@ suite('sneak plugin', () => {
     Globals.mockConfiguration.sneak = true;
     await reloadConfiguration();
   });
-  suiteTeardown(cleanUpWorkspace);
 
   newTest({
     title: 'Can handle s motion',
@@ -165,7 +164,6 @@ suite('sneakReplacesF', () => {
     Globals.mockConfiguration.sneakReplacesF = true;
     await reloadConfiguration();
   });
-  suiteTeardown(cleanUpWorkspace);
 
   newTest({
     title: 'sneakReplacesF forward',

--- a/test/plugins/surround.test.ts
+++ b/test/plugins/surround.test.ts
@@ -1,4 +1,4 @@
-import { cleanUpWorkspace, setupWorkspace } from './../testUtils';
+import { setupWorkspace } from './../testUtils';
 import { newTest } from '../testSimplifier';
 import {
   CommandSurroundAddSurroundingFunction,
@@ -14,7 +14,6 @@ suite('surround plugin', () => {
       fileExtension: '.js',
     });
   });
-  suiteTeardown(cleanUpWorkspace);
 
   newTest({
     title: "'ysiw)' surrounds word without space",

--- a/test/register/register.test.ts
+++ b/test/register/register.test.ts
@@ -9,7 +9,7 @@ import { RecordedState } from '../../src/state/recordedState';
 import { VimState } from '../../src/state/vimState';
 import { Clipboard } from '../../src/util/clipboard';
 import { newTest } from '../testSimplifier';
-import { assertEqualLines, cleanUpWorkspace, setupWorkspace } from '../testUtils';
+import { assertEqualLines, setupWorkspace } from '../testUtils';
 
 suite('register', () => {
   let modeHandler: ModeHandler;
@@ -18,8 +18,6 @@ suite('register', () => {
     await setupWorkspace();
     modeHandler = (await getAndUpdateModeHandler())!;
   });
-
-  teardown(cleanUpWorkspace);
 
   suite('clipboard', () => {
     setup(async () => {

--- a/test/register/repeatableMovement.test.ts
+++ b/test/register/repeatableMovement.test.ts
@@ -1,10 +1,6 @@
 import { newTest } from '../testSimplifier';
-import { cleanUpWorkspace, setupWorkspace } from '../testUtils';
 
 suite('Repeatable movements with f and t', () => {
-  suiteSetup(setupWorkspace);
-  suiteTeardown(cleanUpWorkspace);
-
   newTest({
     title: 'Can repeat f<character>',
     start: ['|abc abc abc'],

--- a/test/search/search.test.ts
+++ b/test/search/search.test.ts
@@ -1,11 +1,7 @@
 import { Mode } from '../../src/mode/mode';
 import { newTest } from '../testSimplifier';
-import { setupWorkspace, cleanUpWorkspace } from '../testUtils';
 
 suite('Search (/ and ?)', () => {
-  suiteSetup(setupWorkspace);
-  suiteTeardown(cleanUpWorkspace);
-
   newTest({
     title: '/ does not affect mark',
     start: ['|one', 'twooo', 'thurr'],

--- a/test/search/searchTextObject.test.ts
+++ b/test/search/searchTextObject.test.ts
@@ -3,7 +3,7 @@ import { getAndUpdateModeHandler } from '../../extensionBase';
 import { Mode } from '../../src/mode/mode';
 import { ModeHandler } from '../../src/mode/modeHandler';
 import { newTest } from '../testSimplifier';
-import { cleanUpWorkspace, setupWorkspace } from '../testUtils';
+import { setupWorkspace } from '../testUtils';
 
 suite('Search text objects (gn and gN)', () => {
   let modeHandler: ModeHandler;
@@ -12,7 +12,6 @@ suite('Search text objects (gn and gN)', () => {
     await setupWorkspace();
     modeHandler = (await getAndUpdateModeHandler())!;
   });
-  teardown(cleanUpWorkspace);
 
   suite('can handle gn', () => {
     test(`gn selects the next match text`, async () => {

--- a/test/sentenceMotion.test.ts
+++ b/test/sentenceMotion.test.ts
@@ -1,11 +1,10 @@
 import { newTest } from './testSimplifier';
-import { cleanUpWorkspace, setupWorkspace } from './testUtils';
+import { setupWorkspace } from './testUtils';
 
 suite('sentence motion', () => {
   suiteSetup(async () => {
     await setupWorkspace({ fileExtension: '.js' });
   });
-  suiteTeardown(cleanUpWorkspace);
 
   suite('[count] sentences backward', () => {
     newTest({

--- a/test/testSimplifier.ts
+++ b/test/testSimplifier.ts
@@ -15,7 +15,7 @@ import { Register } from '../src/register/register';
 import { globalState } from '../src/state/globalState';
 import { StatusBar } from '../src/statusBar';
 import { TextEditor } from '../src/textEditor';
-import { assertEqualLines, reloadConfiguration } from './testUtils';
+import { assertEqualLines, reloadConfiguration, setupWorkspace } from './testUtils';
 
 function newTestGeneric<T extends ITestObject | ITestWithRemapsObject>(
   testObj: T,
@@ -194,6 +194,12 @@ function tokenizeKeySequence(sequence: string): string[] {
 }
 
 async function testIt(testObj: ITestObject): Promise<ModeHandler> {
+  if (vscode.window.activeTextEditor === undefined) {
+    await setupWorkspace({
+      config: testObj.config,
+    });
+  }
+
   const editor = vscode.window.activeTextEditor;
   assert(editor, 'Expected an active editor');
 
@@ -212,9 +218,10 @@ async function testIt(testObj: ITestObject): Promise<ModeHandler> {
         start.lines.join('\n'),
       );
     }),
+    'Edit failed',
   );
   if (testObj.saveDocBeforeTest) {
-    assert.ok(await editor.document.save());
+    assert.ok(await editor.document.save(), 'Save failed');
   }
   editor.selections = [new vscode.Selection(start.cursor, start.cursor)];
 


### PR DESCRIPTION
The main change here is that `setupWorkspace` will try to re-use an existing editor rather than create a new one. `setupWorkspace` also does more cleanup, so manual teardown is rarely necessary. Similarly, `testIt` calls `setupWorkspace` if there's no editor, so manual setup is often unnecessary. There's some flakiness and more jank than I'd like, so this is WIP...