### PR TITLE
fix(search): keep Insert mode when starting search fixes #8908

### DIFF
--- a/src/mode/modeHandler.ts
+++ b/src/mode/modeHandler.ts
@@ -266,7 +266,6 @@ export class ModeHandler implements vscode.Disposable, IModeHandler {
             } else if (!selection.active.isEqual(selection.anchor)) {
               Logger.trace('Creating Visual Selection from command!');
               this.vimState.cursor = Cursor.fromSelection(selection);
-              await this.setCurrentMode(Mode.Visual);
               this.updateView({ drawSelection: false, revealRange: false });
 
               // Store selection for commands like gv


### PR DESCRIPTION
What this PR does / why we need it:

This PR fixes a regression where starting search while in Insert mode could switch the editor into Visual mode unexpectedly.

The fix keeps Insert mode active when search starts, while still updating cursor and selection state correctly for command-driven selections.

Which issue(s) this PR fixes

fixes #8908 
fixes #9516 