### PR TITLE
Add C-w (H|J|K|L) commands to move editor groups

### DIFF
--- a/src/actions/commands/window.ts
+++ b/src/actions/commands/window.ts
@@ -152,6 +152,70 @@ class MoveToUpperPane extends BaseCommand {
 }
 
 @RegisterAction
+class MovePaneLeft extends BaseCommand {
+  modes = [Mode.Normal, Mode.Visual, Mode.VisualLine];
+  keys = [['<C-w>', 'H']];
+  override runsOnceForEveryCursor(): boolean {
+    return false;
+  }
+
+  public override async exec(position: Position, vimState: VimState): Promise<void> {
+    vimState.postponedCodeViewChanges.push({
+      command: 'workbench.action.moveActiveEditorGroupLeft',
+      args: {},
+    });
+  }
+}
+
+@RegisterAction
+class MovePaneRight extends BaseCommand {
+  modes = [Mode.Normal, Mode.Visual, Mode.VisualLine];
+  keys = [['<C-w>', 'L']];
+  override runsOnceForEveryCursor(): boolean {
+    return false;
+  }
+
+  public override async exec(position: Position, vimState: VimState): Promise<void> {
+    vimState.postponedCodeViewChanges.push({
+      command: 'workbench.action.moveActiveEditorGroupRight',
+      args: {},
+    });
+  }
+}
+
+@RegisterAction
+class MovePaneDown extends BaseCommand {
+  modes = [Mode.Normal, Mode.Visual, Mode.VisualLine];
+  keys = [['<C-w>', 'J']];
+  override runsOnceForEveryCursor(): boolean {
+    return false;
+  }
+
+  public override async exec(position: Position, vimState: VimState): Promise<void> {
+    vimState.postponedCodeViewChanges.push({
+      command: 'workbench.action.moveActiveEditorGroupDown',
+      args: {},
+    });
+  }
+}
+
+@RegisterAction
+class MovePaneUp extends BaseCommand {
+  modes = [Mode.Normal, Mode.Visual, Mode.VisualLine];
+  keys = [['<C-w>', 'K']];
+  override runsOnceForEveryCursor(): boolean {
+    return false;
+  }
+
+  public override async exec(position: Position, vimState: VimState): Promise<void> {
+    vimState.postponedCodeViewChanges.push({
+      command: 'workbench.action.moveActiveEditorGroupUp',
+      args: {},
+    });
+  }
+}
+
+@RegisterAction
 class CycleThroughPanes extends BaseCommand {
   modes = [Mode.Normal, Mode.Visual, Mode.VisualLine];
   keys = [


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds the default Vim mappings for the four directional commands for moving windows (editor groups in VSCode parlance).

**Which issue(s) this PR fixes**
Fixes https://github.com/VSCodeVim/Vim/issues/8284

**Special notes for your reviewer**:
These commands don't exactly match the original Vim maps: the Vim commands move a window as far as possible in the given direction, whereas the VSCode commands move an editor group one space over. However, I still think it's better than nothing, and I didn't see any simple way of making them behave exactly the same.