### PR TITLE
fix: u should undo one action at a time, not entire stack

### DIFF
--- a/src/mode/modeHandler.ts
+++ b/src/mode/modeHandler.ts
@@ -915,7 +915,8 @@ export class ModeHandler implements vscode.Disposable, IModeHandler {
 
     // Don't record an undo point for every action of a macro, only at the very end
     if (
-      ranRepeatableAction &&
+      ranAction &&
+      this.vimState.currentMode === Mode.Normal &&
       !this.vimState.isReplayingMacro &&
       this.vimState.normalCommandState !== NormalCommandState.Executing &&
       this.vimState.dotCommandStatus !== DotCommandStatus.Executing &&


### PR DESCRIPTION
Fixes #2007.

`finishCurrentStep()` in modeHandler.ts was gated on `ranRepeatableAction`, which only gets set for commands with `createsUndoPoint`, mode transitions back to Normal, and operator execution. Plain commands that don't set this flag never created undo boundaries, so their changes piled up in a single step — pressing `u` then undid everything at once.

The fix replaces the `ranRepeatableAction` check with `ranAction && currentMode === Normal`, so every completed normal-mode action gets its own undo step. The macro/dot/remap guards are unchanged (those should still batch into a single undo).

Verified with `tsc --noEmit` — two-line diff.