### PR TITLE
feat: add case preservation support via custom :s flag P (#3978)

### DIFF
--- a/src/cmd_line/commands/substitute.ts
+++ b/src/cmd_line/commands/substitute.ts
@@ -180,6 +180,7 @@ export interface SubstituteFlags {
   printLastMatchedLineWithNumber?: true;
   printLastMatchedLineWithList?: true;
   usePreviousPattern?: true;
+  preserveCase?: boolean;
 }
 
 // TODO: `:help sub-replace-special`
@@ -233,7 +234,7 @@ const replaceStringParser = (delimiter: string): Parser<ReplaceString> =>
 
 const substituteFlagsParser: Parser<SubstituteFlags> = seq(
   string('&').fallback(undefined),
-  oneOf('cegiInp#lr').many(),
+  oneOf('cegiInp#lrP').many(),
 ).map(([amp, flagChars]) => {
   const flags: SubstituteFlags = {};
   if (amp === '&') {
@@ -261,6 +262,9 @@ const substituteFlagsParser: Parser<SubstituteFlags> = seq(
         break;
       case 'p':
         flags.printLastMatchedLine = true;
+        break;
+      case 'P':
+        flags.preserveCase = true;
         break;
       case '#':
         flags.printLastMatchedLineWithNumber = true;
@@ -415,7 +419,12 @@ export class SubstituteCommand extends ExCommand {
       return 0;
     }
 
-    const replaceText = this.arguments.replace.resolve(vimState, match.groups);
+    let replaceText = this.arguments.replace.resolve(vimState, match.groups);
+
+    if (this.arguments.flags.preserveCase) {
+      const originalText = vimState.document.getText(match.range);
+      replaceText = this.preserveCase(originalText, replaceText);
+    }
 
     if (this.arguments.flags.confirmEach) {
       if (await this.confirmReplacement(vimState, match, replaceText)) {
@@ -675,5 +684,18 @@ export class SubstituteCommand extends ExCommand {
         }`,
       );
     }
+  }
+
+  private preserveCase(original: string, replacement: string): string {
+    if (original === original.toUpperCase() && original !== original.toLowerCase()) {
+      return replacement.toUpperCase();
+    }
+    if (original === original.toLowerCase() && original !== original.toUpperCase()) {
+      return replacement.toLowerCase();
+    }
+    if (original.length > 0 && original[0] === original[0].toUpperCase()) {
+      return replacement.charAt(0).toUpperCase() + replacement.slice(1).toLowerCase();
+    }
+    return replacement;
   }
 }

--- a/test/cmd_line/substitute.test.ts
+++ b/test/cmd_line/substitute.test.ts
@@ -524,6 +524,13 @@ suite('Basic substitute', () => {
       end: ['1', '2', "[3, '4']", '', 'two', '1', '2', "[3, '4']", '|'],
     });
 
+    newTest({
+      title: 'Replace with preserve case `P` flag (UPPER, lower, Title)',
+      start: ['|FOO foo Foo'],
+      keysPressed: sub('foo', 'bar', { lineRange: '%', flags: 'P' }),
+      end: ['|BAR bar Bar'],
+    });
+
     // TODO: Test submatch()
   });
 });


### PR DESCRIPTION
<!--
Yay! Thanks for sending us a PR! 🎊

Please ensure your PR adheres to:

- [ ] Commit messages has a short & issue references when necessary
- [ ] Each commit does a logical chunk of work.
- [ ] It builds and tests pass (e.g `gulp`)
-->

**What this PR does / why we need it**:
This PR adds support for preserving case during a substitution command (`:s`), matching the native behavior found in VSCode's built-in Find and Replace functionality. 

Because standard Vim uses the lowercase `p` flag for printing the last matched line, this introduces a custom uppercase `P` flag to handle case preservation (e.g., running `:%s/foo/bar/P` will dynamically transform `FOO foo Foo` into `BAR bar Bar`).

It intercepts the substitution loop via a custom utility function that checks the original matched string's text layout (UPPERCASE, lowercase, or Title Case) and applies the identical format to the incoming replacement string before writing it to the document transformer.

**Which issue(s) this PR fixes**
Fixes #3978

**Special notes for your reviewer**:
- Added an automated framework unit test under `test/cmd_line/substitute.test.ts` to validate UPPER, lower, and Title Case execution scenarios simultaneously.
- Compilation is successful locally via `yarn build-dev`.

