### PR TITLE
Add :help command

### DIFF
--- a/src/cmd_line/commands/help.ts
+++ b/src/cmd_line/commands/help.ts
@@ -10,7 +10,6 @@ export class HelpCommand extends ExCommand {
 
     panel.webview.html = `
 <html>
-
 <body>
   <pre>
             VsCodeVim - Main Help
@@ -94,7 +93,6 @@ export class HelpCommand extends ExCommand {
       For more help, see the <a href="https://github.com/VSCodeVim/Vim" target="_blank">project repository</a> or the <a href="https://vimhelp.org/" target="_blank">official Vim guide</a>.
       </pre>
 </body>
-
 </html>
     `;
   }

--- a/src/cmd_line/commands/help.ts
+++ b/src/cmd_line/commands/help.ts
@@ -1,0 +1,31 @@
+import { ExCommand } from '../../vimscript/exCommand';
+import { VimState } from '../../state/vimState';
+import { window, ViewColumn } from 'vscode';
+
+export class HelpCommand extends ExCommand {
+  async execute(_vimState: VimState): Promise<void> {
+    const panel = window.createWebviewPanel('vimHelp', 'Help Vim', ViewColumn.Active, {
+      enableScripts: false,
+    });
+
+    panel.webview.html = `
+      <html>
+        <body style="font-family: sans-serif; padding: 2em;">
+          <h2>Vim Help for VSCode</h2>
+          <b>Basic Commands:</b><br>
+          <code>:w</code> Save file<br>
+          <code>:q</code> Quit editor<br>
+          <code>:wq</code> Save and quit<br>
+          <code>:help</code> Show this help<br>
+          <br>
+          <b>Movement:</b><br>
+          <code>h, j, k, l</code> Move cursor<br>
+          <code>gg</code> Go to start of file<br>
+          <code>G</code> Go to end of file<br>
+          <br>
+          And much more! See the documentation for details.
+        </body>
+      </html>
+    `;
+  }
+}

--- a/src/cmd_line/commands/index.html
+++ b/src/cmd_line/commands/index.html
@@ -1,14 +1,7 @@
-import { ExCommand } from '../../vimscript/exCommand';
-import { VimState } from '../../state/vimState';
-import { window, ViewColumn } from 'vscode';
-
-export class HelpCommand extends ExCommand {
-  async execute(_vimState: VimState): Promise<void> {
-    const panel = window.createWebviewPanel('vimHelp', 'Help Vim', ViewColumn.Active, {
-      enableScripts: false,
-    });
-
-    panel.webview.html = `
+<!--
+  NOTE: This file is for debugging and previewing the help content in a web browser only.
+  To make changes effective in VS Code, copy the relevant content to help.ts.
+-->
 <html>
 
 <body>
@@ -96,6 +89,3 @@ export class HelpCommand extends ExCommand {
 </body>
 
 </html>
-    `;
-  }
-}

--- a/src/vimscript/exCommandParser.ts
+++ b/src/vimscript/exCommandParser.ts
@@ -54,6 +54,7 @@ import { nameAbbrevParser } from './parserUtils';
 import { LetCommand, UnletCommand } from '../cmd_line/commands/let';
 import { CallCommand, EvalCommand } from '../cmd_line/commands/eval';
 import { PwdCommand } from '../cmd_line/commands/pwd';
+import { HelpCommand } from '../cmd_line/commands/help';
 
 type ArgParser = Parser<ExCommand>;
 
@@ -253,7 +254,7 @@ export const builtinExCommands: ReadonlyArray<[[string, string], ArgParser | und
   [['grepa', 'dd'], undefined],
   [['gu', 'i'], undefined],
   [['gv', 'im'], undefined],
-  [['h', 'elp'], undefined],
+  [['h', 'elp'], succeed(new HelpCommand())],
   [['ha', 'rdcopy'], undefined],
   [['helpc', 'lose'], undefined],
   [['helpg', 'rep'], undefined],


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds support for the `:h[elp]` command, allowing users to access help documentation directly within the editor.

**Which issue(s) this PR fixes**
Fixes: https://github.com/VSCodeVim/Vim/issues/9128
