### PR TITLE
added revert to normal mode in case of bad sequence of selectionchang…

### DIFF
--- a/src/mode/modeHandler.ts
+++ b/src/mode/modeHandler.ts
@@ -253,8 +253,7 @@ export class ModeHandler implements vscode.Disposable, IModeHandler {
             // like 'editor.action.smartSelect.grow' are handled.
             if (this.vimState.currentMode === Mode.Visual) {
               const isEol =
-                e.textEditor.document &&
-                e.textEditor.document.lineAt(selection.active.line).text.length ===
+                e.textEditor.document?.lineAt(selection.active.line).text.length ===
                   selection.active.character;
               const lastSelection = this.vimState.lastVisualSelection;
               const previousVisualSelectionIsFromLastCharToEol =


### PR DESCRIPTION




**What this PR does / why we need it**:
Fixes mouseclick at eol when in normal mode sometimes triggers visual mode.

I was able to reproduce the problem - the core issue is that vscode
sometimes issues a specific sequence of selection change events on a single mouse click.
When the error occurs the sequence of events for the single mouse click is:
1. Selection change event that selects the last character of the line
- This causes the change to visual mode
2. Selection change event that selects no characters and is at end of line
- This moves the cursor to the end of line having no characters selected

These two events leave the editor in the state which was also shown in
the issue: visual mode and no characters selected.

**Which issue(s) this PR fixes**
#9887 
