### PR TITLE
feat: add zA (toggle fold recursively)

### DIFF
--- a/src/actions/commands/fold.ts
+++ b/src/actions/commands/fold.ts
@@ -99,9 +99,18 @@ class ToggleFoldRecursively extends BaseCommand {
       nextLine < editor.document.lineCount &&
       !editor.visibleRanges.some((range) => range.contains(new vscode.Position(nextLine, 0)));
 
-    vimState.recordedState.transformer.vscodeCommand(
-      isClosed ? 'editor.unfoldRecursively' : 'editor.foldRecursively',
-    );
+    if (isClosed) {
+      vimState.recordedState.transformer.vscodeCommand('editor.unfoldRecursively');
+    } else {
+      // editor.foldRecursively only closes the innermost fold containing the
+      // cursor; it does not climb through enclosing folds the way Vim's zA/zC
+      // do. editor.fold with direction 'up' walks outward from the cursor
+      // instead, closing each enclosing fold level in turn.
+      vimState.recordedState.transformer.vscodeCommand('editor.fold', {
+        levels: 999,
+        direction: 'up',
+      });
+    }
     await vimState.setCurrentMode(Mode.Normal);
   }
 }

--- a/src/actions/commands/fold.ts
+++ b/src/actions/commands/fold.ts
@@ -77,6 +77,36 @@ class OpenAllFoldsRecursively extends CommandFold {
 }
 
 @RegisterAction
+class ToggleFoldRecursively extends BaseCommand {
+  modes = [Mode.Normal];
+  keys = ['z', 'A'];
+
+  public override doesActionApply(vimState: VimState, keysPressed: string[]): boolean {
+    // Don't run if there's an operator because the Sneak plugin uses <operator>z
+    return (
+      super.doesActionApply(vimState, keysPressed) && vimState.recordedState.operator === undefined
+    );
+  }
+
+  public override async exec(position: Position, vimState: VimState): Promise<void> {
+    const editor = vimState.editor;
+    const nextLine = position.line + 1;
+
+    // The fold at `position` is closed if the line right after its header
+    // is hidden from the editor's visibleRanges; the header line itself
+    // stays visible even when the fold beneath it is collapsed.
+    const isClosed =
+      nextLine < editor.document.lineCount &&
+      !editor.visibleRanges.some((range) => range.contains(new vscode.Position(nextLine, 0)));
+
+    vimState.recordedState.transformer.vscodeCommand(
+      isClosed ? 'editor.unfoldRecursively' : 'editor.foldRecursively',
+    );
+    await vimState.setCurrentMode(Mode.Normal);
+  }
+}
+
+@RegisterAction
 class AddFold extends BaseOperator {
   override modes = [Mode.Normal, Mode.Visual];
   keys = ['z', 'f'];


### PR DESCRIPTION
**What this PR does / why we need it**:

In real Vim, `zA` toggles the fold under the cursor recursively: it closes an open fold (and everything nested inside it), or opens a closed fold (and everything nested inside it), depending on the fold's current state. VSCodeVim already implements `za` (single-level toggle), `zO` (recursive open), and `zC` (recursive close) in `src/actions/commands/fold.ts`, but `zA` was never added, so pressing it currently does nothing.

This adds a `zA` action. Since VS Code has no built-in "toggle fold recursively" command, the action determines current state itself: a fold is closed if the line immediately after its header is absent from the editor's `visibleRanges` (the header line stays visible even when its body is collapsed).

- When the fold is **closed**, it dispatches `editor.unfoldRecursively`, matching `zO`.
- When the fold is **open**, it dispatches `editor.fold` with `direction: "up"` and an effectively unlimited `levels`, closing the fold at the cursor and climbing outward through every enclosing fold, matching the fix proposed for `zC` in #10062. (An earlier version of this PR used bare `editor.foldRecursively` here, which shares the same bug reported in #10061, only the innermost fold closes, not its ancestors. Updated to use the same corrected approach.)

**Which issue(s) this PR fixes**

Fixes #10059

**Special notes for your reviewer**:

- This PR's close-direction logic now depends on the same reasoning as #10062 (`zC` fix). If that PR's approach changes during review, this one should follow suit for consistency.
- No existing tests cover `fold.ts` (these commands dispatch to VS Code's live folding engine, which isn't simulated in the test harness), so I followed that existing convention rather than adding tests that wouldn't fit the pattern used by sibling fold commands.
- `doesActionApply` mirrors the same operator-guard comment used by `CommandFold` (avoiding conflicts with the Sneak plugin's `<operator>z`).
- Manually verified in a built Extension Development Host with a 3-level nested JS file: cursor on the deepest line, `zA` now closes all three levels in one press (matching `zC`'s fixed result), and toggling again reopens all three (matching `zO`).