### PR TITLE
fix: read composed text from document on compositionEnd (#9672)

### DIFF
--- a/extensionBase.ts
+++ b/extensionBase.ts
@@ -371,6 +371,7 @@ export async function activate(context: vscode.ExtensionContext, handleLocal: bo
   overrideCommand(context, 'compositionStart', async () => {
     taskQueue.enqueueTask(async () => {
       compositionState.isInComposition = true;
+      compositionState.composingStart = vscode.window.activeTextEditor?.selection.active;
     });
   });
 
@@ -380,19 +381,27 @@ export async function activate(context: vscode.ExtensionContext, handleLocal: bo
       if (mh) {
         if (compositionState.insertedText) {
           mh.internalSelectionsTracker.startIgnoringIntermediateSelections();
+          // IME candidate selection doesn't trigger `replacePreviousChar` with `editor.editContext` enabled,
+          // so `composingText` may be stale.
+          const editor = mh.vimState.editor;
+          const text = editor.document.getText(
+            new vscode.Range(
+              compositionState.composingStart ?? editor.selection.active,
+              editor.selection.active,
+            ),
+          );
           await vscode.commands.executeCommand('default:replacePreviousChar', {
             text: '',
-            replaceCharCnt: compositionState.composingText.length,
+            replaceCharCnt: text.length,
           });
           mh.vimState.cursorStopPosition = mh.vimState.editor.selection.active;
           mh.vimState.cursorStartPosition = mh.vimState.editor.selection.active;
           mh.internalSelectionsTracker.stopIgnoringIntermediateSelections();
-        }
-        const text = compositionState.composingText;
-        if (compositionState.insertedText) {
-          await mh.handleMultipleKeyEvents([text]);
+          if (text) {
+            await mh.handleMultipleKeyEvents([text]);
+          }
         } else {
-          await mh.handleMultipleKeyEvents(text.split(''));
+          await mh.handleMultipleKeyEvents(compositionState.composingText.split(''));
         }
       }
       compositionState.reset();

--- a/src/state/compositionState.ts
+++ b/src/state/compositionState.ts
@@ -1,11 +1,15 @@
+import * as vscode from 'vscode';
+
 export class CompositionState {
   isInComposition: boolean = false;
   insertedText: boolean = false;
   composingText: string = '';
+  composingStart: vscode.Position | undefined = undefined;
 
   reset() {
     this.isInComposition = false;
     this.insertedText = false;
     this.composingText = '';
+    this.composingStart = undefined;
   }
 }


### PR DESCRIPTION
<!--
Yay! Thanks for sending us a PR! 🎊

Please ensure your PR adheres to:

- [ ] Commit messages has a short & issue references when necessary
- [ ] Each commit does a logical chunk of work.
- [ ] It builds and tests pass (e.g `gulp`)
-->

**What this PR does / why we need it**:

Since `editor.editContext` is enabled by default, IME candidate selection is handled natively and doesn't fire `replacePreviousChar`, so the raw input would always be replayed at `compositionEnd`, reverting the IME conversion (#9672).

This PR records the cursor position at `compositionStart` and reads the composed text from the document at `compositionEnd` without using the stale `composingText`.

**Which issue(s) this PR fixes**

Fixes #9672.

**Special notes for your reviewer**: