### PR TITLE
Fix change surrounding tag, fixes #8177

### DIFF
--- a/src/actions/plugins/surround.ts
+++ b/src/actions/plugins/surround.ts
@@ -585,11 +585,11 @@ class SurroundHelper {
       // start -> <foo>bar</foo> <-- stop
       const openTagNameStart = rangeStart.getRight();
       const openTagNameEnd = openTagNameStart
-        .nextWordEnd(vimState.document, { inclusive: true })
+        .nextWordEnd(vimState.document, { wordType: WordType.TagName, inclusive: true })
         .getRight();
       const closeTagNameStart = rangeEnd
         .getLeft(2)
-        .prevWordStart(vimState.document, { inclusive: true });
+        .prevWordStart(vimState.document, { wordType: WordType.TagName, inclusive: true });
       const closeTagNameEnd = rangeEnd.getLeft();
       vimState.cursorStartPosition = position; // some textobj (MoveInsideCharacter) expect this
       vimState.cursorStopPosition = position;

--- a/src/actions/plugins/surround.ts
+++ b/src/actions/plugins/surround.ts
@@ -6,6 +6,7 @@ import {
   SelectWord,
   TextObject,
 } from '../../textobject/textobject';
+import { WordType } from '../../textobject/word';
 import { isIMovement } from '../baseMotion';
 import {
   MoveAroundBacktick,

--- a/src/textobject/word.ts
+++ b/src/textobject/word.ts
@@ -8,10 +8,12 @@ export enum WordType {
   Big,
   CamelCase,
   FileName,
+  TagName,
 }
 
 const nonBigWordCharRegex = makeWordRegex('');
 const nonFileNameRegex = makeWordRegex('"\'`;<>{}[]()');
+const nonTagNameRegex = makeWordRegex('</>');
 
 function regexForWordType(wordType: WordType): RegExp {
   switch (wordType) {
@@ -23,6 +25,8 @@ function regexForWordType(wordType: WordType): RegExp {
       return makeCamelCaseWordRegex(configuration.iskeyword);
     case WordType.FileName:
       return nonFileNameRegex;
+    case WordType.TagName:
+      return nonTagNameRegex;
   }
 }
 

--- a/test/plugins/surround.test.ts
+++ b/test/plugins/surround.test.ts
@@ -457,6 +457,18 @@ suite('surround plugin', () => {
   });
 
   newTest({
+    title: 'change surround with tags with kebab case names',
+    start: ['<custom-tag>|</custom-tag>'],
+    keysPressed: 'cstt',
+    end: ['<h1>|</h1>'],
+    stub: {
+      stubClass: CommandSurroundAddSurroundingTag,
+      methodName: 'readTag',
+      returnValue: 'h1',
+    },
+  });
+
+  newTest({
     title: 'change surround with tags that contain an attribute and remove them',
     start: ['<h2 test class="foo">b|ar</h2>'],
     keysPressed: 'cstt',


### PR DESCRIPTION
<!--
Yay! Thanks for sending us a PR! 🎊

Please ensure your PR adheres to:

- [ ] Commit messages has a short & issue references when necessary
- [ ] Each commit does a logical chunk of work.
- [ ] It builds and tests pass (e.g `gulp`)
-->

Big thanks @J-Fields for maintaining this project 😊

**What this PR does / why we need it**:
Fixes a "change surrounding tag" issue when using kebab case
```html
<custom-tag></custom-tag>
```
When using a command to replace the tag with `h1` you get this:
```html
<h1-tag></custom-h1>
```

**Which issue(s) this PR fixes**
- #8177

<!--
Commits in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)
-->

**Special notes for your reviewer**:
What I've done to try fix the issue is created a new `WordType` of `TagName`. Currently it's using `nextWordEnd` and `prevWordStart` to select the tag name which is why we are getting that strange behaviour.