### PR TITLE
Fix: keep the selection of the space after the last character

### DIFF
--- a/src/mode/modeHandler.ts
+++ b/src/mode/modeHandler.ts
@@ -992,23 +992,27 @@ export class ModeHandler implements vscode.Disposable, IModeHandler {
           !this.vimState.returnToInsertAfterCommand &&
           (this.vimState.currentMode === Mode.Normal || isVisualMode(this.vimState.currentMode))
         ) {
-          const currentLineLength = TextEditor.getLineLength(cursor.stop.line);
+          const currentStopLineLength = TextEditor.getLineLength(cursor.stop.line);
           const currentStartLineLength = TextEditor.getLineLength(cursor.start.line);
 
           // When in visual mode you can move the cursor past the last character in order
           // to select that character. We use this offset to allow for that, otherwise
           // we would consider the position invalid and change it to the left of the last
           // character.
-          const offsetAllowed =
-            isVisualMode(this.vimState.currentMode) && currentLineLength > 0 ? 1 : 0;
-          if (cursor.start.character >= currentStartLineLength) {
+          const offsetStartAllowed =
+            isVisualMode(this.vimState.currentMode) && currentStartLineLength > 0 ? 1 : 0;
+          const offsetStopAllowed =
+            isVisualMode(this.vimState.currentMode) && currentStopLineLength > 0 ? 1 : 0;
+
+          if (cursor.start.character >= currentStartLineLength + offsetStartAllowed) {
             cursor = cursor.withNewStart(
               cursor.start.withColumn(Math.max(currentStartLineLength - 1, 0)),
             );
           }
-
-          if (cursor.stop.character >= currentLineLength + offsetAllowed) {
-            cursor = cursor.withNewStop(cursor.stop.withColumn(Math.max(currentLineLength - 1, 0)));
+          if (cursor.stop.character >= currentStopLineLength + offsetStopAllowed) {
+            cursor = cursor.withNewStop(
+              cursor.stop.withColumn(Math.max(currentStopLineLength - 1, 0)),
+            );
           }
         }
         return cursor;

--- a/test/mode/modeVisual.test.ts
+++ b/test/mode/modeVisual.test.ts
@@ -1699,6 +1699,25 @@ suite('Mode Visual', () => {
     endMode: Mode.Normal,
   });
 
+  suite('Can handle o', () => {
+    newTest({
+      title: 'Can select the space after the last character',
+      start: ['ab', 'ab|c', 'abcd'],
+      keysPressed: 'vkd',
+      end: ['a|b', 'abcd'],
+      endMode: Mode.Normal,
+    });
+
+    newTest({
+      title:
+        'After executing o twice, can keep the selection of the space after the last character',
+      start: ['ab', 'ab|c', 'abcd'],
+      keysPressed: 'vkood',
+      end: ['a|b', 'abcd'],
+      endMode: Mode.Normal,
+    });
+  });
+
   suite('C, R, and S', () => {
     for (const command of ['C', 'R', 'S']) {
       newTest({


### PR DESCRIPTION
- [x] Commit messages has a short & issue references when necessary
- [x] Each commit does a logical chunk of work.
- [x] It builds and tests pass (e.g `gulp`)

**What this PR does / why we need it**:
After executing o twice, keep the selection of the space after the last character

AS-IS
![as-is](https://github.com/user-attachments/assets/268afe60-e999-453f-bd3c-822ed21db77d)

TO-BE
![to-be](https://github.com/user-attachments/assets/e1e8bad4-9aa4-4423-884c-2e177f36e7bb)

**Which issue(s) this PR fixes**

not yet
<!--
Commits in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)
-->

**Special notes for your reviewer**:
