### PR TITLE
fix: allow to disable ctrl+<up|down|left|right> by vim.handleKeys

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,22 +77,22 @@
       {
         "key": "Home",
         "command": "extension.vim_home",
-        "when": "editorTextFocus && vim.active && !inDebugRepl && vim.mode != 'Insert'"
+        "when": "editorTextFocus && vim.active && vim.use<Home> && !inDebugRepl && vim.mode != 'Insert'"
       },
       {
         "key": "ctrl+home",
         "command": "extension.vim_ctrl+home",
-        "when": "editorTextFocus && vim.active && !inDebugRepl && vim.mode != 'Insert'"
+        "when": "editorTextFocus && vim.active && vim.use<C-Home> && !inDebugRepl && vim.mode != 'Insert'"
       },
       {
         "key": "End",
         "command": "extension.vim_end",
-        "when": "editorTextFocus && vim.active && !inDebugRepl && vim.mode != 'Insert'"
+        "when": "editorTextFocus && vim.active && vim.use<End> && !inDebugRepl && vim.mode != 'Insert'"
       },
       {
         "key": "ctrl+end",
         "command": "extension.vim_ctrl+end",
-        "when": "editorTextFocus && vim.active && !inDebugRepl && vim.mode != 'Insert'"
+        "when": "editorTextFocus && vim.active && vim.use<C-End> && !inDebugRepl && vim.mode != 'Insert'"
       },
       {
         "key": "Insert",
@@ -342,22 +342,22 @@
       {
         "key": "ctrl+up",
         "command": "extension.vim_ctrl+up",
-        "when": "editorTextFocus && vim.active && vim.mode != 'Insert' && !inDebugRepl"
+        "when": "editorTextFocus && vim.active && vim.use<C-up> && vim.mode != 'Insert' && !inDebugRepl"
       },
       {
         "key": "ctrl+down",
         "command": "extension.vim_ctrl+down",
-        "when": "editorTextFocus && vim.active && vim.mode != 'Insert' && !inDebugRepl"
+        "when": "editorTextFocus && vim.active && vim.use<C-down> && vim.mode != 'Insert' && !inDebugRepl"
       },
       {
         "key": "ctrl+left",
         "command": "extension.vim_ctrl+left",
-        "when": "editorTextFocus && vim.active && vim.mode != 'Insert' && !inDebugRepl"
+        "when": "editorTextFocus && vim.active && vim.use<C-left> && vim.mode != 'Insert' && !inDebugRepl"
       },
       {
         "key": "ctrl+right",
         "command": "extension.vim_ctrl+right",
-        "when": "editorTextFocus && vim.active && vim.mode != 'Insert' && !inDebugRepl"
+        "when": "editorTextFocus && vim.active && vim.use<C-right> && vim.mode != 'Insert' && !inDebugRepl"
       },
       {
         "key": "ctrl+pagedown",


### PR DESCRIPTION
<!--
Yay! Thanks for sending us a PR! 🎊

Please ensure your PR adheres to:

- [ ] Commit messages has a short & issue references when necessary
- [ ] Each commit does a logical chunk of work.
- [ ] It builds and tests pass (e.g `gulp`)
-->

**What this PR does / why we need it**:
Now these mappings prevent to use macOS default tiling shortcuts

**Which issue(s) this PR fixes**

<!--
Commits in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)
-->

**Special notes for your reviewer**:
