### PR TITLE
Fix relative line numbers showing in disabled mode

### DIFF
--- a/extensionBase.ts
+++ b/extensionBase.ts
@@ -96,6 +96,8 @@ export async function loadConfiguration() {
 export async function activate(context: vscode.ExtensionContext, handleLocal: boolean = true) {
   ExCommandLine.parser = exCommandParser;
 
+  const compositionState = new CompositionState();
+
   Logger.init();
 
   // before we do anything else, we need to load the configuration
@@ -122,7 +124,11 @@ export async function activate(context: vscode.ExtensionContext, handleLocal: bo
     vscode.workspace.onDidChangeConfiguration,
     async () => {
       Logger.info('Configuration changed');
+      const oldDisableExtension = configuration.disableExtension;
       await loadConfiguration();
+      if (configuration.disableExtension !== oldDisableExtension) {
+        await toggleExtension(configuration.disableExtension, compositionState);
+      }
     },
     false,
   );
@@ -316,8 +322,6 @@ export async function activate(context: vscode.ExtensionContext, handleLocal: bo
     },
   );
 
-  const compositionState = new CompositionState();
-
   // Override VSCode commands
   overrideCommand(context, 'type', async (args: { text: string }) => {
     taskQueue.enqueueTask(async () => {
@@ -454,7 +458,7 @@ export async function activate(context: vscode.ExtensionContext, handleLocal: bo
 
   registerCommand(context, 'toggleVim', async () => {
     configuration.disableExtension = !configuration.disableExtension;
-    void toggleExtension(configuration.disableExtension, compositionState);
+    await toggleExtension(configuration.disableExtension, compositionState);
   });
 
   for (const boundKey of configuration.boundKeyCombinations) {
@@ -518,13 +522,19 @@ export async function activate(context: vscode.ExtensionContext, handleLocal: bo
  */
 async function toggleExtension(isDisabled: boolean, compositionState: CompositionState) {
   await VSCodeContext.set('vim.active', !isDisabled);
-  const mh = await getAndUpdateModeHandler();
-  if (mh) {
-    if (isDisabled) {
-      await mh.handleKeyEvent(SpecialKeys.ExtensionDisable);
-      compositionState.reset();
-      ModeHandlerMap.clear();
-    } else {
+  if (isDisabled) {
+    for (const [uri, mh] of ModeHandlerMap.entries()) {
+      try {
+        await mh.handleKeyEvent(SpecialKeys.ExtensionDisable);
+      } catch (e) {
+        Logger.error(`Error disabling ModeHandler: ${e}`);
+      }
+    }
+    compositionState.reset();
+    ModeHandlerMap.clear();
+  } else {
+    const mh = await getAndUpdateModeHandler();
+    if (mh) {
       await mh.handleKeyEvent(SpecialKeys.ExtensionEnable);
     }
   }
@@ -567,7 +577,7 @@ export function registerCommand(
       return;
     }
 
-    callback(args);
+    await callback(args);
   });
   context.subscriptions.push(disposable);
 }

--- a/package.json
+++ b/package.json
@@ -1245,6 +1245,7 @@
     "gulp-shell": "^0.8.0",
     "gulp-tag-version": "1.3.1",
     "gulp-typescript": "5.0.1",
+    "glob": "^7.2.3",
     "husky": "^9.0.0",
     "lint-staged": "^17.0.0",
     "minimist": "1.2.8",

--- a/src/mode/modeHandler.ts
+++ b/src/mode/modeHandler.ts
@@ -112,7 +112,13 @@ export class ModeHandler implements vscode.Disposable, IModeHandler {
     const shouldStartInsert =
       configuration.startInInsertMode || configuration.startInInsertModeSchemes.includes(scheme);
 
-    await modeHandler.setCurrentMode(shouldStartInsert ? Mode.Insert : Mode.Normal);
+    const initialMode = configuration.disableExtension
+      ? Mode.Disabled
+      : shouldStartInsert
+        ? Mode.Insert
+        : Mode.Normal;
+
+    await modeHandler.setCurrentMode(initialMode);
     modeHandler.syncCursors();
     return modeHandler;
   }

--- a/test/configuration/configuration.test.ts
+++ b/test/configuration/configuration.test.ts
@@ -58,6 +58,59 @@ suite('Configuration', () => {
     }
   });
 
+  test('initializes in Mode.Disabled and absolute line numbers if disableExtension is true', async () => {
+    await setupWorkspace({
+      config: {
+        smartRelativeLine: true,
+        disableExtension: true,
+      },
+    });
+
+    const activeTextEditor = vscode.window.activeTextEditor!;
+    const { getAndUpdateModeHandler } = await import('../../extensionBase');
+    const mh = (await getAndUpdateModeHandler())!;
+
+    assert.strictEqual(mh.vimState.currentMode, Mode.Disabled);
+    assert.strictEqual(activeTextEditor.options.lineNumbers, vscode.TextEditorLineNumbersStyle.On);
+  });
+
+  test('switching disableExtension setting toggles the active mode handler', async () => {
+    await setupWorkspace({
+      config: {
+        smartRelativeLine: true,
+        disableExtension: false,
+      },
+    });
+
+    const activeTextEditor = vscode.window.activeTextEditor!;
+    const { getAndUpdateModeHandler } = await import('../../extensionBase');
+    const mh = (await getAndUpdateModeHandler())!;
+    mh.vimState.setTextEditorLineNumbersStyle(mh.vimState.currentMode);
+
+    // Starts in Normal mode with relative line numbers
+    assert.strictEqual(mh.vimState.currentMode, Mode.Normal);
+    assert.strictEqual(
+      activeTextEditor.options.lineNumbers,
+      vscode.TextEditorLineNumbersStyle.Relative,
+    );
+
+    // Call toggleVim command
+    await vscode.commands.executeCommand('toggleVim');
+
+    // Should transition to Disabled mode and absolute line numbers
+    assert.strictEqual(mh.vimState.currentMode, Mode.Disabled);
+    assert.strictEqual(activeTextEditor.options.lineNumbers, vscode.TextEditorLineNumbersStyle.On);
+
+    // Toggle back
+    await vscode.commands.executeCommand('toggleVim');
+    const newMh = (await getAndUpdateModeHandler())!;
+    assert.strictEqual(newMh.vimState.currentMode, Mode.Normal);
+    assert.strictEqual(
+      activeTextEditor.options.lineNumbers,
+      vscode.TextEditorLineNumbersStyle.Relative,
+    );
+  });
+
   newTest({
     title: 'Can handle long key chords',
     start: ['|'],

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,6 +18,7 @@
     "resolveJsonModule": true,
     "forceConsistentCasingInFileNames": true,
     "esModuleInterop": true,
+    "skipLibCheck": true,
     "rootDir": "."
     // "isolatedModules": true,
   },


### PR DESCRIPTION
Closes #10006.

### Summary of Changes:
- **`src/mode/modeHandler.ts`**: Set `initialMode` of newly created `ModeHandler`s to `Mode.Disabled` if `configuration.disableExtension` is true.
- **`extensionBase.ts`**:
  - Moved `compositionState` definition to the top of `activate` so it can be referenced in earlier configuration change listeners.
  - Added configuration change listener check: when `disableExtension` setting changes, trigger `toggleExtension` to update all editors.
  - Updated `toggleExtension`: when disabling, loop through all active `ModeHandler`s in `ModeHandlerMap` and run `mh.handleKeyEvent(SpecialKeys.ExtensionDisable)` to transition them to Disabled mode (which reverts line numbers to absolute) before disposing them and clearing the map.
  - Awaited `toggleExtension` in the `toggleVim` command handler to prevent race conditions.
  - Updated the `registerCommand` wrapper to `await callback(args)` to ensure async commands can be fully awaited in tests.
- **`test/configuration/configuration.test.ts`**: Added two unit tests to verify that new editors start with absolute line numbers when `disableExtension` is true, and that toggling the extension correctly toggles mode handler and updates line numbers style.
- **`tsconfig.json` & `package.json`**: Added `"skipLibCheck": true` and pinned devDependency `glob: "^7.2.3"` to resolve type definition and version conflicts during test compilation.
