### PR TITLE
fix: guard against undefined editor in multiple code paths (#3033)

### DIFF
--- a/src/mode/modeHandler.ts
+++ b/src/mode/modeHandler.ts
@@ -131,6 +131,9 @@ export class ModeHandler implements vscode.Disposable, IModeHandler {
    * This loses some information, so it should only be done when necessary.
    */
   public syncCursors() {
+    if (this.vimState.document.isClosed) {
+      return;
+    }
     // TODO: getCursorsAfterSync() is basically this, but stupider
     const { selections } = this.vimState.editor;
     // TODO: this if block is a workaround for a problem described here https://github.com/VSCodeVim/Vim/pull/8426
@@ -386,7 +389,7 @@ export class ModeHandler implements vscode.Disposable, IModeHandler {
         }
 
         // If we prevented from clicking past eol but it is part of this selection, include the last char
-        if (this.lastClickWasPastEol) {
+        if (this.lastClickWasPastEol && !this.vimState.document.isClosed) {
           const newStart = new Position(selection.anchor.line, selection.anchor.character + 1);
           this.vimState.editor.selection = new vscode.Selection(newStart, selection.active);
           this.vimState.cursorStartPosition = selectionStart;
@@ -1245,6 +1248,9 @@ export class ModeHandler implements vscode.Disposable, IModeHandler {
   }
 
   private updateSearchHighlights(showHighlights: boolean) {
+    if (this.vimState.document.isClosed) {
+      return;
+    }
     const cacheKey = this.searchDecorationCacheKey;
     this.searchDecorationCacheKey = undefined;
 
@@ -1298,6 +1304,10 @@ export class ModeHandler implements vscode.Disposable, IModeHandler {
       revealRange: true,
     },
   ): void {
+    if (this.vimState.document.isClosed) {
+      return;
+    }
+
     // Draw selection (or cursor)
     if (args.drawSelection) {
       let selectionMode: Mode = this.vimState.currentMode;


### PR DESCRIPTION
**What this PR does / why we need it:**

When you close an editor tab, `this.vimState.editor` goes stale but a bunch of methods still try to use it, `updateView()` being the main one. That's what causes the `TypeError: Cannot read property 'options' of undefined` crash.

I added `this.vimState.document.isClosed` checks to the entry points that touch the editor without guarding first: `updateView()`, `syncCursors()`, `updateSearchHighlights()`, and one spot in `handleSelectionChange()`. Same pattern that's already used in `runAction()`.

**Which issue(s) this PR fixes:**

Fixes #3033

**Special notes for your reviewer:**

Pretty small change, just early returns, no logic changes. Build and lint are clean. Tested manually by opening/closing tabs in the Extension Development Host, no crashes.
