### PR TITLE
Add `$` as a surround character (#8895)

### DIFF
--- a/src/actions/motion.ts
+++ b/src/actions/motion.ts
@@ -2090,7 +2090,7 @@ export class MoveAroundSquareBracket extends MoveInsideCharacter {
 export abstract class MoveQuoteMatch extends BaseMovement {
   override modes = [Mode.Normal, Mode.Visual, Mode.VisualBlock];
   protected readonly anyQuote: boolean = false;
-  protected abstract readonly charToMatch: '"' | "'" | '`';
+  protected abstract readonly charToMatch: '"' | "'" | '`' | '$';
   protected includeQuotes = false;
   override isJump = true;
   readonly which: WhichQuotes = 'current';
@@ -2230,6 +2230,20 @@ class MoveInsideSingleQuotes extends MoveQuoteMatch {
   keys = ['i', "'"];
   readonly charToMatch = "'";
   override includeQuotes = false;
+}
+
+@RegisterAction
+export class MoveInsideDollarSign extends MoveQuoteMatch {
+  keys = ['i', '$'];
+  readonly charToMatch = '$';
+  override includeQuotes = false;
+}
+
+@RegisterAction
+export class MoveAroundDollarSign extends MoveQuoteMatch {
+  keys = ['a', '$'];
+  readonly charToMatch = '$';
+  override includeQuotes = true;
 }
 
 @RegisterAction

--- a/src/actions/plugins/surround.ts
+++ b/src/actions/plugins/surround.ts
@@ -11,6 +11,7 @@ import {
   MoveAroundBacktick,
   MoveAroundCaret,
   MoveAroundCurlyBrace,
+  MoveAroundDollarSign,
   MoveAroundDoubleQuotes,
   MoveAroundParentheses,
   MoveAroundSingleQuotes,
@@ -498,6 +499,12 @@ class SurroundHelper {
       right: '`',
       removeSpace: false,
       movement: () => new MoveAroundBacktick(false),
+    },
+    $: {
+      left: '$',
+      right: '$',
+      removeSpace: true,
+      movement: () => new MoveAroundDollarSign(false),
     },
     '<': { left: '', right: '', removeSpace: false, movement: () => new MoveAroundTag() },
     '*': {

--- a/src/actions/plugins/targets/smartQuotesMatcher.ts
+++ b/src/actions/plugins/targets/smartQuotesMatcher.ts
@@ -2,7 +2,7 @@ import { Position } from 'vscode';
 import { TextDocument } from 'vscode';
 import { configuration } from '../../../configuration/configuration';
 
-type Quote = '"' | "'" | '`';
+type Quote = '"' | "'" | '`' | '$';
 enum QuoteMatch {
   Opening,
   Closing,

--- a/src/common/matching/matcher.ts
+++ b/src/common/matching/matcher.ts
@@ -33,6 +33,7 @@ export class PairMatcher {
     '"': { match: '"', isNextMatchForward: false, directionless: true },
     "'": { match: "'", isNextMatchForward: false, directionless: true },
     '`': { match: '`', isNextMatchForward: false, directionless: true },
+    $: { match: '$', isNextMatchForward: false, directionless: true },
   };
 
   private static findPairedChar(

--- a/src/common/matching/quoteMatcher.ts
+++ b/src/common/matching/quoteMatcher.ts
@@ -11,7 +11,7 @@ export class QuoteMatcher {
 
   private readonly quoteMap: QuoteMatch[] = [];
 
-  constructor(quote: '"' | "'" | '`', corpus: string) {
+  constructor(quote: '"' | "'" | '`' | '$', corpus: string) {
     let openingQuote = true;
     // Loop over corpus, marking quotes and respecting escape characters.
     for (let i = 0; i < corpus.length; i++) {

--- a/test/plugins/smartQuotes.test.ts
+++ b/test/plugins/smartQuotes.test.ts
@@ -34,6 +34,18 @@ suite('smartQuotes plugin', () => {
       end: ['aaa "bbb" c \'|\' '],
     });
     newTest({
+      title: 'dollar sign - 1',
+      start: ['|aaa "bbb" c $d$ '],
+      keysPressed: "di'",
+      end: ['aaa "bbb" c $|$ '],
+    });
+    newTest({
+      title: 'dollar sign - 2',
+      start: ['aaa "bbb" |c $d$ '],
+      keysPressed: "di'",
+      end: ['aaa "bbb" c $|$ '],
+    });
+    newTest({
       title: 'backtick - 1',
       start: ['|aaa "bbb" c `d` '],
       keysPressed: 'di`',
@@ -62,6 +74,12 @@ suite('smartQuotes plugin', () => {
       start: ['  \'aaa\' "bbb" |c `d` '],
       keysPressed: 'diq',
       end: ['  \'aaa\' "bbb" c `|` '],
+    });
+    newTest({
+      title: 'any-quote - 4',
+      start: ['  \'aaa\' "bbb" |c $d$ '],
+      keysPressed: 'diq',
+      end: ['  \'aaa\' "bbb" c $|$ '],
     });
     // test basic usage
     newTest({


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds `$` as a "quote"-like character to support surround and bracket-like actions (e.g. `yi$`, `ysi$}`). These actions are supported by vim surround, so users expect this to line up when interacting  with VSCodeVim.

**Which issue(s) this PR fixes**

Fixes #8895 

**Special notes for your reviewer**:

This creates a weird mismatch between the names for `Quote` behavior, since it now supports a `$`. The naming for "quotes" makes sense given things like `diq`, but I think in essense the quote matching really lines up with a "directionless" behavior.