### PR TITLE
fixed format on save not always being done

### DIFF
--- a/src/cmd_line/commands/write.ts
+++ b/src/cmd_line/commands/write.ts
@@ -8,6 +8,7 @@ import { StatusBar } from '../../statusBar';
 import { Logger } from '../../util/logger';
 import { ExCommand } from '../../vimscript/exCommand';
 import { bangParser, fileNameParser, FileOpt, fileOptParser } from '../../vimscript/parserUtils';
+import { configuration } from './../../configuration/configuration';
 
 export type IWriteCommandArguments = {
   bang: boolean;
@@ -136,6 +137,14 @@ export class WriteCommand extends ExCommand {
   private async save(vimState: VimState): Promise<void> {
     if (this.shouldShowDocument(vimState.document.uri)) {
       await vscode.window.showTextDocument(vimState.document, { preview: false });
+    }
+
+    // Fixes https://github.com/VSCodeVim/Vim/issues/9883
+    const shouldRunFormatDocSinceExpectedAndWontBeDoneBySave =
+      !vimState.document.isDirty &&
+      configuration?.getConfiguration('editor')?.get<boolean>('formatOnSave');
+    if (shouldRunFormatDocSinceExpectedAndWontBeDoneBySave) {
+      await vscode.commands.executeCommand('editor.action.formatDocument');
     }
 
     await this.background(


### PR DESCRIPTION

**What this PR does / why we need it**:
Fixes format on save problem.
I was able to reproduce the problem using the video from the issue,
but also found a more reliable way of reproducing it: 
  - create a file that needs formatting on disk
  - open the file in vscode
  - have the 'editor.formatOnSave' setting toggled
  - without changing any text of the file do ':w'
  - won't format
  - do ctrl + s
  - will do format

The problem is that vscode won't do format on save when calling 'vimState.document.save()' if the textual contents is no different from disk (document not 'dirty'). 

**Which issue(s) this PR fixes**
https://github.com/VSCodeVim/Vim/issues/9883
