### PR TITLE
#9742 : Add support for externally provided text objects

### DIFF
--- a/README.md
+++ b/README.md
@@ -802,13 +802,10 @@ The command should return a result object:
 {
   start: Position;
   stop: Position;
-  failed?: boolean;
 }
 ```
 
 or `undefined` if the text object cannot be determined.
-
-If `failed` is true, the text object operation will be cancelled.
 
 ## 🎩 VSCodeVim tricks!
 

--- a/README.md
+++ b/README.md
@@ -145,6 +145,7 @@ These settings are specific to VSCodeVim.
 | vim.highlightedyank.enable       | Enable highlighting when yanking                                                                                                                                                                                                                                                                                                                                                                                                   | Boolean | false                                                         |
 | vim.highlightedyank.color        | Set the color of yank highlights                                                                                                                                                                                                                                                                                                                                                                                                   | String  | rgba(250, 240, 170, 0.5)                                      |
 | vim.highlightedyank.duration     | Set the duration of yank highlights                                                                                                                                                                                                                                                                                                                                                                                                | Number  | 200                                                           |
+| vim.textObjects                  | Configure external command text objects. An array of objects with `keys` and `command` properties.                                                                                                                                                                                                                                                                                                                                 | Array   | []                                                            |
 
 ### Neovim Integration
 
@@ -765,6 +766,49 @@ Usage examples:
 | vim.argumentObjectOpeningDelimiters | A list of opening delimiters | String list | ["(", "["]    |
 | vim.argumentObjectClosingDelimiters | A list of closing delimiters | String list | [")", "]"]    |
 | vim.argumentObjectSeparators        | A list of object separators  | String list | [","]         |
+
+### External Command Text Objects
+
+This feature allows you to define custom text objects using external commands. Configure them via the `vim.textObjects` setting.
+
+Example configuration:
+
+```json
+"vim.textObjects": [
+  {
+    "keys": ["i", "f"],
+    "command": "myExtension.textObjectCommand"
+  }
+]
+```
+
+- `keys`: An array of strings representing the key sequence for the text object (e.g., `["i", "f"]` for `if`).
+- `command`: The VS Code command identifier that will be executed to compute the text object range.
+
+The external command will receive arguments in the form of:
+
+```typescript
+{
+  position: Position;
+  mode: 'visual' | 'normal' | 'insert';
+}
+```
+
+Where `Position` is an object with `line` and `character` properties.
+
+The command should return a result object:
+
+```typescript
+{
+  start: Position;
+  stop: Position;
+  failed?: boolean;
+}
+```
+
+or `undefined` if the text object cannot be determined.
+
+If `failed` is true, the text object operation will be cancelled.
 
 ## 🎩 VSCodeVim tricks!
 

--- a/extensionBase.ts
+++ b/extensionBase.ts
@@ -17,6 +17,7 @@ import { Logger } from './src/util/logger';
 import { SpecialKeys } from './src/util/specialKeys';
 import { VSCodeContext } from './src/util/vscodeContext';
 import { exCommandParser } from './src/vimscript/exCommandParser';
+import { registerTextObjects } from './src/textobject/externalCommandTextObject';
 
 let extensionContext: vscode.ExtensionContext;
 let previousActiveEditorUri: vscode.Uri | undefined;
@@ -88,6 +89,7 @@ export async function loadConfiguration() {
       }
     }
   }
+  registerTextObjects(configuration.textObjects);
 }
 
 /**

--- a/package.json
+++ b/package.json
@@ -453,6 +453,31 @@
           "markdownDescription": "Remapped keys in Normal mode. Allows mapping to Vim commands or VS Code actions. See [README](https://github.com/VSCodeVim/Vim/#key-remapping) for details.",
           "scope": "application"
         },
+        "vim.textObjects": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "keys": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "description": "Key combinations to trigger the text object."
+              },
+              "command": {
+                "type": "string",
+                "description": "VSCode command ID to execute for the text object."
+              }
+            },
+            "required": [
+              "keys",
+              "command"
+            ]
+          },
+          "markdownDescription": "Configure external text objects powered by VSCode commands. Each object must specify keys and command ID.",
+          "scope": "application"
+        },
         "vim.normalModeKeyBindingsNonRecursive": {
           "type": "array",
           "markdownDescription": "Non-recursive remapped keys in Normal mode. Allows mapping to Vim commands or VS Code actions. See [README](https://github.com/VSCodeVim/Vim/#key-remapping) for details.",

--- a/src/configuration/configuration.ts
+++ b/src/configuration/configuration.ts
@@ -16,6 +16,7 @@ import {
   IKeyRemapping,
   IModeSpecificStrings,
   ITargetsConfiguration,
+  ITextObjectConfig,
 } from './iconfiguration';
 
 import { SUPPORT_VIMRC } from 'platform/constants';
@@ -203,6 +204,11 @@ class Configuration implements IConfiguration {
     // workaround for circular dependency that would
     // prevent packaging if we simply called `updateLangmap(configuration.langmap);`
     this.loadListeners.forEach((listener) => listener());
+
+    // Load external text objects from vim.textObjects
+    this.textObjects = Array.isArray(vimConfigs.textObjects)
+      ? (vimConfigs.textObjects as ITextObjectConfig[])
+      : [];
 
     return validatorResults;
   }
@@ -490,6 +496,8 @@ class Configuration implements IConfiguration {
   langmapBindingsMap: Map<string, string> = new Map();
   langmapReverseBindingsMap: Map<string, string> = new Map();
   langmap = '';
+
+  textObjects: ITextObjectConfig[] = [];
 
   get textwidth(): number {
     const textwidth = this.getConfiguration('vim').get('textwidth', 80);

--- a/src/configuration/iconfiguration.ts
+++ b/src/configuration/iconfiguration.ts
@@ -86,6 +86,11 @@ export interface ITargetsConfiguration {
   smartQuotes: ISmartQuotesConfiguration;
 }
 
+export interface ITextObjectConfig {
+  keys: string[];
+  command: string;
+}
+
 export interface IConfiguration {
   [key: string]: any;
 
@@ -372,6 +377,11 @@ export interface IConfiguration {
    * InputMethodSwicher
    */
   autoSwitchInputMethod: IAutoSwitchInputMethod;
+
+  /**
+   * External text objects powered by VSCode commands
+   */
+  textObjects: ITextObjectConfig[];
 
   /**
    * Keybindings

--- a/src/textobject/externalCommandTextObject.ts
+++ b/src/textobject/externalCommandTextObject.ts
@@ -1,0 +1,97 @@
+import { TextObject } from './textobject';
+import { VimState } from '../state/vimState';
+import { Position } from 'vscode';
+import { IMovement, failedMovement } from '../actions/baseMotion';
+import { commands } from 'vscode';
+import { isVisualMode, Mode } from '../mode/mode';
+import type { ITextObjectConfig } from '../configuration/iconfiguration';
+import { RegisterAction } from '../actions/base';
+
+type TextObjectResult = {
+  start: Position;
+  stop: Position;
+  failed?: boolean;
+};
+
+type TextObjectArgs = {
+  position: Position;
+  mode: 'visual' | 'normal' | 'insert';
+};
+
+export class ExternalCommandTextObject extends TextObject {
+  keys: string[];
+  command: string;
+  override modes: Mode[] = [Mode.Normal, Mode.Visual, Mode.VisualBlock];
+
+  constructor(keys: string[], command: string) {
+    super();
+    this.keys = keys;
+    this.command = command;
+  }
+
+  public override async execAction(position: Position, vimState: VimState): Promise<IMovement> {
+    try {
+      const mode = vimState.currentMode;
+      const args: TextObjectArgs = {
+        position,
+        mode: isVisualMode(mode) ? 'visual' : mode === Mode.Insert ? 'insert' : 'normal',
+      };
+      const result = await commands.executeCommand(this.command, args);
+      assertResult(result);
+      return {
+        start: result.start,
+        stop: result.stop,
+        failed: !!result.failed,
+      };
+    } catch (e) {
+      return failedMovement(vimState);
+    }
+  }
+}
+
+function assertResult(result: unknown): asserts result is TextObjectResult {
+  if (typeof result !== 'object' || result === null) {
+    throw new Error('Invalid result');
+  }
+
+  if (!('start' in result) || !('stop' in result)) {
+    throw new Error('Invalid result');
+  }
+  const start = result.start;
+  const stop = result.stop;
+
+  if (typeof start !== 'object' || start === null) {
+    throw new Error('Invalid start');
+  }
+
+  if (typeof stop !== 'object' || stop === null) {
+    throw new Error('Invalid stop');
+  }
+
+  if (!('line' in start) || typeof start.line !== 'number') {
+    throw new Error('Invalid start line');
+  }
+
+  if (!('character' in start) || typeof start.character !== 'number') {
+    throw new Error('Invalid start character');
+  }
+
+  if (!('line' in stop) || typeof stop.line !== 'number') {
+    throw new Error('Invalid stop line');
+  }
+
+  if (!('character' in stop) || typeof stop.character !== 'number') {
+    throw new Error('Invalid stop character');
+  }
+}
+
+export function registerTextObjects(objects: ITextObjectConfig[]): void {
+  for (const obj of objects) {
+    class DynamicTextObject extends ExternalCommandTextObject {
+      constructor() {
+        super(obj.keys, obj.command);
+      }
+    }
+    RegisterAction(DynamicTextObject);
+  }
+}

--- a/src/textobject/externalCommandTextObject.ts
+++ b/src/textobject/externalCommandTextObject.ts
@@ -10,7 +10,6 @@ import { RegisterAction } from '../actions/base';
 type TextObjectResult = {
   start: Position;
   stop: Position;
-  failed?: boolean;
 };
 
 type TextObjectArgs = {
@@ -41,7 +40,6 @@ export class ExternalCommandTextObject extends TextObject {
       return {
         start: result.start,
         stop: result.stop,
-        failed: !!result.failed,
       };
     } catch (e) {
       return failedMovement(vimState);

--- a/test/testConfiguration.ts
+++ b/test/testConfiguration.ts
@@ -149,4 +149,5 @@ export class Configuration implements IConfiguration {
     '<C-d>': true,
   };
   langmap = '';
+  textObjects = [];
 }


### PR DESCRIPTION
## Background

This PR implements support for providing new text objects from other extensions. For example an extension which has support for parting source code using treesitter library can provide more text objects based on treesitter queries. 

## What has implemented

The implementation is based on binding extension commands to vim keybindings using the same approach that has taken for in built text objects.

## What has not implemented

I have not considered validating against conflicting text objects which another extension might have provided. This is because the implementation depends on the user to configure such external text objects in settings rather than they become available automatically. Only exception for this assumption is default setting value an extension might provide, But it is unlikely an external extension might provide a default value using Vim extension configuration keys.


## Testing

I have my own private extension which implements treesitter support for few languages I work with daily. But as automated tests I'm open to help out implementing such tests here in this project if this feature is something the project owners consider including. 

