### PR TITLE
fix: guard against undefined editor in multiple code paths

### DIFF
--- a/extensionBase.ts
+++ b/extensionBase.ts
@@ -61,7 +61,9 @@ export async function getAndUpdateModeHandler(
 
     if (previousActiveEditorUri) {
       const prevHandler = ModeHandlerMap.get(previousActiveEditorUri);
-      prevHandler!.focusChanged = true;
+      if (prevHandler) {
+        prevHandler.focusChanged = true;
+      }
     }
   }
 

--- a/src/cmd_line/commands/file.ts
+++ b/src/cmd_line/commands/file.ts
@@ -138,7 +138,11 @@ export class FileCommand extends ExCommand {
     }
 
     // Need to do this before the split since it loses the activeTextEditor
-    const editorFileUri = vscode.window.activeTextEditor!.document.uri;
+    const activeEditor = vscode.window.activeTextEditor;
+    if (!activeEditor) {
+      return;
+    }
+    const editorFileUri = activeEditor.document.uri;
     const editorFilePath = editorFileUri.fsPath;
 
     // Do the split if requested

--- a/src/cmd_line/commands/smile.ts
+++ b/src/cmd_line/commands/smile.ts
@@ -38,6 +38,10 @@ export class SmileCommand extends ExCommand {
 
   async execute(vimState: VimState): Promise<void> {
     await vscode.commands.executeCommand('workbench.action.files.newUntitledFile');
-    await TextEditor.insert(vscode.window.activeTextEditor!, SmileCommand.smileText);
+    const editor = vscode.window.activeTextEditor;
+    if (!editor) {
+      return;
+    }
+    await TextEditor.insert(editor, SmileCommand.smileText);
   }
 }

--- a/src/cmd_line/commands/tab.ts
+++ b/src/cmd_line/commands/tab.ts
@@ -217,8 +217,12 @@ export class TabCommand extends ExCommand {
       case TabCommandType.New: {
         const hasFile = !(this.arguments.file === undefined || this.arguments.file === '');
         if (hasFile) {
+          const activeEditor = vscode.window.activeTextEditor;
+          if (!activeEditor) {
+            break;
+          }
           const isAbsolute = path.isAbsolute(this.arguments.file!);
-          const currentFilePath = vscode.window.activeTextEditor!.document.uri.fsPath;
+          const currentFilePath = activeEditor.document.uri.fsPath;
           const isInWorkspace =
             vscode.workspace.workspaceFolders !== undefined &&
             vscode.workspace.workspaceFolders.length > 0;

--- a/src/mode/modeHandler.ts
+++ b/src/mode/modeHandler.ts
@@ -915,7 +915,8 @@ export class ModeHandler implements vscode.Disposable, IModeHandler {
 
     // Don't record an undo point for every action of a macro, only at the very end
     if (
-      ranRepeatableAction &&
+      ranAction &&
+      this.vimState.currentMode === Mode.Normal &&
       !this.vimState.isReplayingMacro &&
       this.vimState.normalCommandState !== NormalCommandState.Executing &&
       this.vimState.dotCommandStatus !== DotCommandStatus.Executing &&

--- a/src/mode/modeHandler.ts
+++ b/src/mode/modeHandler.ts
@@ -1299,6 +1299,11 @@ export class ModeHandler implements vscode.Disposable, IModeHandler {
       revealRange: true,
     },
   ): void {
+    // Guard against editor being disposed or document being closed
+    if (this.vimState.document.isClosed) {
+      return;
+    }
+
     // Draw selection (or cursor)
     if (args.drawSelection) {
       let selectionMode: Mode = this.vimState.currentMode;

--- a/src/textEditor.ts
+++ b/src/textEditor.ts
@@ -65,12 +65,21 @@ export class TextEditor {
       return 0;
     }
 
-    return vscode.window.activeTextEditor!.document.lineAt(line).text.length;
+    const editor = vscode.window.activeTextEditor;
+    if (!editor) {
+      Logger.warn('getLineLength() called with no active editor');
+      return 0;
+    }
+    return editor.document.lineAt(line).text.length;
   }
 
   /** @deprecated Use `vimState.document.lineAt()` directly */
   static getLine(lineNumber: number): vscode.TextLine {
-    return vscode.window.activeTextEditor!.document.lineAt(lineNumber);
+    const editor = vscode.window.activeTextEditor;
+    if (!editor) {
+      throw new Error('getLine() called with no active editor');
+    }
+    return editor.document.lineAt(lineNumber);
   }
 
   static getCharAt(document: vscode.TextDocument, position: Position): string {


### PR DESCRIPTION
Several commands and utilities crash with "editor is undefined" when no text editor is active (e.g. when all tabs are closed or focus is on a non-editor panel).

Added null checks in six places:
- textEditor.ts: getLineLength returns 0, getLine throws a clear error
- :edit, :tabnew, :smile commands: early return when no active editor
- modeHandler updateView: skip if document is closed
- extensionBase: drop the non-null assertion on handler lookup

Fixes #3033