### PR TITLE
keybindings: Add conditional when support to remapped commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,7 @@ Custom remappings are defined on a per-mode basis.
 
 - Keybinding overrides to use for insert, normal, operatorPending and visual modes.
 - Keybinding overrides can include `"before"`, `"after"`, `"commands"`, and `"silent"`.
+- Command objects inside `"commands"` can also include `"when"`. These `when` expressions are evaluated against contexts published by VSCodeVim itself, such as `vim.active`, `vim.mode`, and `vim.isTextDiffEditor`.
 - Bind `jj` to `<Esc>` in insert mode:
 
 ```json
@@ -317,6 +318,28 @@ Custom remappings are defined on a per-mode basis.
         }
     ]
 ```
+
+    - Conditionally bind `]c` to diff navigation in a text diff editor and to another command otherwise:
+
+    ```json
+      "vim.normalModeKeyBindingsNonRecursive": [
+        {
+          "before": ["]", "c"],
+          "commands": [
+            {
+              "command": "workbench.action.compareEditor.nextChange",
+              "when": "vim.isTextDiffEditor"
+            },
+            {
+              "command": "chatEditor.action.navigateNext",
+              "when": "!vim.isTextDiffEditor"
+            }
+          ]
+        }
+      ]
+    ```
+
+    Supported operators in `when`: `!`, `&&`, `||`, `==`, `!=`, and parentheses.
 
 #### `"vim.insertModeKeyBindingsNonRecursive"`/`"normalModeKeyBindingsNonRecursive"`/`"visualModeKeyBindingsNonRecursive"`/`"operatorPendingModeKeyBindingsNonRecursive"`
 

--- a/extensionBase.ts
+++ b/extensionBase.ts
@@ -27,6 +27,19 @@ interface ICodeKeybinding {
   commands?: Array<{ command: string; args: any[] }>;
 }
 
