### PR TITLE
fix: Copy to clipboard on yank

### DIFF
--- a/src/actions/operator.ts
+++ b/src/actions/operator.ts
@@ -12,6 +12,7 @@ import { Register, RegisterMode } from './../register/register';
 import { VimState } from './../state/vimState';
 import { TextEditor } from './../textEditor';
 import { BaseAction, RegisterAction } from './base';
+import { Clipboard } from '../../src/util/clipboard';
 
 export abstract class BaseOperator extends BaseAction {
   override actionType = 'operator' as const;
@@ -252,6 +253,8 @@ export class YankOperator extends BaseOperator {
         : start;
 
     await vimState.setCurrentMode(Mode.Normal);
+
+    await Clipboard.Copy(text);
 
     const numLinesYanked = text.split('\n').length;
     reportLinesYanked(numLinesYanked, vimState);


### PR DESCRIPTION
As per the current moment, yank commands do not copy content to external clipboard.
This PR introduces functionality for transferring yanked text to external clipboard.

