### PR TITLE
WIP: Handling jk motion for cjk and full width characters

### DIFF
--- a/test/mode/normalModeTests/motions.test.ts
+++ b/test/mode/normalModeTests/motions.test.ts
@@ -5,6 +5,22 @@ import { newTest, newTestSkip } from '../../testSimplifier';
 suite('Motions in Normal Mode', () => {
   suiteSetup(setupWorkspace);
 
+  suite('cjk', () => {
+    newTest({
+      title: 'j moves to right char downwards',
+      start: ['ああ|あああ123456', 'aaaaaaaaaa123456'],
+      keysPressed: 'j',
+      end: ['あああああ123456', 'aaaa|aaaaaa123456'],
+    });
+
+    newTest({
+      title: 'k moves to right char upwards',
+      start: ['あああああ123456', 'aaaa|aaaaaa123456'],
+      keysPressed: 'k',
+      end: ['ああ|あああ123456', 'aaaaaaaaaa123456'],
+    });
+  });
+
   suite('w', () => {
     newTest({
       title: 'w moves to next word',


### PR DESCRIPTION
<!--
Yay! Thanks for sending us a PR! 🎊

Please ensure your PR adheres to:

- [ ] Commit messages has a short & issue references when necessary
- [ ] Each commit does a logical chunk of work.
- [ ] It builds and tests pass (e.g `gulp`)
-->

**What this PR does / why we need it**:
To handle full width character correctly (as VSCode does and neovim/vim) on jk motions
**Which issue(s) this PR fixes**
This is to address issue: https://github.com/VSCodeVim/Vim/issues/4096
<!--
Commits in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)
-->

**Special notes for your reviewer**:
The code is WIP (needs cleaning after making sure things work), the changes broke the logic of `desiredColumn` property.
I am trying to understand why we need it (since VSCode already handles this properly), and how to fix it.

If anybody want to contribute to the PR, please do so, or at least share your ideas ❤️.

**helpful files from VSCode repo**:
https://github.com/microsoft/vscode/blob/f253ed1e6c2868ba648681a3a7942603c2ba836b/src/vs/editor/common/cursor/cursorMoveOperations.ts#L157
https://github.com/microsoft/vscode/blob/main/src/vs/editor/common/core/cursorColumns.ts#L25
https://github.com/microsoft/vscode/blob/main/src/vs/base/common/strings.ts#L687