### PR TITLE
Make prominent item in statusBar has custom bgcolor

### DIFF
--- a/src/statusBar.ts
+++ b/src/statusBar.ts
@@ -149,11 +149,13 @@ class StatusBarImpl implements vscode.Disposable {
       colorCustomizations['statusBar.background'] = background;
       colorCustomizations['statusBar.noFolderBackground'] = background;
       colorCustomizations['statusBar.debuggingBackground'] = background;
+      colorCustomizations['statusBarItem.prominentBackground'] = background;
     }
 
     if (foreground !== undefined) {
       colorCustomizations['statusBar.foreground'] = foreground;
       colorCustomizations['statusBar.debuggingForeground'] = foreground;
+      colorCustomizations['statusBarItem.prominentForeground'] = foreground;
     }
 
     if (currentColorCustomizations !== colorCustomizations) {


### PR DESCRIPTION
<!--
Yay! Thanks for sending us a PR! 🎊

Please ensure your PR adheres to:

- [ ] Commit messages has a short & issue references when necessary
- [ ] Each commit does a logical chunk of work.
- [ ] It builds and tests pass (e.g `gulp`)
-->

**What this PR does / why we need it**:
the background of windowZoom statusItem is not apply custom color 
![image](https://github.com/user-attachments/assets/c13eae81-8f70-4f48-bcc0-27064364fd4b)

 

<!--
Commits in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)
-->

**Special notes for your reviewer**:

add  vim-airline setting and zoom editor (cmd+=) can reproduce it