### PR TITLE
 fix(keybindings): make tab and escape play nicer with native vscode keybindings

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
       {
         "key": "Escape",
         "command": "extension.vim_escape",
-        "when": "editorTextFocus && vim.active && !inDebugRepl"
+        "when": "editorTextFocus && vim.active && !inDebugRepl && !inlineSuggestionVisible && !inlineEditIsVisible && !testing.isPeekVisible && !testing.isInPeek && !suggestWidgetVisible && !findWidgetVisible && !dirtyDiffVisible && (vim.mode == 'Insert' || !notebookEditorFocused)"
       },
       {
         "key": "Escape",
@@ -112,7 +112,7 @@
       {
         "key": "tab",
         "command": "extension.vim_tab",
-        "when": "editorTextFocus && vim.active && vim.mode != 'Insert' && !inDebugRepl"
+        "when": "editorTextFocus && vim.active && vim.mode != 'Insert' && !inDebugRepl && !inlineEditIsVisible"
       },
       {
         "key": "shift+tab",


### PR DESCRIPTION
Hello! :wave:

I'm a VS Code team member, who uses this extension daily and loves it! Thank you so much this awesome extension! :heart: 

From personal experience and through issue reports, we've figured that some Escape- and Tab-related keybindings do not play very well with VS Code features, so I thought it's worth creating a PR. I've self-hosted on my changes for several weeks and think they could be good quality-of-life improvement. 

This PR fixes:

- `extension.vim_tab` should not take priority over `tab` keybinding that accepts Next Edit Suggestions (aka Inline Edits; NES for short)
- `extension.vim_escape` should not take priority over:
	- `escape` keybinding to hide inline suggestion/completion (eg. Copilot's ghost text completion)
	- `escape` keybinding to hide NES
	- `escape` to hide:
		- testing-explorer peek
		- suggest (aka intellisense) widget
		- find widget (escape currently cannot hide find widget if it's not focused)
		- dirty-diff widget
	- de-focusing notebook cell when vim is in normal mode

fixes https://github.com/VSCodeVim/Vim/issues/9490
fixes https://github.com/microsoft/vscode-copilot-release/issues/7259
fixes https://github.com/microsoft/vscode-copilot-release/issues/6004

<!--
Yay! Thanks for sending us a PR! 🎊

Please ensure your PR adheres to:

- [ ] Commit messages has a short & issue references when necessary
- [ ] Each commit does a logical chunk of work.
- [ ] It builds and tests pass (e.g `gulp`)
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**

<!--
Commits in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)
-->

**Special notes for your reviewer**:
