### PR TITLE
fix: allow overriding textwidth via `:set tw=N`

### DIFF
--- a/src/configuration/configuration.ts
+++ b/src/configuration/configuration.ts
@@ -118,6 +118,8 @@ class Configuration implements IConfiguration {
   }
 
   public async load(): Promise<ValidatorResults> {
+    this._textwidth = undefined;
+
     const vimConfigs: { [key: string]: any } = Globals.isTesting
       ? Globals.mockConfiguration
       : this.getConfiguration('vim');
@@ -496,14 +498,27 @@ class Configuration implements IConfiguration {
   langmapReverseBindingsMap: Map<string, string> = new Map();
   langmap = '';
 
+  private _textwidth: number | undefined = undefined;
+
   get textwidth(): number {
-    const textwidth = this.getConfiguration('vim').get('textwidth', 80);
+    if (this._textwidth !== undefined) {
+      return this._textwidth;
+    }
+
+    const textwidth =
+      (Globals.isTesting
+        ? Globals.mockConfiguration.textwidth
+        : this.getConfiguration('vim').get('textwidth', 80)) ?? 80;
 
     if (typeof textwidth !== 'number') {
       return 80;
     }
 
     return textwidth;
+  }
+
+  set textwidth(textwidth: number) {
+    this._textwidth = textwidth;
   }
 
   private static unproxify(obj: { [key: string]: any }): object {

--- a/test/configuration/configuration.test.ts
+++ b/test/configuration/configuration.test.ts
@@ -59,6 +59,14 @@ suite('Configuration', () => {
   });
 
   newTest({
+    title: 'textwidth can be overridden with the set command',
+    config: { textwidth: 80 },
+    start: ['|1 12 1 1'],
+    keysPressed: ':set tw=2\ngqq',
+    end: ['|1', '12', '1', '1'],
+  });
+
+  newTest({
     title: 'Can handle long key chords',
     start: ['|'],
     // <leader>fes


### PR DESCRIPTION
Fixes the `:set tw=N` (`:set textwidth=N`) command.

In PR #7747, `vim.textwidth` was made language-configurable by turning `textwidth` into a getter without a setter. As a result, running `:set tw=N` threw:
`TypeError: Cannot set property textwidth of #<Configuration> which has only a getter`
(which was caught and logged only to the Vim extension output channel).

### Context & Comparison to PR #7811

@adamjhawley previously attempted to fix this in #7811 by calling `vscode.workspace.getConfiguration('vim').update('textwidth', ...)` in the setter. However, as noted in the discussion there, writing to `settings.json` on disk whenever someone runs `:set tw=N` has unwanted side effects: it dirties project repositories and triggers VS Code configuration reload events across extensions.

This PR implements an in-memory override:
- When `:set tw=N` is executed, the session override takes precedence in memory without writing to or dirtying `settings.json` on disk (preserving traditional Vim session semantics).
- When no override is active, it continues to respect language-specific VS Code settings (`[python]`, `[markdown]`, etc.).
- Reloading configuration cleanly resets the session override.

Fixes #7809
Supersedes and closes #7811