### PR TITLE
Enable "let" to assign registers

### DIFF
--- a/src/error.ts
+++ b/src/error.ts
@@ -81,6 +81,10 @@ export enum ErrorCode {
   UsingABlobAsANumber = 974,
   CannotModifyExistingVariable = 995,
   CannotLockARegister = 996,
+  CannotAccessClipboardRegister = 997,
+  UsingARegisterAsANumber = 998,
+  CannotAccessRecordedStateRegister = 999,
+  InvalidOperationForRegister = 1000,
 }
 
 export const ErrorMessage: IErrorMessage = {
@@ -162,6 +166,10 @@ export const ErrorMessage: IErrorMessage = {
   974: 'Using a Blob as a Number',
   995: 'Cannot modify existing variable',
   996: 'Cannot lock a register',
+  997: 'Cannot access clipboard register',
+  998: 'Using a register as a Number',
+  999: 'Cannot access recorded state register',
+  1000: 'Invalid operation for register',
 };
 
 export class VimError extends Error {

--- a/src/vimscript/expression/build.ts
+++ b/src/vimscript/expression/build.ts
@@ -1,21 +1,22 @@
 import {
-  NumberValue,
-  Expression,
-  ListExpression,
-  UnaryExpression,
-  BinaryOp,
   BinaryExpression,
-  FunctionCallExpression,
-  StringValue,
-  LambdaExpression,
-  VariableExpression,
-  Namespace,
+  BinaryOp,
+  BlobValue,
+  DictionaryValue,
+  Expression,
   FloatValue,
   FuncRefValue,
+  FunctionCallExpression,
+  LambdaExpression,
+  ListExpression,
   ListValue,
-  DictionaryValue,
+  Namespace,
+  NumberValue,
+  RegisterValue,
+  StringValue,
+  UnaryExpression,
   Value,
-  BlobValue,
+  VariableExpression,
 } from './types';
 
 export function int(value: number): NumberValue {
@@ -63,6 +64,17 @@ export function blob(data: ArrayBuffer): BlobValue {
   return {
     type: 'blob',
     data,
+  };
+}
+
+export function register(
+  content: string,
+  registerMode: 'character' | 'line' | 'block',
+): RegisterValue {
+  return {
+    type: 'register_val',
+    content,
+    registerMode,
   };
 }
 

--- a/src/vimscript/expression/displayValue.ts
+++ b/src/vimscript/expression/displayValue.ts
@@ -42,5 +42,7 @@ export function displayValue(value: Value, topLevel = true): string {
           .join('')
           .toUpperCase()
       );
+    case 'register_val':
+      return `register('${value.content}',  ${value.registerMode})`;
   }
 }

--- a/src/vimscript/expression/registerUtils.ts
+++ b/src/vimscript/expression/registerUtils.ts
@@ -1,0 +1,47 @@
+import { ErrorCode, VimError } from '../../error';
+import { Register, RegisterMode } from '../../register/register';
+import { list, register } from './build';
+import { Value } from './types';
+
+export function lookupRegister(registerName: string): Value {
+  if (Register.isClipboardRegister(registerName)) {
+    // Reading from the clipboard register is async, so for now is not supported
+    throw VimError.fromCode(ErrorCode.CannotAccessClipboardRegister, registerName);
+  }
+  const registerArray = Register.getRegisterArray(registerName);
+  if (registerArray === undefined || registerArray.length === 0) {
+    throw VimError.fromCode(ErrorCode.NothingInRegister, registerName);
+  }
+  const values = registerArray.map((val) => {
+    if (typeof val.text !== 'string') {
+      throw VimError.fromCode(ErrorCode.CannotAccessRecordedStateRegister, registerName);
+    }
+    return register(val.text, registerModeToString(val.registerMode));
+  });
+  if (values.length === 1) {
+    return values[0];
+  }
+  return list(values);
+}
+
+function registerModeToString(mode: RegisterMode): 'character' | 'line' | 'block' {
+  switch (mode) {
+    case RegisterMode.CharacterWise:
+      return 'character';
+    case RegisterMode.LineWise:
+      return 'line';
+    case RegisterMode.BlockWise:
+      return 'block';
+  }
+}
+
+export function stringToRegisterMode(mode: 'character' | 'line' | 'block'): RegisterMode {
+  switch (mode) {
+    case 'character':
+      return RegisterMode.CharacterWise;
+    case 'line':
+      return RegisterMode.LineWise;
+    case 'block':
+      return RegisterMode.BlockWise;
+  }
+}

--- a/src/vimscript/expression/types.ts
+++ b/src/vimscript/expression/types.ts
@@ -38,6 +38,12 @@ export type BlobValue = {
   data: ArrayBuffer;
 };
 
+export type RegisterValue = {
+  type: 'register_val';
+  content: string;
+  registerMode: 'character' | 'line' | 'block';
+};
+
 export type Value =
   | NumberValue
   | FloatValue
@@ -45,7 +51,8 @@ export type Value =
   | ListValue
   | DictionaryValue
   | FuncRefValue
-  | BlobValue;
+  | BlobValue
+  | RegisterValue;
 
 // -------------------- Expressions --------------------
 


### PR DESCRIPTION
The PR enables support of the command `let @1=@2`

**What this PR does / why we need it**:
This PR implements register evaluation and handles assignment in the `let` command

**Which issue(s) this PR fixes**
https://github.com/VSCodeVim/Vim/issues/9312

