### PR TITLE
Add 'vim.statusBarCursor' setting to customize status bar cursor

### DIFF
--- a/package.json
+++ b/package.json
@@ -1156,6 +1156,11 @@
         "vim.langmap": {
           "type": "string",
           "description": "Language map for alternate keyboard layouts. When you are typing text in Insert (or Replace, etc.) mode, the characters are inserted derectly. Otherwise, they are translated based on the provided map."
+        },
+        "vim.statusBarCursor": {
+          "type": "string",
+          "description": "The character to use as the cursor in the status bar (e.g. during search or command line mode).",
+          "default": "|"
         }
       }
     },

--- a/src/configuration/configuration.ts
+++ b/src/configuration/configuration.ts
@@ -328,6 +328,8 @@ class Configuration implements IConfiguration {
     replace: ['#000000', '#ffffff'],
   };
 
+  statusBarCursor = '|';
+
   searchHighlightColor = '';
   searchHighlightTextColor = '';
 

--- a/src/configuration/iconfiguration.ts
+++ b/src/configuration/iconfiguration.ts
@@ -252,6 +252,7 @@ export interface IConfiguration {
    * Status bar colors to change to based on mode
    */
   statusBarColors: IModeSpecificStrings<string | string[]>;
+  statusBarCursor: string;
 
   /**
    * Color of search highlights.

--- a/src/statusBar.ts
+++ b/src/statusBar.ts
@@ -168,7 +168,7 @@ export function statusBarText(vimState: VimState) {
   const cursorChar =
     vimState.recordedState.actionKeys[vimState.recordedState.actionKeys.length - 1] === '<C-r>'
       ? '"'
-      : '|';
+      : configuration.statusBarCursor;
   switch (vimState.modeData.mode) {
     case Mode.Normal:
       return '-- NORMAL --';

--- a/test/testConfiguration.ts
+++ b/test/testConfiguration.ts
@@ -79,6 +79,7 @@ export class Configuration implements IConfiguration {
     visualblock: '#A3BE8C',
     replace: '#D08770',
   };
+  statusBarCursor = '|';
   searchHighlightColor = 'rgba(150, 150, 255, 0.3)';
   searchHighlightTextColor = '';
   searchMatchColor = 'rgba(255, 150, 150, 0.3)';


### PR DESCRIPTION
**What this PR does / why we need it:** 

This PR adds a new configuration option `vim.statusBarCursor` that allows users to customize the cursor character displayed in the status bar (e.g., during search or command line mode). 
Previously, this character was hardcoded to `|`. This change enables users to choose a character that better fits their aesthetic preferences or visibility needs (e.g., _, ▐).

**Which issue(s) this PR fixes:** N/A

Special notes for your reviewer: The default value for vim.statusBarCursor is set to `|`, ensuring that the existing behavior is preserved for all users who do not configure this setting.