### PR TITLE
Fixing Vi{ incorrectly grabbing the ending braces

### DIFF
--- a/src/actions/motion.ts
+++ b/src/actions/motion.ts
@@ -1901,6 +1901,7 @@ export abstract class MoveInsideCharacter extends ExpandingSelection {
     firstIteration: boolean,
     lastIteration: boolean,
   ): Promise<IMovement> {
+    console.log("MoveInsideCharacter's execAction initiated");
     const closingChar = PairMatcher.pairings[this.charToMatch].match;
     const [selStart, selEnd] = sorted(vimState.cursorStartPosition, position);
 
@@ -1966,6 +1967,21 @@ export abstract class MoveInsideCharacter extends ExpandingSelection {
 
     if (lastIteration && !isVisualMode(vimState.currentMode) && selStart.isBefore(openPos)) {
       vimState.recordedState.operatorPositionDiff = openPos.subtract(selStart);
+    }
+
+    // Adjust for VisualLine mode: exclude the line containing the closing brace
+    // moves the cursor back to just within the brackets, accurately mirroring what
+    // Vim does for Vi{ Vi( Vi[ etc.
+    if (
+      !this.includeSurrounding &&
+      vimState.currentMode === Mode.VisualLine &&
+      closePos.line > openPos.line
+    ) {
+      const adjustedLine = closePos.line - 1;
+      if (adjustedLine >= 0) {
+        const lineText = vimState.document.lineAt(adjustedLine).text;
+        closePos = new Position(adjustedLine, lineText.length);
+      }
     }
 
     // TODO: setting the cursor manually like this shouldn't be necessary (probably a Cursor, not Position, should be passed to `exec`)

--- a/src/actions/motion.ts
+++ b/src/actions/motion.ts
@@ -1901,7 +1901,6 @@ export abstract class MoveInsideCharacter extends ExpandingSelection {
     firstIteration: boolean,
     lastIteration: boolean,
   ): Promise<IMovement> {
-    console.log("MoveInsideCharacter's execAction initiated");
     const closingChar = PairMatcher.pairings[this.charToMatch].match;
     const [selStart, selEnd] = sorted(vimState.cursorStartPosition, position);
 

--- a/test/mode/modeVisualLine.test.ts
+++ b/test/mode/modeVisualLine.test.ts
@@ -3,7 +3,7 @@ import * as assert from 'assert';
 import { getAndUpdateModeHandler } from '../../extension';
 import { Mode } from '../../src/mode/mode';
 import { ModeHandler } from '../../src/mode/modeHandler';
-import { newTest } from '../testSimplifier';
+import { newTest, newTestOnly } from '../testSimplifier';
 import { assertEqualLines, setupWorkspace } from './../testUtils';
 
 suite('Mode Visual Line', () => {
@@ -584,5 +584,27 @@ suite('Mode Visual Line', () => {
         endMode: Mode.Insert,
       });
     }
+  });
+
+  suite('Vi{ should not select the ending brace, if it is on a new line.', () => {
+    test('Vi{ selection content test', async () => {
+      // Insert the full block using insert mode simulation
+      await modeHandler.handleMultipleKeyEvents('i{\nsome text on new line\n}'.split(''));
+
+      // Back to normal mode
+      await modeHandler.handleKeyEvent('<Esc>');
+
+      // Move cursor to start of "some text..."
+      await modeHandler.handleMultipleKeyEvents(['g', 'g', 'j', 'l', 'l', 'l', 'l']);
+
+      // Simulate Vi{
+      await modeHandler.handleMultipleKeyEvents(['V', 'i', '{']);
+
+      const doc = modeHandler.vimState.editor.document;
+      const sel = modeHandler.vimState.editor.selection;
+      const selectedText = doc.getText(sel);
+
+      assert.strictEqual(selectedText, '  some text on new line');
+    });
   });
 });


### PR DESCRIPTION
<!--
Yay! Thanks for sending us a PR! 🎊

Please ensure your PR adheres to:

- [ ] Commit messages has a short & issue references when necessary
- [ ] Each commit does a logical chunk of work.
- [ ] It builds and tests pass (e.g `gulp`)
-->

**What this PR does / why we need it**:
Fixes the weird behaviour when using `VisualLine` mode with the `Vi{` or `Vi(` or `Vi[` when the matching braces are on different lines. The issue is well explained in #9337 (relevant images explaining the problem are present there so I have omitted them here).

**Which issue(s) this PR fixes**
As a fix for issue #9337 
<!--
Commits in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)
-->

**Special notes for your reviewer**:
Only affects `VisualLine` mode when using `Vi{`. Everything else is left untouched, all tests pass locally.

