### PR TITLE
adjust the way surround loads its default keybindings

### DIFF
--- a/README.md
+++ b/README.md
@@ -599,6 +599,15 @@ Some examples:
 - `"test"` with cursor inside quotes type `ds"` to end up with `test`
 - `"test"` with cursor inside quotes type `cs"t` and enter `123>` to end up with `<123>test</123>`
 
+Surround mappings:
+since 1.20, we internally use special key notation for surround ( `<plugys>`, `<plugcs>`, `<plugds>` ), for which we create default mappings. This has two consequences:
+
+- custom mappings need to use these too.\
+  Example: `nnoremap s" <plugys>iw"`
+- if you use a custom keyboard layout (workman, dvorak, etc.), the default mappings will not fit for you.
+  You need to disable by settting `vim.enableDefaultPluginMappings` to false and then create a mapping for the 3 key sequences above, like so:\
+  Example: `nnoremap ys <plugys>` where you replace `ys` with what fits for your layout.
+
 ### vim-commentary
 
 Similar to [vim-commentary](https://github.com/tpope/vim-commentary), but uses the VS Code native _Toggle Line Comment_ and _Toggle Block Comment_ features.

--- a/package.json
+++ b/package.json
@@ -732,6 +732,11 @@
           "markdownDescription": "Enable the [Surround](https://github.com/tpope/vim-surround) plugin for Vim.",
           "default": true
         },
+        "vim.enableDefaultPluginMappings": {
+          "type": "boolean",
+          "markdownDescription": "For users of custom keyboard layouts. Disable default keymappings starting with c/d/y. At present only affects surround.",
+          "default": true
+        },
         "vim.argumentObjectSeparators": {
           "type": "array",
           "items": {

--- a/src/actions/plugins/pluginDefaultMappings.ts
+++ b/src/actions/plugins/pluginDefaultMappings.ts
@@ -28,11 +28,30 @@ export class PluginDefaultMappings {
       configSwitch: 'surround',
       mapping: { before: ['d', 's'], after: ['<plugds>'] },
     },
+    // support some special cases with mappings
+    // see: https://github.com/tpope/vim-surround/blob/master/doc/surround.txt, TARGETS w,W,s
+    {
+      mode: 'normalModeKeyBindingsNonRecursive',
+      configSwitch: 'surround',
+      mapping: { before: ['c', 's', 'w'], after: ['<plugys>', 'i', 'w'] },
+    },
+    {
+      mode: 'normalModeKeyBindingsNonRecursive',
+      configSwitch: 'surround',
+      mapping: { before: ['c', 's', 'W'], after: ['<plugys>', 'i', 'W'] },
+    },
+    {
+      mode: 'normalModeKeyBindingsNonRecursive',
+      configSwitch: 'surround',
+      mapping: { before: ['c', 's', 's'], after: ['<plugys>', 'i', 's'] },
+    },
   ];
 
   public static getPluginDefaultMappings(mode: string, config: IConfiguration): IKeyRemapping[] {
-    return this.defaultMappings
-      .filter((m) => m.mode === mode && config[m.configSwitch])
-      .map((m) => m.mapping);
+    return config.enableDefaultPluginMappings
+      ? this.defaultMappings
+          .filter((m) => m.mode === mode && config[m.configSwitch])
+          .map((m) => m.mapping)
+      : [];
   }
 }

--- a/src/configuration/configuration.ts
+++ b/src/configuration/configuration.ts
@@ -262,6 +262,8 @@ class Configuration implements IConfiguration {
 
   surround = true;
 
+  enableDefaultPluginMappings = true;
+
   argumentObjectSeparators = [','];
   argumentObjectOpeningDelimiters = ['(', '['];
   argumentObjectClosingDelimiters = [')', ']'];

--- a/src/configuration/iconfiguration.ts
+++ b/src/configuration/iconfiguration.ts
@@ -176,6 +176,10 @@ export interface IConfiguration {
   surround: boolean;
 
   /**
+   * create default mappings for surround plugin
+   */
+  enableDefaultPluginMappings: boolean;
+  /**
    * Customize argument textobject delimiter and separator characters
    */
   argumentObjectSeparators: string[];

--- a/test/plugins/surround.test.ts
+++ b/test/plugins/surround.test.ts
@@ -30,6 +30,13 @@ suite('surround plugin', () => {
   });
 
   newTest({
+    title: "'csw' as shortform for ysiw",
+    start: ['first li|ne test'],
+    keysPressed: 'csw(',
+    end: ['first |( line ) test'],
+  });
+
+  newTest({
     title: "'ysw)' surrounds word without space",
     start: ['first |line test'],
     keysPressed: 'ysw)',

--- a/test/testConfiguration.ts
+++ b/test/testConfiguration.ts
@@ -29,6 +29,7 @@ export class Configuration implements IConfiguration {
   sneakUseIgnorecaseAndSmartcase = false;
   sneakReplacesF = false;
   surround = false;
+  enableDefaultPluginMappings = true;
   argumentObjectSeparators = [','];
   argumentObjectOpeningDelimiters = ['(', '['];
   argumentObjectClosingDelimiters = [')', ']'];


### PR DESCRIPTION
What this PR does / why we need it:
This deals with a few minor issues, that came up with surround rewrite.

Which issue(s) this PR fixes
fixes https://github.com/VSCodeVim/Vim/issues/6812
fixes https://github.com/VSCodeVim/Vim/issues/6743
fixes https://github.com/VSCodeVim/Vim/issues/6848
fixes https://github.com/VSCodeVim/Vim/issues/7003

Special notes for your reviewer:
I tested this, with the switch set, there is no map on cs and lagfree maps on c are possible.


This PR is fixed version of [this one](https://github.com/VSCodeVim/Vim/pull/6860), with passing tests.