### PR TITLE
fix: Clean up stale `ourSelections` to not indefinitely ignore external selections

### DIFF
--- a/src/mode/ourSelectionsUpdates.ts
+++ b/src/mode/ourSelectionsUpdates.ts
@@ -1,0 +1,59 @@
+import * as vscode from 'vscode';
+
+import { Logger } from '../util/logger';
+
+/** Expiry time for our selections updates queue, after which we can reasonably expect a selection
+ * update to have triggered a VSCode selection change event resulting in its dequeueing.
+ *
+ * We want the expiry time to be generous enough to allow for delayed VSCode event firings. If we
+ * remove an update too early, we might mistakenly treat its change event as an external change that
+ * we should be tracking, rather than an internal one we've already accounted for.
+ *
+ * We also want the expiry time to be short enough to discard stale internal updates, whose change
+ * events have likely already fired, or will never fire. Note that VSCode selectionChange events
+ * only fire if the editor's selections have actually changed in value, hence why we compare against
+ * `editor.selections` to choose whether to add an update to `ourSelectionsUpdates`. But because we
+ * receive VSCode's selection events at a different rate from our own updates, `editor.selections`
+ * can be outdated when we do that comparison, and we can mistakenly think an internal update will
+ * trigger a selectionChange event when it actually won't. Such an update will be added to
+ * `ourSelectionsUpdates`, and will only be removed when we clean it up after the expiry time. */
+const SELECTIONS_UPDATE_EXPIRY_MS = 1000;
+
+/**
+ * An internally-triggered selections update, which will trigger a VSCode selection change event
+ * that we can ignore as an already-tracked change.
+ */
+export type OurSelectionsUpdate = {
+  selectionsHash: string;
+  updatedAt: number;
+};
+
+/**
+ * Removes our selections updates that are older than the expiry time. Ideally there shouldn't be
+ * any stale updates present when this is called. But if there are, we remove them so that VSCode
+ * selectionChange events aren't being ignored indefinitely under the incorrect assumption that
+ * they were triggered by internal updates we've already tracked.
+ */
+export function cleanupOurSelectionsUpdates(
+  ourSelectionsUpdates: OurSelectionsUpdate[],
+): OurSelectionsUpdate[] {
+  const now = Date.now();
+  return ourSelectionsUpdates.filter((entry) => {
+    const age = now - entry.updatedAt;
+    const shouldKeep = age < SELECTIONS_UPDATE_EXPIRY_MS;
+    if (!shouldKeep) {
+      Logger.warn(
+        `OurSelectionsUpdate ${entry.selectionsHash} still around after ${age}ms; removing now`,
+      );
+    }
+    return shouldKeep;
+  });
+}
+
+export function hashSelections(selections: readonly vscode.Selection[]): string {
+  return selections.reduce(
+    (hash, s) =>
+      hash + `[${s.anchor.line}, ${s.anchor.character}; ${s.active.line}, ${s.active.character}]`,
+    '',
+  );
+}


### PR DESCRIPTION
## What this PR does / why we need it

This PR fixes the issue of external selections changes (e.g. from commands like `Go to Next/Previous Change`) often not being properly tracked in VSCodeVim's internal selections state.

For instance, here's a screen recording where running `Go to Previous Change` and then pressing `Escape` takes the cursor back to where it was, as if `Go to Previous Change` was never run: 

https://github.com/user-attachments/assets/6c420fda-633a-43e0-a470-d0f39b523078


## Which issue(s) this PR fixes

Fixes: #8903 (assuming this is indeed the same root issue)
Fixes: #5746 (although it's currently marked as closed)

## Special notes for your reviewer

I've been encountering this issue pretty regularly for a good while. It would happen at varying frequencies for me (sometimes every couple days, sometimes many times a day), so I figured it'd be a pretty obscure problem to fix (e.g. a memory leak issue like one commenter suggested). I dug into it today though and think I've found the cause and a reasonable fix (although not perfect).

I first turned on VSCodeVim's debug logs (helpfully [described](https://github.com/VSCodeVim/Vim/?tab=readme-ov-file#debugging-remappings) in the README, thanks) and waited for the issue to crop up again. When it did, I saw some useful warning logs:

<img width="1365" alt="Screen Shot 2025-05-21 at 9 37 02 AM" src="https://github.com/user-attachments/assets/dc7f0fc0-51d8-4b5d-a1e6-0593e5c1d29b" />

Then I toggled vim off/on as usual for a workaround (`Vim: Toggle Vim Mode`) and contrasted those with normal behavior logs:

<img width="1369" alt="Screen Shot 2025-05-21 at 9 37 28 AM" src="https://github.com/user-attachments/assets/52fd10b6-95ce-4b41-ade0-2baf908c1ca9" />

I eventually found a reliable repro that can be done in seconds instead of waiting hours or days:

### Repro steps

