### PR TITLE
fix: abnormal issues during IME composition input

### DIFF
--- a/src/state/compositionState.ts
+++ b/src/state/compositionState.ts
@@ -8,4 +8,12 @@ export class CompositionState {
     this.insertedText = false;
     this.composingText = '';
   }
+
+  clone() {
+    const cloned = new CompositionState();
+    cloned.isInComposition = this.isInComposition;
+    cloned.insertedText = this.insertedText;
+    cloned.composingText = this.composingText;
+    return cloned;
+  }
 }


### PR DESCRIPTION
## **What this PR does / why we need it**:
The composition of IME expects input to be reflected immediately in the document. The delay caused by Vim's controls interferes with the normal operation of IEM composition. I believe we don't need to intercept IME composition input in insert mode.

## **Which issue(s) this PR fixes**:
#9864, #7417, #2607, #9531