### PR TITLE
Fix: Escape exits Zen Mode when pressed in Normal mode

### DIFF
--- a/src/actions/commands/actions.ts
+++ b/src/actions/commands/actions.ts
@@ -171,6 +171,7 @@ class CommandEsc extends BaseCommand {
           vscode.commands.executeCommand('closeDirtyDiff'),
           vscode.commands.executeCommand('closeQuickDiff'),
           vscode.commands.executeCommand('editor.action.inlineSuggest.hide'),
+          vscode.commands.executeCommand('workbench.action.exitZenMode'),
         ]);
       }
     } else {


### PR DESCRIPTION
Fixes #9981

When in Zen Mode with Vim active, pressing Escape while focused on a file tab never reaches VS Code's native Zen Mode exit handler. Vim intercepts the key and the Esc, Esc sequence to exit Zen Mode does nothing.

**Cause**

CommandEsc in Normal mode already calls a set of VS Code cleanup commands (close reference search, close markers, hide inline suggestions, etc.) via Promise.allSettled. workbench.action.exitZenMode was missing from that list.

**Change**

- Added workbench.action.exitZenMode to the existing cleanup commands in CommandEsc.exec() for Normal mode

This means:
- From Insert mode: first Esc goes to Normal, second Esc exits Zen Mode (matches VS Code's double-Esc behavior)
- From Normal mode: Esc exits Zen Mode directly (Vim has nothing else to do with it)
- Outside Zen Mode: the command is a no-op, no side effects