### PR TITLE
docs: fix missing angle brackets in leader keybinding example

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,7 +243,7 @@ Custom remappings are defined on a per-mode basis.
             ]
         },
         {
-            "before": ["leader", "w"],
+            "before": ["<leader>", "w"],
             "commands": [
                 "workbench.action.files.save",
             ]


### PR DESCRIPTION
In the Key Remapping section, the JSON example for saving a file was missing the angle brackets around <leader>. I added them so the snippet works correctly when users copy and paste it.