1. Have a keymapping like `J` mapped to `5+`
2. Hold down `J` for a few seconds until it's run at least about 5-7 times
3. Try `Go to Next/Previous Change`
4. Press `Escape` and observe the cursor jumps back to before step 3

### Root cause

There are a few complicated things going on under the hood, so I'll try to be detailed for the sake of anyone reviewing and future maintainers.

After digging into the relevant code and past PRs (#5015, #5250), and lots of debugging, here's what I concluded:

The [`ModeHandler.selectionsChanged.ourSelections`](https://github.com/VSCodeVim/Vim/blob/fa5461b056dff9dedad2502141d2ffdfc275cd41/src/mode/modeHandler.ts#L105) array of hashed selections is used to track 'internal' selection changes (performed by VSCodeVim itself), so that when a [`vscode.TextEditorSelectionChangeEvent` fires](https://github.com/VSCodeVim/Vim/blob/fa5461b056dff9dedad2502141d2ffdfc275cd41/extensionBase.ts#L264-L267) due to an internal selection update, we can ignore it as already accounted for. We only want to update internal selection state because of externally-triggered SelectionChange events (e.g. by mouse clicks or builtin / extension commands).

Since **VSCode only triggers SelectionChange events if the selection actually changes in value**, we determine whether or not to add a given internal selection update to `ourSelections` by comparing it to the current `editor.selections` value.

However, VSCode unreliably fires those SelectionChange events. In this case, after key-repeating something like `J` (mapped to `5+`) around 5-7 times, `editor.selections` can lag behind `updateView`. Worse yet, after we [set `editor.selections`](https://github.com/VSCodeVim/Vim/blob/fa5461b056dff9dedad2502141d2ffdfc275cd41/src/mode/modeHandler.ts#L1473), VSCode seems to quickly reset `editor.selections` to its previous value before properly registering the change and firing a SelectionChange event for it. **By the time we calculate `willTriggerChange` again, `editor.selections` can have lagged enough to still have the old value, and we can add `selectionsHash` to `ourSelections` even if this selection update won't actually trigger a VSCode SelectionChange event**.

For example, with cursor starting on line 10 and `J` mapped to `5+`:
1. Key repeat `JJ` (usually takes 5-7 to repro but we'll assume 2 for simplicity)
2. `handleKeyAsAnAction('5')` => `updateView` =>  set `editor.selections` to line 10 => `editor.selections` was already line 10 => `willTriggerChange = false` and we do nothing else
3. `handleKeyAsAnAction('+')` => `updateView` => change `editor.selections` from line 10 to line 15 => `willTriggerChange = true`, push line 15's hash  to `ourSelections`
4. Under the hood, VSCode seems to reset `editor.selections` to 10
5. `handleKeyAsAnAction('5')` => `updateView` => we'll set `editor.selections` to line 15 => even though we already previously set `editor.selections` to 15, when calculating `willTriggerChange` the value of `editor.selections` is 10 => `willTriggerChange = true` and we push line 15's hash to `ourSelections` *again*
6. `vscode.TextEditorSelectionChangeEvent(15)` fires for step 3 => we pop off only one of the two hashes for line 15 in `ourSelections`, and the other remains
7. `handleKeyAsAnAction('+')` => `updateView` => set `editor.selections` to line 15 => `editor.selections` finally reads as 15, so `willTriggerChange = false` and we do nothing
8. End result: `ourSelections = [hash(15)]`

**Once we have a `selectionsHash` in `ourSelections` that won't ever trigger a SelectionChange event, it'll stay there indefinitely.**

Almost all subsequent SelectionChange events will hit [this block of code](https://github.com/VSCodeVim/Vim/blob/fa5461b056dff9dedad2502141d2ffdfc275cd41/extensionBase.ts#L303-L310) and result in those `Ignoring slipped selection` warnings and being ignored by VSCodeVim's internal selections tracking state. If they're external events, they won't be accounted for at all, leading to the undesired behavior seen in the filed issues.

### Fix

The fix here is quite simple compared to the more complicated explanation above: we timestamp each `ourSelections` entry so that we can remove each one when it gets stale.

- `ourSelections` is now renamed to `ourSelectionsUpdates` and is an array of `{selectionHash, updatedAt}` objects
- In the `TextEditorSelectionChangeEvent` handler, before checking against `ourSelectionUpdates`, we clean out any stale entries older than 1 second (hardcoded constant)
    - We want enough time to receive change events for our selection updates so we don't treat them as external changes, but we also don't want to take an annoyingly long time to clean up stale items when this bug occurs due to key repeats
    - Not sure @berknam is still around, but looks like they were considering a timeout approach of [500ms to 1-2s](https://github.com/VSCodeVim/Vim/pull/5250#issuecomment-700367535)

Detailed docstrings have been added to the logic in the new `src/mode/ourSelectionsUpdates.ts` file to help explain the reasoning behind the cleanup and the various pitfalls and tradeoffs involved with all this stuff.

---


More than happy to hear any alternate approaches. And thanks for making VSCodeVim :) it's been awesome on the whole.
