### PR TITLE
feat: use vscode native nav back to avoid surpurise and inconsistency

### DIFF
--- a/src/actions/commands/actions.ts
+++ b/src/actions/commands/actions.ts
@@ -1286,9 +1286,9 @@ export class CommandInsertNewLineBefore extends BaseCommand {
 }
 
 @RegisterAction
-class CommandNavigateBack extends BaseCommand {
+class CommandJumpBack extends BaseCommand {
   modes = [Mode.Normal];
-  keys = [['<C-o>'], ['<C-t>']];
+  keys = [['<C-t>']];
 
   override runsOnceForEveryCursor() {
     return false;
@@ -1296,6 +1296,24 @@ class CommandNavigateBack extends BaseCommand {
 
   public override async exec(position: Position, vimState: VimState): Promise<void> {
     await globalState.jumpTracker.jumpBack(position, vimState);
+  }
+}
+
+@RegisterAction
+class CommandNavigateBack extends BaseCommand {
+  modes = [Mode.Normal];
+  keys = [['<C-o>']];
+
+  override isJump = true;
+
+  public override async exec(position: Position, vimState: VimState): Promise<void> {
+    await vscode.commands.executeCommand('workbench.action.navigateBack');
+
+    if (vimState.editor === vscode.window.activeTextEditor) {
+      // We didn't switch to a different editor
+      vimState.cursorStartPosition = vimState.editor.selection.start;
+      vimState.cursorStopPosition = vimState.editor.selection.end;
+    }
   }
 }
 


### PR DESCRIPTION
Notice: This is more or less a BREAKING CHANGE!

**What this PR does / why we need it**:
- Currently `<C-o>` use hand rolled track list to go back, and it breaks after mouse navigation (eg. `Cmd+Click`). This surprises lots of people, like https://github.com/microsoft/vscode/issues/177598
- This PR changed the default behaviour of `<C-o>` to let it use `workbench.action.navigateBack`

Changes:
- `<C-o>` now use workbench.action.navigateBack instead of hand rolled jump list, so that `gd` and mouse goto state are consistent.
- `<C-t>` is unchanged and still use hand rolled jump list.

**Which issue(s) this PR fixes**
- close: https://github.com/VSCodeVim/Vim/issues/9195


**Special notes for your reviewer**:
This will be a breaking change but IMO it's worth it since `workbench.action.navigateBack` is used much more often then Vim's jump list