+function isTextDiffEditorActive(): boolean {
+  const activeTab = vscode.window.tabGroups.activeTabGroup?.activeTab;
+  if (!activeTab?.input) {
+    return false;
+  }
+
+  return activeTab.input instanceof vscode.TabInputTextDiff;
+}
+
+async function updateEditorContexts(): Promise<void> {
+  await VSCodeContext.set('vim.isTextDiffEditor', isTextDiffEditorActive());
+}
+
 export async function getAndUpdateModeHandler(
   forceSyncAndUpdate = false,
 ): Promise<ModeHandler | undefined> {
@@ -232,6 +245,7 @@ export async function activate(context: vscode.ExtensionContext, handleLocal: bo
       }
 
       taskQueue.enqueueTask(async () => {
+        await updateEditorContexts();
         const mh = await getAndUpdateModeHandler(true);
         if (mh) {
           globalState.jumpTracker.handleFileJump(
@@ -243,6 +257,15 @@ export async function activate(context: vscode.ExtensionContext, handleLocal: bo
     },
     true,
     true,
+  );
+
+  registerEventListener(
+    context,
+    vscode.window.tabGroups.onDidChangeTabs,
+    async () => {
+      await updateEditorContexts();
+    },
+    false,
   );
 
   registerEventListener(
@@ -504,6 +527,7 @@ export async function activate(context: vscode.ExtensionContext, handleLocal: bo
   // Disable automatic keyboard navigation in lists, so it doesn't interfere
   // with our list navigation keybindings
   await VSCodeContext.set('listAutomaticKeyboardNavigation', false);
+  await updateEditorContexts();
 
   await toggleExtension(configuration.disableExtension, compositionState);
 

--- a/src/configuration/iconfiguration.ts
+++ b/src/configuration/iconfiguration.ts
@@ -2,6 +2,12 @@ import * as vscode from 'vscode';
 
 export type Digraph = [string, number | number[]];
 
+export interface IRemappingCommand {
+  command: string;
+  args?: any[];
+  when?: string;
+}
+
 export interface IModeSpecificStrings<T> {
   normal: T | undefined;
   insert: T | undefined;
@@ -17,7 +23,7 @@ export interface IKeyRemapping {
   silent?: boolean;
   // 'recursive' is calculated when validating, according to the config that stored the remapping
   recursive?: boolean;
-  commands?: Array<{ command: string; args: any[] } | string>;
+  commands?: Array<IRemappingCommand | string>;
   source?: 'vscode' | 'vimrc';
 }
 

--- a/src/configuration/remapper.ts
+++ b/src/configuration/remapper.ts
@@ -6,8 +6,10 @@ import { ModeHandler } from '../mode/modeHandler';
 import { StatusBar } from '../statusBar';
 import { Logger } from '../util/logger';
 import { SpecialKeys } from '../util/specialKeys';
+import { VSCodeContext } from '../util/vscodeContext';
 import { exCommandParser } from '../vimscript/exCommandParser';
 import { IKeyRemapping } from './iconfiguration';
+import { evaluateWhenClause } from './whenExpression';
 
 interface IRemapper {
   /**
@@ -491,6 +493,7 @@ export class Remapper implements IRemapper {
         for (const command of remapping.commands) {
           let commandString: string;
           let commandArgs: string[];
+          let shouldExecuteCommand = true;
           if (typeof command === 'string') {
             commandString = command;
             commandArgs = [];
@@ -501,6 +504,16 @@ export class Remapper implements IRemapper {
               : command.args
                 ? [command.args]
                 : [];
+
+            if (command.when) {
+              shouldExecuteCommand = evaluateWhenClause(command.when, (contextKey) =>
+                VSCodeContext.get(contextKey),
+              );
+            }
+          }
+
+          if (!shouldExecuteCommand) {
+            continue;
           }
 
           if (commandString.slice(0, 1) === ':') {

--- a/src/configuration/validators/remappingValidator.ts
+++ b/src/configuration/validators/remappingValidator.ts
@@ -4,6 +4,7 @@ import { configurationValidator } from '../configurationValidator';
 import { IConfiguration, IKeyRemapping } from '../iconfiguration';
 import { IConfigurationValidator, ValidatorResults } from '../iconfigurationValidator';
 import { Notation } from '../notation';
+import { validateWhenClause } from '../whenExpression';
 
 export class RemappingValidator implements IConfigurationValidator {
   private commandMap!: Map<string, boolean>;
@@ -138,13 +139,23 @@ export class RemappingValidator implements IConfigurationValidator {
         } else if (command.command) {
           cmd = command.command;
 
+          if (command.when !== undefined) {
+            const whenValidationError = validateWhenClause(command.when);
+            if (whenValidationError) {
+              result.append({
+                level: 'error',
+                message: `Remapping of '${remapping.before}' has invalid \"when\" expression: ${whenValidationError}`,
+              });
+            }
+          }
+
           if (!(await this.isCommandValid(cmd))) {
             result.append({ level: 'warning', message: `${cmd} does not exist.` });
           }
         } else {
           result.append({
             level: 'error',
-            message: `Remapping of '${remapping.before}' has wrong "commands" structure. Should be 'string[] | { "command": string, "args": any[] }[]'.`,
+            message: `Remapping of '${remapping.before}' has wrong "commands" structure. Should be 'string[] | { "command": string, "args"?: any[], "when"?: string }[]'.`,
           });
         }
       }

--- a/src/configuration/whenExpression.ts
+++ b/src/configuration/whenExpression.ts
@@ -1,0 +1,278 @@
+export type WhenContextValue = boolean | string | undefined;
+
+type TokenType =
+  | 'identifier'
+  | 'string'
+  | 'boolean'
+  | 'and'
+  | 'or'
+  | 'not'
+  | 'equals'
+  | 'notEquals'
+  | 'lparen'
+  | 'rparen'
+  | 'eof';
+
+interface Token {
+  type: TokenType;
+  value?: string | boolean;
+}
+
+class WhenExpressionSyntaxError extends Error {}
+
+class Tokenizer {
+  private position = 0;
+  private readonly expression: string;
+
+  constructor(expression: string) {
+    this.expression = expression;
+  }
+
+  public tokenize(): Token[] {
+    const tokens: Token[] = [];
+
+    while (this.position < this.expression.length) {
+      this.skipWhitespace();
+      if (this.position >= this.expression.length) {
+        break;
+      }
+
+      const remaining = this.expression.slice(this.position);
+      if (remaining.startsWith('&&')) {
+        tokens.push({ type: 'and' });
+        this.position += 2;
+        continue;
+      }
+
+      if (remaining.startsWith('||')) {
+        tokens.push({ type: 'or' });
+        this.position += 2;
+        continue;
+      }
+
+      if (remaining.startsWith('==')) {
+        tokens.push({ type: 'equals' });
+        this.position += 2;
+        continue;
+      }
+
+      if (remaining.startsWith('!=')) {
+        tokens.push({ type: 'notEquals' });
+        this.position += 2;
+        continue;
+      }
+
+      const current = this.expression[this.position];
+      if (current === '!') {
+        tokens.push({ type: 'not' });
+        this.position += 1;
+        continue;
+      }
+
+      if (current === '(') {
+        tokens.push({ type: 'lparen' });
+        this.position += 1;
+        continue;
+      }
+
+      if (current === ')') {
+        tokens.push({ type: 'rparen' });
+        this.position += 1;
+        continue;
+      }
+
+      if (current === '"' || current === "'") {
+        tokens.push({ type: 'string', value: this.readString(current) });
+        continue;
+      }
+
+      const identifier = this.readIdentifier();
+      if (identifier.length === 0) {
+        throw new WhenExpressionSyntaxError(
+          `Unexpected character '${this.expression[this.position]}' in when clause.`,
+        );
+      }
+
+      if (identifier === 'true' || identifier === 'false') {
+        tokens.push({ type: 'boolean', value: identifier === 'true' });
+      } else {
+        tokens.push({ type: 'identifier', value: identifier });
+      }
+    }
+
+    tokens.push({ type: 'eof' });
+    return tokens;
+  }
+
+  private skipWhitespace(): void {
+    while (this.position < this.expression.length && /\s/u.test(this.expression[this.position])) {
+      this.position += 1;
+    }
+  }
+
+  private readString(quote: string): string {
+    this.position += 1;
+    let value = '';
+
+    while (this.position < this.expression.length) {
+      const current = this.expression[this.position];
+      if (current === '\\') {
+        this.position += 1;
+        if (this.position >= this.expression.length) {
+          break;
+        }
+
+        value += this.expression[this.position];
+        this.position += 1;
+        continue;
+      }
+
+      if (current === quote) {
+        this.position += 1;
+        return value;
+      }
+
+      value += current;
+      this.position += 1;
+    }
+
+    throw new WhenExpressionSyntaxError('Unterminated string literal in when clause.');
+  }
+
+  private readIdentifier(): string {
+    const start = this.position;
+
+    while (this.position < this.expression.length) {
+      const current = this.expression[this.position];
+      if (/\s/u.test(current) || ['(', ')', '!', '&', '|', '=', '"', "'"].includes(current)) {
+        break;
+      }
+
+      this.position += 1;
+    }
+
+    return this.expression.slice(start, this.position);
+  }
+}
+
+class Parser {
+  private position = 0;
+  private readonly tokens: Token[];
+  private readonly getContextValue: (key: string) => WhenContextValue;
+
+  constructor(tokens: Token[], getContextValue: (key: string) => WhenContextValue) {
+    this.tokens = tokens;
+    this.getContextValue = getContextValue;
+  }
+
+  public parse(): boolean {
+    const value = this.parseOr();
+    this.expect('eof');
+    return value;
+  }
+
+  private parseOr(): boolean {
+    let value = this.parseAnd();
+
+    while (this.match('or')) {
+      const right = this.parseAnd();
+      value = value || right;
+    }
+
+    return value;
+  }
+
+  private parseAnd(): boolean {
+    let value = this.parseEquality();
+
+    while (this.match('and')) {
+      const right = this.parseEquality();
+      value = value && right;
+    }
+
+    return value;
+  }
+
+  private parseEquality(): boolean {
+    const left = this.parseOperand();
+
+    if (this.match('equals')) {
+      return left === this.parseOperand();
+    }
+
+    if (this.match('notEquals')) {
+      return left !== this.parseOperand();
+    }
+
+    return this.toBoolean(left);
+  }
+
+  private parseOperand(): WhenContextValue {
+    if (this.match('not')) {
+      return !this.toBoolean(this.parseOperand());
+    }
+
+    if (this.match('lparen')) {
+      const value = this.parseOr();
+      this.expect('rparen');
+      return value;
+    }
+
+    const token = this.peek();
+    if (token.type === 'identifier') {
+      this.position += 1;
+      return this.getContextValue(String(token.value));
+    }
+
+    if (token.type === 'string' || token.type === 'boolean') {
+      this.position += 1;
+      return token.value as string | boolean;
+    }
+
+    throw new WhenExpressionSyntaxError('Unexpected token in when clause.');
+  }
+
+  private toBoolean(value: WhenContextValue): boolean {
+    if (typeof value === 'boolean') {
+      return value;
+    }
+
+    return Boolean(value);
+  }
+
+  private match(type: TokenType): boolean {
+    if (this.peek().type === type) {
+      this.position += 1;
+      return true;
+    }
+
+    return false;
+  }
+
+  private expect(type: TokenType): void {
+    if (!this.match(type)) {
+      throw new WhenExpressionSyntaxError(`Expected token '${type}' in when clause.`);
+    }
+  }
+
+  private peek(): Token {
+    return this.tokens[this.position];
+  }
+}
+
+export function evaluateWhenClause(
+  expression: string,
+  getContextValue: (key: string) => WhenContextValue,
+): boolean {
+  const tokens = new Tokenizer(expression).tokenize();
+  return new Parser(tokens, getContextValue).parse();
+}
+
+export function validateWhenClause(expression: string): string | undefined {
+  try {
+    evaluateWhenClause(expression, () => undefined);
+    return undefined;
+  } catch (error) {
+    return error instanceof Error ? error.message : 'Invalid when clause.';
+  }
+}

--- a/test/configuration/remapper.test.ts
+++ b/test/configuration/remapper.test.ts
@@ -9,6 +9,7 @@ import { ModeHandler } from '../../src/mode/modeHandler';
 import { IRegisterContent, Register } from '../../src/register/register';
 import { VimState } from '../../src/state/vimState';
 import { StatusBar } from '../../src/statusBar';
+import { VSCodeContext } from '../../src/util/vscodeContext';
 import { Configuration } from '../testConfiguration';
 import { assertEqualLines, setupWorkspace } from '../testUtils';
 
@@ -377,6 +378,54 @@ suite('Remapper', () => {
     }
 
     // assert
+    assert.strictEqual(actual, true);
+    assert.strictEqual(vscode.window.visibleTextEditors.length, 0);
+  });
+
+  test('conditional commands are skipped when when is false', async () => {
+    await setupWithBindings({
+      normalModeKeyBindingsNonRecursive: [
+        {
+          before: [leaderKey, 'w'],
+          commands: [
+            {
+              command: 'workbench.action.closeActiveEditor',
+              when: 'vim.isTextDiffEditor',
+            },
+          ],
+        },
+      ],
+    });
+
+    await VSCodeContext.set('vim.isTextDiffEditor', false);
+
+    const remapper = new Remappers();
+    const actual = await remapper.sendKey([leaderKey, 'w'], modeHandler);
+
+    assert.strictEqual(actual, true);
+    assert.strictEqual(vscode.window.visibleTextEditors.length, 1);
+  });
+
+  test('conditional commands are executed when when is true', async () => {
+    await setupWithBindings({
+      normalModeKeyBindingsNonRecursive: [
+        {
+          before: [leaderKey, 'w'],
+          commands: [
+            {
+              command: 'workbench.action.closeActiveEditor',
+              when: 'vim.isTextDiffEditor',
+            },
+          ],
+        },
+      ],
+    });
+
+    await VSCodeContext.set('vim.isTextDiffEditor', true);
+
+    const remapper = new Remappers();
+    const actual = await remapper.sendKey([leaderKey, 'w'], modeHandler);
+
     assert.strictEqual(actual, true);
     assert.strictEqual(vscode.window.visibleTextEditors.length, 0);
   });

--- a/test/configuration/validators/remappingValidator.test.ts
+++ b/test/configuration/validators/remappingValidator.test.ts
@@ -244,4 +244,58 @@ suite('Remapping Validator', () => {
     assert.strictEqual(configuration.commandLineModeKeyBindingsMap.size, 2);
     assert.strictEqual(configuration.operatorPendingModeKeyBindingsMap.size, 2);
   });
+
+  test('command remappings accept when clauses', async () => {
+    const testConfiguration = new Configuration();
+    testConfiguration.normalModeKeyBindings = [
+      {
+        before: ['g', 'c'],
+        commands: [
+          {
+            command: 'workbench.action.files.save',
+            when: 'vim.active && vim.mode == "Normal"',
+          },
+        ],
+      },
+    ];
+    testConfiguration.normalModeKeyBindingsNonRecursive = [];
+    testConfiguration.insertModeKeyBindings = [];
+    testConfiguration.insertModeKeyBindingsNonRecursive = [];
+    testConfiguration.visualModeKeyBindings = [];
+    testConfiguration.visualModeKeyBindingsNonRecursive = [];
+
+    const remappingValidator = new RemappingValidator();
+    const validationResult = await remappingValidator.validate(testConfiguration);
+
+    assert.strictEqual(validationResult.numErrors, 0);
+    assert.strictEqual(validationResult.hasError, false);
+    assert.strictEqual(testConfiguration.normalModeKeyBindingsMap.size, 1);
+  });
+
+  test('command remappings reject invalid when clauses', async () => {
+    const testConfiguration = new Configuration();
+    testConfiguration.normalModeKeyBindings = [
+      {
+        before: ['g', 'c'],
+        commands: [
+          {
+            command: 'workbench.action.files.save',
+            when: 'vim.active && (',
+          },
+        ],
+      },
+    ];
+    testConfiguration.normalModeKeyBindingsNonRecursive = [];
+    testConfiguration.insertModeKeyBindings = [];
+    testConfiguration.insertModeKeyBindingsNonRecursive = [];
+    testConfiguration.visualModeKeyBindings = [];
+    testConfiguration.visualModeKeyBindingsNonRecursive = [];
+
+    const remappingValidator = new RemappingValidator();
+    const validationResult = await remappingValidator.validate(testConfiguration);
+
+    assert.strictEqual(validationResult.numErrors, 1);
+    assert.strictEqual(validationResult.hasError, true);
+    assert.strictEqual(testConfiguration.normalModeKeyBindingsMap.size, 0);
+  });
 });

--- a/test/configuration/whenExpression.test.ts
+++ b/test/configuration/whenExpression.test.ts
@@ -1,0 +1,32 @@
+import * as assert from 'assert';
+
+import { evaluateWhenClause, validateWhenClause } from '../../src/configuration/whenExpression';
+
+suite('When Expression', () => {
+  test('evaluates booleans and equality checks', () => {
+    const context = new Map<string, boolean | string>([
+      ['vim.active', true],
+      ['vim.mode', 'Normal'],
+      ['vim.isTextDiffEditor', true],
+    ]);
+
+    assert.strictEqual(
+      evaluateWhenClause('vim.active && vim.mode == "Normal"', (key) => context.get(key)),
+      true,
+    );
+    assert.strictEqual(
+      evaluateWhenClause('vim.active && !vim.isTextDiffEditor', (key) => context.get(key)),
+      false,
+    );
+    assert.strictEqual(
+      evaluateWhenClause('vim.mode != "Insert" && (vim.active || vim.isTextDiffEditor)', (key) =>
+        context.get(key),
+      ),
+      true,
+    );
+  });
+
+  test('reports syntax errors', () => {
+    assert.notStrictEqual(validateWhenClause('vim.active && ('), undefined);
+  });
+});


### PR DESCRIPTION
Allow remapped command entries to declare a when clause evaluated against VSCodeVim-owned contexts, and publish `vim.isTextDiffEditor`  to support diff-aware remaps.

What this PR does / why we need it

Partially addresses #1372 and #2030.

This PR adds when-clause support for remapped command entries, but scopes that support to contexts owned and published by VSCodeVim itself.

It also introduces `vim.isTextDiffEditor`, which makes it possible to write diff-aware remaps such as invoking compare editor navigation only when the active editor is a text diff editor.

This does not fully implement arbitrary VS Code when-clause support. Based on the current VS Code extension API, I could not find a reliable way for VSCodeVim to evaluate general workbench context keys from remap definitions, so this PR keeps the feature within the set of contexts controlled by VSCodeVim.