### PR TITLE
📝 Add Cursor support for Mac key-repeat settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ defaults write com.microsoft.VSCode ApplePressAndHoldEnabled -bool false        
 defaults write com.microsoft.VSCodeInsiders ApplePressAndHoldEnabled -bool false      # For VS Code Insider
 defaults write com.vscodium ApplePressAndHoldEnabled -bool false                      # For VS Codium
 defaults write com.microsoft.VSCodeExploration ApplePressAndHoldEnabled -bool false   # For VS Codium Exploration users
+defaults write -app Cursor ApplePressAndHoldEnabled -bool false                       # For Cursor Users
 defaults delete -g ApplePressAndHoldEnabled                                           # If necessary, reset global default
 ```
 


### PR DESCRIPTION
Add Cursor text editor to the Mac setup instructions for enabling key-repeat functionality. This allows Cursor users to properly configure key-repeat behavior when using VSCodeVim by running the appropriate defaults write command.

<!--
Yay! Thanks for sending us a PR! 🎊

Please ensure your PR adheres to:

- [ ] Commit messages has a short & issue references when necessary
- [ ] Each commit does a logical chunk of work.
- [ ] It builds and tests pass (e.g `gulp`)
-->

**What this PR does / why we need it**:

This PR adds support for the Cursor text editor in the Mac setup instructions. Cursor is gaining popularity as a VS Code fork with AI integration, and users need the same key-repeat configuration as VS Code for VSCodeVim to work properly. 
Without this setting, Cursor users experience the default macOS press-and-hold behavior instead of key repetition, significantly impacting the Vim experience.

**Which issue(s) this PR fixes**
No existing issue, but this is a proactive documentation update to support Cursor users.

<!--
Commits in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)
-->

**Special notes for your reviewer**:
- This is a simple documentation change that follows the existing pattern for other VS Code variants (VS Code, VS Code Insiders, VS Codium)
- The command has been tested and confirmed working on Cursor
- The change maintains the consistent formatting of the existing documentation
- This helps reduce support requests from Cursor users who might otherwise need to ask about key-repeat configuration
