### PR TITLE
Fix: #9576 | Move Inside Character when multiple character pairs are there and the cursor is out not in between the character pairs

### DIFF
--- a/src/actions/motion.ts
+++ b/src/actions/motion.ts
@@ -1894,7 +1894,7 @@ export abstract class MoveInsideCharacter extends ExpandingSelection {
           break;
         }
         const lineText = vimState.document.lineAt(lineNum).text;
-        const matchIndex = lineText.indexOf(this.charToMatch);
+        const matchIndex = lineText.indexOf(this.charToMatch, selStart.character);
         if (matchIndex !== -1) {
           openPos = new Position(lineNum, matchIndex);
           break;


### PR DESCRIPTION
<!--
Yay! Thanks for sending us a PR! 🎊

Please ensure your PR adheres to:

- [ ] Commit messages has a short & issue references when necessary
- [ ] Each commit does a logical chunk of work.
- [ ] It builds and tests pass (e.g `gulp`)
-->

**What this PR does / why we need it**: This PR makes the moveInsideCharacter behavior more consistent with the actual vim move inside commands like "di(" or "ca{"

Original Line: `this (is) a (bug)`
&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;^
- Old Behavior: `this () a (bug)`
- New/Expected Behavior: `this (is) a ()`
                                          
**Which issue(s) this PR fixes**: #9576

<!--
Commits in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)
-->

**Special notes for your reviewer**: Hi I am new to open source and have never worked on a VS Code extension so I apologize in advance if I did anything wrong.