### PR TITLE
Add "mouseSelectionGoesIntoVisualModeFromInsert" to allow for insert -> visual transition without changing current behavior.  

### DIFF
--- a/package.json
+++ b/package.json
@@ -965,6 +965,11 @@
           "description": "If enabled, dragging with the mouse activates Visual mode.",
           "default": true
         },
+        "vim.mouseSelectionGoesIntoVisualModeFromInsert": {
+          "type": "boolean",
+          "markdownDescription": "If enabled, dragging with the mouse activates Visual mode even when starting from Insert mode. Requires `vim.mouseSelectionGoesIntoVisualMode` to be true.",
+          "default": false
+        },
         "vim.disableExtension": {
           "type": "boolean",
           "description": "Disables the VSCodeVim extension. The extension will continue to be loaded and activated, but Vim functionality will be disabled.",

--- a/src/configuration/configuration.ts
+++ b/src/configuration/configuration.ts
@@ -414,6 +414,7 @@ class Configuration implements IConfiguration {
   visualstar = false;
 
   mouseSelectionGoesIntoVisualMode = true;
+  mouseSelectionGoesIntoVisualModeFromInsert = false;
 
   changeWordIncludesWhitespace = false;
 

--- a/src/configuration/iconfiguration.ts
+++ b/src/configuration/iconfiguration.ts
@@ -322,9 +322,14 @@ export interface IConfiguration {
   visualstar: boolean;
 
   /**
-   * Does dragging with the mouse put you into visual mode
+   * Does dragging with the mouse put you into visual mode (except for insert mode)
    */
   mouseSelectionGoesIntoVisualMode: boolean;
+
+  /**
+   * Does dragging with the mouse put you into visual mode when you're in insert mode
+   */
+  mouseSelectionGoesIntoVisualModeFromInsert: boolean;
 
   /**
    * Includes trailing whitespace when changing word.

--- a/src/mode/modeHandler.ts
+++ b/src/mode/modeHandler.ts
@@ -414,7 +414,8 @@ export class ModeHandler implements vscode.Disposable, IModeHandler {
         if (
           configuration.mouseSelectionGoesIntoVisualMode &&
           !isVisualMode(this.vimState.currentMode) &&
-          this.currentMode !== Mode.Insert
+          (this.currentMode !== Mode.Insert ||
+            configuration.mouseSelectionGoesIntoVisualModeFromInsert)
         ) {
           await this.setCurrentMode(Mode.Visual);
 

--- a/test/testConfiguration.ts
+++ b/test/testConfiguration.ts
@@ -99,6 +99,7 @@ export class Configuration implements IConfiguration {
   matchpairs = '(:),{:},[:]';
   visualstar = false;
   mouseSelectionGoesIntoVisualMode = true;
+  mouseSelectionGoesIntoVisualModeFromInsert = false;
   changeWordIncludesWhitespace = false;
   foldfix = false;
   disableExtension = false;


### PR DESCRIPTION
Fixes #9214

<!--
Yay! Thanks for sending us a PR! 🎊

Please ensure your PR adheres to:

- [ ] Commit messages has a short & issue references when necessary
- [ ] Each commit does a logical chunk of work.
- [ ] It builds and tests pass (e.g `gulp`)
-->

**What this PR does / why we need it**:

This patch optionally allows selection of text in Insert mode to trigger a switch into Visual mode.  It adds a setting to avoid changing current behavior.

**Which issue(s) this PR fixes**

Fixes #9214, supercedes #9215, partially undoes 8e23c88ff43e591919dfca9859c7e8cce0ac3647

**Special notes for your reviewer**:
