### PR TITLE
Execute action closeQuickDiff on <Esc>

### DIFF
--- a/src/actions/commands/actions.ts
+++ b/src/actions/commands/actions.ts
@@ -289,6 +289,7 @@ class CommandEsc extends BaseCommand {
           vscode.commands.executeCommand('closeReferenceSearchEditor'),
           vscode.commands.executeCommand('closeMarkersNavigation'),
           vscode.commands.executeCommand('closeDirtyDiff'),
+          vscode.commands.executeCommand('closeQuickDiff'),
           vscode.commands.executeCommand('editor.action.inlineSuggest.hide'),
         ]);
       }


### PR DESCRIPTION
<!--
Yay! Thanks for sending us a PR! 🎊

Please ensure your PR adheres to:

- [ ] Commit messages has a short & issue references when necessary
- [ ] Each commit does a logical chunk of work.
- [ ] It builds and tests pass (e.g `gulp`)
-->

**What this PR does / why we need it**:

When viewing a dirty diff (opened for example via `editor.action.dirtydiff.next` on a version-controlled file with changes) pressing `<Esc>` doesn't escape the diff view. This is because as of https://github.com/microsoft/vscode/pull/235601 `closeDirtyDiff` has been renamed to `closeQuickDiff`.


**Which issue(s) this PR fixes**

<!--
Commits in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)
-->

**Special notes for your reviewer**:
