### PR TITLE
fix: hide editor cursor during command-line mode

### DIFF
--- a/src/mode/mode.ts
+++ b/src/mode/mode.ts
@@ -25,6 +25,7 @@ export enum VSCodeVimCursorType {
   TextDecoration,
   Native,
   UnderlineThin,
+  Hidden,
 }
 
 export enum NormalCommandState {
@@ -75,6 +76,8 @@ export function getCursorStyle(cursorType: VSCodeVimCursorType) {
       return vscode.TextEditorCursorStyle.UnderlineThin;
     case VSCodeVimCursorType.TextDecoration:
       return vscode.TextEditorCursorStyle.LineThin;
+    case VSCodeVimCursorType.Hidden:
+      return vscode.TextEditorCursorStyle.BlockOutline;
     case VSCodeVimCursorType.Native:
     default:
       return vscode.TextEditorCursorStyle.Block;

--- a/src/mode/modeHandler.ts
+++ b/src/mode/modeHandler.ts
@@ -1694,9 +1694,9 @@ function getCursorType(vimState: VimState, mode: Mode): VSCodeVimCursorType {
     case Mode.VisualLine:
       return VSCodeVimCursorType.TextDecoration;
     case Mode.SearchInProgressMode:
-      return VSCodeVimCursorType.UnderlineThin;
+      return VSCodeVimCursorType.Hidden;
     case Mode.CommandlineInProgress:
-      return VSCodeVimCursorType.UnderlineThin;
+      return VSCodeVimCursorType.Hidden;
     case Mode.Replace:
       return VSCodeVimCursorType.Underline;
     case Mode.EasyMotionMode:

--- a/test/index.ts
+++ b/test/index.ts
@@ -9,7 +9,7 @@
 // host can call to run the tests. The test runner is expected to use console.log
 // to report the results back to the caller. When the tests are finished, return
 // a possible error to the callback or null if none.
-import glob from 'glob';
+import { glob } from 'glob';
 import Mocha from 'mocha';
 import * as path from 'path';
 
@@ -33,27 +33,27 @@ export function run(): Promise<void> {
   const testsRoot = path.resolve(__dirname, '.');
 
   return new Promise((c, e) => {
-    glob('**/**.test.js', { cwd: testsRoot }, (err, files) => {
-      if (err) {
-        return e(err);
-      }
+    glob('**/**.test.js', { cwd: testsRoot })
+      .then((files: string[]) => {
+        // Add files to the test suite
+        files.forEach((f) => mocha.addFile(path.resolve(testsRoot, f)));
 
-      // Add files to the test suite
-      files.forEach((f) => mocha.addFile(path.resolve(testsRoot, f)));
-
-      try {
-        // Run the mocha test
-        mocha.run((failures) => {
-          if (failures > 0) {
-            e(new Error(`${failures} tests failed.`));
-          } else {
-            c();
-          }
-        });
-      } catch (error) {
-        console.error(error);
-        e(error as Error);
-      }
-    });
+        try {
+          // Run the mocha test
+          mocha.run((failures) => {
+            if (failures > 0) {
+              e(new Error(`${failures} tests failed.`));
+            } else {
+              c();
+            }
+          });
+        } catch (error) {
+          console.error(error);
+          e(error as Error);
+        }
+      })
+      .catch((err: unknown) => {
+        e(err instanceof Error ? err : new Error(String(err)));
+      });
   });
 }


### PR DESCRIPTION
## Description
Resolves #2436.

Currently, when a user enters command-line mode (`:`), search mode (`/`), or reverse search mode (`?`), the cursor remains visibly blinking in the active editor. Because Vim is terminal-based, the cursor is supposed to jump to the bottom status line and disappear from the main editor entirely to prevent confusion. 

Since the VS Code extension API does not natively support completely hiding the cursor (`TextEditorCursorStyle.Hidden` does not exist), this PR approximates the native Vim behavior by mapping these modes to `BlockOutline`. 

This effectively turns the cursor into a static, hollow box that represents a defocused/inactive state, which eliminates the distracting blinking cursor while typing in the status bar command-line.

## Changes Made
- **`src/mode/mode.ts`**: Introduced a new `VSCodeVimCursorType.Hidden` cursor type enum and mapped it to use `vscode.TextEditorCursorStyle.BlockOutline`.
- **`src/mode/modeHandler.ts`**: Updated `getCursorType()` so that `SearchInProgressMode` and `CommandlineInProgress` now return the new `Hidden` cursor type instead of `UnderlineThin`.
- **`test/index.ts`**: Updated the `glob` import and usage to conform to `glob` v10's Promise API to fix local test runner build errors.

## Testing
- Verified that compiling via `yarn build-dev` succeeds.
- Verified that local tests run cleanly.
- Manually tested entering `:`, `/`, and `?` modes to ensure the active cursor stops blinking and transforms into the `BlockOutline` style until the mode is exited.
