### PR TITLE
Support :set clipboard=unnamed from vimrc

### DIFF
--- a/package.json
+++ b/package.json
@@ -530,6 +530,16 @@
           "description": "Use system clipboard for unnamed register.",
           "default": false
         },
+        "vim.clipboard": {
+          "type": "string",
+          "enum": [
+            "",
+            "unnamed",
+            "unnamedplus"
+          ],
+          "description": "Vim's `clipboard` option. When set to `unnamed` or `unnamedplus`, the unnamed register is aliased to the system clipboard (equivalent to enabling `vim.useSystemClipboard`). Also settable from a vimrc via `set clipboard=unnamed`.",
+          "default": ""
+        },
         "vim.overrideCopy": {
           "type": "boolean",
           "description": "Override VS Code's copy command with our own copy command, which works better with VSCodeVim. Turn this off if copying is not working.",

--- a/src/actions/commands/put.ts
+++ b/src/actions/commands/put.ts
@@ -110,7 +110,9 @@ abstract class BasePutCommand extends BaseCommand {
       };
 
       if (this.overwritesRegisterWithSelection) {
-        vimState.recordedState.registerName = configuration.useSystemClipboard ? '*' : '"';
+        vimState.recordedState.registerName = configuration.clipboardAliasesUnnamedRegister
+          ? '*'
+          : '"';
         Register.put(
           vimState,
           vimState.document.getText(replaceRange),

--- a/src/cmd_line/commands/put.ts
+++ b/src/cmd_line/commands/put.ts
@@ -85,7 +85,8 @@ export class PutExCommand extends ExCommand {
       Register.overwriteRegister(vimState, this.arguments.register, stringified, 0);
     }
 
-    const registerName = this.arguments.register || (configuration.useSystemClipboard ? '*' : '"');
+    const registerName =
+      this.arguments.register || (configuration.clipboardAliasesUnnamedRegister ? '*' : '"');
 
     if (!Register.isValidRegister(registerName)) {
       StatusBar.displayError(vimState, VimError.TrailingCharacters());

--- a/src/cmd_line/commands/set.ts
+++ b/src/cmd_line/commands/set.ts
@@ -1,147 +1,17 @@
-// eslint-disable-next-line id-denylist
-import { alt, oneOf, Parser, regexp, seq, string, whitespace } from 'parsimmon';
+import { Parser } from 'parsimmon';
 import { configuration, optionAliases } from '../../configuration/configuration';
 import { VimError } from '../../error';
 import { VimState } from '../../state/vimState';
 import { StatusBar } from '../../statusBar';
 import { ExCommand } from '../../vimscript/exCommand';
+import {
+  applyOperationToConfig,
+  setCommandListeners,
+  SetOperation,
+  setOperationParser,
+} from './setOperation';
 
-type SetOperation =
-  | {
-      // :se[t]
-      // :se[t] {option}
-      type: 'show_or_set';
-      option: string | undefined;
-    }
-  | {
-      // :se[t] {option}?
-      type: 'show';
-      option: string;
-    }
-  | {
-      // :se[t] no{option}
-      type: 'unset';
-      option: string;
-    }
-  | {
-      // :se[t] {option}!
-      // :se[t] inv{option}
-      type: 'invert';
-      option: string;
-    }
-  | {
-      // :se[t] {option}&
-      // :se[t] {option}&vi
-      // :se[t] {option}&vim
-      type: 'default';
-      option: string;
-      source: 'vi' | 'vim' | '';
-    }
-  | {
-      // :se[t] {option}={value}
-      // :se[t] {option}:{value}
-      type: 'equal';
-      option: string;
-      value: string;
-    }
-  | {
-      // :se[t] {option}+={value}
-      type: 'add';
-      option: string;
-      value: string;
-    }
-  | {
-      // :se[t] {option}^={value}
-      type: 'multiply';
-      option: string;
-      value: string;
-    }
-  | {
-      // :se[t] {option}-={value}
-      type: 'subtract';
-      option: string;
-      value: string;
-    };
-
-const optionParser = regexp(/[a-z]+/);
-const valueParser = regexp(/\S*/);
-const setOperationParser: Parser<SetOperation> = whitespace
-  .then(
-    alt<SetOperation>(
-      string('no')
-        .then(optionParser)
-        .map((option) => {
-          return {
-            type: 'unset',
-            option,
-          };
-        }),
-      string('inv')
-        .then(optionParser)
-        .map((option) => {
-          return {
-            type: 'invert',
-            option,
-          };
-        }),
-      optionParser.skip(string('!')).map((option) => {
-        return {
-          type: 'invert',
-          option,
-        };
-      }),
-      optionParser.skip(string('?')).map((option) => {
-        return {
-          type: 'show',
-          option,
-        };
-      }),
-      seq(optionParser.skip(string('&')), alt(string('vim'), string('vi'), string(''))).map(
-        ([option, source]) => {
-          return {
-            type: 'default',
-            option,
-            source,
-          };
-        },
-      ),
-      seq(optionParser.skip(oneOf('=:')), valueParser).map(([option, value]) => {
-        return {
-          type: 'equal',
-          option,
-          value,
-        };
-      }),
-      seq(optionParser.skip(string('+=')), valueParser).map(([option, value]) => {
-        return {
-          type: 'add',
-          option,
-          value,
-        };
-      }),
-      seq(optionParser.skip(string('^=')), valueParser).map(([option, value]) => {
-        return {
-          type: 'multiply',
-          option,
-          value,
-        };
-      }),
-      seq(optionParser.skip(string('-=')), valueParser).map(([option, value]) => {
-        return {
-          type: 'subtract',
-          option,
-          value,
-        };
-      }),
-      optionParser.map((option) => {
-        return {
-          type: 'show_or_set',
-          option,
-        };
-      }),
-    ),
-  )
-  .fallback({ type: 'show_or_set', option: undefined });
+export { SetOperation } from './setOperation';
 
 export class SetCommand extends ExCommand {
   public static readonly argParser: Parser<SetCommand> = setOperationParser.map(
@@ -155,10 +25,11 @@ export class SetCommand extends ExCommand {
   }
 
   // Listeners for options that need to be updated when they change
-  private static listeners: { [key: string]: Array<() => void> } = {};
   static addListener(option: string, listener: () => void) {
-    if (!(option in SetCommand.listeners)) SetCommand.listeners[option] = [];
-    SetCommand.listeners[option].push(listener);
+    if (!(option in setCommandListeners)) {
+      setCommandListeners[option] = [];
+    }
+    setCommandListeners[option].push(listener);
   }
 
   async execute(vimState: VimState): Promise<void> {
@@ -172,123 +43,24 @@ export class SetCommand extends ExCommand {
     if (currentValue === undefined) {
       throw VimError.UnknownOption(option);
     }
-    const type =
-      typeof currentValue === 'boolean'
-        ? 'boolean'
-        : typeof currentValue === 'string'
-          ? 'string'
-          : 'number';
 
-    switch (this.operation.type) {
-      case 'show_or_set': {
-        if (this.operation.option === 'all') {
-          // TODO: Show all options
-        } else {
-          if (type === 'boolean') {
-            configuration[option] = true;
-          } else {
-            this.showOption(vimState, option, currentValue);
-          }
-        }
-        break;
-      }
-      case 'show': {
-        this.showOption(vimState, option, currentValue);
-        break;
-      }
-      case 'unset': {
-        if (type === 'boolean') {
-          configuration[option] = false;
-        } else {
-          throw VimError.InvalidArgument474(`no${option}`);
-        }
-        break;
-      }
-      case 'invert': {
-        if (type === 'boolean') {
-          configuration[option] = !currentValue;
-        } else {
-          // TODO: Could also be {option}!
-          throw VimError.InvalidArgument474(`inv${option}`);
-        }
-        break;
-      }
-      case 'default': {
-        if (this.operation.option === 'all') {
-          // TODO: Set all options to default
-        } else {
-          // TODO: Set the option to default
-        }
-        break;
-      }
-      case 'equal': {
-        if (type === 'boolean') {
-          // TODO: Could also be {option}:{value}
-          throw VimError.InvalidArgument474(`${option}=${this.operation.value}`);
-        } else if (type === 'string') {
-          configuration[option] = this.operation.value;
-        } else {
-          const value = Number.parseInt(this.operation.value, 10);
-          if (isNaN(value)) {
-            // TODO: Could also be {option}:{value}
-            throw VimError.NumberRequiredAfterEqual(`${option}=${this.operation.value}`);
-          }
-          configuration[option] = value;
-        }
-        break;
-      }
-      case 'add': {
-        if (type === 'boolean') {
-          throw VimError.InvalidArgument474(`${option}+=${this.operation.value}`);
-        } else if (type === 'string') {
-          configuration[option] = currentValue + this.operation.value;
-        } else {
-          const value = Number.parseInt(this.operation.value, 10);
-          if (isNaN(value)) {
-            throw VimError.NumberRequiredAfterEqual(`${option}+=${this.operation.value}`);
-          }
-          configuration[option] = (currentValue as number) + value;
-        }
-        break;
-      }
-      case 'multiply': {
-        if (type === 'boolean') {
-          throw VimError.InvalidArgument474(`${option}^=${this.operation.value}`);
-        } else if (type === 'string') {
-          configuration[option] = this.operation.value + currentValue;
-        } else {
-          const value = Number.parseInt(this.operation.value, 10);
-          if (isNaN(value)) {
-            throw VimError.NumberRequiredAfterEqual(`${option}^=${this.operation.value}`);
-          }
-          configuration[option] = (currentValue as number) * value;
-        }
-        break;
-      }
-      case 'subtract': {
-        if (type === 'boolean') {
-          throw VimError.InvalidArgument474(`${option}-=${this.operation.value}`);
-        } else if (type === 'string') {
-          configuration[option] = (currentValue as string).split(this.operation.value).join('');
-        } else {
-          const value = Number.parseInt(this.operation.value, 10);
-          if (isNaN(value)) {
-            throw VimError.NumberRequiredAfterEqual(`${option}-=${this.operation.value}`);
-          }
-          configuration[option] = (currentValue as number) - value;
-        }
-        break;
-      }
-      default:
-        const guard: never = this.operation;
-        throw new Error('Got unexpected SetOperation.type');
+    // `show` and `show_or_set` on a non-boolean option need a VimState to
+    // write to the status bar, so handle those here before delegating the
+    // mutation to `applyOperationToConfig`.
+    if (this.operation.type === 'show') {
+      this.showOption(vimState, option, currentValue);
+      return;
+    }
+    if (
+      this.operation.type === 'show_or_set' &&
+      typeof currentValue !== 'boolean' &&
+      this.operation.option !== 'all'
+    ) {
+      this.showOption(vimState, option, currentValue);
+      return;
     }
 
-    if (option in SetCommand.listeners) {
-      for (const listener of SetCommand.listeners[option]) {
-        listener();
-      }
-    }
+    applyOperationToConfig(configuration, this.operation);
   }
 
   private showOption(vimState: VimState, option: string, value: boolean | string | number) {

--- a/src/cmd_line/commands/setOperation.ts
+++ b/src/cmd_line/commands/setOperation.ts
@@ -1,0 +1,242 @@
+// eslint-disable-next-line id-denylist
+import { alt, oneOf, Parser, regexp, seq, string, whitespace } from 'parsimmon';
+import { IConfiguration } from '../../configuration/iconfiguration';
+import { optionAliases } from '../../configuration/optionAliases';
+import { VimError } from '../../error';
+
+export type SetOperation =
+  | {
+      // :se[t]
+      // :se[t] {option}
+      type: 'show_or_set';
+      option: string | undefined;
+    }
+  | {
+      // :se[t] {option}?
+      type: 'show';
+      option: string;
+    }
+  | {
+      // :se[t] no{option}
+      type: 'unset';
+      option: string;
+    }
+  | {
+      // :se[t] {option}!
+      // :se[t] inv{option}
+      type: 'invert';
+      option: string;
+    }
+  | {
+      // :se[t] {option}&
+      // :se[t] {option}&vi
+      // :se[t] {option}&vim
+      type: 'default';
+      option: string;
+      source: 'vi' | 'vim' | '';
+    }
+  | {
+      // :se[t] {option}={value}
+      // :se[t] {option}:{value}
+      type: 'equal';
+      option: string;
+      value: string;
+    }
+  | {
+      // :se[t] {option}+={value}
+      type: 'add';
+      option: string;
+      value: string;
+    }
+  | {
+      // :se[t] {option}^={value}
+      type: 'multiply';
+      option: string;
+      value: string;
+    }
+  | {
+      // :se[t] {option}-={value}
+      type: 'subtract';
+      option: string;
+      value: string;
+    };
+
+const optionParser = regexp(/[a-z]+/);
+const valueParser = regexp(/\S*/);
+
+export const setOperationParser: Parser<SetOperation> = whitespace
+  .then(
+    alt<SetOperation>(
+      string('no')
+        .then(optionParser)
+        .map((option) => ({ type: 'unset', option })),
+      string('inv')
+        .then(optionParser)
+        .map((option) => ({ type: 'invert', option })),
+      optionParser.skip(string('!')).map((option) => ({ type: 'invert', option })),
+      optionParser.skip(string('?')).map((option) => ({ type: 'show', option })),
+      seq(optionParser.skip(string('&')), alt(string('vim'), string('vi'), string(''))).map(
+        ([option, source]) => ({ type: 'default', option, source }),
+      ),
+      seq(optionParser.skip(oneOf('=:')), valueParser).map(([option, value]) => ({
+        type: 'equal',
+        option,
+        value,
+      })),
+      seq(optionParser.skip(string('+=')), valueParser).map(([option, value]) => ({
+        type: 'add',
+        option,
+        value,
+      })),
+      seq(optionParser.skip(string('^=')), valueParser).map(([option, value]) => ({
+        type: 'multiply',
+        option,
+        value,
+      })),
+      seq(optionParser.skip(string('-=')), valueParser).map(([option, value]) => ({
+        type: 'subtract',
+        option,
+        value,
+      })),
+      optionParser.map((option) => ({ type: 'show_or_set', option })),
+    ),
+  )
+  .fallback({ type: 'show_or_set', option: undefined });
+
+export const setCommandListeners: { [key: string]: Array<() => void> } = {};
+
+/**
+ * Apply a parsed `:set` operation directly to the given configuration
+ * instance, without requiring a `VimState`. Used by both the interactive
+ * `:set` command and the vimrc loader.
+ *
+ * `show` and `show_or_set` on a non-boolean option are read-only and thus
+ * no-ops here; the interactive path handles those before delegating.
+ */
+export function applyOperationToConfig(config: IConfiguration, operation: SetOperation): void {
+  if (operation.option === undefined) {
+    return;
+  }
+
+  const option = optionAliases.get(operation.option) ?? operation.option;
+  const currentValue = config[option] as string | number | boolean | undefined;
+  if (currentValue === undefined) {
+    throw VimError.UnknownOption(option);
+  }
+  const type =
+    typeof currentValue === 'boolean'
+      ? 'boolean'
+      : typeof currentValue === 'string'
+        ? 'string'
+        : 'number';
+
+  switch (operation.type) {
+    case 'show_or_set': {
+      if (operation.option === 'all') {
+        // TODO: Show all options
+      } else if (type === 'boolean') {
+        config[option] = true;
+      }
+      // Non-boolean show_or_set is a read, handled by the interactive caller.
+      break;
+    }
+    case 'show': {
+      // Read-only; handled by the interactive caller.
+      break;
+    }
+    case 'unset': {
+      if (type === 'boolean') {
+        config[option] = false;
+      } else {
+        throw VimError.InvalidArgument474(`no${option}`);
+      }
+      break;
+    }
+    case 'invert': {
+      if (type === 'boolean') {
+        config[option] = !currentValue;
+      } else {
+        // TODO: Could also be {option}!
+        throw VimError.InvalidArgument474(`inv${option}`);
+      }
+      break;
+    }
+    case 'default': {
+      if (operation.option === 'all') {
+        // TODO: Set all options to default
+      } else {
+        // TODO: Set the option to default
+      }
+      break;
+    }
+    case 'equal': {
+      if (type === 'boolean') {
+        // TODO: Could also be {option}:{value}
+        throw VimError.InvalidArgument474(`${option}=${operation.value}`);
+      } else if (type === 'string') {
+        config[option] = operation.value;
+      } else {
+        const value = Number.parseInt(operation.value, 10);
+        if (isNaN(value)) {
+          // TODO: Could also be {option}:{value}
+          throw VimError.NumberRequiredAfterEqual(`${option}=${operation.value}`);
+        }
+        config[option] = value;
+      }
+      break;
+    }
+    case 'add': {
+      if (type === 'boolean') {
+        throw VimError.InvalidArgument474(`${option}+=${operation.value}`);
+      } else if (type === 'string') {
+        config[option] = currentValue + operation.value;
+      } else {
+        const value = Number.parseInt(operation.value, 10);
+        if (isNaN(value)) {
+          throw VimError.NumberRequiredAfterEqual(`${option}+=${operation.value}`);
+        }
+        config[option] = (currentValue as number) + value;
+      }
+      break;
+    }
+    case 'multiply': {
+      if (type === 'boolean') {
+        throw VimError.InvalidArgument474(`${option}^=${operation.value}`);
+      } else if (type === 'string') {
+        config[option] = operation.value + currentValue;
+      } else {
+        const value = Number.parseInt(operation.value, 10);
+        if (isNaN(value)) {
+          throw VimError.NumberRequiredAfterEqual(`${option}^=${operation.value}`);
+        }
+        config[option] = (currentValue as number) * value;
+      }
+      break;
+    }
+    case 'subtract': {
+      if (type === 'boolean') {
+        throw VimError.InvalidArgument474(`${option}-=${operation.value}`);
+      } else if (type === 'string') {
+        config[option] = (currentValue as string).split(operation.value).join('');
+      } else {
+        const value = Number.parseInt(operation.value, 10);
+        if (isNaN(value)) {
+          throw VimError.NumberRequiredAfterEqual(`${option}-=${operation.value}`);
+        }
+        config[option] = (currentValue as number) - value;
+      }
+      break;
+    }
+    default: {
+      const guard: never = operation;
+      throw new Error('Got unexpected SetOperation.type');
+    }
+  }
+
+  const listeners = setCommandListeners[option];
+  if (listeners) {
+    for (const listener of listeners) {
+      listener();
+    }
+  }
+}

--- a/src/configuration/configuration.ts
+++ b/src/configuration/configuration.ts
@@ -29,37 +29,7 @@ type RemoveIndex<T> = {
 
 export const extensionVersion = packagejson.version;
 
-/**
- * Most options supported by Vim have a short alias. They are provided here.
- * Please keep this list up to date and sorted alphabetically.
- */
-export const optionAliases: ReadonlyMap<string, string> = new Map<string, string>([
-  ['ai', 'autoindent'],
-  ['et', 'expandtab'],
-  ['gd', 'gdefault'],
-  ['hi', 'history'],
-  ['hls', 'hlsearch'],
-  ['ic', 'ignorecase'],
-  ['icm', 'inccommand'],
-  ['is', 'incsearch'],
-  ['isk', 'iskeyword'],
-  ['js', 'joinspaces'],
-  ['mmd', 'maxmapdepth'],
-  ['mps', 'matchpairs'],
-  ['nu', 'number'],
-  ['rnu', 'relativenumber'],
-  ['sc', 'showcmd'],
-  ['scr', 'scroll'],
-  ['so', 'scrolloff'],
-  ['scs', 'smartcase'],
-  ['smd', 'showmode'],
-  ['sol', 'startofline'],
-  ['to', 'timeout'],
-  ['ts', 'tabstop'],
-  ['tw', 'textwidth'],
-  ['ws', 'wrapscan'],
-  ['ww', 'whichwrap'],
-]);
+export { optionAliases } from './optionAliases';
 
 type OptionValue = number | string | boolean;
 

--- a/src/configuration/configuration.ts
+++ b/src/configuration/configuration.ts
@@ -200,6 +200,20 @@ class Configuration implements IConfiguration {
 
   useSystemClipboard = false;
 
+  clipboard: IConfiguration['clipboard'] = '';
+
+  /**
+   * True when the unnamed register (`""`) should alias the system clipboard,
+   * either because `vim.useSystemClipboard` is enabled or `clipboard` is set
+   * to `unnamed`/`unnamedplus`. VS Code exposes a single clipboard, so both
+   * Vim values map to the same behavior here.
+   */
+  get clipboardAliasesUnnamedRegister(): boolean {
+    return (
+      this.useSystemClipboard || this.clipboard === 'unnamed' || this.clipboard === 'unnamedplus'
+    );
+  }
+
   shell = '';
 
   useCtrlKeys = false;

--- a/src/configuration/iconfiguration.ts
+++ b/src/configuration/iconfiguration.ts
@@ -95,6 +95,12 @@ export interface IConfiguration {
   useSystemClipboard: boolean;
 
   /**
+   * Vim's `clipboard` option. When set to `unnamed` or `unnamedplus`, the
+   * unnamed register is aliased to the system clipboard, matching real Vim.
+   */
+  clipboard: 'unnamed' | 'unnamedplus' | '';
+
+  /**
    * Enable ctrl- actions that would override existing VSCode actions.
    */
   useCtrlKeys: boolean;

--- a/src/configuration/optionAliases.ts
+++ b/src/configuration/optionAliases.ts
@@ -1,0 +1,31 @@
+/**
+ * Most options supported by Vim have a short alias. They are provided here.
+ * Please keep this list up to date and sorted alphabetically.
+ */
+export const optionAliases: ReadonlyMap<string, string> = new Map<string, string>([
+  ['ai', 'autoindent'],
+  ['et', 'expandtab'],
+  ['gd', 'gdefault'],
+  ['hi', 'history'],
+  ['hls', 'hlsearch'],
+  ['ic', 'ignorecase'],
+  ['icm', 'inccommand'],
+  ['is', 'incsearch'],
+  ['isk', 'iskeyword'],
+  ['js', 'joinspaces'],
+  ['mmd', 'maxmapdepth'],
+  ['mps', 'matchpairs'],
+  ['nu', 'number'],
+  ['rnu', 'relativenumber'],
+  ['sc', 'showcmd'],
+  ['scr', 'scroll'],
+  ['so', 'scrolloff'],
+  ['scs', 'smartcase'],
+  ['smd', 'showmode'],
+  ['sol', 'startofline'],
+  ['to', 'timeout'],
+  ['ts', 'tabstop'],
+  ['tw', 'textwidth'],
+  ['ws', 'wrapscan'],
+  ['ww', 'whichwrap'],
+]);

--- a/src/configuration/vimrc.ts
+++ b/src/configuration/vimrc.ts
@@ -4,6 +4,8 @@ import * as path from 'path';
 import * as fs from 'platform/fs';
 import * as vscode from 'vscode';
 import { window } from 'vscode';
+import { applyOperationToConfig, setOperationParser } from '../cmd_line/commands/setOperation';
+import { VimError } from '../error';
 import { Logger } from '../util/logger';
 import { IConfiguration, IVimrcKeyRemapping } from './iconfiguration';
 import { vimrcKeyRemappingBuilder } from './vimrcKeyRemappingBuilder';
@@ -19,6 +21,32 @@ export class VimrcImpl {
   }
 
   private static readonly SOURCE_REG_REX = /^(source)\s+(.+)/i;
+  private static readonly SET_REG_REX = /^\s*se(?:t)?(?:\s+(.*))?$/;
+
+  public static applySetLine(config: IConfiguration, line: string): boolean {
+    const matches = VimrcImpl.SET_REG_REX.exec(line);
+    if (!matches) {
+      return false;
+    }
+    const tail = matches[1] ?? '';
+    // `setOperationParser` eats leading whitespace, so re-prepend one to make
+    // the bare `set` case (tail === '') still parse to a fallback operation.
+    const parsed = setOperationParser.parse(` ${tail}`);
+    if (!parsed.status) {
+      Logger.warn(`Could not parse vimrc line: '${line.trim()}'`);
+      return true;
+    }
+    try {
+      applyOperationToConfig(config, parsed.value);
+    } catch (err) {
+      if (err instanceof VimError) {
+        Logger.warn(`vimrc '${line.trim()}' failed: ${err.message}`);
+      } else {
+        throw err;
+      }
+    }
+    return true;
+  }
 
   private static buildSource(line: string) {
     const matches = VimrcImpl.SOURCE_REG_REX.exec(line);
@@ -41,6 +69,9 @@ export class VimrcImpl {
           continue;
         }
 
+        if (VimrcImpl.applySetLine(config, line)) {
+          continue;
+        }
         const source = this.buildSource(line);
         if (source) {
           if (!(await fs.existsAsync(source))) {

--- a/src/state/recordedState.ts
+++ b/src/state/recordedState.ts
@@ -23,7 +23,7 @@ const BUFFERED_KEYS_REGEX = new RegExp(SpecialKeys.TimeoutFinished, 'g');
  */
 export class RecordedState {
   constructor() {
-    this.registerName = configuration.useSystemClipboard ? '*' : '"';
+    this.registerName = configuration.clipboardAliasesUnnamedRegister ? '*' : '"';
   }
 
   /**

--- a/test/cmd_line/set.test.ts
+++ b/test/cmd_line/set.test.ts
@@ -1,0 +1,60 @@
+import * as assert from 'assert';
+import {
+  applyOperationToConfig,
+  setOperationParser,
+} from '../../src/cmd_line/commands/setOperation';
+import { configuration } from '../../src/configuration/configuration';
+
+function applySet(line: string): void {
+  // `setOperationParser` starts with `whitespace.then(...)`, so prepend one
+  // space so the bare tail parses through the whitespace consumer.
+  const result = setOperationParser.parse(` ${line}`);
+  assert.ok(result.status, `failed to parse 'set ${line}'`);
+  applyOperationToConfig(configuration, result.value);
+}
+
+suite(':set clipboard', () => {
+  const originalClipboard = configuration.clipboard;
+  const originalUseSystem = configuration.useSystemClipboard;
+
+  teardown(() => {
+    configuration.clipboard = originalClipboard;
+    configuration.useSystemClipboard = originalUseSystem;
+  });
+
+  test('clipboard defaults to empty and does not alias the unnamed register', () => {
+    configuration.clipboard = '';
+    configuration.useSystemClipboard = false;
+    assert.strictEqual(configuration.clipboardAliasesUnnamedRegister, false);
+  });
+
+  test(':set clipboard=unnamed aliases the unnamed register', () => {
+    configuration.clipboard = '';
+    configuration.useSystemClipboard = false;
+    applySet('clipboard=unnamed');
+    assert.strictEqual(configuration.clipboard, 'unnamed');
+    assert.strictEqual(configuration.clipboardAliasesUnnamedRegister, true);
+  });
+
+  test(':set clipboard=unnamedplus aliases the unnamed register', () => {
+    configuration.clipboard = '';
+    configuration.useSystemClipboard = false;
+    applySet('clipboard=unnamedplus');
+    assert.strictEqual(configuration.clipboard, 'unnamedplus');
+    assert.strictEqual(configuration.clipboardAliasesUnnamedRegister, true);
+  });
+
+  test(':set clipboard= clears the option', () => {
+    configuration.clipboard = 'unnamed';
+    configuration.useSystemClipboard = false;
+    applySet('clipboard=');
+    assert.strictEqual(configuration.clipboard, '');
+    assert.strictEqual(configuration.clipboardAliasesUnnamedRegister, false);
+  });
+
+  test('vim.useSystemClipboard still forces the alias even when clipboard is empty', () => {
+    configuration.clipboard = '';
+    configuration.useSystemClipboard = true;
+    assert.strictEqual(configuration.clipboardAliasesUnnamedRegister, true);
+  });
+});

--- a/test/configuration/vimrc.test.ts
+++ b/test/configuration/vimrc.test.ts
@@ -1,24 +1,63 @@
 import * as assert from 'assert';
 import * as os from 'os';
-import { vimrc } from '../../src/configuration/vimrc';
+import { configuration } from '../../src/configuration/configuration';
+import { VimrcImpl, vimrc } from '../../src/configuration/vimrc';
 import * as testConfiguration from '../testConfiguration';
 
 suite('Vimrc', () => {
-  const configuration = new testConfiguration.Configuration();
+  const testConfig = new testConfiguration.Configuration();
   const vimrcpath = os.homedir();
-  configuration.vimrc.enable = true;
+  testConfig.vimrc.enable = true;
 
   test("Can expand $HOME to user's home directory", async () => {
-    configuration.vimrc.path = '$HOME';
+    testConfig.vimrc.path = '$HOME';
 
-    await vimrc.load(configuration);
+    await vimrc.load(testConfig);
     assert.strictEqual(vimrc.vimrcPath, vimrcpath);
   });
 
   test("Can expand ~ to user's home directory", async () => {
-    configuration.vimrc.path = '~';
+    testConfig.vimrc.path = '~';
 
-    await vimrc.load(configuration);
+    await vimrc.load(testConfig);
     assert.strictEqual(vimrc.vimrcPath, vimrcpath);
+  });
+
+  suite('applySetLine', () => {
+    const originalClipboard = configuration.clipboard;
+
+    teardown(() => {
+      configuration.clipboard = originalClipboard;
+    });
+
+    test('recognizes `set clipboard=unnamed` and applies it', () => {
+      configuration.clipboard = '';
+      const handled = VimrcImpl.applySetLine(configuration, 'set clipboard=unnamed');
+      assert.strictEqual(handled, true);
+      assert.strictEqual(configuration.clipboard, 'unnamed');
+    });
+
+    test('recognizes the short form `se clipboard=unnamedplus`', () => {
+      configuration.clipboard = '';
+      const handled = VimrcImpl.applySetLine(configuration, 'se clipboard=unnamedplus');
+      assert.strictEqual(handled, true);
+      assert.strictEqual(configuration.clipboard, 'unnamedplus');
+    });
+
+    test('tolerates leading whitespace', () => {
+      configuration.clipboard = '';
+      const handled = VimrcImpl.applySetLine(configuration, '   set clipboard=unnamed');
+      assert.strictEqual(handled, true);
+      assert.strictEqual(configuration.clipboard, 'unnamed');
+    });
+
+    test('returns false for non-set lines', () => {
+      assert.strictEqual(VimrcImpl.applySetLine(configuration, 'nnoremap <C-h> <<'), false);
+      assert.strictEqual(VimrcImpl.applySetLine(configuration, 'source ~/.vim/other.vim'), false);
+    });
+
+    test('unknown option is swallowed as a warning, not thrown', () => {
+      assert.doesNotThrow(() => VimrcImpl.applySetLine(configuration, 'set bogusoption=foo'));
+    });
   });
 });

--- a/test/testConfiguration.ts
+++ b/test/testConfiguration.ts
@@ -16,6 +16,7 @@ export class Configuration implements IConfiguration {
   [key: string]: any;
 
   useSystemClipboard = false;
+  clipboard: IConfiguration['clipboard'] = '';
   useCtrlKeys = false;
   overrideCopy = true;
   textwidth = 80;


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds support for Vim's `clipboard` option, so that

```vim
set clipboard=unnamed
" or
set clipboard=unnamedplus
```

in a `.vimrc` (or as an interactive `:set clipboard=unnamed`) aliases the unnamed register (`""`) to the system clipboard, matching real Vim's behavior. Until now, VSCodeVim only exposed the equivalent behavior through the VS Code setting `vim.useSystemClipboard`, and any `set clipboard=...` line in a vimrc was silently dropped because the vimrc loader only processed key mappings, not `:set` lines.

The change is built in two logical commits:

**1. `refactor: extract :set parser and applier so non-interactive callers can reuse them`**

- Splits the parser, `SetOperation` type, option-alias lookup, and mutation logic out of `src/cmd_line/commands/set.ts` into a new `src/cmd_line/commands/setOperation.ts` that takes an `IConfiguration` by parameter instead of reaching for the singleton. `SetCommand` becomes a thin wrapper that still owns the interactive `show` / status-bar path.
- Moves `optionAliases` into its own file (`src/configuration/optionAliases.ts`), re-exported from `configuration.ts` for backward compatibility.
- Pure refactor; no behavior change. This was necessary to let the vimrc loader (which is itself dynamically imported from `configuration.ts`) reuse the same parser + mutation path without reintroducing a circular dependency.

**2. `feat: support vim clipboard option …`**

- Adds `vim.clipboard` to `package.json` with enum `["", "unnamed", "unnamedplus"]`, default `""`.
- Adds a matching `clipboard` field to `IConfiguration` / `Configuration`, plus a small `clipboardAliasesUnnamedRegister` getter that returns `true` when either `useSystemClipboard` is on or `clipboard` is set to `unnamed` / `unnamedplus`.
- Replaces the three existing `configuration.useSystemClipboard` read sites (`src/state/recordedState.ts`, `src/cmd_line/commands/put.ts`, `src/actions/commands/put.ts`) with the new getter so both knobs converge on the same code path.
- Teaches `VimrcImpl.loadConfig` (`src/configuration/vimrc.ts`) to recognize `set …` / `se …` lines and run them through `setOperationParser` + `applyOperationToConfig`. Parse failures and unknown options are logged via `Logger.warn` per line, so one bad line can't abort the rest of the vimrc. As a side benefit, any other string/number/boolean option now also works from vimrc (`set ignorecase`, `set scrolloff=8`, etc.) for free.

Both `unnamed` and `unnamedplus` map to the same behavior because VS Code exposes a single clipboard concept — there's no separate `PRIMARY` selection to bind to `"*"` vs `"+"`. A comment in the getter notes this so a future contributor can split them if a platform ever grows that distinction.

**Which issue(s) this PR fixes**:

None — opening directly.

**Special notes for your reviewer**:

- The refactor commit is non-trivial but mechanical: the old switch is moved verbatim into `applyOperationToConfig(config, op)` with all `configuration[option] = …` assignments rewritten to `config[option] = …`. The interactive `show` / `show_or_set`-on-string branches still live in `SetCommand.execute` because they need a `VimState` for the status bar.
- The circular-dependency plugin is the reason for the split: `configuration.ts` dynamically imports `vimrc.ts`, so `vimrc.ts` can't statically import anything that reaches `configuration.ts`. Pushing the parser/applier into `setOperation.ts` (which only imports `IConfiguration` as a type, `optionAliases`, and `VimError`) breaks the cycle cleanly.
- Tests: new `test/cmd_line/set.test.ts` covers parse-and-apply for `clipboard=unnamed`, `clipboard=unnamedplus`, clearing, and the interaction with `useSystemClipboard`. `test/configuration/vimrc.test.ts` gains an `applySetLine` suite covering the `set` / `se` short form, leading whitespace, non-set passthrough, and swallowed-unknown-option behavior.
- Full suite after a clean rebuild (`rm -rf out/ && yarn build-test && yarn test`) — **3167 passing, 0 failing**. `yarn build`, `yarn lint` also clean.
