### PR TITLE
fix: zC only closes the innermost fold, not enclosing ones

### DIFF
--- a/src/actions/commands/fold.ts
+++ b/src/actions/commands/fold.ts
@@ -66,7 +66,20 @@ class OpenAllFolds extends CommandFold {
 class CloseAllFoldsRecursively extends CommandFold {
   override modes = [Mode.Normal];
   keys = ['z', 'C'];
-  commandName = 'editor.foldRecursively';
+  commandName = 'editor.fold';
+
+  public override async exec(position: Position, vimState: VimState): Promise<void> {
+    // editor.foldRecursively only closes the innermost fold containing the
+    // cursor; it does not climb through enclosing folds the way Vim's zC
+    // does. editor.fold with direction 'up' and an effectively unlimited
+    // level count walks outward from the cursor instead, closing each
+    // enclosing fold level in turn.
+    vimState.recordedState.transformer.vscodeCommand(this.commandName, {
+      levels: 999,
+      direction: 'up',
+    });
+    await vimState.setCurrentMode(Mode.Normal);
+  }
 }
 
 @RegisterAction


### PR DESCRIPTION
**What this PR does / why we need it**:

`zC` is meant to close the fold under the cursor and every fold enclosing it, all the way out to the outermost level. Instead it only closes the single innermost fold directly containing the cursor, folds enclosing it stay open. This is because `zC` dispatches VS Code's native `editor.foldRecursively`, which recurses into descendants of the fold at the cursor, not ancestors.

`zc` (lowercase) already avoids this problem by using `editor.fold` with `direction: "up"` and a count-based `levels` argument, which correctly climbs outward through enclosing folds. This PR applies the same mechanism to `zC`, with an effectively unlimited level count instead of a count prefix, since `zC` (unlike `zc`) isn't meant to take a count, it always means "all levels."

**Which issue(s) this PR fixes**

Fixes #10061

**Special notes for your reviewer**:

- This only touches `zC`. `zO` doesn't have the equivalent problem: closing a fold already hides everything nested inside it regardless of descendants' own state, so "recursing into descendants" is meaningless for close, but opening genuinely needs to cascade into nested closed folds, which `editor.unfoldRecursively` already does correctly.
- Manually verified in a built Extension Development Host with a 3-level nested JS file: cursor on the deepest line, `zC` now collapses all three levels in one press, matching the fixed result exactly.
- `levels: 999` is a pragmatic "effectively unlimited" sentinel, VS Code's `editor.fold` naturally clamps to however many enclosing levels actually exist, verified directly rather than assumed.