### PR TITLE
Fix dot repeat for tab-only insertions

### DIFF
--- a/src/actions/commands/insert.ts
+++ b/src/actions/commands/insert.ts
@@ -224,11 +224,39 @@ export class ExitInsertMode extends BaseCommand {
       vimState.cursors = vimState.cursors.map((x) => x.withNewStop(x.stop.getRight()));
     }
 
+    const lastActionBeforeEsc =
+      vimState.recordedState.actionsRun[vimState.recordedState.actionsRun.length - 2];
+    const hasPendingContentChanges = vimState.historyTracker.currentContentChanges.length > 0;
+    const hasRecordedContentChange = vimState.recordedState.actionsRun.some(
+      (action) => action instanceof DocumentContentChangeAction,
+    );
+    const insertSessionHasNoRecordedEditAction =
+      lastActionBeforeEsc instanceof Insert ||
+      lastActionBeforeEsc instanceof Append ||
+      lastActionBeforeEsc instanceof InsertAtLineBegin ||
+      lastActionBeforeEsc instanceof InsertAtLineEnd ||
+      lastActionBeforeEsc instanceof InsertAfterFirstWhitespaceOnLine ||
+      lastActionBeforeEsc instanceof InsertAtLastChange ||
+      lastActionBeforeEsc instanceof InsertAbove ||
+      lastActionBeforeEsc instanceof InsertBelow;
+    if (
+      hasPendingContentChanges &&
+      !hasRecordedContentChange &&
+      insertSessionHasNoRecordedEditAction
+    ) {
+      const firstChange = vimState.historyTracker.currentContentChanges[0];
+      const contentChange = new DocumentContentChangeAction(firstChange.range.start);
+      contentChange.addChanges(
+        vimState.historyTracker.currentContentChanges,
+        vimState.cursorStopPosition,
+      );
+      vimState.recordedState.actionsRun.splice(-1, 0, contentChange);
+      vimState.historyTracker.currentContentChanges = [];
+    }
+
     // only remove leading spaces inserted by vscode.
     // vscode only inserts them when user enter a new line,
     // ie, o/O in Normal mode or \n in Insert mode.
-    const lastActionBeforeEsc =
-      vimState.recordedState.actionsRun[vimState.recordedState.actionsRun.length - 2];
     if (
       vimState.document.languageId !== 'plaintext' &&
       (lastActionBeforeEsc instanceof InsertBelow ||

--- a/test/mode/normalModeTests/dot.test.ts
+++ b/test/mode/normalModeTests/dot.test.ts
@@ -55,6 +55,13 @@ suite('Dot Operator', () => {
   });
 
   newTest({
+    title: 'Can handle dot with I and tab',
+    start: ['on|e', 'two', 'three'],
+    keysPressed: 'I\t<Esc>j.j.',
+    end: ['\tone', '\ttwo', '|\tthree'],
+  });
+
+  newTest({
     title: 'Can repeat actions that require selections',
     start: ['on|e', 'two'],
     keysPressed: 'Vj>.',
@@ -179,6 +186,13 @@ suite('Repeat content change', () => {
     start: ['on|e', 'two'],
     keysPressed: 'a<C-t><Esc>j.',
     end: ['\tone', '\ttw|o'],
+  });
+
+  newTest({
+    title: 'Can repeat tab-only insert count',
+    start: ['|one'],
+    keysPressed: '5i\t<Esc>',
+    end: ['\t\t\t\t|\tone'],
   });
 
   newTest({


### PR DESCRIPTION
<!--
Yay! Thanks for sending us a PR! 🎊

Please ensure your PR adheres to:

- [ ] Commit messages has a short & issue references when necessary
- [ ] Each commit does a logical chunk of work.
- [ ] It builds and tests pass (e.g `gulp`)
-->

**What this PR does / why we need it**:

Fixes `.` repeat for insert sessions that only change the document through VS Code-managed edits, such as a plain `<Tab>` in Insert mode.

Before this change, a tab-only insert like:

`I<Tab><Esc>j.j.`

would not replay with `.` because no `DocumentContentChangeAction` was ever recorded for that insert session. Mixed insertions like `iabc<Tab><Esc>.` worked because normal typing had already created a content-change action.

**Which issue(s) this PR fixes**
Fixes #2337

<!--
Commits in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)
-->

**Special notes for your reviewer**:

Added regression coverage for:
- `I<Tab><Esc>j.j.`
- `5i<Tab><Esc>`

I also ran the repo's Docker-based test flow from the contributing guide:

- `npx gulp test`

Full Docker suite result on this branch:
- `3150 passing`
- `19 pending`
- `0 failing`

For comparison, clean `master` in the same Docker path produced:
- `3148 passing`
- `19 pending`
- `0 failing`

So this branch adds the 2 new regression tests without introducing new failures.